### PR TITLE
Bug 349477 - Using criteria.in(…) with ParameterExpression of type Collection creates invalid SQL

### DIFF
--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/criteria/AdvancedCriteriaQueryTestSuite.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/criteria/AdvancedCriteriaQueryTestSuite.java
@@ -447,15 +447,15 @@ public class AdvancedCriteriaQueryTestSuite extends JUnitTestCase {
     public void testInParameterCollection2(){
         EntityManager em = createEntityManager();
         beginTransaction(em);
-        List respons = new Vector();
-        respons.add("NoResults");
-        respons.add("Bug fixes");
+        List<String> response = new Vector<>();
+        response.add("NoResults");
+        response.add("Bug fixes");
         try {
             CriteriaBuilder qbuilder = em.getCriteriaBuilder();
-            CriteriaQuery<Employee> cquery =qbuilder.createQuery(Employee.class);
+            CriteriaQuery<Employee> cquery = qbuilder.createQuery(Employee.class);
             Root<Employee> emp = cquery.from(Employee.class);
             cquery.where(emp.join("responsibilities").in(qbuilder.parameter(java.util.Collection.class, "param")));
-            List<Employee> result = em.createQuery(cquery).setParameter("param",respons).getResultList();
+            List<Employee> result = em.createQuery(cquery).setParameter("param", response).getResultList();
             assertFalse("testInParameterCollection failed: No Employees were returned", result.isEmpty());
         } finally {
             closeEntityManagerAndTransaction(em);

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/criteria/AdvancedCriteriaQueryTestSuite.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/criteria/AdvancedCriteriaQueryTestSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2017 Oracle and/or its affiliates, IBM Corporation. All rights reserved.
+ * Copyright (c) 1998, 2018 Oracle and/or its affiliates, IBM Corporation. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -122,6 +122,7 @@ public class AdvancedCriteriaQueryTestSuite extends JUnitTestCase {
         suite.addTest(new AdvancedCriteriaQueryTestSuite("testInCollectionEntity"));
         suite.addTest(new AdvancedCriteriaQueryTestSuite("testInCollectionPrimitives"));
         suite.addTest(new AdvancedCriteriaQueryTestSuite("testInParameterCollection"));
+        suite.addTest(new AdvancedCriteriaQueryTestSuite("testInParameterCollection2"));
         suite.addTest(new AdvancedCriteriaQueryTestSuite("testProd"));
         suite.addTest(new AdvancedCriteriaQueryTestSuite("testSize"));
         suite.addTest(new AdvancedCriteriaQueryTestSuite("testJoinDistinct"));
@@ -439,6 +440,28 @@ public class AdvancedCriteriaQueryTestSuite extends JUnitTestCase {
             closeEntityManagerAndTransaction(em);
         }
     }
+
+    /*
+     * bug 349477 - Using criteria.in(...) with ParameterExpression of type Collection creates invalid SQL
+     */
+    public void testInParameterCollection2(){
+        EntityManager em = createEntityManager();
+        beginTransaction(em);
+        List respons = new Vector();
+        respons.add("NoResults");
+        respons.add("Bug fixes");
+        try {
+            CriteriaBuilder qbuilder = em.getCriteriaBuilder();
+            CriteriaQuery<Employee> cquery =qbuilder.createQuery(Employee.class);
+            Root<Employee> emp = cquery.from(Employee.class);
+            cquery.where(emp.join("responsibilities").in(qbuilder.parameter(java.util.Collection.class, "param")));
+            List<Employee> result = em.createQuery(cquery).setParameter("param",respons).getResultList();
+            assertFalse("testInParameterCollection failed: No Employees were returned", result.isEmpty());
+        } finally {
+            closeEntityManagerAndTransaction(em);
+        }
+    }
+
     public void testInlineInParameter(){
         EntityManager em = createEntityManager();
         beginTransaction(em);

--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/querydef/ExpressionImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/querydef/ExpressionImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -10,7 +10,8 @@
  * Contributors:
  *     Gordon Yorke - Initial development
  *
- ******************************************************************************/package org.eclipse.persistence.internal.jpa.querydef;
+ ******************************************************************************/
+package org.eclipse.persistence.internal.jpa.querydef;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -87,6 +88,13 @@ public class ExpressionImpl<X> extends SelectionImpl<X> implements Expression<X>
      */
     public Predicate in(Expression<?>... values) {
         if (values != null) {
+            if (values.length == 1 && ((InternalExpression) values[0]).isParameter()
+                    && Collection.class.isAssignableFrom(((ParameterExpressionImpl) values[0]).getJavaType())) {
+                // bug 349477 - Collection from Expression<Collection> was lost during compilation
+                // and if we know that Collection is there we should help the runtime
+                // and route the execution to the right method
+                return in((Expression<Collection<?>>) values[0]);
+            }
             List list = new ArrayList();
             list.add(this);
             if (values.length == 1 && ((InternalExpression) values[0]).isSubquery()) {


### PR DESCRIPTION
fix for https://bugs.eclipse.org/bugs/show_bug.cgi?id=349477:

Type erasure removes Collection from Expression<Collection> and this leads to unexpected method being invoked. Since we know the right type during runtime, we can intercept it and route the execution to the expected path. 

Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>