### PR TITLE
[2.7] Bug 349477 - Using criteria.in(…) with ParameterExpression of type Co…

### DIFF
--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/querydef/ExpressionImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/querydef/ExpressionImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -10,7 +10,8 @@
  * Contributors:
  *     Gordon Yorke - Initial development
  *
- ******************************************************************************/package org.eclipse.persistence.internal.jpa.querydef;
+ ******************************************************************************/
+package org.eclipse.persistence.internal.jpa.querydef;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -87,6 +88,13 @@ public class ExpressionImpl<X> extends SelectionImpl<X> implements Expression<X>
      */
     public Predicate in(Expression<?>... values) {
         if (values != null) {
+            if (values.length == 1 && ((InternalExpression) values[0]).isParameter()
+                    && Collection.class.isAssignableFrom(((ParameterExpressionImpl) values[0]).getJavaType())) {
+                // bug 349477 - Collection from Expression<Collection> was lost during compilation
+                // and if we know that Collection is there we should help the runtime
+                // and route the execution to the right method
+                return in((Expression<Collection<?>>) values[0]);
+            }
             List list = new ArrayList();
             list.add(this);
             if (values.length == 1 && ((InternalExpression) values[0]).isSubquery()) {


### PR DESCRIPTION
* Bug 349477: Using criteria.in(…) with ParameterExpression of type Collection creates invalid SQL

Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>
Reviewed-by: Dmitry