### PR TITLE
Bug 531349 - XmlSchema Prefix is not honoured if root element is  nil

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLMarshaller.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLMarshaller.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -1107,6 +1107,8 @@ public abstract class XMLMarshaller<
                     session = context.getSession(((Root)object).getObject());
                     if(session != null){
                         descriptor = getDescriptor(((Root)object).getObject(), session);
+                    } else if (descriptor == null) {
+                        descriptor = context.getDescriptor(new QName(((Root)object).getNamespaceURI(),((Root)object).getLocalName()));
                     }
                 }catch (XMLMarshalException marshalException) {
                     if (!isSimpleXMLRoot((Root) object)) {

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/JAXBTestSuite3.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/JAXBTestSuite3.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -26,6 +26,7 @@ import org.eclipse.persistence.testing.jaxb.jaxbintrospector.elementname.JAXBInt
 import org.eclipse.persistence.testing.jaxb.prefixmapper.DefaultNSPrefixMapperSimpleTestCases;
 import org.eclipse.persistence.testing.jaxb.prefixmapper.PrefixMapperContextTestCases;
 import org.eclipse.persistence.testing.jaxb.prefixmapper.PrefixMapperMapTestCases;
+import org.eclipse.persistence.testing.jaxb.prefixmapper.PrefixMapperPackageInfoTestCases;
 import org.eclipse.persistence.testing.jaxb.prefixmapper.PrefixMapperTestCases;
 import org.eclipse.persistence.testing.jaxb.properties.PropertyTestCases;
 import org.eclipse.persistence.testing.jaxb.readonly.ReadAndWriteOnlyTestCases;
@@ -135,6 +136,7 @@ public class JAXBTestSuite3 extends TestCase {
         suite.addTestSuite(UnmarshalWithSpaceEventTestCases.class);
         suite.addTestSuite(PrefixMapperTestCases.class);
         suite.addTestSuite(PrefixMapperMapTestCases.class);
+        suite.addTestSuite(PrefixMapperPackageInfoTestCases.class);
         suite.addTestSuite(PrefixMapperContextTestCases.class);
         suite.addTestSuite(DefaultNSPrefixMapperSimpleTestCases.class);
         suite.addTestSuite(ChildURITestCases.class);

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/prefixmapper/PrefixMapperContextTestCases.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/prefixmapper/PrefixMapperContextTestCases.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -28,6 +28,14 @@ public class PrefixMapperContextTestCases extends TestCase {
     private static final String CONTROL_XML = "<newPrefix:employeeContext xmlns:ns0=\"extraUri\" xmlns:newPrefix=\"someuri\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:somePrefix=\"my.uri\">" +
               "<firstName>Jon</firstName><lastName>Doe</lastName><acmeNS:employeeId>123</acmeNS:employeeId>" +
               "</newPrefix:employeeContext>";
+
+    public PrefixMapperContextTestCases(String name) {
+        super(name);
+    }
+
+    public String getName() {
+        return "JAXB set/getProperty Tests: " + super.getName();
+    }
 
     public void testMarshalWithContextualNamespaces() throws Exception  {
         JAXBContext ctx = JAXBContextFactory.createContext(new Class[]{EmployeeContext.class}, null);

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/prefixmapper/PrefixMapperPackageInfoTestCases.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/prefixmapper/PrefixMapperPackageInfoTestCases.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     03/16/2018-2.7.2 Radek Felcman
+ *       - 531349 - @XmlSchema Prefix is not honoured if root element is nil
+ ******************************************************************************/
+
+package org.eclipse.persistence.testing.jaxb.prefixmapper;
+
+import java.io.StringWriter;
+import java.util.HashMap;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.Marshaller;
+
+import org.eclipse.persistence.jaxb.JAXBContextFactory;
+import org.eclipse.persistence.testing.jaxb.prefixmapper.packageinfonamespace.EmailAddress;
+import org.eclipse.persistence.testing.jaxb.prefixmapper.packageinfonamespace.ObjectFactory;
+import org.eclipse.persistence.testing.oxm.OXTestCase;
+
+
+public class PrefixMapperPackageInfoTestCases extends OXTestCase {
+
+    private static final String EXPECTED_ROOT_NAME = "PRE:emailAddress-Root";
+
+    public PrefixMapperPackageInfoTestCases(String name) {
+        super(name);
+    }
+
+    public void testMarshalWithPackageInfoNamespacePrefix() throws Exception  {
+
+        final ObjectFactory of = new ObjectFactory();
+        final JAXBElement<EmailAddress> o = of.createEmailAddress(null);
+
+        final JAXBContext ctx = JAXBContextFactory.createContext(new Class<?>[] { ObjectFactory.class, EmailAddress.class}, new HashMap<>());
+
+        final StringWriter writer = new StringWriter();
+        Marshaller marshaller = ctx.createMarshaller();
+        marshaller.marshal(o, writer);
+
+        assertTrue("Expected: " + EXPECTED_ROOT_NAME + " But was: " + writer.toString(), writer.toString().indexOf(EXPECTED_ROOT_NAME) != -1);
+
+    }
+
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/prefixmapper/packageinfonamespace/EmailAddress.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/prefixmapper/packageinfonamespace/EmailAddress.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     03/16/2018-2.7.2 Radek Felcman
+ *       - 531349 - @XmlSchema Prefix is not honoured if root element is nil
+ ******************************************************************************/
+
+package org.eclipse.persistence.testing.jaxb.prefixmapper.packageinfonamespace;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+public class EmailAddress {
+
+  public EmailAddress() {
+    super();
+  }
+
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/prefixmapper/packageinfonamespace/ObjectFactory.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/prefixmapper/packageinfonamespace/ObjectFactory.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     03/16/2018-2.7.2 Radek Felcman
+ *       - 531349 - @XmlSchema Prefix is not honoured if root element is nil
+ ******************************************************************************/
+
+package org.eclipse.persistence.testing.jaxb.prefixmapper.packageinfonamespace;
+
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.annotation.XmlElementDecl;
+import javax.xml.bind.annotation.XmlRegistry;
+import javax.xml.namespace.QName;
+
+@XmlRegistry
+public class ObjectFactory {
+
+    @XmlElementDecl(namespace = "extraUri", name = "emailAddress-Root")
+    public JAXBElement<EmailAddress> createEmailAddress(EmailAddress value) {
+        return new JAXBElement<EmailAddress>(new QName("extraUri", "emailAddress-Root"), EmailAddress.class, null, value);
+    }
+
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/prefixmapper/packageinfonamespace/package-info.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/prefixmapper/packageinfonamespace/package-info.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     03/16/2018-2.7.2 Radek Felcman
+ *       - 531349 - @XmlSchema Prefix is not honoured if root element is nil
+ ******************************************************************************/
+
+@XmlSchema(
+        namespace = "NS", elementFormDefault = XmlNsForm.QUALIFIED,
+        xmlns = {
+                @XmlNs(namespaceURI = "extraUri", prefix = "PRE"),
+                @XmlNs(namespaceURI = "http://www.w3.org/2001/XMLSchema-instance", prefix = "xsi") })
+        package org.eclipse.persistence.testing.jaxb.prefixmapper.packageinfonamespace;
+
+            import javax.xml.bind.annotation.XmlNs;
+            import javax.xml.bind.annotation.XmlNsForm;
+            import javax.xml.bind.annotation.XmlSchema;


### PR DESCRIPTION
MOXy marshaller ignores custom namespace prefix mapping specified in package-info class. It generates default one "ns0" instead custom "PRE". After patch it can use mapping from package-info class. See https://bugs.eclipse.org/bugs/show_bug.cgi?id=531349 .

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>