### PR TITLE
[master] Bug 487838: Metamodel gen fails if class hierarchy contains enclosed interfaces

### DIFF
--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/modelgen/TestProcessor.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/modelgen/TestProcessor.java
@@ -29,8 +29,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
 import javax.persistence.Entity;
+import javax.persistence.metamodel.StaticMetamodel;
 import javax.tools.Diagnostic;
 import javax.tools.DiagnosticCollector;
 import javax.tools.JavaCompiler;
@@ -57,7 +59,7 @@ public class TestProcessor {
             }
         }
     }
-    
+
     @Test
     public void testProc() throws Exception {
         File runDir = new File(System.getProperty("run.dir"), "testproc");
@@ -82,7 +84,7 @@ public class TestProcessor {
         sfm.setLocation(StandardLocation.CLASS_OUTPUT, Arrays.asList(cpDir));
 
         TestFO entity = new TestFO("org.Sample",
-                "package org; import javax.persistence.Entity; @Entity public class Sample { public  Sample() {} public int getX() {return 1;}}");
+                "package org; import javax.persistence.Entity; @Entity public class Sample { public  Sample() {} public int getX() {return 1;} interface A {}}");
         TestFO nonEntity = new TestFO("org.NotE",
                 "package org; import javax.persistence.Entity; public class NotE extends some.IF { public  NotE() {} @custom.Ann public external.Cls getW() {return new Object();}}");
         TestFO generated8 = new TestFO("org.Gen8",
@@ -99,7 +101,9 @@ public class TestProcessor {
         for ( Diagnostic<? extends JavaFileObject> diagnostic : diagnostics.getDiagnostics()) {
             System.out.println(diagnostic);
         }
-        Assert.assertTrue("Model file not generated", new File(srcOut, "org/Sample_.java").exists());
+        File outputFile = new File(srcOut, "org/Sample_.java");
+        Assert.assertTrue("Model file not generated", outputFile.exists());
+        Assert.assertTrue(Files.lines(outputFile.toPath()).anyMatch(s -> s.contains("@StaticMetamodel(Sample.class)")));
     }
 
     @Test

--- a/jpa/org.eclipse.persistence.jpa.modelgen/src/org/eclipse/persistence/internal/jpa/modelgen/visitors/ElementVisitor.java
+++ b/jpa/org.eclipse.persistence.jpa.modelgen/src/org/eclipse/persistence/internal/jpa/modelgen/visitors/ElementVisitor.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.PackageElement;
@@ -242,7 +243,8 @@ public class ElementVisitor<R, P> extends AbstractElementVisitor6<MetadataAnnota
 
             // Visit the enclosed elements.
             for (Element enclosedElement : typeElement.getEnclosedElements()) {
-                if (enclosedElement.getKind().isClass()) {
+                ElementKind kind = enclosedElement.getKind();
+                if (kind.isClass() || kind.isInterface()) {
                     metadataClass.addEnclosedClass(factory.getMetadataClass(enclosedElement));
                 } else {
                     enclosedElement.accept(this, metadataClass);


### PR DESCRIPTION
Note that the test uses Stream and lambda call implying dependency on JDK8+ which should be fine for master (JDK9+) and 2.7 (JDK8+) streams

Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>