### PR TITLE
Add configuration for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: java
 sudo: required
 
+branches:
+  only:
+    - travis_experiment
+
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ addons:
       - mysql-client
 
 before_install:
-  - sudo mysql -u root -e "use mysql; update user set authentication_string=PASSWORD('root') where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;CREATE DATABASE IF NOT EXISTS ecltest;"
   - sudo mysql_upgrade
+  - sudo mysql -u root -e "use mysql; update user set authentication_string=PASSWORD('root') where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;CREATE DATABASE IF NOT EXISTS ecltest;"
   - sudo service mysql restart
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
       - libmysql-java
       - mysql-server
       - mysql-client
+
 env:
   global:
     - ANT_HOME=/usr/share/ant
@@ -25,10 +26,12 @@ before_install:
   - sudo service mysql restart
 
 install:
-  - wget http://repo1.maven.org/maven2/org/jmockit/jmockit/1.35/jmockit-1.35.jar
+  - mkdir $HOME/extension.lib.external
+  - wget http://repo1.maven.org/maven2/org/jmockit/jmockit/1.35/jmockit-1.35.jar -O $HOME/extension.lib.external/jmockit-1.35.jar
 
 before_script:
   - env | sort
+  - echo "extensions.depend.dir=$HOME/extension.lib.external" >> $HOME/build.properties
   - echo 'junit.lib=/usr/share/java/junit4.jar:/usr/share/java/hamcrest-all-1.3.jar' >> $HOME/build.properties
   - echo 'jdbc.driver.jar=/usr/share/java/mysql.jar' >> $HOME/build.properties
   - echo 'db.driver=com.mysql.jdbc.Driver' >> $HOME/build.properties
@@ -36,9 +39,8 @@ before_script:
   - echo 'db.user=root' >> $HOME/build.properties
   - echo 'db.pwd=root' >> $HOME/build.properties
   - echo 'db.platform=org.eclipse.persistence.platform.database.MySQLPlatform' >> $HOME/build.properties
-  - echo "jmockit.jar=$HOME/jmockit-1.35.jar" >> $HOME/build.properties
 
 script:
   - cat $HOME/build.properties
-  - ant -f antbuild.xml build clear-db
+  - ant -f antbuild.xml build clear-db 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ jdk:
 
 cache:
   directories:
-    - .autoconf
     - $HOME/.m2
 
 before_install:
@@ -45,11 +44,11 @@ before_script:
   - echo 'db.user=root' >> $HOME/build.properties
   - echo 'db.pwd=root' >> $HOME/build.properties
   - echo 'db.platform=org.eclipse.persistence.platform.database.MySQLPlatform' >> $HOME/build.properties
-  - if [ `java -version 2>&1|awk -F\" '/version/ {print $2}' | cut -d'.' -f1` -gt "8" ]; then echo 'additional.jvmargs=--add-modules java.xml.ws,java.corba' >> $HOME/build.properties; fi
+  - if [ `java -version 2>&1|awk -F\" '/version/ {print $2}' | cut -d'.' -f1` -gt "8" ]; then echo 'additional.jvmargs=--add-modules java.xml.ws,java.xml.ws.annotation,java.corba' >> $HOME/build.properties; fi
 
 script:
   - cat $HOME/build.properties
   - ant -f antbuild.xml build
   - echo 'RUNNING TESTS, BE PATIENT...'
-  - ant -f antbuild.xml test-core-srg test-ext test-jpa22 test-jpa-jse test-jpql test-wdf test-jpars test-moxy test-sdo test-dbws test-dbws-builder test-osgi | grep -E "\[junit\] Running|\[junit\] Tests run:"
+  - ant -f antbuild.xml test-lrg | grep -E "\[junit\] Running|\[junit\] Tests run:"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
 
 jdk:
   - oraclejdk8
+  - oraclejdk9
 
 cache:
   directories:
@@ -44,6 +45,7 @@ before_script:
   - echo 'db.user=root' >> $HOME/build.properties
   - echo 'db.pwd=root' >> $HOME/build.properties
   - echo 'db.platform=org.eclipse.persistence.platform.database.MySQLPlatform' >> $HOME/build.properties
+  - if [ `java -version 2>&1|awk -F\" '/version/ {print $2}' | cut -d'.' -f1` -gt "8" ]; then echo 'additional.jvmargs=--add-modules java.xml.ws,java.corba' >> $HOME/build.properties; fi
 
 script:
   - cat $HOME/build.properties

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,19 @@ addons:
       - mysql-server
       - mysql-client
 env:
-  - ANT_HOME=/usr/share/ant
-  - M2_HOME=/usr/local/maven-3.5.2
+  global:
+    - ANT_HOME=/usr/share/ant
+    - M2_HOME=/usr/local/maven-3.5.2
 
 before_install:
   - sudo mysql_upgrade
   - sudo mysql -u root -e "use mysql; update user set authentication_string=PASSWORD('root') where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;CREATE DATABASE IF NOT EXISTS ecltest;"
   - sudo service mysql restart
 
-script:
+install:
+  - wget http://repo1.maven.org/maven2/org/jmockit/jmockit/1.35/jmockit-1.35.jar
+
+before_script:
   - env | sort
   - . ./jdk_switcher.sh
   - jdk_switcher use oraclejdk8
@@ -31,6 +35,9 @@ script:
   - echo 'db.user=root' >> $HOME/build.properties
   - echo 'db.pwd=root' >> $HOME/build.properties
   - echo 'db.platform=org.eclipse.persistence.platform.database.MySQLPlatform' >> $HOME/build.properties
+  - echo 'jmockit.jar=$HOME/jmockit-1.35.jar' >> $HOME/build.properties
+
+script:
   - cat $HOME/build.properties
   - ant -f antbuild.xml build clear-db
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,19 @@ env:
   global:
     - ANT_HOME=/usr/share/ant
     - M2_HOME=/usr/local/maven-3.5.2
+  matrix:
+    - TEST_TARGET=test-core
+    - TEST_TARGET=test-ext
+    - TEST_TARGET=test-jpa22
+    - TEST_TARGET=test-jpa-jse
+    - TEST_TARGET=test-jpql
+    - TEST_TARGET=test-wdf
+    - TEST_TARGET=test-jpars
+    - TEST_TARGET=test-moxy
+    - TEST_TARGET=test-sdo
+    - TEST_TARGET=test-dbws
+    - TEST_TARGET=test-dbws-builder
+    - TEST_TARGET=test-osgi
 
 jdk:
   - oraclejdk8
@@ -50,5 +63,5 @@ script:
   - cat $HOME/build.properties
   - ant -f antbuild.xml build
   - echo 'RUNNING TESTS, BE PATIENT...'
-  - ant -f antbuild.xml test-lrg | grep -E "\[junit\] Running|\[junit\] Tests run:"
+  - ant -f antbuild.xml $TEST_TARGET | grep -E "\[junit\] Running|\[junit\] Tests run:"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ script:
   - cat $HOME/build.properties
   - ant -f antbuild.xml build
   - echo 'RUNNING TESTS, BE PATIENT...'
+  - set -o pipefail
   - ant -f antbuild.xml -Dtest.fail.fast=true $TEST_TARGET | grep -E "\[junit\] Running|\[junit\] Tests run:"
-  - test "${PIPESTATUS[0]}" -eq "0"
-
+  - test "${PIPESTATUS[@]}" -eq "0"
+  - echo "${PIPESTATUS[@]}" -eq "0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,5 +42,5 @@ before_script:
 
 script:
   - cat $HOME/build.properties
-  - ant -f antbuild.xml build clear-db 
+  - ant -f antbuild.xml build test-lrg 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,36 @@
 language: java
-sudo: false
+sudo: required
 
 addons:
   apt:
+    sources:
+      - mysql-5.7-trusty
     packages:
-    - maven
-    - ant
-    - openjdk-8-jdk
-    - junit4
-    - libhamcrest-java
+      - junit4
+      - libhamcrest-java
+      - libmysql-java
+      - mysql-server
+      - mysql-client
+
+before_install:
+  - sudo mysql -e "use mysql; update user set authentication_string=PASSWORD('root') where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;CREATE DATABASE IF NOT EXISTS ecltest;"
+  - sudo mysql_upgrade
+  - sudo service mysql restart
 
 script:
-- export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-- export M2_HOME=/usr/share/maven
-- export ANT_HOME=/usr/share/ant
-- echo 'junit.lib=/usr/share/java/junit4.jar:/usr/share/java/hamcrest-all-1.3.jar' >> $HOME/build.properties
-- ant -f antbuild.xml
+  - env | sort
+  - . ./jdk_switcher.sh
+  - jdk_switcher use oraclejdk8
+  - echo $JAVA_HOME
+  - export M2_HOME=/usr/share/maven
+  - export ANT_HOME=/usr/share/ant
+  - echo 'junit.lib=/usr/share/java/junit4.jar:/usr/share/java/hamcrest-all-1.3.jar' >> $HOME/build.properties
+  - echo 'jdbc.driver.jar=/usr/share/java/mysql.jar' >> $HOME/build.properties
+  - echo 'db.driver=com.mysql.jdbc.Driver' >> $HOME/build.properties
+  - echo 'db.url=jdbc:mysql://localhost/ecltest?useSSL=false' >> $HOME/build.properties
+  - echo 'db.user=root' >> $HOME/build.properties
+  - echo 'db.pwd=root' >> $HOME/build.properties
+  - echo 'db.platform=org.eclipse.persistence.platform.database.MySQLPlatform' >> $HOME/build.properties
+  - cat $HOME/build.properties
+  - ant -f antbuild.xml build clear-db
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ addons:
       - libmysql-java
       - mysql-server
       - mysql-client
+env:
+  - ANT_HOME=/usr/share/ant
+  - M2_HOME=/usr/local/maven-3.5.2
 
 before_install:
   - sudo mysql_upgrade
@@ -21,9 +24,6 @@ script:
   - env | sort
   - . ./jdk_switcher.sh
   - jdk_switcher use oraclejdk8
-  - echo $JAVA_HOME
-  - export M2_HOME=/usr/share/maven
-  - export ANT_HOME=/usr/share/ant
   - echo 'junit.lib=/usr/share/java/junit4.jar:/usr/share/java/hamcrest-all-1.3.jar' >> $HOME/build.properties
   - echo 'jdbc.driver.jar=/usr/share/java/mysql.jar' >> $HOME/build.properties
   - echo 'db.driver=com.mysql.jdbc.Driver' >> $HOME/build.properties

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: java
+sudo: false
+
+addons:
+  apt:
+    packages:
+    - maven
+    - ant
+    - openjdk-8-jdk
+    - junit4
+    - libhamcrest-java
+
+script:
+- export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+- export M2_HOME=/usr/share/maven
+- export ANT_HOME=/usr/share/ant
+- echo 'junit.lib=/usr/share/java/junit4.jar:/usr/share/java/hamcrest-all-1.3.jar' >> $HOME/build.properties
+- ant -f antbuild.xml
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: java
 sudo: required
 
 branches:
-  only:
-    - travis_experiment
+  except:
+    - /^[12].[0-6].*/
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,5 +62,5 @@ script:
   - cat $HOME/build.properties
   - ant -f antbuild.xml build
   - echo 'RUNNING TESTS, BE PATIENT...'
-  - ant -f antbuild.xml -Dtest.fail.fast=true $TEST_TARGET | grep -E "\[junit\] Running|\[junit\] Tests run:"
+  - ant -f antbuild.xml -Dtest.fail.fast=true $TEST_TARGET | { grep -E "\[junit\] Running|\[junit\] Tests run:" && test "${PIPESTATUS[0]}" -eq "0";}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ env:
     - ANT_HOME=/usr/share/ant
     - M2_HOME=/usr/local/maven-3.5.2
 
+jdk:
+  - oraclejdk8
+
 before_install:
   - sudo mysql_upgrade
   - sudo mysql -u root -e "use mysql; update user set authentication_string=PASSWORD('root') where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;CREATE DATABASE IF NOT EXISTS ecltest;"
@@ -26,8 +29,6 @@ install:
 
 before_script:
   - env | sort
-  - . ./jdk_switcher.sh
-  - jdk_switcher use oraclejdk8
   - echo 'junit.lib=/usr/share/java/junit4.jar:/usr/share/java/hamcrest-all-1.3.jar' >> $HOME/build.properties
   - echo 'jdbc.driver.jar=/usr/share/java/mysql.jar' >> $HOME/build.properties
   - echo 'db.driver=com.mysql.jdbc.Driver' >> $HOME/build.properties

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,5 +42,8 @@ before_script:
 
 script:
   - cat $HOME/build.properties
-  - ant -f antbuild.xml build test-lrg 
+  - ant -f antbuild.xml build
+  - echo 'RUNNING TESTS, BE PATIENT...'
+  - ant -f antbuild.xml test-lrg > test.log.txt
+  - grep -E "\[junit\] Running|\[junit\] Tests run:" test.log.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,5 @@ script:
   - cat $HOME/build.properties
   - ant -f antbuild.xml build
   - echo 'RUNNING TESTS, BE PATIENT...'
-  - ant -f antbuild.xml test-lrg > test.log.txt
-  - grep -E "\[junit\] Running|\[junit\] Tests run:" test.log.txt
+  - ant -f antbuild.xml test-core-srg test-ext test-jpa22 test-jpa-jse test-jpql test-wdf test-jpars test-moxy test-sdo test-dbws test-dbws-builder test-osgi | grep -E "\[junit\] Running|\[junit\] Tests run:"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ cache:
   directories:
     - .autoconf
     - $HOME/.m2
+    - $HOME/extension.lib.external
 
 before_install:
   - sudo mysql_upgrade
@@ -43,8 +44,12 @@ before_install:
   - sudo service mysql restart
 
 install:
-  - mkdir $HOME/extension.lib.external
-  - wget http://repo1.maven.org/maven2/org/jmockit/jmockit/1.35/jmockit-1.35.jar -O $HOME/extension.lib.external/jmockit-1.35.jar
+  - mkdir $HOME/extension.lib.external || true
+  - wget -nc http://repo1.maven.org/maven2/org/jmockit/jmockit/1.35/jmockit-1.35.jar -O $HOME/extension.lib.external/jmockit-1.35.jar
+  - wget -nc http://repo1.maven.org/maven2/org/hibernate/validator/hibernate-validator/6.0.7.Final/hibernate-validator-6.0.7.Final.jar -O $HOME/extension.lib.external/hibernate-validator-6.0.7.Final.jar
+  - wget -nc http://repo1.maven.org/maven2/org/jboss/logging/jboss-logging/3.3.0.Final/jboss-logging-3.3.0.Final.jar -O $HOME/extension.lib.external/jboss-logging-3.3.0.Final.jar
+  - wget -nc http://repo1.maven.org/maven2/org/glassfish/javax.el/3.0.1-b08/javax.el-3.0.1-b08.jar -O $HOME/extension.lib.external/javax.el-3.0.1-b08.jar
+  - wget -nc http://repo1.maven.org/maven2/com/fasterxml/classmate/1.3.1/classmate-1.3.1.jar -O $HOME/extension.lib.external/classmate-1.3.1.jar
 
 before_script:
   - env | sort
@@ -64,5 +69,3 @@ script:
   - echo 'RUNNING TESTS, BE PATIENT...'
   - set -o pipefail
   - ant -f antbuild.xml -Dtest.fail.fast=true $TEST_TARGET | grep -E "\[junit\] Running|\[junit\] Tests run:"
-  - test "${PIPESTATUS[@]}" -eq "0"
-  - echo "${PIPESTATUS[@]}" -eq "0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,11 @@ env:
 jdk:
   - oraclejdk8
 
+cache:
+  directories:
+    - .autoconf
+    - $HOME/.m2
+
 before_install:
   - sudo mysql_upgrade
   - sudo mysql -u root -e "use mysql; update user set authentication_string=PASSWORD('root') where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;CREATE DATABASE IF NOT EXISTS ecltest;"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,16 +22,10 @@ env:
     - M2_HOME=/usr/local/maven-3.5.2
   matrix:
     - TEST_TARGET=test-core
-    - TEST_TARGET=test-ext
     - TEST_TARGET=test-jpa22
-    - TEST_TARGET=test-jpa-jse
-    - TEST_TARGET=test-jpql
-    - TEST_TARGET=test-wdf
-    - TEST_TARGET=test-jpars
     - TEST_TARGET=test-moxy
     - TEST_TARGET=test-sdo
-    - TEST_TARGET=test-dbws
-    - TEST_TARGET=test-dbws-builder
+    - TEST_TARGET="test-jpa-jse test-ext test-jpql test-wdf test-jpars test-dbws test-dbws-builder"
     - TEST_TARGET=test-osgi
 
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_script:
   - echo 'db.user=root' >> $HOME/build.properties
   - echo 'db.pwd=root' >> $HOME/build.properties
   - echo 'db.platform=org.eclipse.persistence.platform.database.MySQLPlatform' >> $HOME/build.properties
-  - echo 'jmockit.jar=$HOME/jmockit-1.35.jar' >> $HOME/build.properties
+  - echo "jmockit.jar=$HOME/jmockit-1.35.jar" >> $HOME/build.properties
 
 script:
   - cat $HOME/build.properties

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
       - mysql-client
 
 before_install:
-  - sudo mysql -e "use mysql; update user set authentication_string=PASSWORD('root') where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;CREATE DATABASE IF NOT EXISTS ecltest;"
+  - sudo mysql -u root -e "use mysql; update user set authentication_string=PASSWORD('root') where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;CREATE DATABASE IF NOT EXISTS ecltest;"
   - sudo mysql_upgrade
   - sudo service mysql restart
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ jdk:
 
 cache:
   directories:
+    - .autoconf
     - $HOME/.m2
 
 before_install:
@@ -61,5 +62,5 @@ script:
   - cat $HOME/build.properties
   - ant -f antbuild.xml build
   - echo 'RUNNING TESTS, BE PATIENT...'
-  - ant -f antbuild.xml $TEST_TARGET | grep -E "\[junit\] Running|\[junit\] Tests run:"
+  - ant -f antbuild.xml -Dtest.fail.fast=true $TEST_TARGET | grep -E "\[junit\] Running|\[junit\] Tests run:"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,5 +62,6 @@ script:
   - cat $HOME/build.properties
   - ant -f antbuild.xml build
   - echo 'RUNNING TESTS, BE PATIENT...'
-  - ant -f antbuild.xml -Dtest.fail.fast=true $TEST_TARGET | { grep -E "\[junit\] Running|\[junit\] Tests run:" && test "${PIPESTATUS[0]}" -eq "0";}
+  - ant -f antbuild.xml -Dtest.fail.fast=true $TEST_TARGET | grep -E "\[junit\] Running|\[junit\] Tests run:"
+  - test "${PIPESTATUS[0]}" -eq "0"
 

--- a/dbws/eclipselink.dbws.test/antbuild.xml
+++ b/dbws/eclipselink.dbws.test/antbuild.xml
@@ -217,7 +217,7 @@
     <sequential>
       <!-- Can be set e.g. in test.properties to add VM options for a particular platform/driver  -->
       <property name="additional.jvmargs" value="-Ddummy2=dummy"/>
-      <junit
+      <junit failureproperty="junit.failed" logfailedtests="true"
         jvm="${test.junit.jvm.exec}"
         printsummary="withOutAndErr"
         fork="yes"
@@ -264,6 +264,15 @@
           name="dbws.testing.@{package-name}.@{testsuite-name}TestSuite" outfile="${report.dir}/@{package-name}.@{testsuite-name}-test-results"
         />
       </junit>
+      <fail message="TESTS FAILED !">
+        <condition>
+            <and>
+                <isset property="junit.failed"/>
+                <istrue value="${test.fail.fast}"/>
+            </and>
+        </condition>
+      </fail>
+
       <junitreport
         todir="./${report.dir}"
         >

--- a/foundation/eclipselink.core.test/antbuild.xml
+++ b/foundation/eclipselink.core.test/antbuild.xml
@@ -554,7 +554,8 @@
         <property name="additional.jvmargs" value="-Ddummy2=dummy"/>
         <!-- 282012: On a 64-bit JVM - The XML processing at the end of the testing requires at least 1536 -->
         <!-- Note: on a legacy XP OS with 4GB ram - the max is 1536 - use of 2048 will cause [junit] [WARN ] Unable to acquire some virtual address space - reduced from 2048 to 1908MB. -->
-        <junit jvm="${test.junit.jvm.exec}" printsummary="yes" failureproperty="junit.failed" fork="yes" forkmode="once" showoutput="true" maxmemory="${max.heap.memory}" dir="${core_test.run.dir}">
+        <junit jvm="${test.junit.jvm.exec}" printsummary="yes" failureproperty="junit.failed" logfailedtests="true"
+               fork="yes" forkmode="once" showoutput="true" maxmemory="${max.heap.memory}" dir="${core_test.run.dir}">
             <jvmarg value="-Declipselink.logging.level=${logging.level}"/>
             <jvmarg value="-Ddb.driver=${db.driver}"/>
             <jvmarg value="-Ddb.url=${db.url}"/>
@@ -572,6 +573,14 @@
             <test name="${TEST_CLASS}" haltonfailure="no" outfile="${report.dir}/${TEST_CLASS}-test-results">
             </test>
         </junit>
+        <fail message="TESTS FAILED !">
+            <condition>
+                <and>
+                    <isset property="junit.failed"/>
+                    <istrue value="${test.fail.fast}"/>
+                </and>
+            </condition>
+        </fail>
     </target>
 
     <!-- Generic target for running JUnit tests. -->

--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/framework/TestCase.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/framework/TestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -136,7 +136,7 @@ public abstract class TestCase extends junit.framework.TestCase implements TestE
         setTestResult(new TestResult(this, "Passed"));
         setExecutor(executor);
 
-        long startTime = System.currentTimeMillis();
+        long startTime = System.nanoTime();
         try {
             try {
                 setUp();
@@ -187,7 +187,7 @@ public abstract class TestCase extends junit.framework.TestCase implements TestE
                     throw problem;
                 }
             } finally {
-                long endTime = System.currentTimeMillis();
+                long endTime = System.nanoTime();
                 getTestResult().setTotalTime(endTime - startTime);
 
                 // If a failure occurred allow recreation of the database and initialize the identity maps.

--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/framework/TestCollection.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/framework/TestCollection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -363,7 +363,6 @@ public abstract class TestCollection extends junit.framework.TestSuite implement
      */
     public void logResult(Writer log, boolean logOnlyErrors, boolean regression) {
         computeResultSummary();
-        computeNestedLevel();
         setIndentationString(Helper.getTabs(getNestedCounter()));
 
         if (regression) {

--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/framework/TestExecutor.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/framework/TestExecutor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -265,6 +265,7 @@ public class TestExecutor {
                 getListener().endTest(test);
             }
             getSession().logMessage("Failed " + test);
+            System.err.println(test + " FAILED");
         }
     }
 

--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/framework/TestModel.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/framework/TestModel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -198,7 +198,7 @@ public class TestModel extends TestCollection {
     public void execute(TestExecutor executor) throws Throwable {
         setSummary(new TestResultsSummary(this));
         setExecutor(executor);
-        long startTime = System.currentTimeMillis();
+        long startTime = System.nanoTime();
         try {
             setupEntity();
             setFinishedTests(new Vector());
@@ -220,7 +220,7 @@ public class TestModel extends TestCollection {
             }
             resetEntity();
         } finally {
-            long endTime = System.currentTimeMillis();
+            long endTime = System.nanoTime();
             getSummary().setTotalTime(endTime - startTime);
         }
     }

--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/framework/TestSuite.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/framework/TestSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -64,9 +64,14 @@ public class TestSuite extends TestCollection {
     public void execute(TestExecutor executor) throws Throwable {
         setSummary(new TestResultsSummary(this));
         setExecutor(executor);
+        computeNestedLevel();
         setupEntity();
         setFinishedTests(new Vector());
-        long startTime = System.currentTimeMillis();
+        if (getNestedCounter() < 1) {
+            System.out.println();
+            System.out.println("Running " + getSummary().getName());
+        }
+        long startTime = System.nanoTime();
         for (Enumeration tests = getTests().elements(); tests.hasMoreElements();) {
             junit.framework.Test test = (junit.framework.Test)tests.nextElement();
             if ((TestExecutor.getDefaultJUnitTestResult() != null) && TestExecutor.getDefaultJUnitTestResult().shouldStop()) {
@@ -75,9 +80,18 @@ public class TestSuite extends TestCollection {
             executor.execute(test);
             getFinishedTests().addElement(test);
         }
-        long endTime = System.currentTimeMillis();
+        long endTime = System.nanoTime();
         getSummary().setTotalTime(endTime - startTime);
         setFinishedTests((Vector)getTests().clone());
+        if (getNestedCounter() < 1) {
+            computeResultSummary();
+            System.out.printf("Tests run: %d, Failures: %d, Errors: %d, Skipped: %d, Time elapsed: %.3f sec",
+                    getSummary().getPassed(), getSummary().getErrors() + getSummary().getSetupFailures(),
+                    getSummary().getFatalErrors(),
+                    getSummary().getWarnings() + getSummary().getProblems() + getSummary().getSetupWarnings(),
+                    getSummary().getTotalTime() / 1e9);
+            System.out.println();
+        }
     }
 
     /**

--- a/foundation/eclipselink.extension.test/antbuild.xml
+++ b/foundation/eclipselink.extension.test/antbuild.xml
@@ -150,8 +150,8 @@
             <echo message=" - loglevel:  @{loglevel}"/>
             <!-- Can be set e.g. in test.properties to add VM options for a particular platform/driver  -->
             <property name="additional.jvmargs" value="-Ddummy2=dummy"/>
-            <junit jvm="${test.junit.jvm.exec}" printsummary="yes" failureproperty="junit.failed" fork="yes" forkmode="once"
-                   showoutput="true" maxmemory="512m" dir="@{dir}">
+            <junit jvm="${test.junit.jvm.exec}" printsummary="yes" failureproperty="junit.failed" logfailedtests="true"
+                   fork="yes" forkmode="once" showoutput="true" maxmemory="512m" dir="@{dir}">
                 <jvmarg value="-Declipselink.logging.level=@{loglevel}"/>
                 <!--jvmarg value="-Djava.security.manager"/>
                 <jvmarg value="-Djava.security.policy=./java.policy.allpermissions"/-->
@@ -166,6 +166,14 @@
                 </batchtest>
                 <formatter type="xml"/>
             </junit>
+            <fail message="TESTS FAILED !">
+                <condition>
+                    <and>
+                        <isset property="junit.failed"/>
+                        <istrue value="${test.fail.fast}"/>
+                    </and>
+                </condition>
+            </fail>
         </sequential>
     </macrodef>
 

--- a/jpa/eclipselink.jpa.test.jse/antbuild.xml
+++ b/jpa/eclipselink.jpa.test.jse/antbuild.xml
@@ -88,6 +88,7 @@
         <property name="rmi" value="-Djava.naming.provider.url=rmi://localhost:${rmi.port} -Djava.naming.factory.initial=com.sun.jndi.rmi.registry.RegistryContextFactory"/>
         <junit jvm="${test.junit.jvm.exec}" printsummary="on" haltonfailure="false" failureproperty="fail" fork="yes" dir="${jse.classes.dir}" forkmode="once">
             <jvmarg line="${additional.jvmargs} ${rmi}"/>
+            <sysproperty key="additional.jvmargs" value="${additional.jvmargs}"/>
             <sysproperty key="javax.persistence.jdbc.url" value="${db.url}"/>
             <sysproperty key="javax.persistence.jdbc.driver" value="${db.driver}"/>
             <sysproperty key="javax.persistence.jdbc.user" value="${db.user}"/>

--- a/jpa/eclipselink.jpa.test.jse/antbuild.xml
+++ b/jpa/eclipselink.jpa.test.jse/antbuild.xml
@@ -86,7 +86,8 @@
         <property name="additional.jvmargs" value="-Ddummy2=dummy"/>
         <property name="debugargs" value="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=7777"/>
         <property name="rmi" value="-Djava.naming.provider.url=rmi://localhost:${rmi.port} -Djava.naming.factory.initial=com.sun.jndi.rmi.registry.RegistryContextFactory"/>
-        <junit jvm="${test.junit.jvm.exec}" printsummary="on" haltonfailure="false" failureproperty="fail" fork="yes" dir="${jse.classes.dir}" forkmode="once">
+        <junit jvm="${test.junit.jvm.exec}" printsummary="on" haltonfailure="false" failureproperty="fail" logfailedtests="true"
+               fork="yes" dir="${jse.classes.dir}" forkmode="once">
             <jvmarg line="${additional.jvmargs} ${rmi}"/>
             <sysproperty key="additional.jvmargs" value="${additional.jvmargs}"/>
             <sysproperty key="javax.persistence.jdbc.url" value="${db.url}"/>
@@ -108,6 +109,14 @@
             </batchtest>
 
         </junit>
+        <fail message="TESTS FAILED !">
+            <condition>
+                <and>
+                    <isset property="fail"/>
+                    <istrue value="${test.fail.fast}"/>
+                </and>
+            </condition>
+        </fail>
     </target>
     
     <target name="test-report">

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/modelgen/TestProcessor.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/modelgen/TestProcessor.java
@@ -159,7 +159,7 @@ public class TestProcessor {
     private List<String> getJavacOptions(String... opts) {
         List<String> result = new ArrayList<String>();
         String systemOpts = System.getProperty("additional.jvmargs");
-        if (systemOpts != null && !systemOpts.isEmpty()) {
+        if (systemOpts != null && !systemOpts.isEmpty() && !systemOpts.contains("dummy")) {
             result.addAll(Arrays.asList(System.getProperty("additional.jvmargs").split(" ")));
         }
         result.add("-proc:only");

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/modelgen/TestProcessor.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/modelgen/TestProcessor.java
@@ -57,7 +57,7 @@ public class TestProcessor {
             }
         }
     }
-    
+
     @Test
     public void testProc() throws Exception {
         File runDir = new File(System.getProperty("run.dir"), "testproc");
@@ -90,7 +90,7 @@ public class TestProcessor {
         TestFO generated9 = new TestFO("org.Gen9",
                 "package org; @javax.annotation.processing.Generated(\"com.example.Generator\") public class Gen9 { public  Gen9() {} public int getZ() {return 9*42;}}");
         CompilationTask task = compiler.getTask(new PrintWriter(System.out), sfm, diagnostics,
-                Arrays.asList("-proc:only", "-Aeclipselink.logging.level.processor=OFF", "-Aeclipselink.canonicalmodel.use_static_factory=false"), null,
+                getJavacOptions("-Aeclipselink.logging.level.processor=OFF"), null,
                 Arrays.asList(entity, nonEntity, generated8, generated9));
         CanonicalModelProcessor modelProcessor = new CanonicalModelProcessor();
         task.setProcessors(Collections.singleton(modelProcessor));
@@ -156,6 +156,18 @@ public class TestProcessor {
         verifyLogging("testGlobalLoggingFinestFromPU", pu, true);
     }
 
+    private List<String> getJavacOptions(String... opts) {
+        List<String> result = new ArrayList<String>();
+        String systemOpts = System.getProperty("additional.jvmargs");
+        if (systemOpts != null && !systemOpts.isEmpty()) {
+            result.addAll(Arrays.asList(System.getProperty("additional.jvmargs").split(" ")));
+        }
+        result.add("-proc:only");
+        result.add("-Aeclipselink.canonicalmodel.use_static_factory=false");
+        result.addAll(Arrays.asList(opts));
+        System.out.println("OPTIONS: " + result);
+        return result;
+    }
     /**
      * Verify logging output suppression
      * @param testName name of the test
@@ -189,15 +201,8 @@ public class TestProcessor {
         TestFO entity = new TestFO("org.Sample",
                 "package org; import javax.persistence.Entity; @Entity public class Sample { public  Sample() {} public int getX() {return 1;}}");
 
-        List<String> optionsList = new ArrayList<>(options != null ? options.length + 2 : 2);
-        optionsList.add("-proc:only");
-        optionsList.add("-Aeclipselink.canonicalmodel.use_static_factory=false");
-        for (String option : options) {
-            optionsList.add(option);
-        }
-
         CompilationTask task = compiler.getTask(
-                new PrintWriter(System.out), sfm, diagnostics, optionsList, null,
+                new PrintWriter(System.out), sfm, diagnostics, getJavacOptions(options), null,
                 Arrays.asList(entity));
         CanonicalModelProcessor modelProcessor = new CanonicalModelProcessor();
         task.setProcessors(Collections.singleton(modelProcessor));

--- a/jpa/eclipselink.jpa.test/antbuild.xml
+++ b/jpa/eclipselink.jpa.test/antbuild.xml
@@ -2541,7 +2541,8 @@
         <!--<property name="additional.jvmargs" value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8787"/>-->
         <property name="additional.jvmargs" value="-Ddummy2=dummy"/>
 
-        <junit jvm="${test.junit.jvm.exec}" printsummary="yes" haltonfailure="${test.haltonfailure}" fork="yes" forkmode="once" showoutput="true" maxmemory="${max.heap.memory}" dir="${run.dir}">
+        <junit jvm="${test.junit.jvm.exec}" printsummary="yes" haltonfailure="${test.haltonfailure}" failureproperty="junit.failed" logfailedtests="true"
+               fork="yes" forkmode="once" showoutput="true" maxmemory="${max.heap.memory}" dir="${run.dir}">
             <sysproperty key="proxy.user.name" value="PAS_PROXY"/>
             <sysproperty key="pa.connection.user" value="${db.user}"/>
             <sysproperty key="pa.connection.password" value="${db.pwd}"/>
@@ -2566,6 +2567,15 @@
             <test name="${TEST_CLASS}" haltonfailure="no" outfile="${report.dir}/${TEST_CLASS}-test-results">
             </test>
         </junit>
+
+        <fail message="TESTS FAILED !">
+            <condition>
+                <and>
+                    <isset property="junit.failed"/>
+                    <istrue value="${test.fail.fast}"/>
+                </and>
+            </condition>
+        </fail>
     </target>
 
     <!-- Generic target for running spring tests. -->

--- a/jpa/eclipselink.jpa.wdf.test/antbuild.xml
+++ b/jpa/eclipselink.jpa.wdf.test/antbuild.xml
@@ -324,7 +324,8 @@
         </condition>
         <!-- Can be set e.g. in test.properties to add VM options for a particular platform/driver  -->
         <property name="additional.jvmargs" value="-Ddummy2=dummy"/>
-        <junit jvm="${test.junit.jvm.exec}" printsummary="yes" haltonfailure="yes" fork="yes" forkmode="once" showoutput="true" maxmemory="512m" dir="${run.dir}">
+        <junit jvm="${test.junit.jvm.exec}" printsummary="yes" haltonfailure="yes" failureproperty="junit.failed" logfailedtests="true"
+               fork="yes" forkmode="once" showoutput="true" maxmemory="512m" dir="${run.dir}">
             <jvmarg value="${TEST_AGENT}"/>
             <jvmarg value="${TEST_WEAVING}"/>
             <jvmarg value="${ORM_TESTING}"/>
@@ -349,6 +350,14 @@
                          excludes="org/eclipse/persistence/testing/tests/wdf/jpa1/query/QueryTest.java"/>
             </batchtest>
         </junit>
+        <fail message="TESTS FAILED !">
+            <condition>
+                <and>
+                    <isset property="junit.failed"/>
+                    <istrue value="${test.fail.fast}"/>
+                </and>
+            </condition>
+        </fail>
     </target>
 
     <target name="generate-report">

--- a/jpa/eclipselink.jpars.test/antbuild.xml
+++ b/jpa/eclipselink.jpars.test/antbuild.xml
@@ -459,7 +459,8 @@
             <echo message="Running @{testclass} suite"/>
             <!-- Can be set e.g. in test.properties to add VM options for a particular platform/driver  -->
             <property name="additional.jvmargs" value="-Ddummy2=dummy"/>
-            <junit jvm="${test.junit.jvm.exec}" printsummary="withOutAndErr" fork="yes" dir="${classes.dir}" maxmemory="512m" showoutput="yes">
+            <junit jvm="${test.junit.jvm.exec}" printsummary="withOutAndErr" failureproperty="junit.failed" logfailedtests="true"
+                   fork="yes" dir="${classes.dir}" maxmemory="512m" showoutput="yes">
                 <jvmarg value="-Ddb.driver=${db.driver}"/>
                 <jvmarg value="-Ddb.url=${db.url}"/>
                 <jvmarg value="-Ddb.user=${db.user}"/>
@@ -486,6 +487,14 @@
                 </batchtest>
                 <classpath refid="@{runpathref}"/>
             </junit>
+            <fail message="TESTS FAILED !">
+                <condition>
+                    <and>
+                        <isset property="junit.failed"/>
+                        <istrue value="${test.fail.fast}"/>
+                    </and>
+                </condition>
+            </fail>
             <!-- Create JUnit report -->
             <mkdir dir="${report.dir}"/>
             <junitreport todir="${report.dir}">

--- a/jpa/org.eclipse.persistence.jpa.jpql.test/antbuild.xml
+++ b/jpa/org.eclipse.persistence.jpa.jpql.test/antbuild.xml
@@ -200,7 +200,8 @@
         <!-- Can be set e.g. in test.properties to add VM options for a particular platform/driver  -->
         <property name="additional.jvmargs" value="-Ddummy2=dummy"/>
 
-        <junit jvm="${test.junit.jvm.exec}" printsummary="yes" haltonfailure="yes" fork="yes" forkmode="once" showoutput="true" maxmemory="${max.heap.memory}" dir="${run.dir}">
+        <junit jvm="${test.junit.jvm.exec}" printsummary="yes" haltonfailure="yes" failureproperty="junit.failed" logfailedtests="true"
+               fork="yes" forkmode="once" showoutput="true" maxmemory="${max.heap.memory}" dir="${run.dir}">
             <jvmarg value="-Declipselink.logging.level=${logging.level}"/>
             <jvmarg line="${additional.jvmargs}"/>
             <classpath>
@@ -210,6 +211,14 @@
             <test name="${TEST_CLASS}" haltonfailure="no" outfile="${report.dir}/${TEST_CLASS}-test-results">
             </test>
         </junit>
+        <fail message="TESTS FAILED !">
+            <condition>
+                <and>
+                    <isset property="junit.failed"/>
+                    <istrue value="${test.fail.fast}"/>
+                </and>
+            </condition>
+        </fail>
     </target>
 
     <!-- Generate the Hermes tests report -->

--- a/moxy/eclipselink.moxy.test/antbuild.xml
+++ b/moxy/eclipselink.moxy.test/antbuild.xml
@@ -499,7 +499,8 @@
             <mkdir dir="${build.dir}/${test.dir}/${tmp.dir}"/>
             <!-- Can be set e.g. in test.properties to add VM options for a particular platform/driver  -->
             <property name="additional.jvmargs" value="-Ddummy2=dummy"/>
-            <junit jvm="${test.junit.jvm.exec}" printsummary="yes" fork="true" dir="${build.dir}/${test.dir}" tempdir="${build.dir}/${test.dir}" showoutput="yes" maxmemory="512m">
+            <junit jvm="${test.junit.jvm.exec}" failureproperty="junit.failed.jaxb" logfailedtests="true"
+                   printsummary="yes" fork="true" dir="${build.dir}/${test.dir}" tempdir="${build.dir}/${test.dir}" showoutput="yes" maxmemory="512m">
                 <!--<jvmarg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"/>-->
                 <jvmarg value="-ea"/>
                 <jvmarg value="-javaagent:${jmockit.lib}"/>
@@ -554,6 +555,14 @@
                     <path refid="@{runpathref}"/>
                 </classpath>
             </junit>
+            <fail message="TESTS FAILED !">
+                <condition>
+                    <and>
+                        <isset property="junit.failed.jaxb"/>
+                        <istrue value="${test.fail.fast}"/>
+                    </and>
+                </condition>
+            </fail>
         </sequential>
     </macrodef>
     <macrodef name="run_jaxb_srg_tests">
@@ -564,7 +573,8 @@
             <mkdir dir="${build.dir}/${test.dir}/${tmp.dir}"/>
             <!-- Can be set e.g. in test.properties to add VM options for a particular platform/driver  -->
             <property name="additional.jvmargs" value="-Ddummy2=dummy"/>
-            <junit jvm="${test.junit.jvm.exec}" printsummary="yes" fork="true" dir="${build.dir}/${test.dir}" tempdir="${build.dir}/${test.dir}" showoutput="yes" maxmemory="512m">
+            <junit jvm="${test.junit.jvm.exec}" failureproperty="junit.failed.jaxb_srg" logfailedtests="true"
+                   printsummary="yes" fork="true" dir="${build.dir}/${test.dir}" tempdir="${build.dir}/${test.dir}" showoutput="yes" maxmemory="512m">
                 <jvmarg value="-ea"/>
                 <jvmarg line="${additional.jvmargs}"/>
                 <env key="T_WORK" value="${tmp.dir}"/>
@@ -584,6 +594,14 @@
                     <path refid="@{runpathref}"/>
                 </classpath>
             </junit>
+            <fail message="TESTS FAILED !">
+                <condition>
+                    <and>
+                        <isset property="junit.failed.jaxb_srg"/>
+                        <istrue value="${test.fail.fast}"/>
+                    </and>
+                </condition>
+            </fail>
         </sequential>
     </macrodef>
     <macrodef name="run_oxm_srg_tests">
@@ -592,7 +610,8 @@
             <delete dir="${report.dir}/srg/oxm" failonerror="false"/>
             <mkdir dir="${report.dir}/srg/oxm/default"/>
             <mkdir dir="${build.dir}/${test.dir}"/>
-            <junit jvm="${test.junit.jvm.exec}" printsummary="yes" fork="true" dir="${build.dir}/${test.dir}" tempdir="${build.dir}/${test.dir}" showoutput="yes" maxmemory="512m">
+            <junit jvm="${test.junit.jvm.exec}" failureproperty="junit.failed.oxm_srg" logfailedtests="true"
+                   printsummary="yes" fork="true" dir="${build.dir}/${test.dir}" tempdir="${build.dir}/${test.dir}" showoutput="yes" maxmemory="512m">
                 <sysproperty key="useLogging" value="false"/>
                 <sysproperty key="eclipselink.xml.platform" value="${xml.platform}"/>
                 <sysproperty key="parser" value="${parser}"/>
@@ -607,6 +626,14 @@
                     <path refid="@{runpathref}"/>
                 </classpath>
             </junit>
+            <fail message="TESTS FAILED !">
+                <condition>
+                    <and>
+                        <isset property="junit.failed.oxm_srg"/>
+                        <istrue value="${test.fail.fast}"/>
+                    </and>
+                </condition>
+            </fail>
         </sequential>
     </macrodef>
     <macrodef name="run_oxm_tests">
@@ -615,7 +642,8 @@
             <delete dir="${report.dir}/oxm/default" failonerror="false"/>
             <mkdir dir="${report.dir}/oxm/default"/>
             <mkdir dir="${build.dir}/${test.dir}"/>
-            <junit jvm="${test.junit.jvm.exec}" printsummary="yes" fork="true" dir="${build.dir}/${test.dir}" tempdir="${build.dir}/${test.dir}" showoutput="yes" maxmemory="512m">
+            <junit jvm="${test.junit.jvm.exec}" failureproperty="junit.failed.oxm" logfailedtests="true"
+                   printsummary="yes" fork="true" dir="${build.dir}/${test.dir}" tempdir="${build.dir}/${test.dir}" showoutput="yes" maxmemory="512m">
                 <jvmarg value="-ea"/>
                 <jvmarg line="${additional.jvmargs}"/>
                 <sysproperty key="useLogging" value="false"/>
@@ -654,6 +682,14 @@
                     <path refid="@{runpathref}"/>
                 </classpath>
             </junit>
+            <fail message="TESTS FAILED !">
+                <condition>
+                    <and>
+                        <isset property="junit.failed.oxm"/>
+                        <istrue value="${test.fail.fast}"/>
+                    </and>
+                </condition>
+            </fail>
         </sequential>
     </macrodef>
     <macrodef name="run_oxm_dom_tests">
@@ -662,7 +698,8 @@
             <delete dir="${report.dir}/oxm/dom" failonerror="false"/>
             <mkdir dir="${report.dir}/oxm/dom"/>
             <mkdir dir="${build.dir}/${test.dir}"/>
-            <junit jvm="${test.junit.jvm.exec}" printsummary="yes" fork="true" dir="${build.dir}/${test.dir}" tempdir="${build.dir}/${test.dir}" showoutput="yes" maxmemory="512m">
+            <junit jvm="${test.junit.jvm.exec}" failureproperty="junit.failed.oxm_dom" logfailedtests="true"
+                   printsummary="yes" fork="true" dir="${build.dir}/${test.dir}" tempdir="${build.dir}/${test.dir}" showoutput="yes" maxmemory="512m">
                 <jvmarg value="-ea"/>
                 <jvmarg line="${additional.jvmargs}"/>
                 <sysproperty key="platformType" value="DOM"/>
@@ -703,6 +740,14 @@
                     <path refid="@{runpathref}"/>
                 </classpath>
             </junit>
+            <fail message="TESTS FAILED !">
+                <condition>
+                    <and>
+                        <isset property="junit.failed.oxm_dom"/>
+                        <istrue value="${test.fail.fast}"/>
+                    </and>
+                </condition>
+            </fail>
         </sequential>
     </macrodef>
     <macrodef name="run_oxm_deploymentxml_tests">
@@ -711,7 +756,8 @@
             <delete dir="${report.dir}/oxm/deploymentxml" failonerror="false"/>
             <mkdir dir="${report.dir}/oxm/deploymentxml"/>
             <mkdir dir="${build.dir}/${test.dir}"/>
-            <junit jvm="${test.junit.jvm.exec}" printsummary="yes" fork="true" dir="${build.dir}/${test.dir}" tempdir="${build.dir}/${test.dir}" showoutput="yes" maxmemory="512m">
+            <junit jvm="${test.junit.jvm.exec}" failureproperty="junit.failed.oxm_deploymentxml" logfailedtests="true"
+                   printsummary="yes" fork="true" dir="${build.dir}/${test.dir}" tempdir="${build.dir}/${test.dir}" showoutput="yes" maxmemory="512m">
                 <jvmarg value="-ea"/>
                 <jvmarg line="${additional.jvmargs}"/>
                 <sysproperty key="platformType" value="DOM"/>
@@ -770,6 +816,14 @@
                     <path refid="@{runpathref}"/>
                 </classpath>
             </junit>
+            <fail message="TESTS FAILED !">
+                <condition>
+                    <and>
+                        <isset property="junit.failed.oxm_deploymentxml"/>
+                        <istrue value="${test.fail.fast}"/>
+                    </and>
+                </condition>
+            </fail>
         </sequential>
     </macrodef>
     <macrodef name="run_oxm_deploymentxml_tl_tests">
@@ -778,7 +832,8 @@
             <delete dir="${report.dir}/oxm/deploymentxml-tl" failonerror="false"/>
             <mkdir dir="${report.dir}/oxm/deploymentxml-tl"/>
             <mkdir dir="${build.dir}/${test.dir}"/>
-            <junit jvm="${test.junit.jvm.exec}" printsummary="yes" fork="true" dir="${build.dir}/${test.dir}" tempdir="${build.dir}/${test.dir}" showoutput="yes" maxmemory="512m">
+            <junit jvm="${test.junit.jvm.exec}" failureproperty="junit.failed.oxm_deploymentxml_tl" logfailedtests="true"
+                   printsummary="yes" fork="true" dir="${build.dir}/${test.dir}" tempdir="${build.dir}/${test.dir}" showoutput="yes" maxmemory="512m">
                 <jvmarg value="-ea"/>
                 <jvmarg line="${additional.jvmargs}"/>
                 <sysproperty key="platformType" value="DOM"/>
@@ -833,6 +888,14 @@
                     <path refid="@{runpathref}"/>
                 </classpath>
             </junit>
+            <fail message="TESTS FAILED !">
+                <condition>
+                    <and>
+                        <isset property="junit.failed.oxm_deploymentxml_tl"/>
+                        <istrue value="${test.fail.fast}"/>
+                    </and>
+                </condition>
+            </fail>
         </sequential>
     </macrodef>
     <macrodef name="run_oxm_docpres_tests">
@@ -841,7 +904,8 @@
             <delete dir="${report.dir}/oxm/docpres" failonerror="false"/>
             <mkdir dir="${report.dir}/oxm/docpres"/>
             <mkdir dir="${build.dir}/${test.dir}"/>
-            <junit jvm="${test.junit.jvm.exec}" printsummary="yes" fork="true" dir="${build.dir}/${test.dir}" tempdir="${build.dir}/${test.dir}" showoutput="yes" maxmemory="512m">
+            <junit jvm="${test.junit.jvm.exec}" failureproperty="junit.failed.oxm_docpres" logfailedtests="true"
+                   printsummary="yes" fork="true" dir="${build.dir}/${test.dir}" tempdir="${build.dir}/${test.dir}" showoutput="yes" maxmemory="512m">
                 <jvmarg value="-ea"/>
                 <jvmarg line="${additional.jvmargs}"/>
                 <sysproperty key="platformType" value="DOC_PRES"/>
@@ -885,6 +949,14 @@
                     <path refid="@{runpathref}"/>
                 </classpath>
             </junit>
+            <fail message="TESTS FAILED !">
+                <condition>
+                    <and>
+                        <isset property="junit.failed.oxm_docpres"/>
+                        <istrue value="${test.fail.fast}"/>
+                    </and>
+                </condition>
+            </fail>
         </sequential>
     </macrodef>
 

--- a/sdo/eclipselink.sdo.test/antbuild.xml
+++ b/sdo/eclipselink.sdo.test/antbuild.xml
@@ -189,7 +189,8 @@
             <property name="additional.jvmargs" value="-Ddummy2=dummy"/>
             <!-- Fix for 290177 below removed temporarily to avoid out-of-memeory issues with LRG run -->
             <!-- junit printsummary="withOutAndErr" fork="yes" forkmode="once" dir="${resource.dir}" maxmemory="512m" showoutput="yes" -->
-            <junit jvm="${test.junit.jvm.exec}" printsummary="withOutAndErr" fork="yes" dir="${resource.dir}" maxmemory="512m" showoutput="yes">
+            <junit jvm="${test.junit.jvm.exec}" printsummary="withOutAndErr" failureproperty="junit.failed" logfailedtests="true"
+                   fork="yes" dir="${resource.dir}" maxmemory="512m" showoutput="yes">
                 <jvmarg line="${additional.jvmargs}"/>
                 <env key="JAVA_HOME" value="${test.junit.jvm}"/>
                 <sysproperty key="loggingLevelFinest" value="false"/>
@@ -218,6 +219,14 @@
                 </batchtest>
                 <classpath refid="@{runpathref}"/>
             </junit>
+            <fail message="TESTS FAILED !">
+               <condition>
+                   <and>
+                       <isset property="junit.failed"/>
+                       <istrue value="${test.fail.fast}"/>
+                   </and>
+               </condition>
+           </fail>
             <!-- Create JUnit report -->
             <mkdir dir="${report.dir}/@{customcontext}"/>
             <junitreport todir="${report.dir}/@{customcontext}">

--- a/utils/eclipselink.dbws.builder.test/antbuild.xml
+++ b/utils/eclipselink.dbws.builder.test/antbuild.xml
@@ -273,7 +273,7 @@
         <mkdir dir="./${report.dir}"/>
         <!-- Can be set e.g. in test.properties to add VM options for a particular platform/driver  -->
         <property name="additional.jvmargs" value="-Ddummy2=dummy"/>
-        <junit
+        <junit failureproperty="junit.failed" logfailedtests="true"
             jvm="${test.junit.jvm.exec}"
             printsummary="withOutAndErr"
             fork="yes"
@@ -302,6 +302,14 @@
                 </fileset>
             </batchtest>
         </junit>
+        <fail message="TESTS FAILED !">
+            <condition>
+                <and>
+                    <isset property="junit.failed"/>
+                    <istrue value="${test.fail.fast}"/>
+                </and>
+            </condition>
+        </fail>
         <junitreport todir="${report.dir}" >
             <fileset dir="${report.dir}" >
                 <include name="TEST-*.xml" />


### PR DESCRIPTION
While going through issues in old mirror I came across https://github.com/eclipse/eclipselink.runtime/pull/31 and extended that PR to also run LRG tests...

Do we want this in the main repo? I can imagine it can be extended to cover more DBs and tight to every PR... It is not meant to replace nightly jobs on eclipse.org infra. Opinions?