### PR TITLE
Bug 515225 - Marshaller not generating namespace definition

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -9,14 +9,11 @@
     <option name="pathToConfigFileJava" value="$PROJECT_DIR$/project-admin/EclipseLink-Eclipse-Format.xml" />
     <option name="selectedJavaProfile" value="EclipseLink" />
   </component>
-  <component name="EntryPointsManager">
-    <entry_points version="2.0" />
-  </component>
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$/jsonb" />
   </component>
   <component name="IdProvider" IDEtalkID="D25D12225615E907E53EC1D416DAF86F" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="8.0" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLCompositeObjectMappingNodeValue.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLCompositeObjectMappingNodeValue.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -249,10 +249,20 @@ public class XMLCompositeObjectMappingNodeValue extends XMLRelationshipMappingNo
             }
 
             List extraNamespaces = null;
+            boolean equalNamespaceResolvers = marshalRecord.hasEqualNamespaceResolvers();
+            if (marshalRecord.getNamespaceResolver() != null && descriptor.getNamespaceResolver() != null) {
+                for (String prefix: descriptor.getNamespaceResolver().getPrefixesToNamespaces().keySet()) {
+                    if (!marshalRecord.getNamespaceResolver().hasPrefix(prefix)) {
+                        marshalRecord.setEqualNamespaceResolvers(false);
+                        break;
+                    }
+                }
+            }
             if (!marshalRecord.hasEqualNamespaceResolvers()) {
                 extraNamespaces = objectBuilder.addExtraNamespacesToNamespaceResolver(descriptor, marshalRecord, session, true, false);
                 writeExtraNamespaces(extraNamespaces, marshalRecord, session);
             }
+            marshalRecord.setEqualNamespaceResolvers(equalNamespaceResolvers);
             if(!isSelfFragment) {
                 marshalRecord.addXsiTypeAndClassIndicatorIfRequired(descriptor, (Descriptor) xmlCompositeObjectMapping.getReferenceDescriptor(), (Field)xmlCompositeObjectMapping.getField(), false);
             }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLCompositeObjectMappingNodeValue.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLCompositeObjectMappingNodeValue.java
@@ -249,7 +249,6 @@ public class XMLCompositeObjectMappingNodeValue extends XMLRelationshipMappingNo
             }
 
             List extraNamespaces = null;
-            boolean equalNamespaceResolvers = marshalRecord.hasEqualNamespaceResolvers();
             if (marshalRecord.getNamespaceResolver() != null && descriptor.getNamespaceResolver() != null) {
                 for (String prefix: descriptor.getNamespaceResolver().getPrefixesToNamespaces().keySet()) {
                     if (!marshalRecord.getNamespaceResolver().hasPrefix(prefix)) {
@@ -262,7 +261,6 @@ public class XMLCompositeObjectMappingNodeValue extends XMLRelationshipMappingNo
                 extraNamespaces = objectBuilder.addExtraNamespacesToNamespaceResolver(descriptor, marshalRecord, session, true, false);
                 writeExtraNamespaces(extraNamespaces, marshalRecord, session);
             }
-            marshalRecord.setEqualNamespaceResolvers(equalNamespaceResolvers);
             if(!isSelfFragment) {
                 marshalRecord.addXsiTypeAndClassIndicatorIfRequired(descriptor, (Descriptor) xmlCompositeObjectMapping.getReferenceDescriptor(), (Field)xmlCompositeObjectMapping.getField(), false);
             }

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/dynamic/xmlschema-import-cross-first.xsd
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/dynamic/xmlschema-import-cross-first.xsd
@@ -1,0 +1,24 @@
+<xs:schema xmlns="http://first.temp.com/"
+           xmlns:tns="http://first.temp.com/"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://first.temp.com/"
+           xmlns:second="http://second.temp.com/"
+           elementFormDefault="unqualified" attributeFormDefault="unqualified" version="1.0">
+
+    <xs:import namespace="http://second.temp.com/"
+               schemaLocation="xmlschema-import-cross-second.xsd"/>
+
+    <xs:element name="companyId" type="xs:string" />
+
+    <xs:element name="TestReq">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="second:Base_Type">
+                    <xs:sequence>
+                        <xs:element ref="tns:companyId"/>
+                    </xs:sequence>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/dynamic/xmlschema-import-cross-fourth.xsd
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/dynamic/xmlschema-import-cross-fourth.xsd
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns="http://fourth.temp.com/"
+           xmlns:tns="http://fourth.temp.com/"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://fourth.temp.com/"
+           elementFormDefault="unqualified" attributeFormDefault="unqualified" version="1.0">
+
+    <xs:element name="userId" type="xs:string" />
+    <xs:element name="companyId" type="xs:string" />
+
+    <xs:complexType name="User_Type">
+        <xs:sequence>
+            <xs:element minOccurs="0" ref="tns:userId"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:element name="userKey" type="tns:User_Type">
+    </xs:element>
+
+    <xs:complexType name="Company_Type">
+        <xs:sequence>
+            <xs:element minOccurs="0" ref="tns:companyId"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:element name="companyKey" type="tns:Company_Type">
+    </xs:element>
+</xs:schema>

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/dynamic/xmlschema-import-cross-second.xsd
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/dynamic/xmlschema-import-cross-second.xsd
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns="http://second.temp.com/"
+           xmlns:tns="http://second.temp.com/"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://second.temp.com/"
+           xmlns:third="http://third.temp.com/"
+           xmlns:fourth="http://fourth.temp.com/"
+           elementFormDefault="unqualified" attributeFormDefault="unqualified" version="1.0">
+
+    <xs:import namespace="http://third.temp.com/"
+               schemaLocation="xmlschema-import-cross-third.xsd"/>
+    <xs:import namespace="http://fourth.temp.com/"
+               schemaLocation="xmlschema-import-cross-fourth.xsd"/>
+
+    <xs:complexType name="Base_Type">
+        <xs:sequence>
+            <xs:element minOccurs="0" ref="third:fault"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:element name="base" type="tns:Base_Type">
+    </xs:element>
+
+    <xs:complexType name="InheritedFault_Type">
+        <xs:complexContent>
+            <xs:extension base="third:DataReference_Type">
+                <xs:sequence>
+                    <xs:choice>
+                        <xs:element ref="fourth:userKey" />
+                        <xs:element ref="fourth:companyKey" />
+                    </xs:choice>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:element name="inheritedFaultType" type="tns:InheritedFault_Type">
+    </xs:element>
+
+</xs:schema>

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/dynamic/xmlschema-import-cross-third.xsd
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/dynamic/xmlschema-import-cross-third.xsd
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns="http://third.temp.com/"
+           xmlns:tns="http://third.temp.com/"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://third.temp.com/"
+           elementFormDefault="unqualified" attributeFormDefault="unqualified" version="1.0">
+
+    <xs:element name="referenceId" type="xs:string" />
+
+    <xs:complexType name="DataReference_Type">
+        <xs:sequence>
+            <xs:element minOccurs="0" ref="tns:referenceId"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:element name="dataReference" type="tns:DataReference_Type">
+    </xs:element>
+
+    <xs:complexType name="Fault_Type">
+        <xs:sequence>
+            <xs:element minOccurs="0" ref="tns:dataReference"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:element name="fault" type="tns:Fault_Type">
+    </xs:element>
+</xs:schema>

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/dynamic/DynamicJAXBContextCreationTestCases.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/dynamic/DynamicJAXBContextCreationTestCases.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -29,12 +29,11 @@ import junit.framework.TestCase;
 
 import org.eclipse.persistence.dynamic.DynamicEntity;
 import org.eclipse.persistence.exceptions.DynamicException;
-import org.eclipse.persistence.exceptions.i18n.JAXBExceptionResource;
 import org.eclipse.persistence.jaxb.JAXBContextFactory;
 import org.eclipse.persistence.jaxb.JAXBContextProperties;
 import org.eclipse.persistence.jaxb.dynamic.DynamicJAXBContext;
 import org.eclipse.persistence.jaxb.dynamic.DynamicJAXBContextFactory;
-import org.eclipse.persistence.testing.jaxb.dynamic.util.NoExtensionEntityResolver;
+import org.eclipse.persistence.testing.jaxb.dynamic.util.CustomEntityResolver;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -230,7 +229,7 @@ public class DynamicJAXBContextCreationTestCases extends TestCase {
         Map<String, Object> properties = new HashMap<String, Object>();
         properties.put(DynamicJAXBContextFactory.XML_SCHEMA_KEY, xsdElement);
 
-        NoExtensionEntityResolver re = new NoExtensionEntityResolver();
+        CustomEntityResolver re = new CustomEntityResolver(false);
         properties.put(DynamicJAXBContextFactory.ENTITY_RESOLVER_KEY, re);
 
         JAXBException caughtEx = null;

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/dynamic/DynamicJAXBFromXSDTestCases.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/dynamic/DynamicJAXBFromXSDTestCases.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -12,8 +12,7 @@
  ******************************************************************************/
 package org.eclipse.persistence.testing.jaxb.dynamic;
 
-import java.io.File;
-import java.io.InputStream;
+import java.io.*;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -23,6 +22,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
+import javax.xml.XMLConstants;
 import javax.xml.bind.JAXBElement;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
@@ -32,17 +32,20 @@ import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
 
 import org.eclipse.persistence.dynamic.DynamicEntity;
 import org.eclipse.persistence.internal.helper.ClassConstants;
 import org.eclipse.persistence.jaxb.JAXBContextFactory;
 import org.eclipse.persistence.jaxb.dynamic.DynamicJAXBContext;
 import org.eclipse.persistence.jaxb.dynamic.DynamicJAXBContextFactory;
-import org.eclipse.persistence.testing.jaxb.dynamic.util.NoExtensionEntityResolver;
+import org.eclipse.persistence.testing.jaxb.dynamic.util.CustomEntityResolver;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 
 import junit.framework.TestCase;
+
 
 public class DynamicJAXBFromXSDTestCases extends TestCase {
 
@@ -187,7 +190,7 @@ public class DynamicJAXBFromXSDTestCases extends TestCase {
 
         InputStream inputStream = ClassLoader.getSystemResourceAsStream(XMLSCHEMA_IMPORT);
 
-        jaxbContext = DynamicJAXBContextFactory.createContextFromXSD(inputStream, new NoExtensionEntityResolver(), null, null);
+        jaxbContext = DynamicJAXBContextFactory.createContextFromXSD(inputStream, new CustomEntityResolver(false), null, null);
 
         DynamicEntity person = jaxbContext.newDynamicEntity(PACKAGE + "." + PERSON);
         assertNotNull("Could not create Dynamic Entity.", person);
@@ -929,6 +932,45 @@ public class DynamicJAXBFromXSDTestCases extends TestCase {
         }
     }
 
+    /**
+     * Test for element type reference across multiple XML schemas with different namespaces.
+     * Validates result after marshalling against XML Schema.
+     * @throws Exception
+     */
+    public void testXmlSchemaCrossSchema() throws Exception {
+        InputStream inputStream = ClassLoader.getSystemResourceAsStream(XMLSCHEMA_IMPORT_CROSS_SCHEMA);
+        DynamicJAXBContext jaxbContext = DynamicJAXBContextFactory.createContextFromXSD(inputStream, new CustomEntityResolver(true), null, null);
+        System.setProperty("com.sun.tools.xjc.api.impl.s2j.SchemaCompilerImpl.noCorrectnessCheck", "true");
+
+        DynamicEntity testReq = jaxbContext.newDynamicEntity("com.temp.first.TestReq");
+
+        DynamicEntity fault = jaxbContext.newDynamicEntity("com.temp.third.FaultType");
+
+        DynamicEntity dataReference = jaxbContext.newDynamicEntity("com.temp.second.InheritedFaultType");
+        dataReference.set("referenceId", "123456");
+
+        DynamicEntity userKey = jaxbContext.newDynamicEntity("com.temp.fourth.UserType");
+        userKey.set("userId", "TestUserID");
+
+        dataReference.set("userKey", userKey);
+
+        fault.set("dataReference", dataReference);
+
+        testReq.set("fault", fault);
+        testReq.set("companyId", "TestCompanyID");
+
+        final StringWriter sw = new StringWriter();
+        Marshaller marshaller = jaxbContext.createMarshaller();
+        marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+        marshaller.marshal(testReq, sw);
+
+        SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        Schema testReqSchema = factory.newSchema(Thread.currentThread().getContextClassLoader().getResource(XMLSCHEMA_IMPORT_CROSS_SCHEMA));
+        testReqSchema.newValidator().validate(
+                new StreamSource(new StringReader(sw.getBuffer().toString())));
+    }
+
+
     public void testGetByXPathPosition() throws Exception {
         InputStream inputStream = ClassLoader.getSystemResourceAsStream(XPATH_POSITION);
         jaxbContext = DynamicJAXBContextFactory.createContextFromXSD(inputStream, null, null, null);
@@ -984,11 +1026,15 @@ public class DynamicJAXBFromXSDTestCases extends TestCase {
     private static final String RESOURCE_DIR = "org/eclipse/persistence/testing/jaxb/dynamic/";
     private static final String CONTEXT_PATH = "mynamespace";
 
+    // System property name to restrict access to external schemas
+    private static final String PROP_ACCESS_EXTERNAL_SCHEMA = "javax.xml.accessExternalSchema";
+
     // Schema files used to test each annotation
     private static final String XMLSCHEMA_QUALIFIED = RESOURCE_DIR + "xmlschema-qualified.xsd";
     private static final String XMLSCHEMA_UNQUALIFIED = RESOURCE_DIR +  "xmlschema-unqualified.xsd";
     private static final String XMLSCHEMA_DEFAULTS = RESOURCE_DIR + "xmlschema-defaults.xsd";
     private static final String XMLSCHEMA_IMPORT = RESOURCE_DIR + "xmlschema-import.xsd";
+    private static final String XMLSCHEMA_IMPORT_CROSS_SCHEMA = RESOURCE_DIR + "xmlschema-import-cross-first.xsd";
     private static final String XMLSCHEMA_CURRENCY = RESOURCE_DIR + "xmlschema-currency.xsd";
     private static final String XMLSEEALSO = RESOURCE_DIR + "xmlseealso.xsd";
     private static final String XMLROOTELEMENT = RESOURCE_DIR + "xmlrootelement.xsd";

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/dynamic/util/CustomEntityResolver.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/dynamic/util/CustomEntityResolver.java
@@ -9,7 +9,7 @@
  *
  * Contributors:
  *     rbarkhouse - 2.2 - initial implementation
- *     rfelcman - 2.7 - withExtension parameter
+ *     rfelcman - 2.7.2 - withExtension parameter
  ******************************************************************************/
 package org.eclipse.persistence.testing.jaxb.dynamic.util;
 
@@ -34,7 +34,7 @@ public class CustomEntityResolver implements EntityResolver {
         // Grab only the filename part from the full path
         File f = new File(systemId);
 
-        String correctedId = RESOURCE_DIR + f.getName() + (this.withExtension?"":".xsd");
+        String correctedId = RESOURCE_DIR + f.getName() + (this.withExtension ? "" : ".xsd");
 
         InputSource is = new InputSource(ClassLoader.getSystemResourceAsStream(correctedId));
         is.setSystemId(correctedId);

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/dynamic/util/CustomEntityResolver.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/dynamic/util/CustomEntityResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     rbarkhouse - 2.2 - initial implementation
+ *     rfelcman - 2.7 - withExtension parameter
  ******************************************************************************/
 package org.eclipse.persistence.testing.jaxb.dynamic.util;
 
@@ -19,15 +20,21 @@ import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
-public class NoExtensionEntityResolver implements EntityResolver {
+public class CustomEntityResolver implements EntityResolver {
 
     private static final String RESOURCE_DIR = "org/eclipse/persistence/testing/jaxb/dynamic/";
+
+    private static boolean withExtension = false;
+
+    public CustomEntityResolver(boolean withExtension) {
+        this.withExtension = withExtension;
+    }
 
     public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException {
         // Grab only the filename part from the full path
         File f = new File(systemId);
 
-        String correctedId = RESOURCE_DIR + f.getName() + ".xsd";
+        String correctedId = RESOURCE_DIR + f.getName() + (this.withExtension?"":".xsd");
 
         InputSource is = new InputSource(ClassLoader.getSystemResourceAsStream(correctedId));
         is.setSystemId(correctedId);


### PR DESCRIPTION
MOXy marshaller in case of inheritance between types from different schemas and namespaces not generates all required namespace definitions. After patch it will generate namespaces for elements based on type inheritance across multiple schemas. See https://bugs.eclipse.org/bugs/show_bug.cgi?id=515225.

Signed-off-by: Radek Felcman radek.felcman@oracle.com