### PR TITLE
[master] Bug 532160: OraclePlatform QueryHint FIRST_ROWS should use max parameter

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/OraclePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/OraclePlatform.java
@@ -251,7 +251,7 @@ public class OraclePlatform extends org.eclipse.persistence.platform.database.Da
      * @return
      */
     protected String buildFirstRowsHint(int max){
-        return HINT_START + HINT_END;
+        return HINT_START + "(" + max + ")" + HINT_END;
     }
 
     /**


### PR DESCRIPTION
for #67 

Signed-off-by: Will Dazey <dazeydev.3@gmail.com>