### PR TITLE
Bug 420746 - Unmarshal of JAXBElement field annotated with @XmlElementRef nil not unmarshalling xsi:nil="true" correctly.

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLCompositeObjectMappingNodeValue.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLCompositeObjectMappingNodeValue.java
@@ -373,7 +373,7 @@ public class XMLCompositeObjectMappingNodeValue extends XMLRelationshipMappingNo
                     xmlReader.setLexicalHandler(aHandler);
                 }
             } else {
-                if(unmarshalRecord.getXMLReader().isNullRecord(nullPolicy, atts, unmarshalRecord)){
+                if(unmarshalRecord.getXMLReader().isNullRecord(nullPolicy, atts, unmarshalRecord) && nullPolicy.ignoreAttributesForNil()){
                     xmlCompositeObjectMapping.setAttributeValueInObject(unmarshalRecord.getCurrentObject(), null);
                 } else {
                     Field xmlFld = (Field)this.xmlCompositeObjectMapping.getField();

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/record/XMLReader.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/record/XMLReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -26,6 +26,7 @@ import org.xml.sax.SAXNotRecognizedException;
 import org.xml.sax.SAXNotSupportedException;
 import org.xml.sax.ext.LexicalHandler;
 
+import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
 import javax.xml.validation.ValidatorHandler;
 
@@ -329,10 +330,11 @@ public class XMLReader implements org.xml.sax.XMLReader {
     }
 
     private boolean hasAttributes(Attributes attributes) {
-        QName nilAttrName = new QName(javax.xml.XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI, Constants.SCHEMA_NIL_ATTRIBUTE);
+        QName nilAttrName = new QName(XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI, Constants.SCHEMA_NIL_ATTRIBUTE);
         for (int i = 0; i < attributes.getLength(); i++) {
             if (!(nilAttrName.getNamespaceURI().equals(attributes.getURI(i)) &&
-                    nilAttrName.getLocalPart().equals(attributes.getLocalName(i)))) {
+                    nilAttrName.getLocalPart().equals(attributes.getLocalName(i))) &&
+                    !XMLConstants.XMLNS_ATTRIBUTE_NS_URI.equals(attributes.getURI(i))) {
                 return true;
             }
         }

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/xmlelementref/stringNillRootNamespace.json
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/xmlelementref/stringNillRootNamespace.json
@@ -1,0 +1,5 @@
+{
+  "optFoo-Root": {
+    "bar": null
+  }
+}

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/xmlelementref/stringNillRootNamespace.xml
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/xmlelementref/stringNillRootNamespace.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PRE:optFoo-Root xmlns:PRE="NS" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <PRE:bar xsi:nil="true"/>
+</PRE:optFoo-Root>

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/JAXBTestSuite.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/JAXBTestSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2016 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -24,6 +24,7 @@ import org.eclipse.persistence.testing.jaxb.namespaceuri.xml.XMLNamespaceXmlPath
 import org.eclipse.persistence.testing.jaxb.nomappings.NoMappingsTestCases;
 import org.eclipse.persistence.testing.jaxb.xmlelementref.nills.XmlElementRefNillStringTestCases;
 import org.eclipse.persistence.testing.jaxb.xmlelementref.nills.XmlElementRefNillWithAttributesTestCases;
+import org.eclipse.persistence.testing.jaxb.xmlelementref.nills2.XmlElementRefNillStringRootNamespaceTestCases;
 import org.eclipse.persistence.testing.jaxb.xmlelementref.ns.XmlElementRefWithNamespaceTests;
 import org.eclipse.persistence.testing.jaxb.xmlelementref.prefix.XmlElementRefPrefixesTestCases;
 import org.eclipse.persistence.testing.jaxb.xmlvalue.XmlValueByteArrayTestCases;
@@ -139,6 +140,7 @@ public class JAXBTestSuite extends TestCase {
         suite.addTestSuite(FileTestCases.class);
         suite.addTestSuite(XmlElementRefNillWithAttributesTestCases.class);
         suite.addTestSuite(XmlElementRefNillStringTestCases.class);
+        suite.addTestSuite(XmlElementRefNillStringRootNamespaceTestCases.class);
         return suite;
 
     }

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlelementref/nills2/Bar.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlelementref/nills2/Bar.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     Oracle - initial API and implementation from Oracle TopLink
+ ******************************************************************************/
+package org.eclipse.persistence.testing.jaxb.xmlelementref.nills2;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Bar {
+
+    @XmlAttribute
+    private String data;
+
+    public Bar() {
+    }
+
+    public Bar(final String data) {
+        this.data = data;
+    }
+
+    public String getData() {
+        return this.data;
+    }
+
+    public void setData(final String data) {
+        this.data = data;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof Bar)) {
+            return false;
+        }
+        Bar a = (Bar) obj;
+        if (a.getData() == null & this.getData() == null) {
+            return true;
+        } else if (a.getData() != null && this.getData() != null && a.getData().equals(this.getData())) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlelementref/nills2/ObjectFactory.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlelementref/nills2/ObjectFactory.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     Oracle - initial API and implementation from Oracle TopLink
+ ******************************************************************************/
+package org.eclipse.persistence.testing.jaxb.xmlelementref.nills2;
+
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.annotation.XmlElementDecl;
+import javax.xml.bind.annotation.XmlRegistry;
+import javax.xml.namespace.QName;
+
+@XmlRegistry
+public class ObjectFactory {
+
+    @XmlElementDecl(namespace = "NS", name = "optFoo-Root")
+    public JAXBElement<OptFoo> createOptFoo(OptFoo value) {
+        return new JAXBElement<OptFoo>(new QName("NS", "optFoo-Root"), OptFoo.class, null, value);
+    }
+
+    @XmlElementDecl(namespace = "NS", name = "bar", scope = OptFoo.class)
+    public JAXBElement<Bar> createOptFooBar(Bar value) {
+        return new JAXBElement<Bar>(new QName("NS", "bar"), Bar.class, OptFoo.class, value);
+    }
+
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlelementref/nills2/OptFoo.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlelementref/nills2/OptFoo.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     Oracle - initial API and implementation from Oracle TopLink
+ ******************************************************************************/
+package org.eclipse.persistence.testing.jaxb.xmlelementref.nills2;
+
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElementRef;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+public class OptFoo {
+  
+  @XmlElementRef(name = "bar", namespace = "NS", type = JAXBElement.class, required = false)
+  protected JAXBElement<Bar> bar;
+  
+  public OptFoo() {}
+  
+  public OptFoo(final JAXBElement<Bar> bar) {
+    this.bar = bar;
+  }
+  
+  public JAXBElement<Bar> getBar() {
+    return bar;
+  }
+  
+  public void setBar(final JAXBElement<Bar> bar) {
+    this.bar = bar;
+  }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof OptFoo)) {
+            return false;
+        }
+        OptFoo e = (OptFoo) obj;
+        if (!isEqual(e.getBar(), this.getBar())) {
+            return false;
+        }
+        return true;
+    }
+
+    private boolean isEqual(JAXBElement<?> e1, JAXBElement<?> e2) {
+        return e1.getName().equals(e2.getName()) &&
+                e1.getDeclaredType().equals(e2.getDeclaredType()) &&
+                (e1.isNil() == e2.isNil()) &&
+                (e1.getValue()).equals(e2.getValue());
+    }
+
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlelementref/nills2/XmlElementRefNillStringRootNamespaceTestCases.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlelementref/nills2/XmlElementRefNillStringRootNamespaceTestCases.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     Oracle - initial API and implementation from Oracle TopLink
+ ******************************************************************************/
+package org.eclipse.persistence.testing.jaxb.xmlelementref.nills2;
+
+import org.eclipse.persistence.testing.jaxb.JAXBWithJSONTestCases;
+
+import javax.xml.bind.JAXBElement;
+import javax.xml.namespace.QName;
+
+public class XmlElementRefNillStringRootNamespaceTestCases extends JAXBWithJSONTestCases {
+
+    private final static String XML_RESOURCE = "org/eclipse/persistence/testing/jaxb/xmlelementref/stringNillRootNamespace.xml";
+    private final static String JSON_RESOURCE = "org/eclipse/persistence/testing/jaxb/xmlelementref/stringNillRootNamespace.json";
+
+    public XmlElementRefNillStringRootNamespaceTestCases(String name) throws Exception {
+        super(name);
+        setControlDocument(XML_RESOURCE);
+        setControlJSON(JSON_RESOURCE);
+        setClasses(new Class<?>[]{ObjectFactory.class, Bar.class, OptFoo.class});
+    }
+
+    @Override
+    protected Object getControlObject() {
+
+        JAXBElement<Bar> bar = new JAXBElement<>(new QName("NS", "bar"), Bar.class, OptFoo.class, null);
+        bar.setValue(new Bar());
+        bar.setNil(true);
+
+        JAXBElement<OptFoo> foo = new JAXBElement<>(new QName("NS", "optFoo-Root"), OptFoo.class, null, new OptFoo());
+        foo.getValue().setBar(bar);
+
+        return foo;
+    }
+
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlelementref/nills2/package-info.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlelementref/nills2/package-info.java
@@ -1,0 +1,13 @@
+
+
+
+@XmlSchema(
+  namespace = "NS", elementFormDefault = XmlNsForm.QUALIFIED,
+  xmlns = {
+    @XmlNs(namespaceURI = "NS", prefix = "PRE"),
+    @XmlNs(namespaceURI = "http://www.w3.org/2001/XMLSchema-instance", prefix = "xsi") })
+    package org.eclipse.persistence.testing.jaxb.xmlelementref.nills2;
+    
+import javax.xml.bind.annotation.XmlNs;
+import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;


### PR DESCRIPTION
MOXy unmarshaller incorrectly unmarshal element declared with @XmlElementRef if attribute (namespace declaration) xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" is positioned outside element with xsi:nil="true" attribute.
There are no other null policies applied, than xsi:nil="true" in the source document. After patch it will set as a field value instance of JAXBElement (from ObjectFactory) with null value instead of null. See https://bugs.eclipse.org/bugs/show_bug.cgi?id=420746 .
