### PR TITLE
Bug 533577 - Make org.eclipse.persistence.internal.oxm.XMLCompositeCollectionMappingNodeValue#marshal call org.eclipse.persistence.internal.core.queries.CoreContainerPolicy#iteratorFor only once

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLCompositeCollectionMappingNodeValue.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLCompositeCollectionMappingNodeValue.java
@@ -94,10 +94,10 @@ public class XMLCompositeCollectionMappingNodeValue extends XMLRelationshipMappi
             XPathFragment groupingFragment = marshalRecord.openStartGroupingElements(namespaceResolver);
             marshalRecord.closeStartGroupingElements(groupingFragment);
             marshalRecord.startCollection();
-            while (cp.hasNext(iterator)) {
+            do {
                 Object objectValue = cp.next(iterator, session);
                 marshalSingleValue(xPathFragment, marshalRecord, object, objectValue, session, namespaceResolver, ObjectMarshalContext.getInstance());
-            }
+            } while (cp.hasNext(iterator));
             marshalRecord.endCollection();
             return true;
         }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLCompositeCollectionMappingNodeValue.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLCompositeCollectionMappingNodeValue.java
@@ -93,18 +93,15 @@ public class XMLCompositeCollectionMappingNodeValue extends XMLRelationshipMappi
         if (null != iterator && cp.hasNext(iterator)) {
             XPathFragment groupingFragment = marshalRecord.openStartGroupingElements(namespaceResolver);
             marshalRecord.closeStartGroupingElements(groupingFragment);
-        } else {
-            return marshalRecord.emptyCollection(xPathFragment, namespaceResolver, xmlCompositeCollectionMapping.getWrapperNullPolicy() != null);
+            marshalRecord.startCollection();
+            while (cp.hasNext(iterator)) {
+                Object objectValue = cp.next(iterator, session);
+                marshalSingleValue(xPathFragment, marshalRecord, object, objectValue, session, namespaceResolver, ObjectMarshalContext.getInstance());
+            }
+            marshalRecord.endCollection();
+            return true;
         }
-
-        marshalRecord.startCollection();
-        iterator = cp.iteratorFor(collection);
-        while (cp.hasNext(iterator)) {
-            Object objectValue = cp.next(iterator, session);
-            marshalSingleValue(xPathFragment, marshalRecord, object, objectValue, session, namespaceResolver, ObjectMarshalContext.getInstance());
-        }
-        marshalRecord.endCollection();
-        return true;
+        return marshalRecord.emptyCollection(xPathFragment, namespaceResolver, xmlCompositeCollectionMapping.getWrapperNullPolicy() != null);
     }
 
     public boolean startElement(XPathFragment xPathFragment, UnmarshalRecord unmarshalRecord, Attributes atts) {

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLCompositeCollectionMappingNodeValue.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLCompositeCollectionMappingNodeValue.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.


### PR DESCRIPTION
Bug 533577 - Make org.eclipse.persistence.internal.oxm.XMLCompositeCollectionMappingNodeValue#marshal call org.eclipse.persistence.internal.core.queries.CoreContainerPolicy#iteratorFor only once 

Removal of second ...cp.iteratorFor(collection).... call and code optimalization.
See https://bugs.eclipse.org/bugs/show_bug.cgi?id=533577 .