### PR TITLE
Issue #285: Avoid ClassCastException and IllegalArgumentException in cloneFor implementations

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/ArrayListContainerPolicy.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/ArrayListContainerPolicy.java
@@ -55,12 +55,12 @@ public class ArrayListContainerPolicy extends ListContainerPolicy {
         if (container == null) {
             return null;
         }
-        try {
+        if (container.getClass() == ArrayList.class) {
             return ((ArrayList)container).clone();
-        } catch (Exception notArrayList) {
-            // Could potentially be another Collection type as well.
-            return new ArrayList((Collection)container);
         }
+
+        // Could potentially be another Collection type as well.
+        return new ArrayList((Collection) container);
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/IndirectListContainerPolicy.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/IndirectListContainerPolicy.java
@@ -53,12 +53,12 @@ public class IndirectListContainerPolicy extends ListContainerPolicy {
             return null;
         }
         // Use Vector as new objects can have a Vector.
-        try {
+        if (container.getClass() == Vector.class) {
             return ((Vector)container).clone();
-        } catch (Exception notVector) {
-            // Could potentially be another Collection type as well.
-            return IndirectCollectionsFactory.createIndirectList((Collection)container);
         }
+
+        // Could potentially be another Collection type as well.
+        return IndirectCollectionsFactory.createIndirectList((Collection)container);
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/InterfaceContainerPolicy.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/InterfaceContainerPolicy.java
@@ -15,6 +15,9 @@ package org.eclipse.persistence.internal.queries;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
 import java.lang.reflect.*;
 import org.eclipse.persistence.descriptors.changetracking.CollectionChangeEvent;
 import org.eclipse.persistence.exceptions.*;
@@ -99,13 +102,16 @@ public abstract class InterfaceContainerPolicy extends ContainerPolicy {
             return null;
         }
 
-        try {
-            return invokeCloneMethodOn(getCloneMethod(), container);
-        } catch (IllegalArgumentException ex) {
+        Method cloneMethod;
+        Class javaClass = container.getClass();
+        if (javaClass == getContainerClass()) {
+            cloneMethod = getCloneMethod();
+        } else {
             // container may be a superclass of the concrete container class
             // so we have to use the right clone method...
-            return invokeCloneMethodOn(getCloneMethod(container.getClass()), container);
+            cloneMethod = getCloneMethod(javaClass);
         }
+        return invokeCloneMethodOn(cloneMethod, container);
     }
 
     /**
@@ -169,26 +175,77 @@ public abstract class InterfaceContainerPolicy extends ContainerPolicy {
         return cloneMethod;
     }
 
+    private static final class ClassWeakReference extends WeakReference<Class> {
+        private final int hash;
+
+        ClassWeakReference(Class referent) {
+            super(referent);
+            hash = referent.hashCode();
+        }
+
+        ClassWeakReference(Class referent, ReferenceQueue<Class> referenceQueue) {
+            super(referent, referenceQueue);
+            hash = referent.hashCode();
+        }
+
+        @Override
+        public int hashCode() {
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+
+            if (obj instanceof ClassWeakReference) {
+                return get() == ((ClassWeakReference) obj).get();
+            }
+
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            Class referent = get();
+            return new StringBuilder("ClassWeakReference: ").append(referent == null ? null : referent).toString();
+        }
+    }
+
+    private static final ReferenceQueue<Class> refQueue = new ReferenceQueue<>();
+    private static final ConcurrentHashMap<ClassWeakReference, Method> cloneMethodCache = new ConcurrentHashMap<>();
+    
     /**
      * INTERNAL:
      * Return the 'clone()' Method for the specified class.
      * Return null if the method does not exist anywhere in the hierarchy
      */
     protected Method getCloneMethod(Class javaClass) {
+        for (Object key; (key = refQueue.poll()) != null;) {
+            cloneMethodCache.remove(key);
+        }
+        Method cloneMethod = cloneMethodCache.get(new ClassWeakReference(javaClass));
+        if (cloneMethod != null) {
+            return cloneMethod;
+        }
         try {
             // This must not be set "accessible" - clone() must be public, and some JVM's do not allow access to JDK classes.
             if (PrivilegedAccessHelper.shouldUsePrivilegedAccess()){
                 try {
-                    return AccessController.doPrivileged(new PrivilegedGetMethod(javaClass, "clone", (Class[])null, false));
+                    cloneMethod = AccessController.doPrivileged(new PrivilegedGetMethod(javaClass, "clone", (Class[])null, false));
                 } catch (PrivilegedActionException exception) {
                     throw QueryException.methodDoesNotExistInContainerClass("clone", javaClass);
                 }
             } else {
-                return PrivilegedAccessHelper.getMethod(javaClass, "clone", (Class[])null, false);
+                cloneMethod = PrivilegedAccessHelper.getMethod(javaClass, "clone", (Class[])null, false);
             }
         } catch (NoSuchMethodException ex) {
             throw QueryException.methodDoesNotExistInContainerClass("clone", javaClass);
         }
+
+        cloneMethodCache.put(new ClassWeakReference(javaClass, refQueue), cloneMethod);
+        return cloneMethod;
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/VectorContainerPolicy.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/VectorContainerPolicy.java
@@ -54,12 +54,13 @@ public class VectorContainerPolicy extends ListContainerPolicy {
         if (container == null) {
             return null;
         }
-        try {
-            return ((Vector)container).clone();
-        } catch (Exception notVector) {
-            // Could potentially be another Collection type as well.
-            return new Vector((Collection)container);
+
+        if (container.getClass() == Vector.class) {
+            return ((Vector) container).clone();
         }
+
+        // Could potentially be another Collection type as well.
+        return new Vector((Collection) container);
     }
 
     /**


### PR DESCRIPTION
VectorContainerPolicy is used for all List types.  Likely the Object
passed to cloneFor will not be a Vector, but rather an ArrayList,
LinkedList or some other List derivative.  Getting a ClassCastException
is expected to be the normal code path so doing an instanceof check to
avoid the exception.  instanceof will perform better than the
ClassCastException since you need to do a stack walk in order to
generate the stack trace of the exception.  In general Exceptions should
not be a normal decision mechanism if possible.