### PR TITLE
Bug 503015 - NPE in XMLJavaTypeConverter.java

### DIFF
--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/internal/jaxb/XMLJavaTypeConverter.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/internal/jaxb/XMLJavaTypeConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/internal/jaxb/XMLJavaTypeConverter.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/internal/jaxb/XMLJavaTypeConverter.java
@@ -148,7 +148,7 @@ public class XMLJavaTypeConverter extends org.eclipse.persistence.oxm.mappings.c
             }
             return adapter.unmarshal(toConvert);
         } catch (Exception ex) {
-            if(unmarshaller.getErrorHandler() == null){
+            if(unmarshaller == null || unmarshaller.getErrorHandler() == null){
                 throw ConversionException.couldNotBeConverted(dataValue, boundType, ex);
             }
             try {
@@ -181,7 +181,7 @@ public class XMLJavaTypeConverter extends org.eclipse.persistence.oxm.mappings.c
             }
             return dataValue;
         } catch (Exception ex) {
-            if(marshaller.getErrorHandler() == null){
+            if(marshaller == null || marshaller.getErrorHandler() == null){
                 throw ConversionException.couldNotBeConverted(objectValue, valueType, ex);
             }
             try {


### PR DESCRIPTION
Bug 503015 - NPE in XMLJavaTypeConverter.java

Possible source of NPE if marshaller, unmarshaller variable will be null.
This case is not covered by special test case. It's not usual to create and use instance of org.eclipse.persistence.internal.jaxb.XMLJavaTypeConverter directly. There are tests in  org.eclipse.persistence.testing.jaxb.xmladapter package.
See https://bugs.eclipse.org/bugs/show_bug.cgi?id=503015 .
