### PR TITLE
Bug 533861 - JSON unmarshaller incorrectly parse nil elements

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/record/UnmarshalRecordImpl.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/record/UnmarshalRecordImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -841,9 +841,11 @@ public class UnmarshalRecordImpl<TRANSFORMATION_RECORD extends TransformationRec
                 unmarshalContext.startElement(this);
                 levelIndex++;
 
-                String xsiNilValue = atts.getValue(javax.xml.XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI, Constants.SCHEMA_NIL_ATTRIBUTE);
-                if(xsiNilValue != null){
-                    setNil(xsiNilValue.equals(Constants.BOOLEAN_STRING_TRUE) || xsiNilValue.equals("1"));
+                if(xmlReader.getMediaType().isApplicationXML()) {
+                    String xsiNilValue = atts.getValue(javax.xml.XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI, Constants.SCHEMA_NIL_ATTRIBUTE);
+                    if (xsiNilValue != null) {
+                        setNil(xsiNilValue.equals(Constants.BOOLEAN_STRING_TRUE) || xsiNilValue.equals("1"));
+                    }
                 }
 
                 if(node.getNullCapableValue() != null){

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/json/nil/nilElements.json
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/json/nil/nilElements.json
@@ -1,0 +1,31 @@
+{
+  "format": {
+    "formatEntries": {
+      "formatEntry": [
+        {
+          "arrayList": {
+            "item": [
+              "111",
+              "222",
+              "333"
+            ],
+            "nil": 1
+          },
+          "field1": "ABC"
+        },
+        {
+          "arrayList": {
+            "item": [
+              "aaa",
+              "bbb",
+              "ccc"
+            ],
+            "nil": true
+          },
+          "field1": "xyz",
+          "nil": true
+        }
+      ]
+    }
+  }
+}

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/json/nil/nilElementsWrite.json
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/json/nil/nilElementsWrite.json
@@ -1,0 +1,28 @@
+{
+  "format": {
+    "formatEntries": {
+      "formatEntry": [
+        {
+          "arrayList": {
+            "item": [
+              "111",
+              "222",
+              "333"
+            ]
+          },
+          "field1": "ABC"
+        },
+        {
+          "arrayList": {
+            "item": [
+              "aaa",
+              "bbb",
+              "ccc"
+            ]
+          },
+          "field1": "xyz"
+        }
+      ]
+    }
+  }
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/JSONTestSuite.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/JSONTestSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -37,6 +37,7 @@ import org.eclipse.persistence.testing.jaxb.json.namespaces.NamespaceInheritance
 import org.eclipse.persistence.testing.jaxb.json.namespaces.NamespacesOnContextTestCases;
 import org.eclipse.persistence.testing.jaxb.json.namespaces.NamespacesOnUnmarshalOnlyTestCases;
 import org.eclipse.persistence.testing.jaxb.json.namespaces.SeparatorInNameTestCases;
+import org.eclipse.persistence.testing.jaxb.json.nil.NilElementsUsageTestCases;
 import org.eclipse.persistence.testing.jaxb.json.norootelement.IncludeRootFalseWithXMLRootElementTestCases;
 import org.eclipse.persistence.testing.jaxb.json.norootelement.IncludeRootTrueWithXMLRootElementTestCases;
 import org.eclipse.persistence.testing.jaxb.json.norootelement.InheritanceNoRootTestCases;
@@ -74,6 +75,7 @@ public class JSONTestSuite extends TestSuite {
           suite.addTestSuite(NamespaceInheritanceTestCases.class);
           suite.addTestSuite(NamespaceInheritanceSeparatorTestCases.class);
           suite.addTestSuite(NamespaceInheritanceSeparatorContextTestCases.class);
+          suite.addTestSuite(NilElementsUsageTestCases.class);
           suite.addTestSuite(SeparatorInNameTestCases.class);
           suite.addTestSuite(IncludeRootFalseWithXMLRootElementTestCases.class);
           suite.addTestSuite(IncludeRootTrueWithXMLRootElementTestCases.class);

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/nil/MaskFormat.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/nil/MaskFormat.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     Radek Felcman - April 2018 - 2.7.2
+ ******************************************************************************/
+package org.eclipse.persistence.testing.jaxb.json.nil;
+
+import javax.xml.bind.annotation.*;
+import java.util.ArrayList;
+
+@XmlRootElement(name = "format")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class MaskFormat {
+
+    @XmlElementWrapper(name = "formatEntries")
+    @XmlElement(name = "formatEntry")
+    private ArrayList<MaskFormatEntry> formatEntries;
+
+    public ArrayList<MaskFormatEntry> getFormatEntries() {
+        return this.formatEntries;
+    }
+
+    public void setFormatEntries(ArrayList<MaskFormatEntry> formatEntries) {
+        this.formatEntries = formatEntries;
+    }
+
+    public boolean equals(Object obj) {
+        MaskFormat maskFormat = (MaskFormat) obj;
+
+        if((formatEntries == null && maskFormat.getFormatEntries() != null) || (formatEntries != null && !formatEntries.equals(maskFormat.getFormatEntries()))){
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/nil/MaskFormatEntry.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/nil/MaskFormatEntry.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     Radek Felcman - April 2018 - 2.7.2
+ ******************************************************************************/
+package org.eclipse.persistence.testing.jaxb.json.nil;
+
+import org.eclipse.persistence.oxm.annotations.XmlNullPolicy;
+
+import javax.xml.bind.annotation.*;
+import java.util.ArrayList;
+
+@XmlRootElement(name = "maskFormatEntry")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class MaskFormatEntry {
+
+
+    @XmlElementWrapper(name="arrayList")
+    @XmlElement(name="item")
+    @XmlNullPolicy(xsiNilRepresentsNull = false)
+    private ArrayList<String> arrayList;
+
+    @XmlElement(name="field1")
+    private String field1;
+
+    public ArrayList<String> getArrayList() {
+        return arrayList;
+    }
+
+    public void setArrayList(ArrayList<String> arrayList) {
+        this.arrayList = arrayList;
+    }
+
+    public String getField1() {
+        return field1;
+    }
+
+    public void setField1(String field1) {
+        this.field1 = field1;
+    }
+
+    public boolean equals(Object obj) {
+        MaskFormatEntry maskFormatEntry = (MaskFormatEntry) obj;
+
+        if((arrayList == null && maskFormatEntry.getArrayList() != null) || (arrayList != null && !arrayList.equals(maskFormatEntry.getArrayList()))){
+            return false;
+        }
+
+        if((field1 == null && maskFormatEntry.getField1() != null) || (field1 != null && !field1.equals(maskFormatEntry.getField1()))){
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/nil/NilElementsUsageTestCases.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/nil/NilElementsUsageTestCases.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     Radek Felcman - April 2018 - 2.7.2
+ ******************************************************************************/
+package org.eclipse.persistence.testing.jaxb.json.nil;
+
+import org.eclipse.persistence.testing.jaxb.json.JSONMarshalUnmarshalTestCases;
+
+import java.util.ArrayList;
+
+public class NilElementsUsageTestCases extends JSONMarshalUnmarshalTestCases{
+    private final static String JSON_RESOURCE = "org/eclipse/persistence/testing/jaxb/json/nil/nilElements.json";
+    private final static String JSON_RESOURCE_WRITE = "org/eclipse/persistence/testing/jaxb/json/nil/nilElementsWrite.json";
+
+    public NilElementsUsageTestCases(String name) throws Exception {
+        super(name);
+        setControlJSON(JSON_RESOURCE);
+        setWriteControlJSON(JSON_RESOURCE_WRITE);
+        setClasses(new Class[]{MaskFormat.class, MaskFormatEntry.class});
+    }
+
+    protected Object getControlObject() {
+        MaskFormat maskFormat = new MaskFormat();
+
+        MaskFormatEntry maskFormatEntry1 = new MaskFormatEntry();
+        ArrayList<String> list1 = new ArrayList<>();
+        list1.add("111");
+        list1.add("222");
+        list1.add("333");
+        maskFormatEntry1.setArrayList(list1);
+        maskFormatEntry1.setField1("ABC");
+
+        MaskFormatEntry maskFormatEntry2 = new MaskFormatEntry();
+        ArrayList<String> list2 = new ArrayList<>();
+        list2.add("aaa");
+        list2.add("bbb");
+        list2.add("ccc");
+        maskFormatEntry2.setArrayList(list2);
+        maskFormatEntry2.setField1("xyz");
+
+        ArrayList<MaskFormatEntry> maskFormatEntries = new ArrayList<>();
+        maskFormatEntries.add(maskFormatEntry1);
+        maskFormatEntries.add(maskFormatEntry2);
+        maskFormat.setFormatEntries(maskFormatEntries);
+
+        return maskFormat;
+    }
+
+
+}


### PR DESCRIPTION
Bug 533861 - JSON unmarshaller incorrectly parse nil elements

JSON unmarshaller incorrectly parse nil elements in JSON. It parse them like XML xsi:nil="true" control attribute.
New condition in org.eclipse.persistence.internal.oxm.record.UnmarshalRecordImpl to evaluate nil as a control attribute only when input is XML document.
See https://bugs.eclipse.org/bugs/show_bug.cgi?id=533861 .

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>