### PR TITLE
Bug 533874 - Attribute and Element with same name results in element not appearing on parse

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XPathFragment.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XPathFragment.java
@@ -97,6 +97,10 @@ public class XPathFragment <
         this.namespaceAware = isNamespaceAware;
     }
 
+    public char getNamespaceSeparator() {
+        return this.namespaceSeparator;
+    }
+
     public void setNamespaceSeparator(char namespaceSeparator) {
         this.namespaceSeparator = namespaceSeparator;
     }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XPathFragment.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XPathFragment.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/oxm/XMLField.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/oxm/XMLField.java
@@ -928,10 +928,10 @@ public class XMLField extends DatabaseField implements Field<XMLConversionManage
 
     @Override
     public int hashCode() {
-        if(null == xPathFragment) {
+        if(null == xPathFragment && null == xPathFragment.getXPath()) {
             return 1;
         }
-        return xPathFragment.hashCode();
+        return (xPathFragment.getXPath().replace((xPathFragment.getPrefix() != null) ? xPathFragment.getPrefix() + xPathFragment.getNamespaceSeparator() : "", "")).hashCode();
     }
 
 }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/oxm/XMLField.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/oxm/XMLField.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/xmlelement/same_element_attribute_name_nonamespace.json
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/xmlelement/same_element_attribute_name_nonamespace.json
@@ -1,0 +1,11 @@
+{
+  "employee": {
+    "@name": "john.smith",
+    "name": [
+      {
+        "first": "John",
+        "last": "Smith"
+      }
+    ]
+  }
+}

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/xmlelement/same_element_attribute_name_nonamespace.xml
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/xmlelement/same_element_attribute_name_nonamespace.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<employee name="john.smith">
+    <name>
+        <first>John</first>
+        <last>Smith</last>
+    </name>
+</employee>

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlelement/EmployeeSameElementAttributeName.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlelement/EmployeeSameElementAttributeName.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2018  Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     Radek Felcman - 2.7.2 - initial implementation
+ ******************************************************************************/
+package org.eclipse.persistence.testing.jaxb.xmlelement;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import java.util.ArrayList;
+import java.util.List;
+
+@XmlRootElement(name = "employee")
+public class EmployeeSameElementAttributeName {
+    @XmlType
+    public static class EmployeeName {
+        @XmlElement(name = "first")
+        public String firstName;
+
+        @XmlElement(name = "last")
+        public String lastName;
+
+        public boolean equals(Object object) {
+            EmployeeName employeeName = ((EmployeeName) object);
+
+            if ((firstName == null && employeeName.firstName != null) || (firstName != null && !firstName.equals(employeeName.firstName))) {
+                return false;
+            }
+
+            if ((lastName == null && employeeName.lastName != null) || (lastName != null && !lastName.equals(employeeName.lastName))) {
+                return false;
+            }
+            return true;
+        }
+    }
+
+    @XmlAttribute
+    public String name;
+
+    @XmlElement(name = "name")
+    public List<EmployeeName> names = new ArrayList<>();
+
+    public boolean equals(Object object) {
+        EmployeeSameElementAttributeName employee = ((EmployeeSameElementAttributeName) object);
+
+        if ((name == null && employee.name != null) || (name != null && !name.equals(employee.name))) {
+            return false;
+        }
+
+        if ((names == null && employee.names != null) || (names != null && !names.equals(employee.names))) {
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlelement/SameElementAttributeNameTestCases.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlelement/SameElementAttributeNameTestCases.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2018  Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     Radek Felcman - 2.7.2 - initial implementation
+ ******************************************************************************/
+package org.eclipse.persistence.testing.jaxb.xmlelement;
+
+import org.eclipse.persistence.jaxb.MarshallerProperties;
+import org.eclipse.persistence.jaxb.UnmarshallerProperties;
+import org.eclipse.persistence.testing.jaxb.JAXBWithJSONTestCases;
+
+import java.util.ArrayList;
+
+public class SameElementAttributeNameTestCases extends JAXBWithJSONTestCases {
+
+    private final static String XML_RESOURCE = "org/eclipse/persistence/testing/jaxb/xmlelement/same_element_attribute_name_nonamespace.xml";
+    private final static String JSON_RESOURCE = "org/eclipse/persistence/testing/jaxb/xmlelement/same_element_attribute_name_nonamespace.json";
+
+
+    public SameElementAttributeNameTestCases(String name) throws Exception {
+        super(name);
+        setControlDocument(XML_RESOURCE);
+        setControlJSON(JSON_RESOURCE);
+        Class[] classes = new Class<?>[]{EmployeeSameElementAttributeName.class};
+        setClasses(classes);
+        jaxbMarshaller.setProperty(MarshallerProperties.JSON_ATTRIBUTE_PREFIX, "@");
+        jaxbUnmarshaller.setProperty(UnmarshallerProperties.JSON_ATTRIBUTE_PREFIX, "@");
+    }
+
+    protected Object getControlObject() {
+
+        EmployeeSameElementAttributeName.EmployeeName employeeName = new EmployeeSameElementAttributeName.EmployeeName();
+        employeeName.firstName = "John";
+        employeeName.lastName = "Smith";
+
+        ArrayList<EmployeeSameElementAttributeName.EmployeeName> employeeNames = new ArrayList<>();
+        employeeNames.add(employeeName);
+
+        EmployeeSameElementAttributeName employee = new EmployeeSameElementAttributeName();
+        employee.name = "john.smith";
+        employee.names = employeeNames;
+
+        return employee;
+    }
+
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlelement/XmlElementTestSuite.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlelement/XmlElementTestSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -48,6 +48,7 @@ public class XmlElementTestSuite extends TestSuite {
         suite.addTestSuite(XmlElementConstantsTestCases.class);
         suite.addTestSuite(XmlElementDefaultValueTestCases.class);
         suite.addTestSuite(EmpytElementObjectTestCases.class);
+        suite.addTestSuite(SameElementAttributeNameTestCases.class);
         suite.addTestSuite(TypeNoTypeTestCases.class);
         suite.addTestSuite(TypeSimpleTestCases.class);
         suite.addTestSuite(TypeBarTestCases.class);


### PR DESCRIPTION
Bug 533874 - Attribute and Element with same name results in element not appearing on parse

MOXy doesn't unmarshall XML/JSON document correctly if attribute and element with same name is at the same level.
Input XML Example: ...<employee name="john.smith"><name>...
Input JSON Example: ..."employee": {"@name": "john.smith","name": [...
leads into wrong mapping to entity instance.
This patch repairs mapper selection from HashTable to correctly identify attribute and element.
See https://bugs.eclipse.org/bugs/show_bug.cgi?id=533874 .

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>