### PR TITLE
Bug 484561 - JAXB changes null to "" - when @XmlValue is used for JSON

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/record/json/JsonStructureReader.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/record/json/JsonStructureReader.java
@@ -274,7 +274,8 @@ public class JsonStructureReader extends XMLReaderAdapter {
                 break;
             }
             case NULL: {
-                break; // noop
+                contentHandler.setNil(true);
+                break;
             }
             default:
                 throw new IllegalStateException("Unhandled valueType: " + jsonValue.getValueType());

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/xmlvariablenode/rootCollectionNull.json
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/xmlvariablenode/rootCollectionNull.json
@@ -1,0 +1,7 @@
+{
+  "root": {
+    "key1": "value1",
+    "key2": "",
+    "key3": null
+  }
+}

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/xmlvariablenode/rootCollectionNull.xml
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/xmlvariablenode/rootCollectionNull.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<root>
+    <key1>value1</key1>
+    <key2/>
+    <key3 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+</root>

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlvariablenode/AllVariableElementTestCases.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlvariablenode/AllVariableElementTestCases.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -47,6 +47,7 @@ public class AllVariableElementTestCases extends TestSuite {
 
         suite.addTestSuite(XmlVariableNodeSingleTestCases.class);
         suite.addTestSuite(XmlVariableNodeObjectXPathTestCases.class);
+        suite.addTestSuite(XmlVariableNodeCollectionNullValueTestCases.class);
         suite.addTestSuite(XmlVariableNodeCollectionXPathTestCases.class);
         suite.addTestSuite(XmlVariableNodeElementWrapperTestCases.class);
         return suite;

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlvariablenode/ChildNull.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlvariablenode/ChildNull.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     Radek Felcman - May 2018
+ ******************************************************************************/
+package org.eclipse.persistence.testing.jaxb.xmlvariablenode;
+
+import org.eclipse.persistence.oxm.annotations.XmlMarshalNullRepresentation;
+import org.eclipse.persistence.oxm.annotations.XmlNullPolicy;
+
+import javax.xml.bind.annotation.XmlTransient;
+import javax.xml.bind.annotation.XmlValue;
+
+public class ChildNull {
+
+    @XmlTransient
+    public String key;
+
+    @XmlValue
+    @XmlNullPolicy(nullRepresentationForXml= XmlMarshalNullRepresentation.XSI_NIL, xsiNilRepresentsNull=false)
+    private String value;
+
+    public ChildNull() {
+    }
+
+    public ChildNull(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object obj){
+       if(obj instanceof ChildNull){
+           return ((value == null && ((ChildNull)obj).value == null) || (value.equals(((ChildNull)obj).value)));
+       }
+       return false;
+    }
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlvariablenode/RootNull.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlvariablenode/RootNull.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     Radek Felcman - May 2018
+ ******************************************************************************/
+package org.eclipse.persistence.testing.jaxb.xmlvariablenode;
+
+import org.eclipse.persistence.oxm.annotations.XmlVariableNode;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
+
+@XmlRootElement(name = "root")
+public class RootNull {
+
+    @XmlVariableNode("key")
+    public List<ChildNull> childNulls = new ArrayList<>();
+
+    @Override
+    public boolean equals(Object obj){
+        if(obj instanceof RootNull){
+            return childNulls.equals(((RootNull)obj).childNulls);
+        }
+        return false;
+    }
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlvariablenode/XmlVariableNodeCollectionNullValueTestCases.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlvariablenode/XmlVariableNodeCollectionNullValueTestCases.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     Radek Felcman - May 2018
+ ******************************************************************************/
+package org.eclipse.persistence.testing.jaxb.xmlvariablenode;
+
+import org.eclipse.persistence.testing.jaxb.JAXBWithJSONTestCases;
+
+import java.util.ArrayList;
+
+public class XmlVariableNodeCollectionNullValueTestCases extends JAXBWithJSONTestCases{
+
+    protected final static String XML_RESOURCE = "org/eclipse/persistence/testing/jaxb/xmlvariablenode/rootCollectionNull.xml";
+    protected final static String JSON_RESOURCE = "org/eclipse/persistence/testing/jaxb/xmlvariablenode/rootCollectionNull.json";
+
+    public XmlVariableNodeCollectionNullValueTestCases(String name) throws Exception {
+        super(name);
+        setControlDocument(XML_RESOURCE);
+        setControlJSON(JSON_RESOURCE);
+        setClasses(new Class[]{RootNull.class, ChildNull.class});
+    }
+
+    @Override
+    protected Object getControlObject() {
+        RootNull rootNull = new RootNull();
+        rootNull.childNulls = new ArrayList<ChildNull>();
+
+        rootNull.childNulls.add(new ChildNull("key1", "value1"));
+        rootNull.childNulls.add(new ChildNull("key2", ""));
+        rootNull.childNulls.add(new ChildNull("key3", null));
+
+        return rootNull;
+    }
+
+}


### PR DESCRIPTION
Bug 484561 - JAXB changes null to "" - when @XmlValue is used for JSON

MOXy JSON unmarshaller incorrectly unmarshalls null into field marked with @XmlValue annotation and when @XmlVariableNode is used.
Instead of null it returns empty string.
See https://bugs.eclipse.org/bugs/show_bug.cgi?id=484561 .

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>