### PR TITLE
[2.7] Eclipselink#93: Resolve issue with JPA Versoning with java.sql.Timestamp

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/ExpressionQueryMechanism.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/ExpressionQueryMechanism.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2018 Oracle, IBM and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -12,6 +12,8 @@
  *     Thomas Spiegl - fix for bug 324406
  *     10/15/2010-2.2 Guy Pelletier
  *       - 322008: Improve usability of additional criteria applied to queries at the session/EM
+ *     05/10/2018-2.7 Joe Grassel
+ *       - Github#93: Bug with bulk update processing involving version field update parameter
  ******************************************************************************/
 package org.eclipse.persistence.internal.queries;
 
@@ -1833,6 +1835,32 @@ public class ExpressionQueryMechanism extends StatementQueryMechanism {
         }
     }
 
+    private boolean isFieldInUpdate(Expression writeLock, HashMap updateClauses) {
+    	if (!(writeLock instanceof FieldExpression)) {
+    		return false;
+    	}
+    	
+    	final FieldExpression fe = (FieldExpression) writeLock;
+    	final DatabaseField targetField = fe.getField();
+    	
+    	final Set keys = updateClauses.keySet();
+    	for (Object key : keys) {
+    		if (!(key instanceof QueryKeyExpression)) {
+    			continue;
+    		}
+    		
+    		QueryKeyExpression qke = (QueryKeyExpression) key;
+    		ExpressionBuilder eb = qke.getBuilder();
+    		Expression ex = eb.existingDerivedField(targetField);
+    		if (ex != null) {
+    			// Found an expression in the update clause that touches this database field.
+    			return true;
+    		}
+    	}
+    	
+    	return false;
+    }
+    
     /**
      * Pre-build the SQL statement from the expressions.
      */
@@ -1846,12 +1874,18 @@ public class ExpressionQueryMechanism extends StatementQueryMechanism {
         if (policy != null) {
             if(policy.getWriteLockField() != null) {
                 Expression writeLock = builder.getField(policy.getWriteLockField());
-                Expression writeLockUpdateExpression = policy.getWriteLockUpdateExpression(builder, getQuery().getSession());
-                if (writeLockUpdateExpression != null) {
-                    // clone it to keep user's original data intact
-                    updateClauses = (HashMap)updateClauses.clone();
-                    updateClausesHasBeenCloned = true;
-                    updateClauses.put(writeLock, writeLockUpdateExpression);
+                // Note: The spec allows for version fields to be updated in bulk updates.  Adding the writeLockUpdateExpression when there is already
+                // a QueryKeyExpression associated with the version column will result in a scenario where one wins out by virtue of order of iteration
+                // of updateClauses's entrySet.  So we need to check the updateClause to see if the database fields in the writeLock expression are
+                // already targeted for update.
+                if (!isFieldInUpdate(writeLock, updateClauses)) {
+                	Expression writeLockUpdateExpression = policy.getWriteLockUpdateExpression(builder, getQuery().getSession());
+                    if (writeLockUpdateExpression != null) {
+                         // clone it to keep user's original data intact
+                        updateClauses = (HashMap)updateClauses.clone();
+                        updateClausesHasBeenCloned = true;
+                        updateClauses.put(writeLock, writeLockUpdateExpression);
+                    }
                 }
             }
         }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/ExpressionQueryMechanism.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/ExpressionQueryMechanism.java
@@ -1849,11 +1849,9 @@ public class ExpressionQueryMechanism extends StatementQueryMechanism {
     			continue;
     		}
     		
-    		QueryKeyExpression qke = (QueryKeyExpression) key;
-    		ExpressionBuilder eb = qke.getBuilder();
-    		Expression ex = eb.existingDerivedField(targetField);
-    		if (ex != null) {
-    			// Found an expression in the update clause that touches this database field.
+    		QueryKeyExpression qke = (QueryKeyExpression) key;   		
+    		DatabaseField qkField = getDescriptor().getObjectBuilder().getFieldForQueryKeyName(qke.getName());
+    		if (qkField == targetField) {
     			return true;
     		}
     	}

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/version/TestVersioning.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/version/TestVersioning.java
@@ -1,0 +1,182 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     05/10/2018-2.7 Joe Grassel
+ *       - Github#93: Bug with bulk update processing involving version field update parameter
+ ******************************************************************************/
+
+package org.eclipse.persistence.jpa.test.version;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Query;
+
+import org.eclipse.persistence.jpa.test.framework.DDLGen;
+import org.eclipse.persistence.jpa.test.framework.Emf;
+import org.eclipse.persistence.jpa.test.framework.EmfRunner;
+import org.eclipse.persistence.jpa.test.framework.Property;
+import org.eclipse.persistence.jpa.test.version.model.TemporalVersionedEntity;
+import org.eclipse.persistence.jpa.test.version.model.TemporalVersionedEntity2;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(EmfRunner.class)
+public class TestVersioning {
+	@Emf(createTables = DDLGen.DROP_CREATE, classes = { TemporalVersionedEntity.class, TemporalVersionedEntity2.class },
+			properties = { @Property(name="eclipselink.logging.level", value="FINE"),
+					       @Property(name="eclipselink.logging.parameters", value="true")})
+    private EntityManagerFactory emf;
+	
+	private final static String qStr1 = "UPDATE TemporalVersionedEntity " + 
+			"SET updatetimestamp = ?3 " +
+			"WHERE id = ?1 AND updatetimestamp = ?2";
+	
+	private final static String qStr2 = "UPDATE TemporalVersionedEntity2 " + 
+			"SET version = ?3 " +
+			"WHERE id = ?1 AND version = ?2";
+			
+	@Test
+    public void testTemporalVersionField1() throws Exception {
+//		System.out.println("*\n*\n*\n*\nRunning testTemporalVersionField1 ...");
+        if (emf == null)
+            return;
+        
+        EntityManager em = emf.createEntityManager();
+        try {
+        	final TemporalVersionedEntity tve = new TemporalVersionedEntity();
+        	tve.setId(1L);
+        	
+        	em.getTransaction().begin();
+        	em.persist(tve);
+        	em.getTransaction().commit();
+        	em.clear();
+//        	System.out.println("New Entity Timestamp = " + tve.getUpdatetimestamp());
+        	
+        	final TemporalVersionedEntity tve_update1 = performJpqlBulkUpdate(em, tve);
+        	em.clear();
+//        	System.out.println("Timestamp After First Bulk Update = " + tve_update1.getUpdatetimestamp());
+        	
+        	final TemporalVersionedEntity tve_update2 = performJpqlBulkUpdate(em, tve_update1);
+        	em.clear();
+//        	System.out.println("Timestamp After Second Bulk Update = " + tve_update2.getUpdatetimestamp());
+        	
+        	Assert.assertNotEquals(tve.getUpdatetimestamp(), tve_update1.getUpdatetimestamp());
+        	Assert.assertNotEquals(tve.getUpdatetimestamp(), tve_update2.getUpdatetimestamp());
+        	Assert.assertNotEquals(tve_update1.getUpdatetimestamp(), tve_update2.getUpdatetimestamp());
+        	
+        } finally {
+        	if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            em.close();
+        }
+	}
+	
+	private TemporalVersionedEntity performJpqlBulkUpdate(EntityManager em, TemporalVersionedEntity entity) {
+		try { Thread.sleep(500); } catch (Exception e) {}
+		em.getTransaction().begin();
+		
+		final Query q = em.createQuery(qStr1);
+		q.setParameter(1, entity.getId());
+		q.setParameter(2, entity.getUpdatetimestamp());
+		
+		try { Thread.sleep(500); } catch (Exception e) {}
+		final java.sql.Timestamp newTime = new java.sql.Timestamp(System.currentTimeMillis());
+		Assert.assertNotNull(newTime);
+		q.setParameter(3, newTime);
+//		System.out.println("Bulk Update Parameter 3 = " + newTime);
+		
+		try { Thread.sleep(500); } catch (Exception e) {}
+		final int count = q.executeUpdate();
+		Assert.assertEquals(1, count);
+		
+		em.getTransaction().commit();
+		em.clear();
+		
+		final TemporalVersionedEntity tve = em.find(TemporalVersionedEntity.class, entity.getId());
+		Assert.assertNotNull(tve);
+		Assert.assertNotSame(tve,  entity);
+		
+		Assert.assertNotEquals(entity.getUpdatetimestamp(), tve.getUpdatetimestamp());
+		Assert.assertEquals(newTime, tve.getUpdatetimestamp());
+		
+		
+		return tve;
+	}
+	
+	@Test
+    public void testTemporalVersionField2() throws Exception {
+//		System.out.println("*\n*\n*\n*\nRunning testTemporalVersionField2 ...");
+        if (emf == null)
+            return;
+        
+        EntityManager em = emf.createEntityManager();
+        try {
+        	final TemporalVersionedEntity2 tve = new TemporalVersionedEntity2();
+        	tve.setId(1L);
+        	
+        	em.getTransaction().begin();
+        	em.persist(tve);
+        	em.getTransaction().commit();
+        	em.clear();
+//        	System.out.println("New Entity Timestamp = " + tve.getVersion());
+        	
+        	final TemporalVersionedEntity2 tve_update1 = performJpqlBulkUpdate2(em, tve);
+        	em.clear();
+//        	System.out.println("Timestamp After First Bulk Update = " + tve_update1.getVersion());
+        	
+        	final TemporalVersionedEntity2 tve_update2 = performJpqlBulkUpdate2(em, tve_update1);
+        	em.clear();
+//        	System.out.println("Timestamp After Second Bulk Update = " + tve_update2.getVersion());
+        	
+        	Assert.assertNotEquals(tve.getVersion(), tve_update1.getVersion());
+        	Assert.assertNotEquals(tve.getVersion(), tve_update2.getVersion());
+        	Assert.assertNotEquals(tve_update1.getVersion(), tve_update2.getVersion());     	
+        } finally {
+        	if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            em.close();
+        }
+	}
+	
+	private TemporalVersionedEntity2 performJpqlBulkUpdate2(EntityManager em, TemporalVersionedEntity2 entity) {
+		try { Thread.sleep(500); } catch (Exception e) {}
+		em.getTransaction().begin();
+		
+		final Query q = em.createQuery(qStr2);
+		q.setParameter(1, entity.getId());
+		q.setParameter(2, entity.getVersion());
+		
+		try { Thread.sleep(500); } catch (Exception e) {}
+		final java.sql.Timestamp newTime = new java.sql.Timestamp(System.currentTimeMillis());
+		Assert.assertNotNull(newTime);
+		q.setParameter(3, newTime);
+//		System.out.println("Bulk Update Parameter 3 = " + newTime);
+		
+		try { Thread.sleep(500); } catch (Exception e) {}
+		final int count = q.executeUpdate();
+		Assert.assertEquals(1, count);
+		
+		em.getTransaction().commit();
+		em.clear();
+		
+		final TemporalVersionedEntity2 tve = em.find(TemporalVersionedEntity2.class, entity.getId());
+		Assert.assertNotNull(tve);
+		Assert.assertNotSame(tve,  entity);
+		
+		Assert.assertNotEquals(entity.getVersion(), tve.getVersion());
+		Assert.assertEquals(newTime, tve.getVersion());
+		
+		
+		return tve;
+	}
+}

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/version/TestVersioning.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/version/TestVersioning.java
@@ -16,12 +16,14 @@ package org.eclipse.persistence.jpa.test.version;
 
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
+import javax.persistence.OptimisticLockException;
 import javax.persistence.Query;
 
 import org.eclipse.persistence.jpa.test.framework.DDLGen;
 import org.eclipse.persistence.jpa.test.framework.Emf;
 import org.eclipse.persistence.jpa.test.framework.EmfRunner;
 import org.eclipse.persistence.jpa.test.framework.Property;
+import org.eclipse.persistence.jpa.test.version.model.IntegerVersionedEntity;
 import org.eclipse.persistence.jpa.test.version.model.TemporalVersionedEntity;
 import org.eclipse.persistence.jpa.test.version.model.TemporalVersionedEntity2;
 import org.junit.Assert;
@@ -30,7 +32,8 @@ import org.junit.runner.RunWith;
 
 @RunWith(EmfRunner.class)
 public class TestVersioning {
-	@Emf(createTables = DDLGen.DROP_CREATE, classes = { TemporalVersionedEntity.class, TemporalVersionedEntity2.class },
+	@Emf(createTables = DDLGen.DROP_CREATE, classes = { TemporalVersionedEntity.class, TemporalVersionedEntity2.class,
+			IntegerVersionedEntity.class},
 			properties = { @Property(name="eclipselink.logging.level", value="FINE"),
 					       @Property(name="eclipselink.logging.parameters", value="true")})
     private EntityManagerFactory emf;
@@ -178,5 +181,143 @@ public class TestVersioning {
 		
 		
 		return tve;
+	}
+	
+	/**
+	 * Verify basic Integer version incrementation.  
+	 * 
+	 */
+	@Test
+	public void testIntegerVersioning001() throws Exception {
+		if (emf == null)
+            return;
+        
+        EntityManager em = emf.createEntityManager();
+        try {
+        	final IntegerVersionedEntity newEntity = new IntegerVersionedEntity();
+        	newEntity.setId(1L);
+        	newEntity.setData("Data");
+        	
+        	em.getTransaction().begin();
+        	em.persist(newEntity);
+        	em.getTransaction().commit();
+        	em.clear();
+        	
+        	em.getTransaction().begin();
+        	final IntegerVersionedEntity findEntity1 = em.find(IntegerVersionedEntity.class, 1L);
+        	Assert.assertNotNull(findEntity1);
+        	Assert.assertNotSame(newEntity, findEntity1);
+        	Assert.assertEquals("Data", findEntity1.getData());
+        	Assert.assertEquals(newEntity.getTheVersion(), findEntity1.getTheVersion());
+        	
+        	findEntity1.setData("Lore");
+        	
+        	em.getTransaction().commit();
+        	em.clear();
+        	
+        	em.getTransaction().begin();
+        	final IntegerVersionedEntity findEntity2 = em.find(IntegerVersionedEntity.class, 1L);
+        	Assert.assertNotNull(findEntity2);
+        	Assert.assertNotSame(findEntity1, findEntity2);
+        	Assert.assertEquals("Lore", findEntity2.getData());
+        	Assert.assertEquals(newEntity.getTheVersion() + 1, findEntity1.getTheVersion());
+        	
+        	findEntity1.setData("Information");
+        	
+        	em.getTransaction().commit();
+        	em.clear();
+        	
+        } finally {
+        	if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            em.close();
+        }
+	}
+	
+	/**
+	 * Test based on org.eclipse.persistence.testing.tests.jpa.jpql.JUnitJPQLValidationTestSuite.JTAOptimisticLockExceptionTest()
+	 * 
+	 */
+	@Test
+	public void testIntegerVersioning002() throws Throwable {
+		if (emf == null)
+            return;
+        
+        EntityManager em = emf.createEntityManager();
+        try {
+        	final IntegerVersionedEntity newEntity = new IntegerVersionedEntity();
+        	newEntity.setId(2L);
+        	newEntity.setData("Data");
+        	
+        	em.getTransaction().begin();
+        	em.persist(newEntity);
+        	em.getTransaction().commit();
+        	em.clear();
+        	
+        	em.getTransaction().begin();
+        	final IntegerVersionedEntity findEntity1 = (IntegerVersionedEntity) em
+        			.createQuery("SELECT fe FROM IntegerVersionedEntity fe WHERE fe.id = 2")
+        			.getSingleResult();
+        	Assert.assertNotNull(findEntity1);
+        	Assert.assertNotSame(newEntity, findEntity1);
+        	Assert.assertEquals("Data", findEntity1.getData());
+        	Assert.assertEquals(newEntity.getTheVersion(), findEntity1.getTheVersion());
+        	
+        	try {
+            	em.createQuery("UPDATE IntegerVersionedEntity SET data = 'Lore' WHERE id = 2").executeUpdate();
+            	
+            	findEntity1.setData("Information");
+            	
+            	em.getTransaction().commit();
+            	Assert.fail("Lock exception should have been thrown");
+        	} catch (Throwable lockException) {
+        		while ((lockException != null) && !(lockException instanceof OptimisticLockException)) {
+                    lockException = lockException.getCause();
+                }
+                if (lockException instanceof OptimisticLockException) {
+                    return; // Pass
+                }
+                
+                throw lockException;
+        	}       	
+        } finally {
+        	if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            em.close();
+        }
+	}
+	
+	@Test
+	public void testIntegerVersioning003() throws Exception {
+		if (emf == null)
+            return;
+        
+        EntityManager em = emf.createEntityManager();
+        try {
+        	final IntegerVersionedEntity newEntity = new IntegerVersionedEntity();
+        	newEntity.setId(3L);
+        	newEntity.setData("Data");
+        	
+        	em.getTransaction().begin();
+        	em.persist(newEntity);
+        	em.getTransaction().commit();
+        	em.clear();
+        	
+        	em.getTransaction().begin();
+        	int updates = em.createQuery("UPDATE IntegerVersionedEntity SET theVersion = 10 WHERE id = 3 AND theVersion = 1").executeUpdate();
+        	Assert.assertEquals(1,  updates);
+        	
+        	em.getTransaction().commit();
+        	em.clear();
+        	
+        	
+        } finally {
+        	if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            em.close();
+        }
 	}
 }

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/version/TestVersioning.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/version/TestVersioning.java
@@ -84,7 +84,7 @@ public class TestVersioning {
 	}
 	
 	private TemporalVersionedEntity performJpqlBulkUpdate(EntityManager em, TemporalVersionedEntity entity) {
-		try { Thread.sleep(500); } catch (Exception e) {}
+		try { Thread.sleep(1500); } catch (Exception e) {}
 		em.getTransaction().begin();
 		
 		final Query q = em.createQuery(qStr1);
@@ -93,6 +93,7 @@ public class TestVersioning {
 		
 		try { Thread.sleep(500); } catch (Exception e) {}
 		final java.sql.Timestamp newTime = new java.sql.Timestamp(System.currentTimeMillis());
+		newTime.setNanos(0);  // Some DB platforms don't do milli/nano granularity with timestamp.
 		Assert.assertNotNull(newTime);
 		q.setParameter(3, newTime);
 //		System.out.println("Bulk Update Parameter 3 = " + newTime);
@@ -152,7 +153,7 @@ public class TestVersioning {
 	}
 	
 	private TemporalVersionedEntity2 performJpqlBulkUpdate2(EntityManager em, TemporalVersionedEntity2 entity) {
-		try { Thread.sleep(500); } catch (Exception e) {}
+		try { Thread.sleep(1500); } catch (Exception e) {}
 		em.getTransaction().begin();
 		
 		final Query q = em.createQuery(qStr2);
@@ -161,6 +162,7 @@ public class TestVersioning {
 		
 		try { Thread.sleep(500); } catch (Exception e) {}
 		final java.sql.Timestamp newTime = new java.sql.Timestamp(System.currentTimeMillis());
+		newTime.setNanos(0);  // Some DB platforms don't do milli/nano granularity with timestamp.
 		Assert.assertNotNull(newTime);
 		q.setParameter(3, newTime);
 //		System.out.println("Bulk Update Parameter 3 = " + newTime);

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/version/model/IntegerVersionedEntity.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/version/model/IntegerVersionedEntity.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     05/10/2018-2.7 Joe Grassel
+ *       - Github#93: Bug with bulk update processing involving version field update parameter
+ ******************************************************************************/
+
+package org.eclipse.persistence.jpa.test.version.model;
+
+import javax.persistence.Basic;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Version;
+
+@Entity
+public class IntegerVersionedEntity {
+	@Id
+	private long id;
+	
+	@Basic
+	private String data;
+	
+	public String getData() {
+		return data;
+	}
+
+	public void setData(String data) {
+		this.data = data;
+	}
+
+	@Version
+	private int theVersion;
+
+	public long getId() {
+		return id;
+	}
+
+	public void setId(long id) {
+		this.id = id;
+	}
+
+	public int getTheVersion() {
+		return theVersion;
+	}
+
+	public void setTheVersion(int theVersion) {
+		this.theVersion = theVersion;
+	}
+
+	@Override
+	public String toString() {
+		return "IntegerVersionedEntity [id=" + id + ", data=" + data + ", theVersion=" + theVersion + "]";
+	}
+
+	
+	
+}

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/version/model/TemporalVersionedEntity.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/version/model/TemporalVersionedEntity.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     05/10/2018-2.7 Joe Grassel
+ *       - Github#93: Bug with bulk update processing involving version field update parameter
+ ******************************************************************************/
+
+package org.eclipse.persistence.jpa.test.version.model;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Version;
+
+@Entity
+public class TemporalVersionedEntity {
+	@Id
+	private long id;
+	
+	@Version
+	private java.sql.Timestamp updatetimestamp;
+
+	public long getId() {
+		return id;
+	}
+
+	public void setId(long id) {
+		this.id = id;
+	}
+
+	public java.sql.Timestamp getUpdatetimestamp() {
+		return updatetimestamp;
+	}
+
+	public void setUpdatetimestamp(java.sql.Timestamp version) {
+		this.updatetimestamp = version;
+	}
+
+	@Override
+	public String toString() {
+		return "TemporalVersionedEntity [id=" + id + ", version=" + updatetimestamp + "]";
+	}
+	
+	
+}

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/version/model/TemporalVersionedEntity2.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/version/model/TemporalVersionedEntity2.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     05/10/2018-2.7 Joe Grassel
+ *       - Github#93: Bug with bulk update processing involving version field update parameter
+ ******************************************************************************/
+
+package org.eclipse.persistence.jpa.test.version.model;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Version;
+
+@Entity
+public class TemporalVersionedEntity2 {
+	@Id
+	private long id;
+	
+	@Version
+	private java.sql.Timestamp version;
+
+	public long getId() {
+		return id;
+	}
+
+	public void setId(long id) {
+		this.id = id;
+	}
+
+	public java.sql.Timestamp getVersion() {
+		return version;
+	}
+
+	public void setVersion(java.sql.Timestamp version) {
+		this.version = version;
+	}
+
+	@Override
+	public String toString() {
+		return "TemporalVersionedEntity [id=" + id + ", version=" + version + "]";
+	}
+	
+	
+}


### PR DESCRIPTION
fixes #93 
Signed-off-by: Joe Grassel <jgrassel@us.ibm.com>

My solution to resolving the problem is to first check if the database field referenced by the writeLock expression is already part of an existing expression in the updateClause.  For example, during a debug session, I noticed while examining the memory state of the objects available during the method invocation:

```
writeLock	FieldExpression  (id=90)	
	field	DatabaseField  (id=87)	
updateClauses	HashMap<K,V>  (id=77)	
	[0]	HashMap$Node<K,V>  (id=147)	
		key	QueryKeyExpression  (id=152)	
			baseExpression	ExpressionBuilder  (id=71)	
				derivedFields	ArrayList<E>  (id=168)	
					[0]	FieldExpression  (id=90)
						field	DatabaseField  (id=87)	
```	

And I thought a potential solution would be to identify the DatabaseField that is member of the writeLock FieldExpression, and look for it in any derivedFields in the updateClauses.  In practice, this worked (the tests passed), but I would like to hear from the community on whether this is a solid fix, or if there is a better approach to resolving the issue.

The approach I took attempts to prevent the writeLock FieldExpression from being admitted to the updateClauses map, rather than trying to determine that its removal is necessary in the subsequent processing that iterates through the contents of updateClauses.