### PR TITLE
Bug 534935 - Wrong SQL date format in Unit test dbws.testing.simplesp.SimpleSPTestSuite

### DIFF
--- a/utils/eclipselink.dbws.builder.test/src/dbws/testing/simplesp/SimpleSPTestSuite.java
+++ b/utils/eclipselink.dbws.builder.test/src/dbws/testing/simplesp/SimpleSPTestSuite.java
@@ -56,7 +56,7 @@ public class SimpleSPTestSuite extends DBWSTestSuite {
             "\nPRIMARY KEY (EMPNO)" +
         "\n)";
     static String[] POPULATE_SIMPLESP_TABLE = new String[] {
-        "INSERT INTO simplesp VALUES (7369,'SMITH','CLERK',7902,'1980-12--17',800,NULL,20)",
+        "INSERT INTO simplesp VALUES (7369,'SMITH','CLERK',7902,'1980-12-17',800,NULL,20)",
         "INSERT INTO simplesp VALUES (7499,'ALLEN','SALESMAN',7698,'1981-2-20',1600,300,30)",
         "INSERT INTO simplesp VALUES (7521,'WARD','SALESMAN',7698,'1981-2-22',1250,500,30)",
         "INSERT INTO simplesp VALUES (7566,'JONES','MANAGER',7839,'1981-4-2',2975,NULL,20)",


### PR DESCRIPTION
Bug 534935 - Wrong SQL date format in Unit test dbws.testing.simplesp.SimpleSPTestSuite

Modification of date value.
See https://bugs.eclipse.org/bugs/show_bug.cgi?id=534935

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>