### PR TITLE
Bug 534812 - HIERARCHY_REQUEST_ERR marshalling a CDATA-containing XmlAnyElement to a Node result

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLMarshaller.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLMarshaller.java
@@ -502,7 +502,11 @@ public abstract class XMLMarshaller<
      * @throws XMLMarshalException if an error occurred during marshalling
      */
     public void marshal(Object object, ContentHandler contentHandler) throws XMLMarshalException {
-        marshal(object, contentHandler, null);
+        if (contentHandler instanceof LexicalHandler) {
+            marshal(object, contentHandler, (LexicalHandler)contentHandler);
+        } else {
+            marshal(object, contentHandler, null);
+        }
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/oxm/record/ContentHandlerRecord.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/oxm/record/ContentHandlerRecord.java
@@ -383,6 +383,7 @@ public class ContentHandlerRecord extends MarshalRecord {
             } else {
                 XMLFragmentReader xfragReader = new XMLFragmentReader(namespaceResolver);
                 xfragReader.setContentHandler(contentHandler);
+                xfragReader.setLexicalHandler(lexicalHandler);
                 try {
                     xfragReader.parse(node, uri, name);
                 } catch (SAXException sex) {

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/oxm/record/NodeRecord.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/oxm/record/NodeRecord.java
@@ -290,7 +290,11 @@ public class NodeRecord extends MarshalRecord {
     @Override
     public void characters(String value) {
         if (value.length() > 0) {
-            node.appendChild(document.createTextNode(value));
+            if (node instanceof CDATASection) {
+                ((CDATASection) node).setData(value);
+            } else {
+                node.appendChild(document.createTextNode(value));
+            }
         }
     }
 

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/xml/SAXDocumentBuilder.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/xml/SAXDocumentBuilder.java
@@ -22,6 +22,7 @@ import java.util.Map.Entry;
 import org.eclipse.persistence.internal.oxm.Constants;
 import org.eclipse.persistence.internal.oxm.StrBuffer;
 import org.eclipse.persistence.internal.oxm.record.ExtendedContentHandler;
+import org.w3c.dom.CDATASection;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -30,12 +31,13 @@ import org.w3c.dom.Text;
 import org.xml.sax.Attributes;
 import org.xml.sax.Locator;
 import org.xml.sax.SAXException;
+import org.xml.sax.ext.LexicalHandler;
 
 /**
  * <p><b>Purpose</b>:  Build a DOM from SAX events.</p>
  */
 
-public class SAXDocumentBuilder implements ExtendedContentHandler {
+public class SAXDocumentBuilder implements ExtendedContentHandler, LexicalHandler {
     protected Document document;
     protected List<Node> nodes;
     protected XMLPlatform xmlPlatform;
@@ -214,4 +216,35 @@ public class SAXDocumentBuilder implements ExtendedContentHandler {
     }
     @Override
     public void setNil(boolean isNil) {}
+
+    @Override
+    public void startDTD(String name, String publicId, String systemId) throws SAXException {}
+
+    @Override
+    public void endDTD() throws SAXException {}
+
+    @Override
+    public void startEntity(String name) throws SAXException {}
+
+    @Override
+    public void endEntity(String name) throws SAXException {}
+
+    @Override
+    public void startCDATA() throws SAXException {
+        CDATASection cdata = document.createCDATASection(null);
+        Node parentNode = nodes.get(nodes.size() -1);
+        parentNode.appendChild(cdata);
+    }
+
+    @Override
+    public void endCDATA() throws SAXException {
+        CDATASection cdata = (CDATASection)nodes.get(nodes.size()-1).getFirstChild();
+        if (stringBuffer.length() > 0) {
+            cdata.setData(stringBuffer.toString());
+            stringBuffer.reset();
+        }
+    }
+
+    @Override
+    public void comment(char[] ch, int start, int length) throws SAXException {}
 }

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/xmlanyelement/employeeLaxCDATA.xml
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/xmlanyelement/employeeLaxCDATA.xml
@@ -1,0 +1,8 @@
+<employee name="John Doe">
+    <home-address>
+        <street>123 Fake Street</street>
+        <city>Ottawa</city>
+        <country>Canada</country>
+    </home-address>
+    <mytag><![CDATA[Hello world!<>'"]]></mytag>
+</employee>

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/JAXBTestSuite.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/JAXBTestSuite.java
@@ -106,6 +106,7 @@ public class JAXBTestSuite extends TestCase {
         suite.addTestSuite(org.eclipse.persistence.testing.jaxb.xmlanyelement.XmlAnyElementLaxMixedTestCases.class);
         suite.addTestSuite(org.eclipse.persistence.testing.jaxb.xmlanyelement.XmlAnyElementLaxMixedEmptyTestCases.class);
         suite.addTestSuite(org.eclipse.persistence.testing.jaxb.xmlanyelement.XmlAnyJAXBElementTestCases.class);
+        suite.addTestSuite(org.eclipse.persistence.testing.jaxb.xmlanyelement.XmlAnyElementLaxCDATATestCases.class);
         suite.addTestSuite(org.eclipse.persistence.testing.jaxb.xmlanyelement.domhandler.DOMHandlerTestCases.class);
         suite.addTestSuite(org.eclipse.persistence.testing.jaxb.xmlanyelement.ns.DefaultNamespaceTestCases.class);
         suite.addTestSuite(org.eclipse.persistence.testing.jaxb.xmlanyelement.ns.DefaultNamespaceCollectionTestCases.class);

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlanyelement/EmployeeLaxCDATA.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlanyelement/EmployeeLaxCDATA.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     05/24/2018-2.7.2 Radek Felcman
+ *       - 534812 - HIERARCHY_REQUEST_ERR marshalling a CDATA-containing XmlAnyElement to a Node result
+ *******************************************************************************/
+package org.eclipse.persistence.testing.jaxb.xmlanyelement;
+
+import org.eclipse.persistence.platform.xml.XMLComparer;
+import org.w3c.dom.Element;
+
+import javax.xml.bind.annotation.XmlAnyElement;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name="employee")
+public class EmployeeLaxCDATA {
+    @XmlAttribute
+    public String name;
+
+    @XmlElement(name="home-address")
+    public Address homeAddress;
+
+    @XmlAnyElement(lax = true)
+    public Element element;
+
+    public boolean equals(Object obj) {
+        if(!(obj instanceof EmployeeLaxCDATA)) {
+            return false;
+        }
+
+        EmployeeLaxCDATA emp = (EmployeeLaxCDATA)obj;
+        if(!(name.equals(emp.name))) {
+            return false;
+        }
+        if(!(homeAddress.equals(emp.homeAddress))) {
+            return false;
+        }
+
+        XMLComparer comparer = new XMLComparer();
+
+        Object next1 = element;
+        Object next2 =  emp.element;
+
+        if((next1 instanceof Element) && (next2 instanceof Element)) {
+            Element nextElem1 = (Element)next1;
+            Element nextElem2 = (Element)next2;
+            if(!(comparer.isNodeEqual(nextElem1, nextElem2))) {
+                return false;
+            }
+
+        } else if(!(next1.equals(next2))) {
+                return false;
+        }
+        return true;
+    }
+
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlanyelement/XmlAnyElementLaxCDATATestCases.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlanyelement/XmlAnyElementLaxCDATATestCases.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     05/24/2018-2.7.2 Radek Felcman
+ *       - 534812 - HIERARCHY_REQUEST_ERR marshalling a CDATA-containing XmlAnyElement to a Node result
+ *******************************************************************************/
+package org.eclipse.persistence.testing.jaxb.xmlanyelement;
+
+import org.eclipse.persistence.testing.jaxb.JAXBTestCases;
+import org.xml.sax.SAXException;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+public class XmlAnyElementLaxCDATATestCases extends JAXBTestCases {
+
+    private final static String XML_RESOURCE = "org/eclipse/persistence/testing/jaxb/xmlanyelement/employeeLaxCDATA.xml";
+
+    public XmlAnyElementLaxCDATATestCases(String name) throws Exception {
+        super(name);
+        setControlDocument(XML_RESOURCE);
+        Class[] classes = new Class[2];
+        classes[0] = EmployeeLaxCDATA.class;
+        classes[1] = Address.class;
+        setClasses(classes);
+    }
+
+    protected Object getControlObject() {
+        EmployeeLaxCDATA employee = new EmployeeLaxCDATA();
+        employee.name = "John Doe";
+        employee.homeAddress = new Address();
+        employee.homeAddress.street = "123 Fake Street";
+        employee.homeAddress.city = "Ottawa";
+        employee.homeAddress.country = "Canada";
+        try {
+            employee.element = parser.parse(new ByteArrayInputStream("<mytag><![CDATA[Hello world!<>'\"]]></mytag>".getBytes())).getDocumentElement();
+        } catch (SAXException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return employee;
+    }
+
+    @Override
+    public boolean isUnmarshalTest() {
+        return false;
+    }
+
+}


### PR DESCRIPTION
Bug 534812 - HIERARCHY_REQUEST_ERR marshalling a CDATA-containing XmlAnyElement to a Node result

Bug fix in org.eclipse.persitence.NodeRecord.characters().
CDATA handling implementation in org.eclipse.peristence.platform.xml.SAXDocumentBuilder (see MOXy bug 355143).
See https://bugs.eclipse.org/bugs/show_bug.cgi?id=534812