### PR TITLE
Bug 529270 - MOXy may causes classloader leaks

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -9,14 +9,11 @@
     <option name="pathToConfigFileJava" value="$PROJECT_DIR$/project-admin/EclipseLink-Eclipse-Format.xml" />
     <option name="selectedJavaProfile" value="EclipseLink" />
   </component>
-  <component name="EntryPointsManager">
-    <entry_points version="2.0" />
-  </component>
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$/jsonb" />
   </component>
   <component name="IdProvider" IDEtalkID="D25D12225615E907E53EC1D416DAF86F" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="8.0" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/compiler/AnnotationsProcessor.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/compiler/AnnotationsProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2016 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -3817,12 +3817,12 @@ public final class AnnotationsProcessor {
                 if (JAVAX_XML_BIND_JAXBELEMENT.equals(type.getName())) {
                     Object[] actualTypeArguments = type.getActualTypeArguments().toArray();
                     if (actualTypeArguments.length == 0) {
-                        type = helper.OBJECT_CLASS;
+                        type = helper.getObjectClass();
                     } else {
                         type = (JavaClass) actualTypeArguments[0];
                     }
                     type = processXmlElementDecl(type, next, packageInfo, elemDecls);
-                }else if (helper.JAXBELEMENT_CLASS.isAssignableFrom(type)) {
+                }else if (helper.getJaxbElementClass().isAssignableFrom(type)) {
                     this.factoryMethods.put(type.getRawName(), next);
                     type = processXmlElementDecl(type, next, packageInfo, elemDecls);
                 } else {

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/compiler/Property.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/compiler/Property.java
@@ -166,10 +166,8 @@ public class Property implements Cloneable {
     public Property(Helper helper) {
         this.helper = helper;
 
-        if (xmlAdapterClass == null)
-            xmlAdapterClass = helper.getJavaClass(XmlAdapter.class);
-        if (objectClass == null)
-            objectClass = helper.getJavaClass(Object.class);
+        xmlAdapterClass = helper.getJavaClass(XmlAdapter.class);
+        objectClass = helper.getJavaClass(Object.class);
     }
 
     public void setHelper(Helper helper) {

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/compiler/Property.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/compiler/Property.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998 - 2014, 2018  Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2018  Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -152,8 +152,8 @@ public class Property implements Cloneable {
     private boolean isTransientType;
     private static final String MARSHAL_METHOD_NAME = "marshal";
 
-    private static JavaClass XML_ADAPTER_CLASS;
-    private static JavaClass OBJECT_CLASS;
+    private JavaClass xmlAdapterClass;
+    private JavaClass objectClass;
 
     private boolean isTyped;
     private Integer minOccurs;
@@ -166,11 +166,10 @@ public class Property implements Cloneable {
     public Property(Helper helper) {
         this.helper = helper;
 
-        // let's init static fields
-        if (XML_ADAPTER_CLASS == null)
-            XML_ADAPTER_CLASS = helper.getJavaClass(XmlAdapter.class);
-        if (OBJECT_CLASS == null)
-            OBJECT_CLASS = helper.getJavaClass(Object.class);
+        if (xmlAdapterClass == null)
+            xmlAdapterClass = helper.getJavaClass(XmlAdapter.class);
+        if (objectClass == null)
+            objectClass = helper.getJavaClass(Object.class);
     }
 
     public void setHelper(Helper helper) {
@@ -193,7 +192,7 @@ public class Property implements Cloneable {
                 JavaClass boundType = getJavaClassFromType(parameterizedTypeArguments[1]);
 
                 if (valueTypeClass.isInterface()) {
-                    valueTypeClass = OBJECT_CLASS; // during unmarshalling we'll need to instantiate this, so -> no interfaces
+                    valueTypeClass = objectClass; // during unmarshalling we'll need to instantiate this, so -> no interfaces
                 }
 
                 setTypeFromAdapterClass(valueTypeClass, boundType);
@@ -215,7 +214,7 @@ public class Property implements Cloneable {
 
                 // Try and find a marshal method where Object is not the return type,
                 // to avoid processing an inherited default marshal method
-                if (!returnType.getQualifiedName().equals(OBJECT_CLASS.getQualifiedName()) && !returnType.isInterface()) { // if it's interface, we'll use OBJECT instead later
+                if (!returnType.getQualifiedName().equals(objectClass.getQualifiedName()) && !returnType.isInterface()) { // if it's interface, we'll use OBJECT instead later
                     setTypeFromAdapterClass(returnType, parameterTypes[0]);
                     return;
                 }
@@ -228,13 +227,13 @@ public class Property implements Cloneable {
         for (JavaMethod method : marshalMethods) {
             JavaClass paramType = method.getParameterTypes()[0];
             // look for non-Object parameter type
-            if (!paramType.getQualifiedName().equals(OBJECT_CLASS.getQualifiedName())) {
-                setTypeFromAdapterClass(OBJECT_CLASS, paramType);
+            if (!paramType.getQualifiedName().equals(objectClass.getQualifiedName())) {
+                setTypeFromAdapterClass(objectClass, paramType);
                 return;
             }
         }
         if (!marshalMethods.isEmpty())
-            setTypeFromAdapterClass(OBJECT_CLASS, null);
+            setTypeFromAdapterClass(objectClass, null);
         // else impossible? - looks like provided adapted doesn't contain marshal(...) method
     }
 
@@ -257,7 +256,7 @@ public class Property implements Cloneable {
                 return helper.getJavaClass(Array.newInstance((Class) rawType, 1).getClass());
             }
         }
-        return OBJECT_CLASS;
+        return objectClass;
     }
 
     /**

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/javamodel/Helper.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/javamodel/Helper.java
@@ -26,12 +26,6 @@ import org.eclipse.persistence.internal.core.helper.CoreClassConstants;
 import javax.xml.bind.JAXBElement;
 
 import org.eclipse.persistence.internal.oxm.Constants;
-import org.eclipse.persistence.jaxb.javamodel.JavaAnnotation;
-import org.eclipse.persistence.jaxb.javamodel.JavaClass;
-import org.eclipse.persistence.jaxb.javamodel.JavaField;
-import org.eclipse.persistence.jaxb.javamodel.JavaHasAnnotations;
-import org.eclipse.persistence.jaxb.javamodel.JavaMethod;
-import org.eclipse.persistence.jaxb.javamodel.JavaModel;
 
 /**
  * INTERNAL:
@@ -99,12 +93,12 @@ public class Helper {
     protected final static String JAVAX_PKG = "javax.";
     protected final static String JAVAX_WS_PKG = "javax.xml.ws.";
 
-    private static JavaClass COLLECTION_CLASS;
-    private static JavaClass SET_CLASS;
-    private static JavaClass LIST_CLASS;
-    private static JavaClass MAP_CLASS;
-    public static JavaClass JAXBELEMENT_CLASS;
-    public static JavaClass OBJECT_CLASS;
+    private JavaClass collectionClass;
+    private JavaClass setClass;
+    private JavaClass listClass;
+    private JavaClass mapClass;
+    private JavaClass jaxbElementClass;
+    private JavaClass objectClass;
 
     /**
      * INTERNAL:
@@ -119,12 +113,12 @@ public class Helper {
         xmlToJavaTypeMap = buildXMLToJavaTypeMap();
         setJavaModel(model);
         setClassLoader(model.getClassLoader());
-        COLLECTION_CLASS = getJavaClass(CoreClassConstants.Collection_Class);
-        LIST_CLASS = getJavaClass(CoreClassConstants.List_Class);
-        SET_CLASS = getJavaClass(CoreClassConstants.Set_Class);
-        MAP_CLASS = getJavaClass(CoreClassConstants.Map_Class);
-        JAXBELEMENT_CLASS = getJavaClass(JAXBElement.class);
-        OBJECT_CLASS = getJavaClass(CoreClassConstants.OBJECT);
+        collectionClass = getJavaClass(CoreClassConstants.Collection_Class);
+        listClass = getJavaClass(CoreClassConstants.List_Class);
+        setClass = getJavaClass(CoreClassConstants.Set_Class);
+        mapClass = getJavaClass(CoreClassConstants.Map_Class);
+        jaxbElementClass = getJavaClass(JAXBElement.class);
+        objectClass = getJavaClass(CoreClassConstants.OBJECT);
     }
 
     /**
@@ -275,6 +269,28 @@ public class Helper {
             return jModel.getClass(type.getRawName());
         } catch (Exception x) {}
         return null;
+    }
+
+    /**
+     * Return a JavaClass instance based on the @see javax.xml.bind.JAXBElement .
+     *
+     * Replacement of direct access to JAXBELEMENT_CLASS field.
+     *
+     * @return
+     */
+    public JavaClass getJaxbElementClass() {
+        return jaxbElementClass;
+    }
+
+    /**
+     * Return a JavaClass instance based on the @see java.lang.Object .
+     *
+     * Replacement of direct access to OBJECT_CLASS field.
+     *
+     * @return
+     */
+    public JavaClass getObjectClass() {
+        return objectClass;
     }
 
     /**
@@ -430,16 +446,16 @@ public class Helper {
     }
 
     public boolean isCollectionType(JavaClass type) {
-     if (COLLECTION_CLASS.isAssignableFrom(type)
-             || LIST_CLASS.isAssignableFrom(type)
-             || SET_CLASS.isAssignableFrom(type)) {
+     if (collectionClass.isAssignableFrom(type)
+             || listClass.isAssignableFrom(type)
+             || setClass.isAssignableFrom(type)) {
              return true;
          }
          return false;
     }
 
     public boolean isMapType(JavaClass type) {
-        return MAP_CLASS.isAssignableFrom(type);
+        return mapClass.isAssignableFrom(type);
     }
 
     public boolean isFacets() {


### PR DESCRIPTION
Changes API in org.eclipse.persistence.jaxb.javamodel.Helper .
Change of static JavaClass variables/fileds into instance fields.
Change of scope of Helper.JAXBELEMENT_CLASS and Helper.OBJECT_CLASS to private.
Create accessor methods getJaxbElementClass(), getObjectClass().
See https://bugs.eclipse.org/bugs/show_bug.cgi?id=529270

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>