### PR TITLE
BUG534065 - ECLIPSE GETOBJECTFROMRESULTSET ON APPS.XMLTYPE DATA CAUSE…

### DIFF
--- a/foundation/org.eclipse.persistence.oracle/src/org/eclipse/persistence/platform/database/oracle/Oracle9Platform.java
+++ b/foundation/org.eclipse.persistence.oracle/src/org/eclipse/persistence/platform/database/oracle/Oracle9Platform.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.

--- a/foundation/org.eclipse.persistence.oracle/src/org/eclipse/persistence/platform/database/oracle/Oracle9Platform.java
+++ b/foundation/org.eclipse.persistence.oracle/src/org/eclipse/persistence/platform/database/oracle/Oracle9Platform.java
@@ -211,12 +211,8 @@ public class Oracle9Platform extends Oracle8Platform {
             SQLXML sqlXml = resultSet.getSQLXML(columnNumber);
             String str = sqlXml.getString();
             sqlXml.free();
-            if (str != null ) { 
-                // Oracle 12c appends a \n character to the xml string
-                return str.endsWith("\n") ? str.substring(0, str.length() - 1) : str;
-            } else {
-                return str;
-            }
+            // Oracle 12c appends a \n character to the xml string
+            return (str != null && str.endsWith("\n")) ? str.substring(0, str.length() - 1) : str;
         } else if (type == OracleTypes.OPAQUE) {
             try {
                 Object result = resultSet.getObject(columnNumber);

--- a/foundation/org.eclipse.persistence.oracle/src/org/eclipse/persistence/platform/database/oracle/Oracle9Platform.java
+++ b/foundation/org.eclipse.persistence.oracle/src/org/eclipse/persistence/platform/database/oracle/Oracle9Platform.java
@@ -211,8 +211,12 @@ public class Oracle9Platform extends Oracle8Platform {
             SQLXML sqlXml = resultSet.getSQLXML(columnNumber);
             String str = sqlXml.getString();
             sqlXml.free();
-            // Oracle 12c appends a \n character to the xml string
-            return str.endsWith("\n") ? str.substring(0, str.length() - 1) : str;
+            if (str != null ) { 
+                // Oracle 12c appends a \n character to the xml string
+                return str.endsWith("\n") ? str.substring(0, str.length() - 1) : str;
+            } else {
+                return str;
+            }
         } else if (type == OracleTypes.OPAQUE) {
             try {
                 Object result = resultSet.getObject(columnNumber);


### PR DESCRIPTION
Fixes #534065 ECLIPSE GETOBJECTFROMRESULTSET ON APPS.XMLTYPE DATA CAUSES NULLPOINTEREXCEPTION