### PR TITLE
Bug 535830: remove SDO from eclipselink.jar

### DIFF
--- a/antbuild.xml
+++ b/antbuild.xml
@@ -707,7 +707,7 @@
         <ant antfile="antbuild.xml" dir="${eclipselink.jpa.wdf.test}"   target="build-against-jar"/>
         <ant antfile="antbuild.xml" dir="${eclipselink.jpars.test}"     target="build"/>
         <ant antfile="antbuild.xml" dir="${eclipselink.moxy.test}"      target="compile-tests-against-jar"/>
-        <ant antfile="antbuild.xml" dir="${eclipselink.sdo.test}"       target="compile-sdo-tests-against-jar"/>
+        <ant antfile="antbuild.xml" dir="${eclipselink.sdo.test}"       target="compile-sdo-tests"/>
         <ant antfile="antbuild.xml" dir="${eclipselink.dbws.test}"      target="build"/>
     </target>
 
@@ -815,6 +815,7 @@
                 <exclude name="*jpars*.jar"/>
                 <exclude name="*nosql*.jar"/>
                 <exclude name="*extension*.jar"/>
+                <exclude name="*sdo*.jar"/>
             </zipgroupfileset>
             <!-- Include hermes runtime Only -->
             <fileset dir="${build.dir}/hermes/${classes.dir}">
@@ -1640,10 +1641,10 @@
     </target>
     <!-- Run SDO & MOXY tests. -->
     <target name="test-sdo" description="run the sdo tests">
-        <ant antfile="antbuild.xml" dir="${eclipselink.sdo.test}" target="test-against-jar"/>
+        <ant antfile="antbuild.xml" dir="${eclipselink.sdo.test}" target="test"/>
     </target>
     <target name="test-sdo-srg" description="run the sdo srg tests">
-        <ant antfile="antbuild.xml" dir="${eclipselink.sdo.test}" target="test-srg-against-jar"/>
+        <ant antfile="antbuild.xml" dir="${eclipselink.sdo.test}" target="test-srg"/>
     </target>
     <target name="test-moxy" description="run the moxy tests">
         <ant antfile="antbuild.xml" dir="${eclipselink.moxy.test}" target="test-against-jar"/>

--- a/sdo/eclipselink.sdo.test/antbuild.properties
+++ b/sdo/eclipselink.sdo.test/antbuild.properties
@@ -19,9 +19,6 @@ mail.jar=javax.mail_1.4.0.v201005080615.jar
 
 eclipselink.core.depend=javax.resource_1.6.0.v201204270900.jar,javax.ejb_3.1.0.v201205171433.jar,javax.jms_1.1.0.v200906010428.jar,javax.transaction.api_1.3.0.jar,javax.mail_1.4.0.v201005080615.jar
 
-sdo.classgen.run.path=../../../${eclipselink.jar}${path.separator}../classes${path.separator}../${eclipselink.sdo.plugins}/${commonj.sdo.jar}${path.separator}../${eclipselink.plugins}/${mail.jar}
-
-eclipselink.jar=eclipselink.jar
 eclipselink.sdo.base=..
 eclipselink.core=../org.eclipse.persistence.core
 eclipselink.plugins=../../plugins
@@ -37,7 +34,7 @@ classes.dir=classes
 resource.dir=resource
 report.dir=reports
 
-asm=org.eclipse.persistence.asm_6.1.1.v201804051226.jar
+asm.jar=org.eclipse.persistence.asm_6.1.1.v201804051226.jar
 
 xml.platform=org.eclipse.persistence.platform.xml.jaxp.JAXPPlatform
 parser=org.eclipse.persistence.platform.xml.jaxp.JAXPParser

--- a/sdo/eclipselink.sdo.test/antbuild.xml
+++ b/sdo/eclipselink.sdo.test/antbuild.xml
@@ -106,7 +106,7 @@
         <pathelement path="${resource.dir}"/>
         <pathelement path="${classes.dir}"/>
         <pathelement path="${jacocoagent.lib}"/>
-        <pathelement path="${sdotest.2.common.plugins.dir}/${asm}"/>
+        <pathelement path="${sdotest.2.common.plugins.dir}/${asm.jar}"/>
     </path>
 
     <!-- Set Compile/Run Paths using product OSGi bundles -->
@@ -119,30 +119,19 @@
         <path refid="sdotest.thirdparty.run.path"/>
     </path>
 
-    <!-- The following compile/run paths reference eclipselink.jar for non-test classes and resources -->
-    <path id="sdotest.compile.against.jar.path">
-        <pathelement path="${sdotest.2.base.dir}/${eclipselink.jar}"/>
-        <path refid="sdotest.thirdparty.compile.path"/>
-    </path>
-    <path id="sdotest.run.against.jar.path">
-        <path refid="sdotest.compile.against.jar.path"/>
-        <path refid="sdotest.thirdparty.run.path"/>
-    </path>
-
     <!-- Should be relative from the eclipselink.sdo.test/resource directory -->
     <path id="sdotest.classgen.run.path">
         <pathelement path="${jacocoagent.lib}"/>
-        <pathelement path="../${sdotest.2.common.plugins.dir}/org.eclipse.persistence.core_${version.string}.jar"/>
-        <pathelement path="../${sdotest.2.common.plugins.dir}/org.eclipse.persistence.sdo_${version.string}.jar"/>
-        <pathelement path="../${classes.dir}"/>
-        <pathelement path="../${sdotest.plugins.dir}/${commonj.sdo.jar}"/>
-        <pathelement path="../${sdotest.2.common.plugins.dir}/javax.mail_1.4.0.jar"/>
+        <pathelement path="${sdotest.2.common.plugins.dir}/org.eclipse.persistence.core_${version.string}.jar"/>
+        <pathelement path="${sdotest.2.common.plugins.dir}/org.eclipse.persistence.sdo_${version.string}.jar"/>
+        <pathelement path="${classes.dir}"/>
+        <pathelement path="${sdotest.plugins.dir}/${commonj.sdo.jar}"/>
+        <pathelement path="${sdotest.2.common.plugins.dir}/javax.mail_1.4.0.jar"/>
     </path>
 
     <available file="${sdotest.2.common.plugins.dir}/org.eclipse.persistence.core_${version.string}.jar" property="core.bundle.exist"/>
     <available file="${sdotest.2.common.plugins.dir}/org.eclipse.persistence.moxy_${version.string}.jar" property="moxy.bundle.exist"/>
     <available file="${sdotest.2.common.plugins.dir}/org.eclipse.persistence.sdo_${version.string}.jar" property="sdo.bundle.exist"/>
-    <available file="${sdotest.2.base.dir}/${eclipselink.jar}" property="eclipselink.jar.exist"/>
 
     <!-- Clean targets -->
     <target name="clean" description="clean the build">
@@ -153,10 +142,6 @@
     </target>
 
     <!-- Build targets -->
-    <target name="compile-sdo-tests-against-jar" depends="clean" description="build sdo test classes against eclipselink.jar">
-        <fail message="Cannot find EclipseLink: '${sdotest.2.base.dir}/${eclipselink.jar}'." unless="eclipselink.jar.exist"/>
-        <compile_sdo_tests compilepathref="sdotest.compile.against.jar.path"/>
-    </target>
     <target name="compile-sdo-tests" depends="clean" description="build sdo test classes">
         <fail message="Cannot find CORE: '${sdotest.2.common.plugins.dir}/org.eclipse.persistence.core_${version.string}.jar'." unless="core.bundle.exist"/>
         <fail message="Cannot find MOXY: '${sdotest.2.common.plugins.dir}/org.eclipse.persistence.moxy_${version.string}.jar'." unless="moxy.bundle.exist"/>
@@ -171,15 +156,9 @@
         <!--run_sdo_tests customcontext="false runpathref="${sdotest.run.path}"/-->
         <delete dir="${resource.dir}/${tmp.dir}"/>
     </target>
-    <target name="test-against-jar" depends="compile-sdo-tests-against-jar" description="run sdo tests against eclipselink.jar">
+    <target name="test-srg" depends="compile-sdo-tests" description="run sdo srg tests">
         <mkdir dir="${resource.dir}/${tmp.dir}"/>
-        <run_sdo_tests customcontext="true" runpathref="sdotest.run.against.jar.path"/>
-        <!--run_sdo_tests customcontext="false" runpathref="${sdotest.run.against.jar.path}"/-->
-        <delete dir="${resource.dir}/${tmp.dir}"/>
-    </target>
-    <target name="test-srg-against-jar" depends="compile-sdo-tests-against-jar" description="run sdo srg tests against eclipselink.jar">
-        <mkdir dir="${resource.dir}/${tmp.dir}"/>
-        <run_sdo_srg_tests customcontext="true" runpathref="sdotest.run.against.jar.path"/>
+        <run_sdo_srg_tests customcontext="true" runpathref="sdotest.run.path"/>
         <delete dir="${resource.dir}/${tmp.dir}"/>
     </target>
 
@@ -205,7 +184,7 @@
                 <sysproperty key="tempFileDir" value="${tmp.dir}"/>
                 <sysproperty key="ignoreCRLF" value="true"/>
                 <sysproperty key="useLogging" value="false"/>
-                <sysproperty key="sdo.classgen.compile.path" value="${sdo.classgen.run.path}"/>
+                <sysproperty key="sdo.classgen.compile.path" value="${toString:sdotest.classgen.run.path}"/>
                 <sysproperty key="useSAXParsing" value="true"/>
                 <sysproperty key="useDeploymentXML" value="false"/>
                 <sysproperty key="jaxb.test.contextpath" value="oracle.toplink.testing.ox.jaxb.sax"/>
@@ -264,7 +243,7 @@
                 <sysproperty key="tempFileDir" value="${tmp.dir}"/>
                 <sysproperty key="ignoreCRLF" value="true"/>
                 <sysproperty key="useLogging" value="false"/>
-                <sysproperty key="sdo.classgen.compile.path" value="${sdo.classgen.run.path}"/>
+                <sysproperty key="sdo.classgen.compile.path" value="${toString:sdotest.classgen.run.path}"/>
                 <sysproperty key="useSAXParsing" value="true"/>
                 <sysproperty key="useDeploymentXML" value="false"/>
                 <sysproperty key="jaxb.test.contextpath" value="oracle.toplink.testing.ox.jaxb.sax"/>


### PR DESCRIPTION
This removes SDO from 'eclipselink.jar' bundle. It's intended for master only.