### PR TITLE
Bug 529270 - MOXy may causes classloader leaks

### DIFF
--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/compiler/AnnotationsProcessor.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/compiler/AnnotationsProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2016 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -3817,12 +3817,12 @@ public final class AnnotationsProcessor {
                 if (JAVAX_XML_BIND_JAXBELEMENT.equals(type.getName())) {
                     Object[] actualTypeArguments = type.getActualTypeArguments().toArray();
                     if (actualTypeArguments.length == 0) {
-                        type = helper.OBJECT_CLASS;
+                        type = helper.getObjectClass();
                     } else {
                         type = (JavaClass) actualTypeArguments[0];
                     }
                     type = processXmlElementDecl(type, next, packageInfo, elemDecls);
-                }else if (helper.JAXBELEMENT_CLASS.isAssignableFrom(type)) {
+                }else if (helper.getJaxbElementClass().isAssignableFrom(type)) {
                     this.factoryMethods.put(type.getRawName(), next);
                     type = processXmlElementDecl(type, next, packageInfo, elemDecls);
                 } else {

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/javamodel/Helper.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/javamodel/Helper.java
@@ -26,12 +26,6 @@ import org.eclipse.persistence.internal.core.helper.CoreClassConstants;
 import javax.xml.bind.JAXBElement;
 
 import org.eclipse.persistence.internal.oxm.Constants;
-import org.eclipse.persistence.jaxb.javamodel.JavaAnnotation;
-import org.eclipse.persistence.jaxb.javamodel.JavaClass;
-import org.eclipse.persistence.jaxb.javamodel.JavaField;
-import org.eclipse.persistence.jaxb.javamodel.JavaHasAnnotations;
-import org.eclipse.persistence.jaxb.javamodel.JavaMethod;
-import org.eclipse.persistence.jaxb.javamodel.JavaModel;
 
 /**
  * INTERNAL:
@@ -99,12 +93,12 @@ public class Helper {
     protected final static String JAVAX_PKG = "javax.";
     protected final static String JAVAX_WS_PKG = "javax.xml.ws.";
 
-    private static JavaClass COLLECTION_CLASS;
-    private static JavaClass SET_CLASS;
-    private static JavaClass LIST_CLASS;
-    private static JavaClass MAP_CLASS;
-    public static JavaClass JAXBELEMENT_CLASS;
-    public static JavaClass OBJECT_CLASS;
+    private JavaClass collectionClass;
+    private JavaClass setClass;
+    private JavaClass listClass;
+    private JavaClass mapClass;
+    private JavaClass jaxbElementClass;
+    private JavaClass objectClass;
 
     /**
      * INTERNAL:
@@ -119,12 +113,12 @@ public class Helper {
         xmlToJavaTypeMap = buildXMLToJavaTypeMap();
         setJavaModel(model);
         setClassLoader(model.getClassLoader());
-        COLLECTION_CLASS = getJavaClass(CoreClassConstants.Collection_Class);
-        LIST_CLASS = getJavaClass(CoreClassConstants.List_Class);
-        SET_CLASS = getJavaClass(CoreClassConstants.Set_Class);
-        MAP_CLASS = getJavaClass(CoreClassConstants.Map_Class);
-        JAXBELEMENT_CLASS = getJavaClass(JAXBElement.class);
-        OBJECT_CLASS = getJavaClass(CoreClassConstants.OBJECT);
+        collectionClass = getJavaClass(CoreClassConstants.Collection_Class);
+        listClass = getJavaClass(CoreClassConstants.List_Class);
+        setClass = getJavaClass(CoreClassConstants.Set_Class);
+        mapClass = getJavaClass(CoreClassConstants.Map_Class);
+        jaxbElementClass = getJavaClass(JAXBElement.class);
+        objectClass = getJavaClass(CoreClassConstants.OBJECT);
     }
 
     /**
@@ -275,6 +269,28 @@ public class Helper {
             return jModel.getClass(type.getRawName());
         } catch (Exception x) {}
         return null;
+    }
+
+    /**
+     * Return a JavaClass instance based on the @see javax.xml.bind.JAXBElement .
+     *
+     * Replacement of direct access to JAXBELEMENT_CLASS field.
+     *
+     * @return
+     */
+    public JavaClass getJaxbElementClass() {
+        return jaxbElementClass;
+    }
+
+    /**
+     * Return a JavaClass instance based on the @see java.lang.Object .
+     *
+     * Replacement of direct access to OBJECT_CLASS field.
+     *
+     * @return
+     */
+    public JavaClass getObjectClass() {
+        return objectClass;
     }
 
     /**
@@ -430,16 +446,16 @@ public class Helper {
     }
 
     public boolean isCollectionType(JavaClass type) {
-     if (COLLECTION_CLASS.isAssignableFrom(type)
-             || LIST_CLASS.isAssignableFrom(type)
-             || SET_CLASS.isAssignableFrom(type)) {
+     if (collectionClass.isAssignableFrom(type)
+             || listClass.isAssignableFrom(type)
+             || setClass.isAssignableFrom(type)) {
              return true;
          }
          return false;
     }
 
     public boolean isMapType(JavaClass type) {
-        return MAP_CLASS.isAssignableFrom(type);
+        return mapClass.isAssignableFrom(type);
     }
 
     public boolean isFacets() {


### PR DESCRIPTION
Bug 529270 - MOXy may causes classloader leaks

Changes API in org.eclipse.persistence.jaxb.javamodel.Helper .
Change of static JavaClass variables/fileds into instance fields.
Change of scope of Helper.JAXBELEMENT_CLASS and Helper.OBJECT_CLASS to private.
Create accessor methods getJaxbElementClass(), getObjectClass().
See https://bugs.eclipse.org/bugs/show_bug.cgi?id=529270

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>

(cherry picked from commit d42ca65)
Signed-off-by: Radek Felcman <radek.felcman@oracle.com>