### PR TITLE
Bug 520295 - XBeanVal extension generates unnecesary @NotNull annotation

### DIFF
--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/beanvalidation/sgen_xjc/rich_schema.xsd
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/beanvalidation/sgen_xjc/rich_schema.xsd
@@ -13,6 +13,7 @@
             <xsd:element nillable="true" name="unsignedByte" type="rs:unsignedByte"/>
             <xsd:element nillable="false" name="byteArray" type="rs:byteArray"/>
             <xsd:element name="someCollection" minOccurs="1" maxOccurs="unbounded"/>
+            <xsd:element name="optionalElement" minOccurs="0" maxOccurs="unbounded"/>
         </xsd:sequence>
     </xsd:complexType>
 

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/beanvalidation/BeanValidationBindingsTestCase.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/beanvalidation/BeanValidationBindingsTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2016 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -234,6 +234,12 @@ public class BeanValidationBindingsTestCase extends junit.framework.TestCase {
         assertTrue(size.min() == 1);
         assertNotNull(someCollection.getAnnotation(Valid.class));
         assertNotNull(someCollection.getAnnotation(NotNull.class));
+
+        Field optionalElement = Main.getDeclaredField("optionalElement");
+        size = optionalElement.getAnnotation(Size.class);
+        assertTrue(size.min() == 0);
+        assertNotNull(optionalElement.getAnnotation(Valid.class));
+        assertNull(optionalElement.getAnnotation(NotNull.class));
 
         /* Numbers.class */
         Field minInclusive = Numbers.getDeclaredField("minInclusive");

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/plugins/BeanValidationPlugin.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/plugins/BeanValidationPlugin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -328,19 +328,20 @@ public class BeanValidationPlugin extends Plugin {
 
         XSTerm term = particle.getTerm();
         if (term instanceof XSElementDecl) {
-            processTermElement(fieldVar, (XSElementDecl) term, customizations);
+            processTermElement(particle, fieldVar, (XSElementDecl) term, customizations);
         // When a complex type resides inside another complex type and thus gets lazily loaded or processed.
         } else if (term instanceof DelayedRef.Element) { 
-            processTermElement(fieldVar, ((DelayedRef.Element) term).get(), customizations);
+            processTermElement(particle, fieldVar, ((DelayedRef.Element) term).get(), customizations);
         }
     }
 
-    private void processTermElement(JFieldVar fieldVar, XSElementDecl element, List<FacetCustomization> customizations) {
+    private void processTermElement(XSParticle particle, JFieldVar fieldVar, XSElementDecl element, List<FacetCustomization> customizations) {
+        final int minOccurs = getOccursValue("minOccurs", particle);
         XSType elementType = element.getType();
 
         if (elementType.isComplexType()) {
             validAnnotate(fieldVar);
-            if (!element.isNillable()) {
+            if (!element.isNillable() && minOccurs > 0) {
                 notNullAnnotate(fieldVar);
             }
             if (elementType.getBaseType().isSimpleType()) {


### PR DESCRIPTION
Bug 520295 - XBeanVal extension generates unnecesary @NotNull annotation

XJC XBeanVal extension generates unnecesary @NotNull annotations.
This patch extends condition with minOccurs attribute test.
See https://bugs.eclipse.org/bugs/show_bug.cgi?id=520295