### PR TITLE
Fix classpaths for jpa tests

### DIFF
--- a/jpa/eclipselink.jpa.test/antbuild.xml
+++ b/jpa/eclipselink.jpa.test/antbuild.xml
@@ -468,7 +468,8 @@
             <pathelement path="${jpatest.basedir}/${eclipselink.xml.composite.advanced.model.member_3}.jar"/>
             <pathelement path="${jpatest.basedir}/${eclipselink.xml.mapping.metadata.complete}.jar"/>
             <pathelement path="${jpatest.basedir}/${eclipselink.xml.merge.model}.jar"/>
-            <pathelement path="${jpatest.2.common.plugins.dir}/${json.jar}"/>
+            <pathelement path="${jpatest.2.common.plugins.dir}/${json-api.jar}"/>
+            <pathelement path="${jpatest.2.common.plugins.dir}/${json-impl.jar}"/>
         </path>
         <path id="lrg20.path">
             <path refid="jpa20.run.common.path"/>
@@ -519,7 +520,8 @@
             <pathelement path="${jpatest.basedir}/${eclipselink.cascade.deletes}.jar"/>
             <pathelement path="${jpatest.basedir}/${eclipselink.xml.mapping.metadata.complete}.jar"/>
             <pathelement path="${jpatest.basedir}/${eclipselink.xml.merge.model}.jar"/>
-            <pathelement path="${jpatest.2.common.plugins.dir}/${json.jar}"/>
+            <pathelement path="${jpatest.2.common.plugins.dir}/${json-api.jar}"/>
+            <pathelement path="${jpatest.2.common.plugins.dir}/${json-impl.jar}"/>
         </path>
 
         <path id="run.classpath">
@@ -566,7 +568,8 @@
             <pathelement path="${jpatest.basedir}/${eclipselink.xml.extended.composite.advanced.model.member_1}.jar"/>
             <pathelement path="${jpatest.basedir}/${eclipselink.xml.extended.composite.advanced.model.member_2}.jar"/>
             <pathelement path="${jpatest.basedir}/${eclipselink.xml.extended.composite.advanced.model.member_3}.jar"/>
-            <pathelement path="${jpatest.2.common.plugins.dir}/${json.jar}"/>
+            <pathelement path="${jpatest.2.common.plugins.dir}/${json-api.jar}"/>
+            <pathelement path="${jpatest.2.common.plugins.dir}/${json-impl.jar}"/>
         </path>
         <path id="run.identity.classpath">
             <pathelement path="${jpatest.basedir}/${classes22.dir}"/>
@@ -589,7 +592,8 @@
             <pathelement path="${jpatest.basedir}/${jpa.test.jar}"/>
             <pathelement path="${jpatest.basedir}/${jpa.performance}.jar"/>
             <pathelement path="${jpatest.basedir}/${jpa.performance2}.jar"/>
-            <pathelement path="${jpatest.2.common.plugins.dir}/${json.jar}"/>
+            <pathelement path="${jpatest.2.common.plugins.dir}/${json-api.jar}"/>
+            <pathelement path="${jpatest.2.common.plugins.dir}/${json-impl.jar}"/>
         </path>
          <path id="run.oracle.classpath">
             <path refid="run.classpath"/>


### PR DESCRIPTION
jpa tests in 3.0 nightly are failing with:
```
java.lang.NoClassDefFoundError: javax/json/JsonException
at org.eclipse.persistence.internal.oxm.record.SAXUnmarshaller.getNewXMLReader(SAXUnmarshaller.java:209)
...
```

this is to fix that