### PR TITLE
Bug 535250 - Recursive annotations triggers a StackOverflowError

### DIFF
--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa22/metadata/MetadataASMFactoryTest.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa22/metadata/MetadataASMFactoryTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -8,7 +8,9 @@
  * http://www.eclipse.org/org/documents/edl-v10.php.
  *
  * Contributors:
- *              ljungmann - initial implementation
+ *     ljungmann - initial implementation
+ *     06/206/2018-2.7.2 Tomas Kraus
+ *       - 535250: Test meta-annotations with dependency cycle
  ******************************************************************************/
 package org.eclipse.persistence.testing.tests.jpa22.metadata;
 

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa22/metadata/MetadataASMFactoryTest.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa22/metadata/MetadataASMFactoryTest.java
@@ -12,15 +12,19 @@
  ******************************************************************************/
 package org.eclipse.persistence.testing.tests.jpa22.metadata;
 
-import junit.framework.Test;
-import junit.framework.TestSuite;
 import org.eclipse.persistence.internal.jpa.deployment.PersistenceUnitProcessor;
 import org.eclipse.persistence.internal.jpa.metadata.MetadataLogger;
 import org.eclipse.persistence.internal.jpa.metadata.accessors.objects.MetadataAnnotation;
 import org.eclipse.persistence.internal.jpa.metadata.accessors.objects.MetadataAsmFactory;
 import org.eclipse.persistence.internal.jpa.metadata.accessors.objects.MetadataClass;
 import org.eclipse.persistence.testing.framework.junit.JUnitTestCase;
+import org.eclipse.samples.annotations.CycleA;
+import org.eclipse.samples.annotations.CycleB;
+import org.eclipse.samples.annotations.CycleSelf;
 import org.junit.Assert;
+
+import junit.framework.Test;
+import junit.framework.TestSuite;
 
 public class MetadataASMFactoryTest extends JUnitTestCase {
     
@@ -35,6 +39,8 @@ public class MetadataASMFactoryTest extends JUnitTestCase {
         TestSuite suite = new TestSuite();
         suite.setName("MetadataASMFactoryTest");
         suite.addTest(new MetadataASMFactoryTest("testMetadataAnnotations"));
+        suite.addTest(new MetadataASMFactoryTest("testAnnotationsWithCycle"));
+        suite.addTest(new MetadataASMFactoryTest("testAnnotationsWithPrimitiveCycle"));
         return suite;
     }
 
@@ -48,6 +54,34 @@ public class MetadataASMFactoryTest extends JUnitTestCase {
 
         annotation = metadataClass.getAnnotation("javax.persistence.EntityListeners");
         Assert.assertNotNull(annotation);
+    }
+
+    /**
+     * Check meta-annotations graph with cycle A -> B -> C -> A
+     */
+    public void testAnnotationsWithCycle() {
+        try {
+            MetadataAsmFactory fact = new MetadataAsmFactory(new MetadataLogger(null), MetadataASMFactoryTest.class.getClassLoader());
+            MetadataClass metadataClass = fact.getMetadataClass(CycleA.class.getName());
+            MetadataAnnotation annotation = metadataClass.getAnnotation("org.eclipse.samples.annotations.CycleC");
+            metadataClass = fact.getMetadataClass(CycleB.class.getName());
+            annotation = metadataClass.getAnnotation("org.eclipse.samples.annotations.CycleA");
+        } catch (StackOverflowError e) {
+            fail("Stack overflow while processing cycle in meta-annotations");
+        }
+    }
+
+    /**
+     * Check meta-annotations graph with primitive cycle Self -> Self
+     */
+    public void testAnnotationsWithPrimitiveCycle() {
+        try {
+            MetadataAsmFactory fact = new MetadataAsmFactory(new MetadataLogger(null), MetadataASMFactoryTest.class.getClassLoader());
+            MetadataClass metadataClass = fact.getMetadataClass(CycleSelf.class.getName());
+            MetadataAnnotation annotation = metadataClass.getAnnotation("org.eclipse.samples.annotations.CycleSelf");
+        } catch (StackOverflowError e) {
+            fail("Stack overflow while processing cycle in meta-annotations");
+        }
     }
 
 }

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/samples/annotations/CycleA.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/samples/annotations/CycleA.java
@@ -1,3 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     06/206/2018-2.7.2 Tomas Kraus
+ *       - 535250: Test meta-annotations with dependency cycle
+ ******************************************************************************/
 package org.eclipse.samples.annotations;
 
 @CycleB

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/samples/annotations/CycleA.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/samples/annotations/CycleA.java
@@ -1,0 +1,5 @@
+package org.eclipse.samples.annotations;
+
+@CycleB
+public @interface CycleA {
+}

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/samples/annotations/CycleB.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/samples/annotations/CycleB.java
@@ -1,3 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     06/206/2018-2.7.2 Tomas Kraus
+ *       - 535250: Test meta-annotations with dependency cycle
+ ******************************************************************************/
 package org.eclipse.samples.annotations;
 
 @CycleC

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/samples/annotations/CycleB.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/samples/annotations/CycleB.java
@@ -1,0 +1,5 @@
+package org.eclipse.samples.annotations;
+
+@CycleC
+public @interface CycleB {
+}

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/samples/annotations/CycleC.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/samples/annotations/CycleC.java
@@ -1,0 +1,5 @@
+package org.eclipse.samples.annotations;
+
+@CycleA
+public @interface CycleC {
+}

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/samples/annotations/CycleC.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/samples/annotations/CycleC.java
@@ -1,3 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     06/206/2018-2.7.2 Tomas Kraus
+ *       - 535250: Test meta-annotations with dependency cycle
+ ******************************************************************************/
 package org.eclipse.samples.annotations;
 
 @CycleA

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/samples/annotations/CycleSelf.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/samples/annotations/CycleSelf.java
@@ -1,0 +1,5 @@
+package org.eclipse.samples.annotations;
+
+@CycleSelf
+public @interface CycleSelf {
+}

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/samples/annotations/CycleSelf.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/samples/annotations/CycleSelf.java
@@ -1,3 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     06/206/2018-2.7.2 Tomas Kraus
+ *       - 535250: Test meta-annotations with dependency cycle
+ ******************************************************************************/
 package org.eclipse.samples.annotations;
 
 @CycleSelf

--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/metadata/accessors/objects/MetadataAnnotatedElement.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/metadata/accessors/objects/MetadataAnnotatedElement.java
@@ -66,8 +66,10 @@ import static org.eclipse.persistence.internal.jpa.metadata.MetadataConstants.JP
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.persistence.annotations.Array;
 import org.eclipse.persistence.annotations.BasicCollection;
@@ -137,7 +139,7 @@ public class MetadataAnnotatedElement extends MetadataAccessibleObject {
     private Map<String, MetadataAnnotation> m_annotations;
 
     /** Stores any meta-annotations defined for the element, keyed by meta-annotation name. */
-    private Map<String, MetadataAnnotation> m_metaAnnotations;
+    private final Map<String, MetadataAnnotation> m_metaAnnotations;
 
     /**
      * INTERNAL:
@@ -202,17 +204,32 @@ public class MetadataAnnotatedElement extends MetadataAccessibleObject {
     /**
      * INTERNAL:
      * Return the annotated element for this accessor. Note: This method does
-     * not check against a metadata complete.
+     * not check against a meta-data complete.
+     * @param annotation annotation name
      */
-    public MetadataAnnotation getAnnotation(String annotation) {
+    public MetadataAnnotation getAnnotation(final String annotation) {
+        return getAnnotation(annotation, new HashSet<>());
+    }
+
+    /**
+     * INTERNAL:
+     * Return the annotated element for this accessor. Note: This method does
+     * not check against a meta-data complete.
+     * @param annotation annotation name
+     * @param names meta-annotations names cycle detection set, shall not be {@code null}
+     */
+    protected final MetadataAnnotation getAnnotation(final String annotation, final Set<String> names) {
         if (m_annotations == null && m_metaAnnotations == null) {
             return null;
         }
-
         MetadataAnnotation metadataAnnotation = m_annotations.get(annotation);
         if (metadataAnnotation == null) {
             for (MetadataAnnotation a: m_metaAnnotations.values()) {
-                MetadataAnnotation ma = m_factory.getMetadataClass(a.getName()).getAnnotation(annotation);
+                if (names.contains(a.getName()) && annotation.equals(a.getName())) {
+                    return a;
+                }
+                names.add(getName());
+                MetadataAnnotation ma = m_factory.getMetadataClass(a.getName()).getAnnotation(annotation, names);
                 if (ma != null) {
                     return ma;
                 }
@@ -239,8 +256,10 @@ public class MetadataAnnotatedElement extends MetadataAccessibleObject {
     /**
      * INTERNAL:
      * Return the annotations of this accessible object.
+     * @return annotations defined for the element, keyed by annotation name.
+     *         Never returns {@code null}.
      */
-    public Map<String, MetadataAnnotation> getAnnotations(){
+    public Map<String, MetadataAnnotation> getAnnotations() {
         return m_annotations;
     }
 

--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/metadata/accessors/objects/MetadataAnnotatedElement.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/metadata/accessors/objects/MetadataAnnotatedElement.java
@@ -225,8 +225,12 @@ public class MetadataAnnotatedElement extends MetadataAccessibleObject {
         MetadataAnnotation metadataAnnotation = m_annotations.get(annotation);
         if (metadataAnnotation == null) {
             for (MetadataAnnotation a: m_metaAnnotations.values()) {
-                if (names.contains(a.getName()) && annotation.equals(a.getName())) {
-                    return a;
+                if (names.contains(a.getName())) {
+                    if (annotation.equals(a.getName())) {
+                        return a;
+                    } else {
+                        continue;
+                    }
                 }
                 names.add(getName());
                 MetadataAnnotation ma = m_factory.getMetadataClass(a.getName()).getAnnotation(annotation, names);

--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/metadata/accessors/objects/MetadataAnnotatedElement.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/metadata/accessors/objects/MetadataAnnotatedElement.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2016 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.

--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/metadata/accessors/objects/MetadataAsmFactory.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/metadata/accessors/objects/MetadataAsmFactory.java
@@ -285,6 +285,10 @@ public class MetadataAsmFactory extends MetadataFactory {
         @Override
         public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
             boolean isJPA = false;
+            if (desc.startsWith("Lkotlin")) {
+                //ignore kotlin annotations
+                return null;
+            }
             if (desc.startsWith("Ljava")) {
                 char c = desc.charAt(5);
                 //ignore annotations from 'java' namespace


### PR DESCRIPTION
Replaces PR 133.
Contains getAnnotation part of the fix and jUnit to verify self referencing meta-annotation and cycle of 3 annotations (A->B->C->A).