### PR TITLE
[master][no bug]: fix InvalidPathException: Illegal char exception during ant…

### DIFF
--- a/antbuild.xml
+++ b/antbuild.xml
@@ -474,7 +474,9 @@
         <!-- ant antfile="antbuild.xml" dir="${eclipselink.util.rename}"            target="clean"/ -->
         <ant antfile="antbuild.xml" dir="${eclipselink.util.sigcompare}"        target="clean"/>
         <ant antfile="build.xml"    dir="${eclipselink.util.workbench}"         target="clean"/>
-        <delete file="*${eclipselink.zip.suffix}" failonerror="false"/>
+        <delete failonerror="false">
+            <fileset dir="." includes="*${eclipselink.zip.suffix}"/>
+        </delete>
     </target>
     <target name="clean-core" depends="check-maven" description="Clean the maven built runtime projects">
         <java dir="${eclipselink.mvn.parent}" fork="true" failonerror="true" classname="org.codehaus.plexus.classworlds.launcher.Launcher">


### PR DESCRIPTION
Running "ant -f antbuild.xml clean" fails with the following exception:

BUILD FAILED
...\eclipselink.runtime\antbuild.xml:477: java.nio.file.InvalidPathException: Illegal char <*> at index 43: ...\eclipselink.runtime\*.zip
        at sun.nio.fs.WindowsPathParser.normalize(WindowsPathParser.java:194)
        at sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:165)
        at sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:89)

It doesn't say that you can use wildcards in the file attribute of the [delete task](https://ant.apache.org/manual/Tasks/delete.html)

Signed-off-by: Will Dazey <dazeydev.3@gmail.com>