### PR TITLE
[2.7] [nobug]: dbws builder tests are failing on some JDKs

### DIFF
--- a/utils/eclipselink.dbws.builder.test/src/dbws/testing/secondarysql/SecondarySQLTestSuite.java
+++ b/utils/eclipselink.dbws.builder.test/src/dbws/testing/secondarysql/SecondarySQLTestSuite.java
@@ -21,6 +21,7 @@ import java.io.StringReader;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -499,17 +500,22 @@ public class SecondarySQLTestSuite extends ProviderHelper implements Provider<SO
              DOMResult result = new DOMResult();
              transformer.transform(src, result);
              Document resultDoc = (Document)result.getNode();
-             Document controlDoc = xmlParser.parse(new StringReader(COUNT_RESPONSE_MSG));
-             assertTrue("control document not same as instance document",
-                 comparer.isNodeEqual(controlDoc, resultDoc));
+             Document controlDoc = xmlParser.parse(new StringReader(MessageFormat.format(COUNT_RESPONSE_MSG, NS_STRING, "")));
+             boolean docsEqual = comparer.isNodeEqual(controlDoc, resultDoc);
+             if (!docsEqual) {
+                 // different JDKs put xmlns declaration to different element, so retry
+                 controlDoc = xmlParser.parse(new StringReader(MessageFormat.format(COUNT_RESPONSE_MSG, "", NS_STRING)));
+                 assertTrue("control document not same as instance document",
+                         comparer.isNodeEqual(controlDoc, resultDoc));
+             }
          }
      }
+     private static final String NS_STRING = " xmlns=\"" + SECONDARY_NAMESPACE + "\" xmlns:srvc=\"" + SECONDARY_SERVICE_NAMESPACE + "\"";
      static final String COUNT_RESPONSE_MSG =
          "<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" +
          "<SOAP-ENV:Header/>" +
-         "<SOAP-ENV:Body xmlns=\"" + SECONDARY_NAMESPACE +
-                  "\" xmlns:srvc=\"" + SECONDARY_SERVICE_NAMESPACE + "\">" +
-           "<srvc:countSecondaryResponse>" +
+         "<SOAP-ENV:Body{0}>" +
+           "<srvc:countSecondaryResponse{1}>" +
              "<srvc:result>" +
                "<secondaryAggregate>" +
                  "<count>14</count>" +
@@ -552,17 +558,21 @@ public class SecondarySQLTestSuite extends ProviderHelper implements Provider<SO
              DOMResult result = new DOMResult();
              transformer.transform(src, result);
              Document resultDoc = (Document)result.getNode();
-             Document controlDoc = xmlParser.parse(new StringReader(ALL_RESPONSE_MSG));
-             assertTrue("control document not same as instance document",
-                 comparer.isNodeEqual(controlDoc, resultDoc));
+             Document controlDoc = xmlParser.parse(new StringReader(MessageFormat.format(ALL_RESPONSE_MSG, NS_STRING, "")));
+             boolean docsEqual = comparer.isNodeEqual(controlDoc, resultDoc);
+             if (!docsEqual) {
+                 // different JDKs put xmlns declaration to different element, so retry
+                 controlDoc = xmlParser.parse(new StringReader(MessageFormat.format(ALL_RESPONSE_MSG, "", NS_STRING)));
+                 assertTrue("control document not same as instance document",
+                         comparer.isNodeEqual(controlDoc, resultDoc));
+             }
          }
      }
      static final String ALL_RESPONSE_MSG =
        "<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" +
          "<SOAP-ENV:Header/>" +
-         "<SOAP-ENV:Body xmlns=\"" + SECONDARY_NAMESPACE +
-                 "\" xmlns:srvc=\"" + SECONDARY_SERVICE_NAMESPACE + "\">" +
-           "<srvc:allSecondaryResponse>" +
+         "<SOAP-ENV:Body{0}>" +
+           "<srvc:allSecondaryResponse{1}>" +
              "<srvc:result>" +
                 "<secondaryType>" +
                   "<empno>7369</empno>" +

--- a/utils/eclipselink.dbws.builder.test/src/dbws/testing/sqlascollection/SQLAsCollectionTestSuite.java
+++ b/utils/eclipselink.dbws.builder.test/src/dbws/testing/sqlascollection/SQLAsCollectionTestSuite.java
@@ -21,6 +21,7 @@ import java.io.StringReader;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -66,7 +67,8 @@ import static javax.xml.ws.soap.SOAPBinding.SOAP11HTTP_BINDING;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import static org.junit.Assert.assertTrue;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 //EclipseLink imports
@@ -395,9 +397,16 @@ public class SQLAsCollectionTestSuite extends ProviderHelper implements Provider
             getTransformer().transform(src, result);
             Document resultDoc = (Document)result.getNode();
             String resultString = documentToString(resultDoc);
-            Document controlDoc = xmlParser.parse(new StringReader(GETDATA_RESPONSE));
+            Document controlDoc = xmlParser.parse(new StringReader(MessageFormat.format(GETDATA_RESPONSE, NS_STRING, "")));
             String controlString = documentToString(controlDoc);
-            assertTrue("Control document not same as instance document.\n Expected:\n" + controlString + "\nActual:\n" + resultString, controlString.equals(resultString));
+            boolean docsEqual = controlString.equals(resultString);
+            if (!docsEqual) {
+                // different JDKs put xmlns declaration to different element, so retry
+                controlDoc = xmlParser.parse(new StringReader(MessageFormat.format(GETDATA_RESPONSE, "", NS_STRING)));
+                controlString = documentToString(controlDoc);
+                assertEquals("Control document not same as instance document.\n Expected:\n" + controlString + "\nActual:\n" + resultString,
+                        controlString, resultString);
+            }
         }
     }
 
@@ -427,12 +436,13 @@ public class SQLAsCollectionTestSuite extends ProviderHelper implements Provider
               "<build-statement><![CDATA[select * from sqlascollection where 0=1]]></build-statement>" +
           "</sql>" +
         "</dbws-builder>";
+    private static final String NS_STRING = " xmlns=\"" + SQLCOLLECTION_NAMESPACE + "\" xmlns:srvc=\"" + SQLCOLLECTION_SERVICE_NAMESPACE + "\"";
     static final String GETDATA_RESPONSE =
         "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" +
         "<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" +
             "<SOAP-ENV:Header/>" +
-            "<SOAP-ENV:Body xmlns=\"" + SQLCOLLECTION_NAMESPACE + "\" xmlns:srvc=\"" + SQLCOLLECTION_SERVICE_NAMESPACE + "\">" +
-                "<srvc:"+SQLCOLLECTION_SERVICE+"Response>" +
+            "<SOAP-ENV:Body{0}>" +
+                "<srvc:"+SQLCOLLECTION_SERVICE+"Response{1}>" +
                     "<srvc:result>" +
                         "<sRecord>" +
                             "<id>1</id>" +


### PR DESCRIPTION
Backport of #157 to 2.7

tests in dbws.testing.secondarysql.SecondarySQLTestSuite and dbws.testing.sqlascollection.SQLAsCollectionTestSuite are failing on some JDKs due to different location of xmlns declaration. This is to avoid false alarm by adding second check to tests.

Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>