### PR TITLE
Bug 433822 - JSON_REDUCE_ANY_ARRAYS Marshaller property is not taken into account

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLBinaryDataCollectionMappingNodeValue.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLBinaryDataCollectionMappingNodeValue.java
@@ -101,13 +101,17 @@ public class XMLBinaryDataCollectionMappingNodeValue extends MappingNodeValue im
 
         XPathFragment groupingFragment = marshalRecord.openStartGroupingElements(namespaceResolver);
         marshalRecord.closeStartGroupingElements(groupingFragment);
-
-        marshalRecord.startCollection();
+        int valueSize = cp.sizeFor(collection);
+        if(marshalRecord.getMarshaller().isApplicationJSON() && (valueSize > 1 || !marshalRecord.getMarshaller().isReduceAnyArrays())) {
+            marshalRecord.startCollection();
+        }
         while (cp.hasNext(iterator)) {
             Object objectValue = cp.next(iterator, session);
           marshalSingleValue(xPathFragment, marshalRecord, object, objectValue, session, namespaceResolver, ObjectMarshalContext.getInstance());
         }
+        if(marshalRecord.getMarshaller().isApplicationJSON() && (valueSize > 1 || !marshalRecord.getMarshaller().isReduceAnyArrays())) {
             marshalRecord.endCollection();
+        }
         return true;
     }
 

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLChoiceCollectionMappingMarshalNodeValue.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLChoiceCollectionMappingMarshalNodeValue.java
@@ -235,12 +235,16 @@ public class XMLChoiceCollectionMappingMarshalNodeValue extends MappingNodeValue
                 }
                 if(frag != null || associatedNodeValue.isAnyMappingNodeValue()){
                     int valueSize = listValue.size();
-                    marshalRecord.startCollection();
+                    if(valueSize > 1 || !marshalRecord.getMarshaller().isReduceAnyArrays()) {
+                        marshalRecord.startCollection();
+                    }
 
                     for(int j=0;j<valueSize; j++){
                         marshalSingleValueWithNodeValue(frag, marshalRecord, object, listValue.get(j), session, namespaceResolver, ObjectMarshalContext.getInstance(), associatedNodeValue);
                     }
-                    marshalRecord.endCollection();
+                    if(valueSize > 1 || !marshalRecord.getMarshaller().isReduceAnyArrays()) {
+                        marshalRecord.endCollection();
+                    }
                 }
             }
         }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLCompositeCollectionMappingNodeValue.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLCompositeCollectionMappingNodeValue.java
@@ -96,12 +96,17 @@ public class XMLCompositeCollectionMappingNodeValue extends XMLRelationshipMappi
         if (null != iterator && cp.hasNext(iterator)) {
             XPathFragment groupingFragment = marshalRecord.openStartGroupingElements(namespaceResolver);
             marshalRecord.closeStartGroupingElements(groupingFragment);
-            marshalRecord.startCollection();
+            int valueSize = cp.sizeFor(collection);
+            if(marshalRecord.getMarshaller().isApplicationJSON() && (valueSize > 1 || !marshalRecord.getMarshaller().isReduceAnyArrays())) {
+                marshalRecord.startCollection();
+            }
             do {
                 Object objectValue = cp.next(iterator, session);
                 marshalSingleValue(xPathFragment, marshalRecord, object, objectValue, session, namespaceResolver, ObjectMarshalContext.getInstance());
             } while (cp.hasNext(iterator));
-            marshalRecord.endCollection();
+            if(marshalRecord.getMarshaller().isApplicationJSON() && (valueSize > 1 || !marshalRecord.getMarshaller().isReduceAnyArrays())) {
+                marshalRecord.endCollection();
+            }
             return true;
         }
         return marshalRecord.emptyCollection(xPathFragment, namespaceResolver, xmlCompositeCollectionMapping.getWrapperNullPolicy() != null);

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLCompositeDirectCollectionMappingNodeValue.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLCompositeDirectCollectionMappingNodeValue.java
@@ -132,13 +132,18 @@ public class XMLCompositeDirectCollectionMappingNodeValue extends MappingNodeVal
                 }
             }
         } else {
-            marshalRecord.startCollection();
+            int valueSize = cp.sizeFor(collection);
+            if(marshalRecord.getMarshaller().isApplicationJSON() && (valueSize > 1 || !marshalRecord.getMarshaller().isReduceAnyArrays())) {
+                marshalRecord.startCollection();
+            }
 
             while (cp.hasNext(iterator)) {
                 objectValue = cp.next(iterator, session);
                 marshalSingleValue(xPathFragment, marshalRecord, object, objectValue, session, namespaceResolver, ObjectMarshalContext.getInstance());
             }
-            marshalRecord.endCollection();
+            if(marshalRecord.getMarshaller().isApplicationJSON() && (valueSize > 1 || !marshalRecord.getMarshaller().isReduceAnyArrays())) {
+                marshalRecord.endCollection();
+            }
         }
         return true;
     }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLMarshaller.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLMarshaller.java
@@ -1125,7 +1125,10 @@ public abstract class XMLMarshaller<
         }else{
             Class objectClass = object.getClass();
             if(object instanceof Collection) {
-                marshalRecord.startCollection();
+                int valueSize = ((Collection)object).size();
+                if(marshalRecord.getMarshaller().isApplicationJSON() && (valueSize > 1 || !marshalRecord.getMarshaller().isReduceAnyArrays())) {
+                    marshalRecord.startCollection();
+                }
                 String valueWrapper;
                 for(Object o : (Collection) object) {
                     if (o == null) {
@@ -1151,16 +1154,22 @@ public abstract class XMLMarshaller<
                         }
                     }
                 }
-                marshalRecord.endCollection();
+                if(marshalRecord.getMarshaller().isApplicationJSON() && (valueSize > 1 || !marshalRecord.getMarshaller().isReduceAnyArrays())) {
+                    marshalRecord.endCollection();
+                }
                 marshalRecord.flush();
                 return;
             } else if(objectClass.isArray()) {
-                marshalRecord.startCollection();
                 int arrayLength = Array.getLength(object);
+                if(marshalRecord.getMarshaller().isApplicationJSON() && (arrayLength > 1 || !marshalRecord.getMarshaller().isReduceAnyArrays())) {
+                    marshalRecord.startCollection();
+                }
                 for(int x=0; x<arrayLength; x++) {
                     marshal(Array.get(object, x), marshalRecord);
                 }
-                marshalRecord.endCollection();
+                if(marshalRecord.getMarshaller().isApplicationJSON() && (arrayLength > 1 || !marshalRecord.getMarshaller().isReduceAnyArrays())) {
+                    marshalRecord.endCollection();
+                }
                 marshalRecord.flush();
                 return;
             }

--- a/jpa/eclipselink.jpars.test/src/org/eclipse/persistence/jpars/test/service/noversion/TestService.java
+++ b/jpa/eclipselink.jpars.test/src/org/eclipse/persistence/jpars/test/service/noversion/TestService.java
@@ -575,7 +575,7 @@ public class TestService {
         }
         String resultString = outputStream.toString();
 
-        assertTrue("Incorrect result", resultString.contains("[{\"COUNT\":3}]"));
+        assertTrue("Incorrect result", resultString.contains("{\"COUNT\":3}"));
         clearData();
     }
 

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/collections/emptycollectionholderpopulatedsinglereduced.json
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/collections/emptycollectionholderpopulatedsinglereduced.json
@@ -7,23 +7,23 @@
       "referencedObject" : {
          "id" : "1"
       },
-      "root" : [ "60" ],
+      "root" : "60",
       "referenced-id" : "2",
-      "collection13integer" : [ 123 ],
-      "collection13string" : [ "eee" ],
-      "collection14integer" : [ 123 ],
-      "collection14string" : [ "eee" ],
-      "collection1" : [ 10 ],
-      "collection11" : [ "YWJj" ],
-      "collection3" : [ {
+      "collection13integer" : 123,
+      "collection13string" : "eee",
+      "collection14integer" : 123,
+      "collection14string" : "eee",
+      "collection1" : 10,
+      "collection11" : "YWJj",
+      "collection3" : {
          "@type" : "int",
          "value" : 20
-      } ],
-      "collection5" : [ {
+      },
+      "collection5" : {
          "@collection12" : "",
          "@type" : "collectionHolderInitialized",
          "collection2" : ""
-      } ],
-      "collection9" : [ 1 ]
+      },
+      "collection9" : 1
    }
 }


### PR DESCRIPTION
Bug 433822 - JSON_REDUCE_ANY_ARRAYS Marshaller property is not taken into account

MOXy ignored optional marshaller property JSON_REDUCE_ANY_ARRAYS to marshall
 array or collection with one item as single item without [] boundary characters.
 There was incorrect test/resource file for test CollectionHolderPopulatedSingleItemReducedTestCases.
 This is fix for this bug and test CollectionHolderPopulatedSingleItemReducedTestCases too.

See https://bugs.eclipse.org/bugs/show_bug.cgi?id=433822

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>