### PR TITLE
Bug 536947 – XmlDiscriminatorNode with JSON in MoxyBindings File Is not applied to Root Elements

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/record/AbstractMarshalRecordImpl.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/record/AbstractMarshalRecordImpl.java
@@ -35,6 +35,7 @@ import org.eclipse.persistence.internal.oxm.Root;
 import org.eclipse.persistence.internal.oxm.XPathQName;
 import org.eclipse.persistence.internal.oxm.mappings.Descriptor;
 import org.eclipse.persistence.internal.oxm.mappings.Field;
+import org.eclipse.persistence.oxm.XMLField;
 import org.eclipse.persistence.oxm.schema.XMLSchemaReference;
 import org.w3c.dom.Node;
 
@@ -501,7 +502,13 @@ public boolean addXsiTypeAndClassIndicatorIfRequired(Descriptor descriptor, Desc
                 }
             }
         }
-        attributeWithoutQName(javax.xml.XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI, Constants.SCHEMA_TYPE_ATTRIBUTE, xsiPrefix, typeValue);
+        if (marshaller.isApplicationJSON() && descriptor != null && descriptor.getInheritancePolicyOrNull() != null &&
+                descriptor.getInheritancePolicyOrNull().getClassIndicatorFieldName() != null) {
+            attributeWithoutQName(javax.xml.XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI,
+                    ((XMLField)(descriptor.getInheritancePolicyOrNull().getClassIndicatorField())).getXPathFragment().getLocalName(), xsiPrefix, typeValue);
+        } else {
+            attributeWithoutQName(javax.xml.XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI, Constants.SCHEMA_TYPE_ATTRIBUTE, xsiPrefix, typeValue);
+        }
     }
 
     @Override

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/annotations/xmldiscriminator/vehicle-write.json
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/annotations/xmldiscriminator/vehicle-write.json
@@ -1,5 +1,5 @@
 {"vehicle-data":{
-    "type":"car",
+    "vtype":"car",
     "model":"Mustang GT",
     "manufacturer":"Ford",
     "top-speed":354,

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/externalizedmetadata/xmldiscriminator/vehicle-write.json
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/externalizedmetadata/xmldiscriminator/vehicle-write.json
@@ -1,5 +1,5 @@
 {"vehicle-data":{
-    "type":"car",
+    "vtype":"car",
     "model":"Mustang GT",
     "manufacturer":"Ford",
     "top-speed":354,


### PR DESCRIPTION
Bug 536947 – XmlDiscriminatorNode with JSON in MoxyBindings File Is not applied to Root Elements

MOXy before this fix always applied to the JSON root element attribute name ‘type’ if XmlDiscriminatorNode was enabled (via `XmlDiscriminatorNode` annotation or XML binding configuration file). There was same strategy as in XML with
 `xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="car"` . There was inconsistency with rest of JSON sub elements where custom name, specified in annotation or binding configuration file, is applied.
After this fix custom name of type attribute is applied to the JSON root element too instead of hardcoded ‘type'.
There were incorrect test/resource files ‘vehicle-write.json’ for test classes `org.eclipse.persistence.testing.jaxb.annotations.xmldiscriminator.XmlDiscriminatorTestCases`
and `org.eclipse.persistence.testing.jaxb.externalizedmetadata.xmldiscriminator.XmlDiscriminatorTestCases`.
 This is fix for this bug and test classes too.

See https://bugs.eclipse.org/bugs/show_bug.cgi?id=536947