### PR TITLE
Bug 326728 - Incorrect persistence root calculation for WARs

### DIFF
--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/advanced/PersistenceUnitProcessorTest.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/advanced/PersistenceUnitProcessorTest.java
@@ -72,6 +72,34 @@ public class PersistenceUnitProcessorTest extends JUnitTestCase {
                         "META-INF/persistence.xml"
                 ).toString()
         );
+
+        Assert.assertEquals(
+            // The protocol changes - we view ZIPs as JARs.
+            "jar:file:/foo/bar.war!/WEB-INF/classes",
+            PersistenceUnitProcessor.computePURootURL(
+                new URL("zip", "", -1, "/foo/bar.war!/WEB-INF/classes/META-INF/persistence.xml", dummyZipHandler), 
+                "META-INF/persistence.xml"
+            ).toString()
+        );
+    }
+
+    public void testComputePURootURLForJarFile() throws Exception {
+
+        Assert.assertEquals(
+            new URL("file:/foo/bar.jar"),
+            PersistenceUnitProcessor.computePURootURL(
+                new URL("jar:file:/foo/bar.jar!/META-INF/persistence.xml"),
+                "META-INF/persistence.xml"
+            )
+        );
+
+        Assert.assertEquals(
+            new URL("jar:file:/foo/bar.war!/WEB-INF/classes"),
+            PersistenceUnitProcessor.computePURootURL(
+                new URL("jar:file:/foo/bar.war!/WEB-INF/classes/META-INF/persistence.xml"),
+                "META-INF/persistence.xml"
+            )
+        );
     }
 
     public void testGetArchiveFactory() {


### PR DESCRIPTION
See https://bugs.eclipse.org/bugs/show_bug.cgi?id=326728

Changes the root calculation algorithm for WAR and JAR archives to produce the
result that correlates with the `descriptorLocation` parameter. The new algorithm
follows the link between `persistence.xml` and the persistence root rather
then the rigid list of possible cases in the JPA specification (8.2), which allows it
to handle some exotic cases. For example, given the input
`jar:file:/foo.jar!/bar/META-INF/persistence.xml`, the algorithm will produce root
`jar:file:/foo.jar!/bar`. This is useful for embedded servers (mainly Jetty), where
we wish to maintain separation between the server and application classes.

For `zip:...!/...` URLs the resulting root in such case will have the `jar:file:`
scheme. This allows us to leverage the existing JAR file tooling.

This is compatible with the 2.7.x branch, so it can be backported after merge.