### PR TITLE
Bug 538370: Generated should be from javax.annotation.processing package on jdk9+

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/PersistenceUnitProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/PersistenceUnitProperties.java
@@ -1385,6 +1385,22 @@ public class PersistenceUnitProperties {
     public static final String CANONICAL_MODEL_GENERATE_TIMESTAMP_DEFAULT = "true";
 
     /**
+     * The "<code>eclipselink.canonicalmodel.generate_comments</code>" optional property can be used
+     * to disable usage of comments in declaration of {@code Generated} annotation.
+     * The default value is true.
+     *
+     * @see #CANONICAL_MODEL_GENERATE_COMMENTS_DEFAULT
+     */
+    public static final String CANONICAL_MODEL_GENERATE_COMMENTS = "eclipselink.canonicalmodel.generate_comments";
+
+    /**
+     * Default value for the "<code>eclipselink.canonicalmodel.generate_comments</code>" optional property.
+     *
+     * @see #CANONICAL_MODEL_GENERATE_COMMENTS
+     */
+    public static final String CANONICAL_MODEL_GENERATE_COMMENTS_DEFAULT = "true";
+
+    /**
      * Default caching properties - apply to all entities. May be overridden by
      * individual entity property with the same prefix. If you do not wish to
      * cache your entities, set this to "<code>false</code>".

--- a/jpa/org.eclipse.persistence.jpa.modelgen/src/org/eclipse/persistence/internal/jpa/modelgen/CanonicalModelProperties.java
+++ b/jpa/org.eclipse.persistence.jpa.modelgen/src/org/eclipse/persistence/internal/jpa/modelgen/CanonicalModelProperties.java
@@ -89,6 +89,13 @@ public abstract class CanonicalModelProperties {
     public static final String CANONICAL_MODEL_GENERATE_TIMESTAMP = PersistenceUnitProperties.CANONICAL_MODEL_GENERATE_TIMESTAMP;
     public static final String CANONICAL_MODEL_GENERATE_TIMESTAMP_DEFAULT = PersistenceUnitProperties.CANONICAL_MODEL_GENERATE_TIMESTAMP_DEFAULT;
 
+    /**
+     * This optional property can be used to avoid using of comments in {@code Generated} annotation
+     * The default value is true and should be left as such for full feature support.
+     */
+    public static final String CANONICAL_MODEL_GENERATE_COMMENTS = PersistenceUnitProperties.CANONICAL_MODEL_GENERATE_COMMENTS;
+    public static final String CANONICAL_MODEL_GENERATE_COMMENTS_DEFAULT = PersistenceUnitProperties.CANONICAL_MODEL_GENERATE_COMMENTS_DEFAULT;
+
     // This value must match LogCategory.PROCESSOR.getLogLevelProperty()
     /**
      * This optional property can be used to set processor logging level of Canonical model generator.


### PR DESCRIPTION
This adds ability to generate correct Generated annotation in generated canonical model classes:
* if compiler source level is 8 or lower, then javax.annotation.Generated is used (=current behaviour)
* else javax.annotation.processing.Generated is used

Also added option to not include comments attribute in the new javax.annotation.processing.Generated annotation

Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>