### PR TITLE
Bug 538371: UnsupportedOperationException while weaving JDK11 compiled class file

### DIFF
--- a/dbws/org.eclipse.persistence.dbws/src/org/eclipse/persistence/internal/dbws/SOAPResponseClassLoader.java
+++ b/dbws/org.eclipse.persistence.dbws/src/org/eclipse/persistence/internal/dbws/SOAPResponseClassLoader.java
@@ -27,7 +27,7 @@ import static org.eclipse.persistence.internal.libraries.asm.Opcodes.ACC_SUPER;
 import static org.eclipse.persistence.internal.libraries.asm.Opcodes.ALOAD;
 import static org.eclipse.persistence.internal.libraries.asm.Opcodes.INVOKESPECIAL;
 import static org.eclipse.persistence.internal.libraries.asm.Opcodes.RETURN;
-import static org.eclipse.persistence.internal.libraries.asm.Opcodes.V1_5;
+import static org.eclipse.persistence.internal.libraries.asm.Opcodes.V1_8;
 
 /**
  * <p><b>INTERNAL</b>: A subclass of {@link ClassLoader} that exposes a build method to the hidden
@@ -62,7 +62,7 @@ public class SOAPResponseClassLoader extends ClassLoader {
        *   }
        */
       ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
-      cw.visit(V1_5, ACC_PUBLIC + ACC_SUPER, className, null, SOAP_RESPONSE_CLASSNAME_SLASHES, null);
+      cw.visit(V1_8, ACC_PUBLIC + ACC_SUPER, className, null, SOAP_RESPONSE_CLASSNAME_SLASHES, null);
 
       MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
       mv.visitVarInsn(ALOAD, 0);

--- a/dbws/org.eclipse.persistence.dbws/src/org/eclipse/persistence/internal/xr/XRClassWriter.java
+++ b/dbws/org.eclipse.persistence.dbws/src/org/eclipse/persistence/internal/xr/XRClassWriter.java
@@ -33,7 +33,7 @@ import static org.eclipse.persistence.internal.libraries.asm.Opcodes.INVOKESPECI
 import static org.eclipse.persistence.internal.libraries.asm.Opcodes.NEW;
 import static org.eclipse.persistence.internal.libraries.asm.Opcodes.PUTSTATIC;
 import static org.eclipse.persistence.internal.libraries.asm.Opcodes.RETURN;
-import static org.eclipse.persistence.internal.libraries.asm.Opcodes.V1_5;
+import static org.eclipse.persistence.internal.libraries.asm.Opcodes.V1_8;
 import static org.eclipse.persistence.internal.xr.XRDynamicClassLoader.COLLECTION_WRAPPER_SUFFIX;
 
 /**
@@ -76,7 +76,7 @@ public class XRClassWriter extends DynamicClassWriter {
 
         // special-case: build sub-class of XRDynamicEntityCollection
         if (className.endsWith(COLLECTION_WRAPPER_SUFFIX)) {
-            cw.visit(V1_5, ACC_PUBLIC + ACC_SUPER, classNameAsSlashes, null, XR_DYNAMIC_ENTITY_COLLECTION_CLASSNAME_SLASHES, null);
+            cw.visit(V1_8, ACC_PUBLIC + ACC_SUPER, classNameAsSlashes, null, XR_DYNAMIC_ENTITY_COLLECTION_CLASSNAME_SLASHES, null);
             mv = cw.visitMethod(ACC_PUBLIC, INIT, "()V", null, null);
             mv.visitVarInsn(ALOAD, 0);
             mv.visitMethodInsn(INVOKESPECIAL, XR_DYNAMIC_ENTITY_COLLECTION_CLASSNAME_SLASHES, INIT, "()V", false);
@@ -85,7 +85,7 @@ public class XRClassWriter extends DynamicClassWriter {
             mv.visitEnd();
         } else {
             // public class Foo extends XRDynamicEntity {
-            cw.visit(V1_5, ACC_PUBLIC + ACC_SUPER, classNameAsSlashes, null, XR_DYNAMIC_ENTITY_CLASSNAME_SLASHES, null);
+            cw.visit(V1_8, ACC_PUBLIC + ACC_SUPER, classNameAsSlashes, null, XR_DYNAMIC_ENTITY_CLASSNAME_SLASHES, null);
 
             // public static XRDynamicPropertiesManager DPM = new
             // XRDynamicPropertiesManager();

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/dynamic/DynamicClassWriter.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/dynamic/DynamicClassWriter.java
@@ -49,7 +49,7 @@ import static org.eclipse.persistence.internal.libraries.asm.Opcodes.NEW;
 import static org.eclipse.persistence.internal.libraries.asm.Opcodes.PUTSTATIC;
 import static org.eclipse.persistence.internal.libraries.asm.Opcodes.RETURN;
 import static org.eclipse.persistence.internal.libraries.asm.Opcodes.SIPUSH;
-import static org.eclipse.persistence.internal.libraries.asm.Opcodes.V1_5;
+import static org.eclipse.persistence.internal.libraries.asm.Opcodes.V1_8;
 
 import java.lang.reflect.Modifier;
 
@@ -183,7 +183,7 @@ public class DynamicClassWriter implements EclipseLinkClassWriter {
         ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
 
         // public class Foo extends DynamicEntityImpl {
-        cw.visit(V1_5, ACC_PUBLIC + ACC_SUPER, classNameAsSlashes, null, parentClassNameAsSlashes, null);
+        cw.visit(V1_8, ACC_PUBLIC + ACC_SUPER, classNameAsSlashes, null, parentClassNameAsSlashes, null);
 
         // public static DynamicPropertiesManager DPM = new
         // DynamicPropertiesManager();
@@ -246,7 +246,7 @@ public class DynamicClassWriter implements EclipseLinkClassWriter {
         String internalClassName = className.replace('.', '/');
 
         ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
-        cw.visit(V1_5, ACC_PUBLIC + ACC_FINAL + ACC_SUPER + ACC_ENUM, internalClassName, null, "java/lang/Enum", null);
+        cw.visit(V1_8, ACC_PUBLIC + ACC_FINAL + ACC_SUPER + ACC_ENUM, internalClassName, null, "java/lang/Enum", null);
 
         // Add the individual enum values
         for (String enumValue : enumValues) {

--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/metadata/accessors/objects/MetadataAsmFactory.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/metadata/accessors/objects/MetadataAsmFactory.java
@@ -245,7 +245,7 @@ public class MetadataAsmFactory extends MetadataFactory {
         private MetadataClass classMetadata;
 
         ClassMetadataVisitor(MetadataClass metadataClass, boolean isLazy) {
-            super(Opcodes.ASM5);
+            super(Opcodes.ASM7_EXPERIMENTAL);
             this.isLazy = isLazy;
             this.classMetadata = metadataClass;
         }
@@ -341,7 +341,7 @@ public class MetadataAsmFactory extends MetadataFactory {
         }
 
         MetadataAnnotationVisitor(MetadataAnnotatedElement element, String name, boolean isRegular) {
-            super(Opcodes.ASM5);
+            super(Opcodes.ASM7_EXPERIMENTAL);
             this.element = element;
             this.annotation = new MetadataAnnotation();
             this.annotation.setName(processDescription(name, false).get(0));
@@ -349,7 +349,7 @@ public class MetadataAsmFactory extends MetadataFactory {
         }
 
         public MetadataAnnotationVisitor(MetadataAnnotation annotation) {
-            super(Opcodes.ASM5);
+            super(Opcodes.ASM7_EXPERIMENTAL);
             this.annotation = annotation;
         }
 
@@ -401,7 +401,7 @@ public class MetadataAsmFactory extends MetadataFactory {
         private List<Object> values;
 
         public MetadataAnnotationArrayVisitor(MetadataAnnotation annotation, String name) {
-            super(Opcodes.ASM5);
+            super(Opcodes.ASM7_EXPERIMENTAL);
             this.annotation = annotation;
             this.attributeName = name;
             this.values = new ArrayList<Object>();
@@ -440,7 +440,7 @@ public class MetadataAsmFactory extends MetadataFactory {
         private MetadataField field;
 
         public MetadataFieldVisitor(MetadataClass classMetadata, int access, String name, String desc, String signature, Object value) {
-            super(Opcodes.ASM5);
+            super(Opcodes.ASM7_EXPERIMENTAL);
             this.field = new MetadataField(classMetadata);
             this.field.setModifiers(access);
             this.field.setName(name);
@@ -474,7 +474,7 @@ public class MetadataAsmFactory extends MetadataFactory {
         private MetadataMethod method;
 
         public MetadataMethodVisitor(MetadataClass classMetadata, int access, String name, String desc, String signature, String[] exceptions) {
-            super(Opcodes.ASM5);
+            super(Opcodes.ASM7_EXPERIMENTAL);
             this.method = new MetadataMethod(MetadataAsmFactory.this, classMetadata);
 
             this.method.setName(name);

--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/weaving/ClassWeaver.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/weaving/ClassWeaver.java
@@ -207,7 +207,7 @@ public class ClassWeaver extends ClassVisitor implements Opcodes {
     }
 
     public ClassWeaver(ClassVisitor classWriter, ClassDetails classDetails) {
-        super(ASM5, classWriter);
+        super(ASM7_EXPERIMENTAL, classWriter);
         this.classDetails = classDetails;
     }
 

--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/weaving/CollectionProxyClassWriter.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/weaving/CollectionProxyClassWriter.java
@@ -107,7 +107,7 @@ public class CollectionProxyClassWriter implements EclipseLinkClassWriter, Opcod
         MethodVisitor mv;
 
         // public class Proxy extends SuperType implements CollectionProxy
-        cw.visit(V1_6, ACC_PUBLIC + ACC_SUPER, getASMClassName(), null, getASMParentClassName(), new String[]{INTERFACE});
+        cw.visit(V1_8, ACC_PUBLIC + ACC_SUPER, getASMClassName(), null, getASMParentClassName(), new String[]{INTERFACE});
 
         // private List<LinkV2> links;
         final FieldVisitor fv = cw.visitField(ACC_PRIVATE, "links", "Ljava/util/List;", "Ljava/util/List<Lorg/eclipse/persistence/internal/jpa/rs/metadata/model/LinkV2;>;", null);

--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/weaving/MethodWeaver.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/weaving/MethodWeaver.java
@@ -44,7 +44,7 @@ public class MethodWeaver extends MethodVisitor implements Opcodes {
     protected boolean methodStarted = false;
 
     public MethodWeaver(ClassWeaver tcw, String methodName, String methodDescriptor, MethodVisitor mv) {
-        super(ASM5, mv);
+        super(ASM7_EXPERIMENTAL, mv);
         this.tcw = tcw;
         this.methodName = methodName;
         this.methodDescriptor = methodDescriptor;

--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/weaving/RestAdapterClassWriter.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/weaving/RestAdapterClassWriter.java
@@ -63,7 +63,7 @@ public class RestAdapterClassWriter implements EclipseLinkClassWriter, Opcodes {
             throws ClassNotFoundException {
 
         ClassWriter cw = new ClassWriter(0);
-        cw.visit(V1_6, ACC_PUBLIC + ACC_SUPER, getASMClassName(), "L" + REFERENCE_ADAPTER_SHORT_SIGNATURE + "<L" + getASMParentClassName() + ";>;", REFERENCE_ADAPTER_SHORT_SIGNATURE, null);
+        cw.visit(V1_8, ACC_PUBLIC + ACC_SUPER, getASMClassName(), "L" + REFERENCE_ADAPTER_SHORT_SIGNATURE + "<L" + getASMParentClassName() + ";>;", REFERENCE_ADAPTER_SHORT_SIGNATURE, null);
 
         MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
         mv.visitCode();

--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/weaving/RestCollectionAdapterClassWriter.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/weaving/RestCollectionAdapterClassWriter.java
@@ -87,7 +87,7 @@ public class RestCollectionAdapterClassWriter implements EclipseLinkClassWriter,
 
         // Class signature
         final ClassWriter cw = new ClassWriter(0);
-        cw.visit(V1_6, ACC_PUBLIC + ACC_SUPER, getASMClassName(), "L" + REFERENCE_ADAPTER_SHORT_SIGNATURE + "<L" + getASMParentClassName() + ";>;", REFERENCE_ADAPTER_SHORT_SIGNATURE, null);
+        cw.visit(V1_8, ACC_PUBLIC + ACC_SUPER, getASMClassName(), "L" + REFERENCE_ADAPTER_SHORT_SIGNATURE + "<L" + getASMParentClassName() + ";>;", REFERENCE_ADAPTER_SHORT_SIGNATURE, null);
 
         // Default constructor
         MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);

--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/weaving/RestReferenceAdapterV2ClassWriter.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/weaving/RestReferenceAdapterV2ClassWriter.java
@@ -85,7 +85,7 @@ public class RestReferenceAdapterV2ClassWriter implements EclipseLinkClassWriter
             throws ClassNotFoundException {
 
         final ClassWriter cw = new ClassWriter(0);
-        cw.visit(V1_6, ACC_PUBLIC + ACC_SUPER, getASMClassName(), "L" + REFERENCE_ADAPTER_SHORT_SIGNATURE + "<L" + getASMParentClassName() + ";>;", REFERENCE_ADAPTER_SHORT_SIGNATURE, null);
+        cw.visit(V1_8, ACC_PUBLIC + ACC_SUPER, getASMClassName(), "L" + REFERENCE_ADAPTER_SHORT_SIGNATURE + "<L" + getASMParentClassName() + ";>;", REFERENCE_ADAPTER_SHORT_SIGNATURE, null);
 
         // Default constructor
         MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/events/ClassLoaderTestCases.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/events/ClassLoaderTestCases.java
@@ -44,7 +44,7 @@ public class ClassLoaderTestCases extends TestCase {
     protected void setUp() throws Exception {
 
         ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
-        cw.visit(Opcodes.V1_5, Opcodes.ACC_PUBLIC + Opcodes.ACC_SUPER, CLASS_NAME, null, ClassLoaderRoot.class.getName().replace('.', '/'), null);
+        cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC + Opcodes.ACC_SUPER, CLASS_NAME, null, ClassLoaderRoot.class.getName().replace('.', '/'), null);
         AnnotationVisitor xmlTypeAV = cw.visitAnnotation("Ljavax/xml/bind/annotation/XmlRootElement;", true);
         xmlTypeAV.visit("name", "root");
         xmlTypeAV.visitEnd();

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/compiler/AnnotationsProcessor.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/compiler/AnnotationsProcessor.java
@@ -4263,7 +4263,7 @@ public final class AnnotationsProcessor {
         ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
 
         String sig = "Lorg/eclipse/persistence/internal/jaxb/many/MapValue<L" + mapType.getInternalName() + "<L" + internalKeyName + ";L" + internalValueName + ";>;>;";
-        cw.visit(Opcodes.V1_5, Opcodes.ACC_PUBLIC + Opcodes.ACC_SUPER, qualifiedInternalClassName, sig, "org/eclipse/persistence/internal/jaxb/many/MapValue", null);
+        cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC + Opcodes.ACC_SUPER, qualifiedInternalClassName, sig, "org/eclipse/persistence/internal/jaxb/many/MapValue", null);
 
         // Write Field: @... public Map entry
         String fieldSig = L + mapType.getInternalName() + "<L" + internalKeyName + ";L" + internalValueName + ";>;";
@@ -4574,9 +4574,9 @@ public final class AnnotationsProcessor {
         String componentClassNameSeparatedBySlash = getObjectType(componentType).getQualifiedName().replace(DOT_CHR, SLASH_CHR);
         String containerClassNameSeperatedBySlash = containerType.getQualifiedName().replace(DOT_CHR, SLASH_CHR);
         if("[B".equals(componentClassNameSeparatedBySlash)) {
-            cw.visit(Opcodes.V1_5, Opcodes.ACC_PUBLIC + Opcodes.ACC_SUPER, classNameSeparatedBySlash, "L" + Type.getInternalName(superType) + "<" + componentClassNameSeparatedBySlash + ">;", Type.getInternalName(superType), null);
+            cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC + Opcodes.ACC_SUPER, classNameSeparatedBySlash, "L" + Type.getInternalName(superType) + "<" + componentClassNameSeparatedBySlash + ">;", Type.getInternalName(superType), null);
         } else {
-            cw.visit(Opcodes.V1_5, Opcodes.ACC_PUBLIC + Opcodes.ACC_SUPER, classNameSeparatedBySlash, "L" + Type.getInternalName(superType) + "<L" + componentClassNameSeparatedBySlash + ";>;", Type.getInternalName(superType), null);
+            cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC + Opcodes.ACC_SUPER, classNameSeparatedBySlash, "L" + Type.getInternalName(superType) + "<L" + componentClassNameSeparatedBySlash + ";>;", Type.getInternalName(superType), null);
         }
 
         // Write @XmlType(namespace)

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/compiler/MappingsGenerator.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/compiler/MappingsGenerator.java
@@ -1978,7 +1978,7 @@ public class MappingsGenerator {
         }
 
         String sig = "Ljava/lang/Object;Lorg/eclipse/persistence/internal/jaxb/many/MapEntry<L"+qualifiedInternalKeyClassName+";" + valuePrefix + qualifiedInternalValueClassName+";>;";
-        cw.visit(Opcodes.V1_5, Opcodes.ACC_PUBLIC + Opcodes.ACC_SUPER, qualifiedInternalClassName, sig, "java/lang/Object", new String[] { "org/eclipse/persistence/internal/jaxb/many/MapEntry" });
+        cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC + Opcodes.ACC_SUPER, qualifiedInternalClassName, sig, "java/lang/Object", new String[] { "org/eclipse/persistence/internal/jaxb/many/MapEntry" });
 
         cw.visitField(Opcodes.ACC_PRIVATE, "key", "L"+qualifiedInternalKeyClassName+";", null, null);
 
@@ -3263,7 +3263,7 @@ public class MappingsGenerator {
         ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
 
         String sig = null;
-        cw.visit(Opcodes.V1_5, Opcodes.ACC_PUBLIC, className.replace(".", "/"), sig, Type.getType(WrappedValue.class).getInternalName(), null);
+        cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, className.replace(".", "/"), sig, Type.getType(WrappedValue.class).getInternalName(), null);
 
         String fieldType = null;
         if(isList){

--- a/sdo/org.eclipse.persistence.sdo/src/org/eclipse/persistence/sdo/helper/DynamicClassWriter.java
+++ b/sdo/org.eclipse.persistence.sdo/src/org/eclipse/persistence/sdo/helper/DynamicClassWriter.java
@@ -108,11 +108,11 @@ public class DynamicClassWriter {
         ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
 
         if (null == type.getInstanceClass()) {
-            cw.visit(Opcodes.V1_5, Opcodes.ACC_PUBLIC + Opcodes.ACC_SUPER, typeImplClassDescriptor, null, Type.getType(parentClass).getInternalName(), null);
+            cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC + Opcodes.ACC_SUPER, typeImplClassDescriptor, null, Type.getType(parentClass).getInternalName(), null);
         } else {
             String[] interfaces = new String[1];
             interfaces[0] = type.getInstanceClassName().replace('.', '/');
-            cw.visit(Opcodes.V1_5, Opcodes.ACC_PUBLIC + Opcodes.ACC_SUPER, typeImplClassDescriptor, null, Type.getType(parentClass).getInternalName(), interfaces);
+            cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC + Opcodes.ACC_SUPER, typeImplClassDescriptor, null, Type.getType(parentClass).getInternalName(), interfaces);
             addPropertyIndices(cw);
             for (Object object : type.getDeclaredProperties()) {
                 SDOProperty sdoProperty = (SDOProperty) object;


### PR DESCRIPTION
* updates generated byte-code to be at 1_8 level (was 1_5/1_6)
* allows properly reading JDK11 compiled class files

Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>