### PR TITLE
Bug 539323 - Converter with autoApply=true flag is applied to the @Id, @Version, @Enumerated, @Temporal fields

### DIFF
--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/metadata/accessors/mappings/MappingAccessor.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/metadata/accessors/mappings/MappingAccessor.java
@@ -1837,10 +1837,10 @@ public abstract class MappingAccessor extends MetadataAccessor {
         } else if (hasConverts) {
             // If we have JPA converts, apply them.
             processConverts(converts, mapping, referenceClass, isForMapKey);
-        } else if (getProject().hasAutoApplyConverter(referenceClassWithGenerics)) {
+        } else if (getProject().hasAutoApplyConverter(referenceClassWithGenerics) && !hasAutoApplyConverterExcludeAnnotations(this)) {
             // If no convert is specified and there exist an auto-apply
             // converter for the reference class, apply it.
-            getProject().getAutoApplyConverter(referenceClassWithGenerics).process(mapping, isForMapKey, null);
+                getProject().getAutoApplyConverter(referenceClassWithGenerics).process(mapping, isForMapKey, null);
         } else {
             // Check for original JPA converters. Check for an enum first since
             // it will fall into a serializable mapping otherwise since enums
@@ -1855,6 +1855,16 @@ public abstract class MappingAccessor extends MetadataAccessor {
                 processSerialized(mapping, referenceClass, isForMapKey);
             }
         }
+    }
+
+    private boolean hasAutoApplyConverterExcludeAnnotations(MappingAccessor mappingAccessor) {
+        final Class[] excludeAnnotations = {javax.persistence.Id.class, javax.persistence.Version.class, javax.persistence.Enumerated.class, javax.persistence.Temporal.class};
+        for (Class excludeAnnotation: excludeAnnotations) {
+            if (mappingAccessor.isAnnotationPresent(excludeAnnotation)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/metadata/accessors/mappings/MappingAccessor.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/metadata/accessors/mappings/MappingAccessor.java
@@ -1840,7 +1840,7 @@ public abstract class MappingAccessor extends MetadataAccessor {
         } else if (getProject().hasAutoApplyConverter(referenceClassWithGenerics) && !hasAutoApplyConverterExcludeAnnotations(this)) {
             // If no convert is specified and there exist an auto-apply
             // converter for the reference class, apply it.
-                getProject().getAutoApplyConverter(referenceClassWithGenerics).process(mapping, isForMapKey, null);
+            getProject().getAutoApplyConverter(referenceClassWithGenerics).process(mapping, isForMapKey, null);
         } else {
             // Check for original JPA converters. Check for an enum first since
             // it will fall into a serializable mapping otherwise since enums


### PR DESCRIPTION
Bug 539323 - Converter with autoApply=true flag is applied to the @Id, @Version, @Enumerated, @Temporal fields.

This is fix for JPA custom converter used/applied to the entities via autoApply “@Converter(autoApply=true)” annotation.
JPA specification 2.2 says:
Note that Id attributes, version attributes, relationship attributes, and attributes explicitly annotated as Enumerated or Temporal (or designated as such via XML) will not be converted.

But EclipseLink calls custom converter against these fields too.
After this fix EclipseLink will not apply custom converter with “@Converter(autoApply=true)” annotation to these fields.

See https://bugs.eclipse.org/bugs/show_bug.cgi?id=539323