### PR TITLE
Bug 536947 v 2.0 – XmlDiscriminatorNode with JSON in MoxyBindings File Is not applied to Root Elements

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/JsonTypeConfiguration.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/JsonTypeConfiguration.java
@@ -43,6 +43,16 @@ public class JsonTypeConfiguration {
     private boolean jsonTypeCompatibilitySet = false;
 
     /**
+     * Override default type property name for JSON as MOXy type discriminator.
+     */
+    private String jsonTypeAttributeName = "type";
+
+    /**
+     * Allows system property override with context property.
+     */
+    private boolean jsonTypeAttributeNameSet = false;
+
+    /**
      * Getter for useXsdTypesWithPrefix property.
      *
      * @return value of useXsdTypesWithPrefix property
@@ -110,6 +120,41 @@ public class JsonTypeConfiguration {
     public void setJsonTypeCompatibility(boolean jsonTypeCompatibility) {
         this.jsonTypeCompatibility = jsonTypeCompatibility;
         this.jsonTypeCompatibilitySet = true;
+    }
+
+    /**
+     * Getter for type property name for JSON as MOXy type discriminator.
+     *
+     * @return value of jsonTypeAttributeName property
+     * @since 2.7.4
+     */
+    public String getJsonTypeAttributeName() {
+        return jsonTypeAttributeName;
+    }
+
+    /**
+     * Override default type property name for JSON as MOXy type discriminator.
+     *
+     * @return type property name for JSON as MOXy type discriminator.
+     * @since 2.7.4
+     */
+    public String useJsonTypeAttributeName() {
+        if (jsonTypeAttributeNameSet) {
+            return jsonTypeAttributeName;
+        } else {
+            return OXMSystemProperties.jsonTypeAttributeName;
+        }
+    }
+
+    /**
+     * Override default type property name for JSON as MOXy type discriminator.
+     *
+     * @param jsonTypeAttributeName Type property name for JSON as MOXy type discriminator.
+     * @since 2.6.0
+     */
+    public void setJsonTypeAttributeName(String jsonTypeAttributeName) {
+        this.jsonTypeAttributeName = jsonTypeAttributeName;
+        this.jsonTypeAttributeNameSet = true;
     }
 
 }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/OXMSystemProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/OXMSystemProperties.java
@@ -35,6 +35,13 @@ public final class OXMSystemProperties {
     public static final String JSON_TYPE_COMPATIBILITY = "org.eclipse.persistence.json.type-compatibility";
 
     /**
+     * Override default type property name for JSON as MOXy type discriminator.
+     *
+     * @since 2.7.4
+     */
+    public static final String JSON_TYPE_ATTRIBUTE_NAME = "org.eclipse.persistence.json.type-attribute-name";
+
+    /**
      * If there should be xsd prefix when using simple types, e.g. xsd.int.
      *
      * @since 2.6.0
@@ -46,5 +53,7 @@ public final class OXMSystemProperties {
     public static final Boolean jsonTypeCompatiblity = PrivilegedAccessHelper.getSystemPropertyBoolean(JSON_TYPE_COMPATIBILITY, false);
 
     public static final Boolean jsonUseXsdTypesPrefix = PrivilegedAccessHelper.getSystemPropertyBoolean(JSON_USE_XSD_TYPES_PREFIX, false);
+
+    public static final String jsonTypeAttributeName = PrivilegedAccessHelper.getSystemProperty(JSON_TYPE_ATTRIBUTE_NAME, Constants.SCHEMA_TYPE_ATTRIBUTE);
 
 }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLRelationshipMappingNodeValue.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLRelationshipMappingNodeValue.java
@@ -74,6 +74,11 @@ public abstract class XMLRelationshipMappingNodeValue extends MappingNodeValue {
                         classValue = (Class)indicator;
                     }
                 }
+                // if xsi:type is overriden by JSON_TYPE_ATTRIBUTE_NAME unmarshall property
+                if (classValue == null && unmarshalRecord.getUnmarshaller().isApplicationJSON() &&
+                        unmarshalRecord.getUnmarshaller().getJsonTypeConfiguration().getJsonTypeAttributeName() != null && atts.getValue(unmarshalRecord.getUnmarshaller().getJsonTypeConfiguration().getJsonTypeAttributeName()) != null) {
+                    classValue = (Class)xmlDescriptor.getInheritancePolicy().getClassIndicatorMapping().get(new QName(atts.getValue(unmarshalRecord.getUnmarshaller().getJsonTypeConfiguration().getJsonTypeAttributeName())));
+                }
             }
             if (classValue != null) {
                 xmlDescriptor = (Descriptor)session.getDescriptor(classValue);

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/record/AbstractMarshalRecordImpl.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/record/AbstractMarshalRecordImpl.java
@@ -35,6 +35,7 @@ import org.eclipse.persistence.internal.oxm.Root;
 import org.eclipse.persistence.internal.oxm.XPathQName;
 import org.eclipse.persistence.internal.oxm.mappings.Descriptor;
 import org.eclipse.persistence.internal.oxm.mappings.Field;
+import org.eclipse.persistence.oxm.XMLConstants;
 import org.eclipse.persistence.oxm.XMLField;
 import org.eclipse.persistence.oxm.schema.XMLSchemaReference;
 import org.w3c.dom.Node;
@@ -500,8 +501,14 @@ public class AbstractMarshalRecordImpl<
         }
         if (marshaller.isApplicationJSON() && descriptor != null && descriptor.getInheritancePolicyOrNull() != null &&
                 descriptor.getInheritancePolicyOrNull().getClassIndicatorFieldName() != null) {
-            attributeWithoutQName(javax.xml.XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI,
-                    ((XMLField)(descriptor.getInheritancePolicyOrNull().getClassIndicatorField())).getXPathFragment().getLocalName(), xsiPrefix, typeValue);
+            //true - override default type attribute name by JSON_TYPE_ATTRIBUTE_NAME marshaller property
+            if(XMLConstants.DEFAULT_XML_TYPE_ATTRIBUTE == descriptor.getInheritancePolicyOrNull().getClassIndicatorField() &&
+                    marshaller.getJsonTypeConfiguration().getJsonTypeAttributeName() != null) {
+                attributeWithoutQName(javax.xml.XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI, marshaller.getJsonTypeConfiguration().getJsonTypeAttributeName(), xsiPrefix, typeValue);
+            } else {
+                attributeWithoutQName(javax.xml.XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI,
+                        ((XMLField) (descriptor.getInheritancePolicyOrNull().getClassIndicatorField())).getXPathFragment().getLocalName(), xsiPrefix, typeValue);
+            }
         } else {
             attributeWithoutQName(javax.xml.XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI, Constants.SCHEMA_TYPE_ATTRIBUTE, xsiPrefix, typeValue);
         }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/record/SAXUnmarshallerHandler.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/record/SAXUnmarshallerHandler.java
@@ -212,6 +212,8 @@ public class SAXUnmarshallerHandler implements ExtendedContentHandler {
                     type = atts.getValue(javax.xml.XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI, Constants.SCHEMA_TYPE_ATTRIBUTE);
                 } else if (unmarshaller.getMediaType() != MediaType.APPLICATION_JSON || unmarshaller.getJsonTypeConfiguration().useJsonTypeCompatibility()) {
                     type = atts.getValue(Constants.EMPTY_STRING, Constants.SCHEMA_TYPE_ATTRIBUTE);
+                } else if (unmarshaller.getMediaType() == MediaType.APPLICATION_JSON && unmarshaller.getJsonTypeConfiguration().getJsonTypeAttributeName() != null) {
+                        type = atts.getValue(Constants.EMPTY_STRING, unmarshaller.getJsonTypeConfiguration().getJsonTypeAttributeName());
                 }
                 if (null != type) {
                     XPathFragment typeFragment = new XPathFragment(type, xmlReader.getNamespaceSeparator(), xmlReader.isNamespaceAware());

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/oxm/XMLConstants.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/oxm/XMLConstants.java
@@ -37,4 +37,6 @@ public class XMLConstants extends Constants{
     public static final String ANY_NAMESPACE_LOCAL = "##local";
     public static final String ANY_NAMESPACE_TARGETNS = "##targetNamespace";
 
+    public static final XMLField DEFAULT_XML_TYPE_ATTRIBUTE = new XMLField(Constants.ATTRIBUTE+ Constants.SCHEMA_TYPE_ATTRIBUTE);
+
 }

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/json/type/type_property_custom_name.json
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/json/type/type_property_custom_name.json
@@ -1,0 +1,29 @@
+{
+  "mytype": "customerWithInheritance",
+  "name": "theName",
+  "type": "propertyType",
+  "primaryContact": {
+    "mytype": "address",
+    "contactId": 1,
+    "street": "Main Street 1",
+    "city": "Prague",
+    "zip": "110 00"
+  },
+  "secondaryContacts": [
+    {
+      "mytype": "address",
+      "contactId": 2,
+      "street": "Under Bridge",
+      "city": "Berlin",
+      "zip": "123456"
+    },
+    {
+      "mytype": "phone",
+      "contactId": 3,
+      "number": "987654321"
+    },
+    {
+      "contactId": 4
+    }
+  ]
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/JSONTestSuite.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/JSONTestSuite.java
@@ -48,10 +48,7 @@ import org.eclipse.persistence.testing.jaxb.json.norootelement.NoRootElementNSTe
 import org.eclipse.persistence.testing.jaxb.json.norootelement.NoRootElementTestCases;
 import org.eclipse.persistence.testing.jaxb.json.padding.JSONWithPaddingTestCases;
 import org.eclipse.persistence.testing.jaxb.json.rootlevellist.RootLevelListTestCases;
-import org.eclipse.persistence.testing.jaxb.json.type.TypeNameValueTestCases;
-import org.eclipse.persistence.testing.jaxb.json.type.TypePrefixTestCases;
-import org.eclipse.persistence.testing.jaxb.json.type.TypePropertyInheritanceTestCases;
-import org.eclipse.persistence.testing.jaxb.json.type.TypePropertyTestCases;
+import org.eclipse.persistence.testing.jaxb.json.type.*;
 import org.eclipse.persistence.testing.jaxb.json.unmapped.JsonUnmappedTestCases;
 import org.eclipse.persistence.testing.jaxb.json.wrapper.AllWrapperTestCases;
 import org.eclipse.persistence.testing.jaxb.json.xmlvalue.XMLValuePropDifferentTestCases;
@@ -98,6 +95,7 @@ public class JSONTestSuite extends TestSuite {
           suite.addTestSuite(MultiLineStringTestCases.class);
           suite.addTestSuite(TypeNameValueTestCases.class);
           suite.addTestSuite(TypePrefixTestCases.class);
+          suite.addTestSuite(TypePropertyCustomNameTestCases.class);
           suite.addTestSuite(TypePropertyInheritanceTestCases.class);
           suite.addTestSuite(TypePropertyTestCases.class);
           suite.addTestSuite(JsonUnmappedTestCases.class);

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/type/TypePropertyCustomNameTestCases.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/type/TypePropertyCustomNameTestCases.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Radek Felcman - 2.7.4 - initial implementation
+package org.eclipse.persistence.testing.jaxb.json.type;
+
+import org.eclipse.persistence.jaxb.MarshallerProperties;
+import org.eclipse.persistence.jaxb.UnmarshallerProperties;
+import org.eclipse.persistence.testing.jaxb.json.JSONMarshalUnmarshalTestCases;
+import org.eclipse.persistence.testing.jaxb.json.type.model.*;
+
+import javax.xml.bind.JAXBElement;
+import javax.xml.namespace.QName;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Tests to marshall, unmarshal JSON with JSON_TYPE_ATTRIBUTE_NAME marshall and unmarshall property.
+ *
+ * @author Radek Felcman
+ *
+ */
+public class TypePropertyCustomNameTestCases extends JSONMarshalUnmarshalTestCases {
+    private final static String JSON_RESOURCE = "org/eclipse/persistence/testing/jaxb/json/type/type_property_custom_name.json";
+
+    public TypePropertyCustomNameTestCases(String name) throws Exception {
+        super(name);
+        setClasses(new Class[]{PersonWithType.class, Contact.class});
+        setControlJSON(JSON_RESOURCE);
+    }
+
+    public void setUp() throws Exception{
+        super.setUp();
+
+        jsonMarshaller.setProperty(MarshallerProperties.JSON_INCLUDE_ROOT, false);
+        jsonMarshaller.setProperty(MarshallerProperties.JSON_TYPE_ATTRIBUTE_NAME, "mytype");
+
+        jsonUnmarshaller.setProperty(UnmarshallerProperties.JSON_INCLUDE_ROOT, false);
+        jsonUnmarshaller.setProperty(UnmarshallerProperties.JSON_TYPE_ATTRIBUTE_NAME, "mytype");
+    }
+
+    protected Object getControlObject() {
+
+        Address a = new Address();
+        a.contactId = 1;
+        a.street = "Main Street 1";
+        a.city = "Prague";
+        a.zip = "110 00";
+
+        List<Contact> secondaryContacts = new ArrayList<>();
+        Address a1 = new Address();
+        a1.contactId = 2;
+        a1.street = "Under Bridge";
+        a1.city = "Berlin";
+        a1.zip = "123456";
+        secondaryContacts.add(a1);
+
+        Phone p = new Phone();
+        p.contactId = 3;
+        p.number = "987654321";
+        secondaryContacts.add(p);
+
+        Contact c = new Contact();
+        c.contactId = 4;
+        secondaryContacts.add(c);
+
+        CustomerWithInheritance customer = new CustomerWithInheritance();
+        customer.name = "theName";
+        customer.type = "propertyType";
+        customer.primaryContact = a;
+
+        customer.secondaryContacts = secondaryContacts;
+
+        QName name = new QName("");
+        JAXBElement<Object> jbe = new JAXBElement<Object>(name, Object.class, customer);
+        return jbe;
+    }
+
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/type/model/Address.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/type/model/Address.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Radek Felcman - 2.7.4 - initial implementation
+package org.eclipse.persistence.testing.jaxb.json.type.model;
+
+import java.util.Objects;
+
+public class Address extends Contact{
+
+    public String street;
+
+    public String city;
+
+    public String zip;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Address address = (Address) o;
+        return  Objects.equals(super.contactId, address.contactId) &&
+                Objects.equals(street, address.street) &&
+                Objects.equals(city, address.city) &&
+                Objects.equals(zip, address.zip);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(street, city, zip);
+    }
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/type/model/Contact.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/type/model/Contact.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Radek Felcman - 2.7.4 - initial implementation
+package org.eclipse.persistence.testing.jaxb.json.type.model;
+
+import javax.xml.bind.annotation.XmlSeeAlso;
+import java.util.Objects;
+
+@XmlSeeAlso({Address.class, Phone.class})
+public class Contact {
+
+    public int contactId;
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Contact contact = (Contact) o;
+        return contactId == contact.contactId;
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(contactId);
+    }
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/type/model/PersonWithType.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/type/model/PersonWithType.java
@@ -16,6 +16,7 @@ package org.eclipse.persistence.testing.jaxb.json.type.model;
 
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlSeeAlso;
+import java.util.List;
 
 @XmlRootElement
 @XmlSeeAlso(CustomerWithInheritance.class)
@@ -24,6 +25,10 @@ public class PersonWithType {
     public String name;
 
     public String type;
+
+    public Contact primaryContact;
+
+    public List<Contact> secondaryContacts;
 
     @Override
     public int hashCode() {
@@ -52,6 +57,16 @@ public class PersonWithType {
             if (other.type != null)
                 return false;
         } else if (!type.equals(other.type))
+            return false;
+        if (primaryContact == null) {
+            if (other.primaryContact != null)
+                return false;
+        } else if (!primaryContact.equals(other.primaryContact))
+            return false;
+        if (secondaryContacts == null) {
+            if (other.secondaryContacts != null)
+                return false;
+        } else if (!secondaryContacts.equals(other.secondaryContacts))
             return false;
         return true;
     }

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/type/model/Phone.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/type/model/Phone.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Radek Felcman - 2.7.4 - initial implementation
+package org.eclipse.persistence.testing.jaxb.json.type.model;
+
+import java.util.Objects;
+
+public class Phone extends Contact{
+
+    public String number;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Phone phone = (Phone) o;
+        return  Objects.equals(super.contactId, phone.contactId) &&
+                Objects.equals(number, phone.number);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(number);
+    }
+}

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBContextProperties.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBContextProperties.java
@@ -247,6 +247,55 @@ public class JAXBContextProperties {
     public static final String JSON_TYPE_COMPATIBILITY = "eclipselink.json.type-compatibility";
 
     /**
+     * Override default type property name for JSON as MOXy type discriminator. Settings from binding file have higher priority.
+     *
+     * <p><b>Example</b></p>
+     * <p>Given the following property</p>
+     * <pre>
+     * conf.put(JAXBContextProperties.JSON_TYPE_ATTRIBUTE_NAME, "mytype");
+     * </pre>
+     * <p>If the property is set the JSON output will be:</p>
+     * <pre>
+     * ...
+     * {
+     *      "mytype": "phone",
+     *      "contactId": 3,
+     *      "number": "987654321"
+     * }
+     * ...
+     * </pre>
+     * <p>for following object model<p/>
+     * <pre>
+     * &#64;XmlSeeAlso({Address.class, Phone.class})
+     * public class Contact {
+     *
+     *      public int contactId;
+     *      ...
+     * </pre>
+     * <pre>
+     * public class Phone extends Contact{
+     *
+     *      public String number;
+     *      ...
+     * </pre>
+     * <p>If the property is not set (default value) the JSON output will be:</p>
+     * <pre>
+     * ...
+     * {
+     *      "type": "phone",
+     *      "contactId": 3,
+     *      "number": "987654321"
+     * }
+     * ...
+     * </pre>
+     * Unmarshaller will use it as type discriminator to select right child class.
+     * @since 2.7.4
+     * @see org.eclipse.persistence.jaxb.MarshallerProperties#JSON_TYPE_ATTRIBUTE_NAME
+     * @see org.eclipse.persistence.jaxb.UnmarshallerProperties#JSON_TYPE_ATTRIBUTE_NAME
+     */
+    public static final String JSON_TYPE_ATTRIBUTE_NAME = "eclipselink.json.type-attribute-name";
+
+    /**
      * If set to <i>Boolean.TRUE</i>, {@link org.eclipse.persistence.jaxb.JAXBUnmarshaller} will match
      * XML Elements and XML Attributes to Java fields case insensitively.
      *

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBMarshaller.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBMarshaller.java
@@ -319,6 +319,8 @@ public class JAXBMarshaller implements javax.xml.bind.Marshaller {
             return xmlMarshaller.getJsonTypeConfiguration().isUseXsdTypesWithPrefix();
         } else if (MarshallerProperties.JSON_TYPE_COMPATIBILITY.equals(key)) {
             return xmlMarshaller.getJsonTypeConfiguration().isJsonTypeCompatibility();
+        } else if (MarshallerProperties.JSON_TYPE_ATTRIBUTE_NAME.equals(key)) {
+            return xmlMarshaller.getJsonTypeConfiguration().getJsonTypeAttributeName();
         } else if (SUN_CHARACTER_ESCAPE_HANDLER.equals(key) || SUN_JSE_CHARACTER_ESCAPE_HANDLER.equals(key) ||SUN_CHARACTER_ESCAPE_HANDLER_MARSHALLER.equals(key) || SUN_JSE_CHARACTER_ESCAPE_HANDLER_MARSHALLER.equals(key)) {
             if (xmlMarshaller.getCharacterEscapeHandler() instanceof CharacterEscapeHandlerWrapper) {
                 CharacterEscapeHandlerWrapper wrapper = (CharacterEscapeHandlerWrapper) xmlMarshaller.getCharacterEscapeHandler();
@@ -905,6 +907,8 @@ public class JAXBMarshaller implements javax.xml.bind.Marshaller {
                 xmlMarshaller.getJsonTypeConfiguration().setUseXsdTypesWithPrefix((Boolean)value);
             } else if (MarshallerProperties.JSON_TYPE_COMPATIBILITY.equals(key)) {
                 xmlMarshaller.getJsonTypeConfiguration().setJsonTypeCompatibility((Boolean)value);
+            } else if (MarshallerProperties.JSON_TYPE_ATTRIBUTE_NAME.equals(key)) {
+                xmlMarshaller.getJsonTypeConfiguration().setJsonTypeAttributeName((String)value);
             } else if (MarshallerProperties.CHARACTER_ESCAPE_HANDLER.equals(key)) {
                 xmlMarshaller.setCharacterEscapeHandler((CharacterEscapeHandler) value);
             } else if (SUN_CHARACTER_ESCAPE_HANDLER.equals(key) || SUN_JSE_CHARACTER_ESCAPE_HANDLER.equals(key)  ||SUN_CHARACTER_ESCAPE_HANDLER_MARSHALLER.equals(key) || SUN_JSE_CHARACTER_ESCAPE_HANDLER_MARSHALLER.equals(key)) {

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBUnmarshaller.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBUnmarshaller.java
@@ -865,6 +865,8 @@ public class JAXBUnmarshaller implements Unmarshaller {
             xmlUnmarshaller.getJsonTypeConfiguration().setUseXsdTypesWithPrefix((Boolean)value);
         } else if (UnmarshallerProperties.JSON_TYPE_COMPATIBILITY.equals(key)) {
             xmlUnmarshaller.getJsonTypeConfiguration().setJsonTypeCompatibility((Boolean)value);
+        } else if (UnmarshallerProperties.JSON_TYPE_ATTRIBUTE_NAME.equals(key)) {
+            xmlUnmarshaller.getJsonTypeConfiguration().setJsonTypeAttributeName((String)value);
         } else if (UnmarshallerProperties.ID_RESOLVER.equals(key)) {
             setIDResolver((IDResolver) value);
         } else if (SUN_ID_RESOLVER.equals(key) || SUN_JSE_ID_RESOLVER.equals(key)) {
@@ -961,6 +963,8 @@ public class JAXBUnmarshaller implements Unmarshaller {
             return xmlUnmarshaller.getJsonTypeConfiguration().isUseXsdTypesWithPrefix();
         } else if (UnmarshallerProperties.JSON_TYPE_COMPATIBILITY.equals(key)) {
             return xmlUnmarshaller.getJsonTypeConfiguration().isJsonTypeCompatibility();
+        } else if (MarshallerProperties.JSON_TYPE_ATTRIBUTE_NAME.equals(key)) {
+            return xmlUnmarshaller.getJsonTypeConfiguration().getJsonTypeAttributeName();
         } else if (UnmarshallerProperties.ID_RESOLVER.equals(key)) {
             return xmlUnmarshaller.getIDResolver();
         } else if (SUN_ID_RESOLVER.equals(key) || SUN_JSE_ID_RESOLVER.equals(key)) {

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/MarshallerProperties.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/MarshallerProperties.java
@@ -157,6 +157,55 @@ public class MarshallerProperties {
     public static final String JSON_TYPE_COMPATIBILITY = JAXBContextProperties.JSON_TYPE_COMPATIBILITY;
 
     /**
+     * Override default type property name for JSON as MOXy type discriminator. Settings from binding file have higher priority.
+     *
+     * <p><b>Example</b></p>
+     * <p>Given the following property</p>
+     * <pre>
+     * marshaller.setProperty(MarshallerProperties.JSON_TYPE_ATTRIBUTE_NAME, "mytype");
+     * </pre>
+     * <p>If the property is set the JSON output will be:</p>
+     * <pre>
+     * ...
+     * {
+     *      "mytype": "phone",
+     *      "contactId": 3,
+     *      "number": "987654321"
+     * }
+     * ...
+     * </pre>
+     * <p>for following object model<p/>
+     * <pre>
+     * &#64;XmlSeeAlso({Address.class, Phone.class})
+     * public class Contact {
+     *
+     *      public int contactId;
+     *      ...
+     * </pre>
+     * <pre>
+     * public class Phone extends Contact{
+     *
+     *      public String number;
+     *      ...
+     * </pre>
+     * <p>If the property is not set (default value) the JSON output will be:</p>
+     * <pre>
+     * ...
+     * {
+     *      "type": "phone",
+     *      "contactId": 3,
+     *      "number": "987654321"
+     * }
+     * ...
+     * </pre>
+     * Unmarshaller will use it as type discriminator to select right child class.
+     * @since 2.7.4
+     * @see org.eclipse.persistence.jaxb.JAXBContextProperties#JSON_TYPE_ATTRIBUTE_NAME
+     * @see org.eclipse.persistence.jaxb.UnmarshallerProperties#JSON_TYPE_ATTRIBUTE_NAME
+     */
+    public static final String JSON_TYPE_ATTRIBUTE_NAME = JAXBContextProperties.JSON_TYPE_ATTRIBUTE_NAME;
+
+    /**
      *
      */
     public static final String OBJECT_GRAPH = JAXBContextProperties.OBJECT_GRAPH;

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/UnmarshallerProperties.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/UnmarshallerProperties.java
@@ -114,6 +114,55 @@ public class UnmarshallerProperties {
     public static final String JSON_TYPE_COMPATIBILITY = JAXBContextProperties.JSON_TYPE_COMPATIBILITY;
 
     /**
+     * Override default type property name for JSON as MOXy type discriminator. Settings from binding file have higher priority.
+     *
+     * <p><b>Example</b></p>
+     * <p>Given the following property</p>
+     * <pre>
+     * unmarshaller.setProperty(UnmarshallerProperties.JSON_TYPE_ATTRIBUTE_NAME, "mytype");
+     * </pre>
+     * <p>If the property is set the valid JSON input will be:</p>
+     * <pre>
+     * ...
+     * {
+     *      "mytype": "phone",
+     *      "contactId": 3,
+     *      "number": "987654321"
+     * }
+     * ...
+     * </pre>
+     * <p>for following object model<p/>
+     * <pre>
+     * &#64;XmlSeeAlso({Address.class, Phone.class})
+     * public class Contact {
+     *
+     *      public int contactId;
+     *      ...
+     * </pre>
+     * <pre>
+     * public class Phone extends Contact{
+     *
+     *      public String number;
+     *      ...
+     * </pre>
+     * <p>If the property is not set (default value) the valid JSON input will be:</p>
+     * <pre>
+     * ...
+     * {
+     *      "type": "phone",
+     *      "contactId": 3,
+     *      "number": "987654321"
+     * }
+     * ...
+     * </pre>
+     * Unmarshaller will use it as type discriminator to select right child class.
+     * @since 2.7.4
+     * @see org.eclipse.persistence.jaxb.JAXBContextProperties#JSON_TYPE_ATTRIBUTE_NAME
+     * @see org.eclipse.persistence.jaxb.MarshallerProperties#JSON_TYPE_ATTRIBUTE_NAME
+     */
+    public static final String JSON_TYPE_ATTRIBUTE_NAME = JAXBContextProperties.JSON_TYPE_ATTRIBUTE_NAME;
+
+    /**
      * The name of the property used to specify the type of binding to be
      * performed.  When this property is specified at the <i>JAXBContext</i>
      * level all instances of <i>Marshaller</i> and <i>Unmarshaller</i> will

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/compiler/MappingsGenerator.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/compiler/MappingsGenerator.java
@@ -125,6 +125,7 @@ import org.eclipse.persistence.jaxb.xmlmodel.XmlTransformation.XmlReadTransforme
 import org.eclipse.persistence.jaxb.xmlmodel.XmlTransformation.XmlWriteTransformer;
 import org.eclipse.persistence.mappings.DatabaseMapping;
 import org.eclipse.persistence.mappings.converters.Converter;
+import org.eclipse.persistence.oxm.XMLConstants;
 import org.eclipse.persistence.oxm.XMLDescriptor;
 import org.eclipse.persistence.oxm.XMLField;
 import org.eclipse.persistence.oxm.mappings.FixedMimeTypePolicy;
@@ -2427,7 +2428,7 @@ public class MappingsGenerator {
                 if (rootTypeInfo.isSetXmlDiscriminatorNode()) {
                     classIndicatorField = new XMLField(rootTypeInfo.getXmlDiscriminatorNode());
                 } else {
-                    classIndicatorField = new XMLField(ATT + "type");
+                    classIndicatorField = XMLConstants.DEFAULT_XML_TYPE_ATTRIBUTE;
                     classIndicatorField.getXPathFragment().setNamespaceURI(javax.xml.XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI);
                 }
                 rootDescriptor.getInheritancePolicy().setClassIndicatorField(classIndicatorField);


### PR DESCRIPTION
Bug 536947 v 2.0 – XmlDiscriminatorNode with JSON in MoxyBindings File Is not applied to Root Elements

This fix extends MOXY JAXBContext, MarshallerProperties, UnmarshallerProperties with new JSON_TYPE_ATTRIBUTE_NAME property. It allows to override default type property name “type” for JSON content as MOXy type discriminator with custom name. Before this fix this customization was possible only via XML bindings file xml-discriminator-node attribute in java-type element. Settings from binding file have higher priority if this file is used too.
This fix has test case too.

See https://bugs.eclipse.org/bugs/show_bug.cgi?id=536947

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>

(cherry picked from commit 8539759)
Signed-off-by: Radek Felcman <radek.felcman@oracle.com>