### PR TITLE
Bug 538228 - @XmpPaths + @XmlIDREF + @XmlElements fail due to bad analyze of referenced types

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLObjectReferenceMappingNodeValue.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLObjectReferenceMappingNodeValue.java
@@ -176,7 +176,7 @@ public class XMLObjectReferenceMappingNodeValue extends MappingNodeValue {
         QName schemaType = xmlField.getSchemaTypeForValue(fieldValue, session);
         XPathFragment groupingFragment = marshalRecord.openStartGroupingElements(namespaceResolver);
 
-        if (xPathFragment.isAttribute()) {
+        if (xPathFragment != null && xPathFragment.isAttribute()) {
             marshalRecord.attribute(xPathFragment, namespaceResolver, fieldValue, schemaType);
             marshalRecord.closeStartGroupingElements(groupingFragment);
         } else {

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/oxm/mappings/XMLCollectionReferenceMapping.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/oxm/mappings/XMLCollectionReferenceMapping.java
@@ -211,7 +211,7 @@ public class XMLCollectionReferenceMapping extends XMLObjectReferenceMapping imp
             }
         } else {
             XMLField tgtFld = (XMLField) getSourceToTargetKeyFieldAssociations().get(xmlField);
-            String tgtXPath = tgtFld.getXPath();
+            String tgtXPath = tgtFld.getQualifiedName();
             HashMap primaryKeyMap = reference.getPrimaryKeyMap();
             CacheId pks = (CacheId) primaryKeyMap.get(tgtXPath);
             ClassDescriptor descriptor = session.getClassDescriptor(referenceClass);

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/annotations/xmlidref/inheritance/control.json
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/annotations/xmlidref/inheritance/control.json
@@ -1,0 +1,49 @@
+{
+  "RootNode": {
+    "id": "1",
+    "name": "rootNode1",
+    "refNodes": {
+      "ComplexNodeID": [
+        "10"
+      ],
+      "LeafNodeID": [
+        "20"
+      ]
+    },
+    "ownedNodes": {
+      "ComplexNode": [
+        {
+          "id": "10",
+          "name": "complexNode10",
+          "refNodes": {
+            "ComplexNodeID": [
+              "10"
+            ],
+            "LeafNodeID": [
+              "20"
+            ]
+          },
+          "ownedNodes": {
+            "ComplexNode": []
+          }
+        }
+      ],
+      "LeafNode": [
+        {
+          "id": "20",
+          "name": "leafNode10",
+          "isValid": false,
+          "refNodes": {
+            "ComplexNodeID": [
+              "10"
+            ],
+            "LeafNodeID": [
+              "20"
+            ]
+          },
+          "LNComplexNodeID": "10"
+        }
+      ]
+    }
+  }
+}

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/annotations/xmlidref/inheritance/control.xml
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/annotations/xmlidref/inheritance/control.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0,
+    or the Eclipse Distribution License v. 1.0 which is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+
+    SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+-->
+
+<RootNode id="1" name="rootNode1">
+    <refNodes>
+        <ComplexNodeID>10</ComplexNodeID>
+        <LeafNodeID>20</LeafNodeID>
+    </refNodes>
+    <ownedNodes>
+        <ComplexNode id="10" name="complexNode10">
+            <refNodes>
+                <ComplexNodeID>10</ComplexNodeID>
+                <LeafNodeID>20</LeafNodeID>
+            </refNodes>
+            <ownedNodes/>
+        </ComplexNode>
+        <LeafNode id="20" name="leafNode10" isValid="false">
+            <refNodes>
+                <ComplexNodeID>10</ComplexNodeID>
+                <LeafNodeID>20</LeafNodeID>
+            </refNodes>
+            <LNComplexNodeID>10</LNComplexNodeID>
+        </LeafNode>
+    </ownedNodes>
+</RootNode>

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/annotations/AnnotationsTestSuite.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/annotations/AnnotationsTestSuite.java
@@ -26,6 +26,7 @@ import org.eclipse.persistence.testing.jaxb.annotations.xmlelementnillable.XmlEl
 import org.eclipse.persistence.testing.jaxb.annotations.xmlelementnillable.XmlElementNillableTypeLevelTestCases;
 import org.eclipse.persistence.testing.jaxb.annotations.xmlidref.XmlIdRefMissingIdEventHandlerTestCases;
 import org.eclipse.persistence.testing.jaxb.annotations.xmlidref.XmlIdRefMissingIdTestCases;
+import org.eclipse.persistence.testing.jaxb.annotations.xmlidref.inheritance.XmlIdRefInheritanceTestCases;
 import org.eclipse.persistence.testing.jaxb.annotations.xmlidref.self.XmlIdRefSelfTestCases;
 import org.eclipse.persistence.testing.jaxb.annotations.xmlinlinebinarydata.InlineHexBinaryTestCases;
 import org.eclipse.persistence.testing.jaxb.annotations.xmlinversereference.InverseRefChoiceAdapterTestCases;
@@ -114,6 +115,7 @@ public class AnnotationsTestSuite extends TestSuite {
         suite.addTestSuite(XmlIdRefMissingIdTestCases.class);
         suite.addTestSuite(XmlIdRefMissingIdEventHandlerTestCases.class);
         suite.addTestSuite(XmlIdRefSelfTestCases.class);
+        suite.addTestSuite(XmlIdRefInheritanceTestCases.class);
         suite.addTest(org.eclipse.persistence.testing.jaxb.annotations.xmltransient.XmlTransientTestSuite.suite());
         suite.addTestSuite(org.eclipse.persistence.testing.jaxb.annotations.xmlelementdecl.qualified.QualfiedTestCases.class);
         suite.addTestSuite(org.eclipse.persistence.testing.jaxb.annotations.xmlelementdecl.noxmlrootelement.NoRootElementTestCases.class);

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/annotations/xmlidref/inheritance/ComplexNode.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/annotations/xmlidref/inheritance/ComplexNode.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Radek Felcman - 2.7.4 - initial implementation
+package org.eclipse.persistence.testing.jaxb.annotations.xmlidref.inheritance;
+
+import javax.xml.bind.annotation.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@XmlRootElement(name="ComplexNode")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class ComplexNode extends Node {
+	
+	@XmlElementWrapper(name="ownedNodes")
+	@XmlElements({
+		@XmlElement(name="ComplexNode", type=ComplexNode.class),
+		@XmlElement(name="LeafNode", type=LeafNode.class),
+	})
+	private List<Node> ownedNodes = new ArrayList<Node>();
+
+
+    public List<Node> getOwnedNodes() {
+        return ownedNodes;
+    }
+
+    public void setOwnedNodes(List<Node> ownedNodes) {
+        this.ownedNodes = ownedNodes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        ComplexNode that = (ComplexNode) o;
+        return Objects.equals(getId(), that.getId()) &&
+                Objects.equals(getOwnedNodes(), that.getOwnedNodes());
+    }
+
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/annotations/xmlidref/inheritance/LeafNode.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/annotations/xmlidref/inheritance/LeafNode.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Radek Felcman - 2.7.4 - initial implementation
+package org.eclipse.persistence.testing.jaxb.annotations.xmlidref.inheritance;
+
+import javax.xml.bind.annotation.*;
+import java.util.Objects;
+
+@XmlRootElement(name="LeafNode")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class LeafNode extends Node {
+	
+	@XmlAttribute
+	private boolean isValid;
+	
+	@XmlIDREF
+	@XmlElements({
+		@XmlElement(name="LNComplexNodeID", type=ComplexNode.class),
+		@XmlElement(name="LNLeafNodeID", type=LeafNode.class),
+	})
+	private Node targetNode;
+
+    public boolean isValid() {
+        return isValid;
+    }
+
+    public void setValid(boolean valid) {
+        isValid = valid;
+    }
+
+    public Node getTargetNode() {
+        return targetNode;
+    }
+
+    public void setTargetNode(Node targetNode) {
+        this.targetNode = targetNode;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        LeafNode leafNode = (LeafNode) o;
+        return isValid() == leafNode.isValid() &&
+                Objects.equals(getId(), leafNode.getId()) &&
+                Objects.equals(getTargetNode(), leafNode.getTargetNode());
+    }
+
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/annotations/xmlidref/inheritance/Node.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/annotations/xmlidref/inheritance/Node.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Radek Felcman - 2.7.4 - initial implementation
+package org.eclipse.persistence.testing.jaxb.annotations.xmlidref.inheritance;
+
+import org.eclipse.persistence.oxm.annotations.XmlPath;
+import org.eclipse.persistence.oxm.annotations.XmlPaths;
+
+import javax.xml.bind.annotation.*;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+
+@XmlRootElement(name = "Node")
+@XmlAccessorType(XmlAccessType.FIELD)
+public abstract class Node {
+
+    @XmlID
+    @XmlAttribute(name = "id")
+    private String id;
+
+    @XmlAttribute
+    private String name;
+
+    @XmlIDREF
+    @XmlPaths({
+            @XmlPath("refNodes/ComplexNodeID/text()"),
+            @XmlPath("refNodes/LeafNodeID/text()"),
+    })
+    @XmlElements({
+            @XmlElement(name = "ComplexNodeID", type = ComplexNode.class),
+            @XmlElement(name = "LeafNodeID", type = LeafNode.class),
+    })
+    private List<Node> refNodes = new ArrayList<Node>();
+
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getId() {
+        return this.id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<Node> getRefNodes() {
+        return refNodes;
+    }
+
+    public void setRefNodes(List<Node> refNodes) {
+        this.refNodes = refNodes;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Node node = (Node) o;
+        if (getRefNodes() == null && node.getRefNodes() != null) return false;
+        if (node.getRefNodes() == null && getRefNodes() != null) return false;
+        if (getRefNodes() != null || node.getRefNodes() != null) {
+            if (getRefNodes().size() != node.getRefNodes().size()) return false;
+            Iterator<Node> iterator1 = getRefNodes().iterator();
+            Iterator<Node> iterator2 = node.getRefNodes().iterator();
+            //Compare just IDs to avoid circular references
+            while (iterator1.hasNext()) {
+                if (!iterator1.next().getId().equals(iterator2.next().getId())) return false;
+            }
+        }
+        return Objects.equals(getId(), node.getId()) &&
+                Objects.equals(getName(), node.getName());
+    }
+
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/annotations/xmlidref/inheritance/RootNode.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/annotations/xmlidref/inheritance/RootNode.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Radek Felcman - 2.7.4 - initial implementation
+package org.eclipse.persistence.testing.jaxb.annotations.xmlidref.inheritance;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name="RootNode")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class RootNode extends ComplexNode {
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/annotations/xmlidref/inheritance/XmlIdRefInheritanceTestCases.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/annotations/xmlidref/inheritance/XmlIdRefInheritanceTestCases.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Radek Felcman - 2.7.4 - initial implementation
+package org.eclipse.persistence.testing.jaxb.annotations.xmlidref.inheritance;
+
+import org.eclipse.persistence.jaxb.MarshallerProperties;
+import org.eclipse.persistence.testing.jaxb.JAXBWithJSONTestCases;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class XmlIdRefInheritanceTestCases extends JAXBWithJSONTestCases {
+
+    private static final String CONTROL_JSON = "org/eclipse/persistence/testing/jaxb/annotations/xmlidref/inheritance/control.json";
+    private static final String CONTROL_XML = "org/eclipse/persistence/testing/jaxb/annotations/xmlidref/inheritance/control.xml";
+
+    public XmlIdRefInheritanceTestCases(String name) throws Exception {
+        super(name);
+        setClasses(new Class[] {RootNode.class});
+        setControlJSON(CONTROL_JSON);
+        setControlDocument(CONTROL_XML);
+        jaxbMarshaller.setProperty(MarshallerProperties.JSON_MARSHAL_EMPTY_COLLECTIONS, Boolean.TRUE);
+    }
+
+    @Override
+    protected RootNode getControlObject() {
+
+        ComplexNode complexNode1 = new ComplexNode();
+        complexNode1.setId("10");
+        complexNode1.setName("complexNode10");
+
+        LeafNode leafNode1 = new LeafNode();
+        leafNode1.setId("20");
+        leafNode1.setName("leafNode10");
+
+        List<Node> nodes = new ArrayList<>();
+        nodes.add(complexNode1);
+        nodes.add(leafNode1);
+
+        complexNode1.setRefNodes(nodes);
+
+        leafNode1.setRefNodes(nodes);
+        leafNode1.setTargetNode(complexNode1);
+
+        RootNode rootNode = new RootNode();
+        rootNode.setId("1");
+        rootNode.setName("rootNode1");
+        rootNode.setRefNodes(nodes);
+        rootNode.setOwnedNodes(nodes);
+
+        return rootNode;
+    }
+
+    public void testSchemaGen() throws Exception {
+        MySchemaOutputResolver outputResolver = new MySchemaOutputResolver();
+        getJAXBContext().generateSchema(outputResolver);
+
+        assertEquals("A Schema was generated but should not have been", 1, outputResolver.getSchemaFiles().size());
+    }
+
+
+}

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/compiler/AnnotationsProcessor.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/compiler/AnnotationsProcessor.java
@@ -860,8 +860,8 @@ public final class AnnotationsProcessor {
 
             // handle superclass if necessary
             JavaClass superClass = javaClass.getSuperclass();
-            processReferencedClass(superClass);
             processPropertiesSuperClass(javaClass, info);
+            processReferencedClass(superClass);
 
             // add properties
             info.setProperties(getPropertiesForClass(javaClass, info));
@@ -1108,7 +1108,7 @@ public final class AnnotationsProcessor {
             }
             // if the property is an XmlIDREF, the target must have an
             // XmlID set
-            if (targetInfo != null && targetInfo.getIDProperty() == null) {
+            if (targetInfo != null && targetInfo.getIDProperty() == null && !preCheckXmlID(typeClass, targetInfo)) {
                 throw JAXBException.invalidIdRef(property.getPropertyName(), typeClass.getQualifiedName());
             }
         }
@@ -2429,7 +2429,7 @@ public final class AnnotationsProcessor {
                 TypeInfo tInfo = typeInfos.get(next.getType());
 
 
-                if (tInfo == null || !tInfo.isIDSet()) {
+                if (tInfo == null || (!tInfo.isIDSet() && !preCheckXmlID(nextCls, tInfo))) {
                     throw JAXBException.invalidXmlElementInXmlElementsList(propertyName, name);
                 }
             }
@@ -2487,6 +2487,33 @@ public final class AnnotationsProcessor {
             }
         }
         choiceProperty.setChoiceProperties(choiceProperties);
+    }
+
+    /**
+     * Check if class with specified non complete type info has @XmlID field.
+     * Can update type info. Used in case when annotation processor analyze
+     * inheritance (parent classes) and from parent class is reverse reference
+     * via @XmlIDREF, @XmlPaths and @XmlElements to the some child classes.
+     * In this phase type info is not complete (missing properties).
+     * @param javaClass
+     * @param typeInfo
+     * @return
+     */
+    private boolean preCheckXmlID(JavaClass javaClass, TypeInfo typeInfo) {
+        ArrayList<Property> properties = getPropertiesForClass(javaClass, typeInfo);
+        for (Property property : properties) {
+            // check @XmlID
+            if (helper.isAnnotationPresent(property.getElement(), XmlID.class)) {
+                return true;
+            }
+        }
+        if (typeInfos.get(javaClass.getSuperclass().getQualifiedName()).isIDSet()) {
+            if (typeInfo.getIDProperty() == null) {
+                typeInfo.setIDProperty(typeInfos.get(javaClass.getSuperclass().getQualifiedName()).getIDProperty());
+            }
+            return true;
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
Bug 538228 - @XmpPaths + @XmlIDREF + @XmlElements fail due to bad analyze of referenced types

This is fix for org.eclipse.persistence.jaxb.compiler.AnnotationsProcessor as it's specified in the bug description.
There was problem with resolving @XmlID fields from parent classes if there is inheritance between entities.
But there are some small fixes in classes used by marshaller and unmarshaller too to correctly marshall/unmarshall documents with @XmlIDREF + @XmlPaths + @XmlElements annotations.

See https://bugs.eclipse.org/bugs/show_bug.cgi?id=538228

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>

(cherry picked from commit 98e5422)
Signed-off-by: Radek Felcman <radek.felcman@oracle.com>