### PR TITLE
Bug 536947 v 2.0 – XmlDiscriminatorNode with JSON in MoxyBindings File Is not applied to Root Elements (fix for javadoc comments)

### DIFF
--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBContextProperties.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBContextProperties.java
@@ -264,7 +264,7 @@ public class JAXBContextProperties {
      * }
      * ...
      * </pre>
-     * <p>for following object model<p/>
+     * <p>for following object model</p>
      * <pre>
      * &#64;XmlSeeAlso({Address.class, Phone.class})
      * public class Contact {

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/MarshallerProperties.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/MarshallerProperties.java
@@ -174,7 +174,7 @@ public class MarshallerProperties {
      * }
      * ...
      * </pre>
-     * <p>for following object model<p/>
+     * <p>for following object model</p>
      * <pre>
      * &#64;XmlSeeAlso({Address.class, Phone.class})
      * public class Contact {

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/UnmarshallerProperties.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/UnmarshallerProperties.java
@@ -131,7 +131,7 @@ public class UnmarshallerProperties {
      * }
      * ...
      * </pre>
-     * <p>for following object model<p/>
+     * <p>for following object model</p>
      * <pre>
      * &#64;XmlSeeAlso({Address.class, Phone.class})
      * public class Contact {


### PR DESCRIPTION
Bug 536947 v 2.0 – XmlDiscriminatorNode with JSON in MoxyBindings File Is not applied to Root Elements (fix for javadoc comments)

This fix extends MOXY JAXBContext, MarshallerProperties, UnmarshallerProperties with new JSON_TYPE_ATTRIBUTE_NAME property. It allows to override default type property name “type” for JSON content as MOXy type discriminator with custom name. Before this fix this customization was possible only via XML bindings file xml-discriminator-node attribute in java-type element. Settings from binding file have higher priority if this file is used too.
This fix has test case too.
This commit contains fix for javadoc comments.

See https://bugs.eclipse.org/bugs/show_bug.cgi?id=536947

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>

(cherry picked from commit 629689c)
Signed-off-by: Radek Felcman <radek.felcman@oracle.com>