### PR TITLE
[master] Issue #253: Add support for embedded constructor result expressions

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/ExpressionQueryMechanism.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/ExpressionQueryMechanism.java
@@ -18,6 +18,8 @@
 //       - 322008: Improve usability of additional criteria applied to queries at the session/EM
 //     05/10/2018-master Joe Grassel
 //       - Github#93: Bug with bulk update processing involving version field update parameter
+//     10/01/2018: Will Dazey
+//       - #253: Add support for embedded constructor results with CriteriaBuilder
 package org.eclipse.persistence.internal.queries;
 
 import java.util.*;
@@ -627,20 +629,8 @@ public class ExpressionQueryMechanism extends StatementQueryMechanism {
         }
         Vector fieldExpressions = reportQuery.getQueryExpressions();
         int itemOffset = fieldExpressions.size();
-        for (Iterator items = reportQuery.getItems().iterator(); items.hasNext();) {
-            ReportItem item = (ReportItem)items.next();
-            if (item.isConstructorItem()) {
-                ConstructorReportItem citem= (ConstructorReportItem)item;
-                List reportItems = citem.getReportItems();
-                int size = reportItems.size();
-                for (int i=0; i<size; i++) {
-                    item = (ReportItem)reportItems.get(i);
-                    extractStatementFromItem(item, clonedExpressions, selectStatement, fieldExpressions);
-                }
-            } else {
-                extractStatementFromItem(item, clonedExpressions, selectStatement, fieldExpressions);
-            }
-        }
+        List<ReportItem> items = reportQuery.getItems();
+        computeFieldExpressions(items, clonedExpressions, selectStatement, fieldExpressions);
 
         selectStatement.setFields(fieldExpressions);
         if (reportQuery.hasNonFetchJoinedAttributeExpressions()) {
@@ -652,43 +642,36 @@ public class ExpressionQueryMechanism extends StatementQueryMechanism {
             selectStatement.normalize(getSession(), getDescriptor(), clonedExpressions);
         }
 
-        //calculate indexes after normalize to insure expressions are set up correctly
-        for (Iterator items = reportQuery.getItems().iterator(); items.hasNext();){
-            ReportItem item = (ReportItem)items.next();
-
-            if (item.isConstructorItem()) {
-                ConstructorReportItem citem = (ConstructorReportItem)item;
-                List reportItems = citem.getReportItems();
-                int size = reportItems.size();
-                for (int i=0; i<size; i++) {
-                    item = (ReportItem)reportItems.get(i);
-                    itemOffset = computeAndSetItemOffset(item, itemOffset);
-                }
-            } else {
-                itemOffset = computeAndSetItemOffset(item, itemOffset);
-            }
-        }
+        items = reportQuery.getItems();
+        computeAndSetItemOffset(items, itemOffset);
 
         return selectStatement;
     }
 
-
     /**
-     * calculate indexes for an item, given the current Offset
+     * calculate indexes for given items, given the current Offset
      */
-    protected int computeAndSetItemOffset(ReportItem item, int itemOffset){
-        item.setResultIndex(itemOffset);
-        if (item.getAttributeExpression() != null) {
-            if (item.hasJoining()){
-                itemOffset = item.getJoinedAttributeManager().computeJoiningMappingIndexes(true, getSession(), itemOffset);
+    private int computeAndSetItemOffset(List<ReportItem> items, int itemOffset) {
+        for(ReportItem item : items) {
+            if (item.isConstructorItem()) {
+                List<ReportItem> reportItems = ((ConstructorReportItem) item).getReportItems();
+                itemOffset = computeAndSetItemOffset(reportItems, itemOffset);
             } else {
-                if (item.getDescriptor() != null) {
-                    itemOffset += item.getDescriptor().getAllSelectionFields((ReportQuery)getQuery()).size();
-                } else {
-                    if (item.getMapping() != null && item.getMapping().isAggregateObjectMapping()) {
-                        itemOffset += item.getMapping().getFields().size(); // Aggregate object may consist out of 1..n fields
+                //Don't set the offset on the ConstructorItem
+                item.setResultIndex(itemOffset);
+                if (item.getAttributeExpression() != null) {
+                    if (item.hasJoining()){
+                        itemOffset = item.getJoinedAttributeManager().computeJoiningMappingIndexes(true, getSession(), itemOffset);
                     } else {
-                        ++itemOffset; //only a single attribute can be selected
+                        if (item.getDescriptor() != null) {
+                            itemOffset += item.getDescriptor().getAllSelectionFields((ReportQuery)getQuery()).size();
+                        } else {
+                            if (item.getMapping() != null && item.getMapping().isAggregateObjectMapping()) {
+                                itemOffset += item.getMapping().getFields().size(); // Aggregate object may consist out of 1..n fields
+                            } else {
+                                ++itemOffset; //only a single attribute can be selected
+                            }
+                        }
                     }
                 }
             }
@@ -696,41 +679,52 @@ public class ExpressionQueryMechanism extends StatementQueryMechanism {
         return itemOffset;
     }
 
-    public void extractStatementFromItem(ReportItem item, Map clonedExpressions, SQLSelectStatement selectStatement, Vector fieldExpressions ){
+    private void computeFieldExpressions(List<ReportItem> items, Map clonedExpressions, SQLSelectStatement selectStatement, Vector fieldExpressions) {
+        for (ReportItem item : items) {
+            if (item.isConstructorItem()) {
+                List<ReportItem> reportItems = ((ConstructorReportItem) item).getReportItems();
+                computeFieldExpressions(reportItems, clonedExpressions, selectStatement, fieldExpressions);
+            } else {
+                extractStatementFromItem(item, clonedExpressions, selectStatement, fieldExpressions);
+            }
+        }
+    }
+
+    private void extractStatementFromItem(ReportItem item, Map clonedExpressions, SQLSelectStatement selectStatement, Vector fieldExpressions){
         if (item.getAttributeExpression() != null) {
-                // this allows us to modify the item expression without modifying the original in case of re-prepare
-                Expression attributeExpression = item.getAttributeExpression();
-                ExpressionBuilder clonedBuilder = attributeExpression.getBuilder();
-                if (clonedBuilder.wasQueryClassSetInternally() && ((ReportQuery)getQuery()).getExpressionBuilder() != clonedBuilder) {
-                    // no class specified so use statement builder as it is non-parallel
-                    // must have same builder as it will be initialized
-                    clonedBuilder = selectStatement.getBuilder();
-                    attributeExpression = attributeExpression.rebuildOn(clonedBuilder);
-                } else if (clonedExpressions != null && clonedExpressions.get(clonedBuilder) != null) {
-                    Expression cloneExpression = (Expression)clonedExpressions.get(attributeExpression);
-                    if ((cloneExpression != null) && !cloneExpression.isExpressionBuilder()) {
-                        attributeExpression = cloneExpression;
-                    } else {
-                        //The builder has been cloned ensure that the cloned builder is used
-                        //in the items.
-                        clonedBuilder = (ExpressionBuilder)clonedBuilder.copiedVersionFrom(clonedExpressions);
-                        attributeExpression = attributeExpression.copiedVersionFrom(clonedExpressions);
-                    }
+            // this allows us to modify the item expression without modifying the original in case of re-prepare
+            Expression attributeExpression = item.getAttributeExpression();
+            ExpressionBuilder clonedBuilder = attributeExpression.getBuilder();
+            if (clonedBuilder.wasQueryClassSetInternally() && ((ReportQuery)getQuery()).getExpressionBuilder() != clonedBuilder) {
+                // no class specified so use statement builder as it is non-parallel
+                // must have same builder as it will be initialized
+                clonedBuilder = selectStatement.getBuilder();
+                attributeExpression = attributeExpression.rebuildOn(clonedBuilder);
+            } else if (clonedExpressions != null && clonedExpressions.get(clonedBuilder) != null) {
+                Expression cloneExpression = (Expression)clonedExpressions.get(attributeExpression);
+                if ((cloneExpression != null) && !cloneExpression.isExpressionBuilder()) {
+                    attributeExpression = cloneExpression;
+                } else {
+                    //The builder has been cloned ensure that the cloned builder is used
+                    //in the items.
+                    clonedBuilder = (ExpressionBuilder)clonedBuilder.copiedVersionFrom(clonedExpressions);
+                    attributeExpression = attributeExpression.copiedVersionFrom(clonedExpressions);
                 }
-                if (attributeExpression.isExpressionBuilder()
-                        && (item.getDescriptor().getQueryManager().getAdditionalJoinExpression() != null)
-                        && !(clonedBuilder.wasAdditionJoinCriteriaUsed())) {
-                    if (selectStatement.getWhereClause() == null ) {
-                        selectStatement.setWhereClause(item.getDescriptor().getQueryManager().getAdditionalJoinExpression().rebuildOn(clonedBuilder));
-                    } else {
-                        selectStatement.setWhereClause(selectStatement.getWhereClause().and(item.getDescriptor().getQueryManager().getAdditionalJoinExpression().rebuildOn(clonedBuilder)));
-                    }
+            }
+            if (attributeExpression.isExpressionBuilder()
+                    && (item.getDescriptor().getQueryManager().getAdditionalJoinExpression() != null)
+                    && !(clonedBuilder.wasAdditionJoinCriteriaUsed())) {
+                if (selectStatement.getWhereClause() == null ) {
+                    selectStatement.setWhereClause(item.getDescriptor().getQueryManager().getAdditionalJoinExpression().rebuildOn(clonedBuilder));
+                } else {
+                    selectStatement.setWhereClause(selectStatement.getWhereClause().and(item.getDescriptor().getQueryManager().getAdditionalJoinExpression().rebuildOn(clonedBuilder)));
                 }
-                fieldExpressions.add(attributeExpression);
-                if (item.hasJoining()){
-                    fieldExpressions.addAll(item.getJoinedAttributeManager().getJoinedAttributeExpressions());
-                    fieldExpressions.addAll(item.getJoinedAttributeManager().getJoinedMappingExpressions());
-                }
+            }
+            fieldExpressions.add(attributeExpression);
+            if (item.hasJoining()){
+                fieldExpressions.addAll(item.getJoinedAttributeManager().getJoinedAttributeExpressions());
+                fieldExpressions.addAll(item.getJoinedAttributeManager().getJoinedMappingExpressions());
+            }
         }
     }
 

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/ConstructorReportItem.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/ConstructorReportItem.java
@@ -12,6 +12,8 @@
 
 // Contributors:
 //     Oracle - initial API and implementation from Oracle TopLink
+//     10/01/2018: Will Dazey
+//       - #253: Add support for embedded constructor results with CriteriaBuilder
 package org.eclipse.persistence.queries;
 
 import java.util.ArrayList;
@@ -68,8 +70,8 @@ public class ConstructorReportItem extends ReportItem  {
     private static final String TO_STR_SUFFIX = "])";
 
     protected Class[] constructorArgTypes;
-    protected List constructorMappings;
-    protected List reportItems;
+    protected List<DatabaseMapping> constructorMappings;
+    protected List<ReportItem> reportItems;
     protected Constructor constructor;
 
     /**
@@ -116,7 +118,7 @@ public class ConstructorReportItem extends ReportItem  {
      * INTERNAL:
      * Return the mappings for the items.
      */
-    public List getConstructorMappings(){
+    public List<DatabaseMapping> getConstructorMappings(){
         return constructorMappings;
     }
 
@@ -136,9 +138,9 @@ public class ConstructorReportItem extends ReportItem  {
         this.constructor = constructor;
     }
 
-    public List getReportItems(){
+    public List<ReportItem> getReportItems(){
         if (reportItems == null) {
-            reportItems = new ArrayList();
+            reportItems = new ArrayList<ReportItem>();
         }
         return reportItems;
     }
@@ -150,9 +152,9 @@ public class ConstructorReportItem extends ReportItem  {
     @Override
     public void initialize(ReportQuery query) throws QueryException {
         int size= getReportItems().size();
-        List mappings = new ArrayList();
+        List<DatabaseMapping> mappings = new ArrayList<DatabaseMapping>();
         for (int index = 0; index < size; index++) {
-            ReportItem item = (ReportItem)reportItems.get(index);
+            ReportItem item = reportItems.get(index);
             item.initialize(query);
             mappings.add(item.getMapping());
         }
@@ -166,9 +168,9 @@ public class ConstructorReportItem extends ReportItem  {
         Class[] constructorArgTypes = getConstructorArgTypes();
         for (int index = 0; index < numberOfItems; index++) {
             if (constructorArgTypes[index] == null) {
-                ReportItem argumentItem = (ReportItem)getReportItems().get(index);
+                ReportItem argumentItem = getReportItems().get(index);
                 if (mappings.get(index) != null) {
-                    DatabaseMapping mapping = (DatabaseMapping)constructorMappings.get(index);
+                    DatabaseMapping mapping = constructorMappings.get(index);
                     if (argumentItem.getAttributeExpression() != null && argumentItem.getAttributeExpression().isMapEntryExpression()){
                         if (((MapEntryExpression)argumentItem.getAttributeExpression()).shouldReturnMapEntry()){
                             constructorArgTypes[index] = Map.Entry.class;
@@ -222,11 +224,11 @@ public class ConstructorReportItem extends ReportItem  {
      * INTERNAL:
      * Return the mappings for the items.
      */
-    public void setConstructorMappings(List constructorMappings){
+    public void setConstructorMappings(List<DatabaseMapping> constructorMappings){
         this.constructorMappings = constructorMappings;
     }
 
-    public void setReportItems(List reportItems){
+    public void setReportItems(List<ReportItem> reportItems){
         this.reportItems = reportItems;
     }
 

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/ReportQuery.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/ReportQuery.java
@@ -1181,11 +1181,11 @@ public class ReportQuery extends ReadAllQuery {
      * If the descriptor has a single pk, it is used, otherwise any pk is used if distinct, otherwise a subselect is used.
      * If the object was obtained through an outer join, then the subselect also will not work, so an error is thrown.
      */
-    private void prepareObjectAttributeCount(List items, Map clonedExpressions) {
+    private void prepareObjectAttributeCount(List<ReportItem> items, Map clonedExpressions) {
         int numOfReportItems = items.size();
         //gf675: need to loop through all items to fix all count(..) instances
         for (int i =0;i<numOfReportItems; i++){
-            ReportItem item = (ReportItem)items.get(i);
+            ReportItem item = items.get(i);
             if (item == null) {
                 continue;
             } else if (item instanceof ConstructorReportItem) {

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/ReportQueryResult.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/ReportQueryResult.java
@@ -14,6 +14,8 @@
 //     Oracle - initial API and implementation from Oracle TopLink
 //     11/10/2011-2.4 Guy Pelletier
 //       - 357474: Address primaryKey option from tenant discriminator column
+//     10/01/2018: Will Dazey
+//       - #253: Add support for embedded constructor results with CriteriaBuilder
 package org.eclipse.persistence.queries;
 
 import java.io.*;
@@ -90,48 +92,19 @@ public class ReportQueryResult implements Serializable, Map {
         if (query.shouldDistinctBeUsed() && (query.shouldFilterDuplicates())) {
             this.key = new StringBuffer();
         }
-        List items = query.getItems();
-        int itemSize = items.size();
-        List results = new ArrayList(itemSize);
 
         if (query.shouldRetrievePrimaryKeys()) {
             setId(query.getDescriptor().getObjectBuilder().extractPrimaryKeyFromRow(row, query.getSession()));
             // For bug 3115576 this is only used for EXISTS sub-selects so no result is needed.
         }
-        for (int index = 0; index < itemSize; index++) {
+
+        List items = query.getItems();
+        List results = new ArrayList();
+        for (int index = 0; index < items.size(); index++) {
             ReportItem item = (ReportItem)items.get(index);
             if (item.isConstructorItem()) {
-                // For constructor items need to process each constructor argument.
-                ConstructorReportItem constructorItem = (ConstructorReportItem)item;
-                Class[] constructorArgTypes = constructorItem.getConstructorArgTypes();
-                int numberOfArguments = constructorItem.getReportItems().size();
-                Object[] constructorArgs = new Object[numberOfArguments];
-
-                for (int argumentIndex = 0; argumentIndex < numberOfArguments; argumentIndex++) {
-                    ReportItem argumentItem = (ReportItem)constructorItem.getReportItems().get(argumentIndex);
-                    Object result = processItem(query, row, toManyData, argumentItem);
-                    constructorArgs[argumentIndex] = ConversionManager.getDefaultManager().convertObject(result, constructorArgTypes[argumentIndex]);
-                }
-                try {
-                    Constructor constructor = constructorItem.getConstructor();
-                    Object returnValue = null;
-                    if (PrivilegedAccessHelper.shouldUsePrivilegedAccess()){
-                        try {
-                            returnValue = AccessController.doPrivileged(new PrivilegedInvokeConstructor(constructor, constructorArgs));
-                        } catch (PrivilegedActionException exception) {
-                            throw QueryException.exceptionWhileUsingConstructorExpression(exception.getException(), query);                       }
-                    } else {
-                        returnValue = PrivilegedAccessHelper.invokeConstructor(constructor, constructorArgs);
-                    }
-                    results.add(returnValue);
-                } catch (IllegalAccessException exc){
-                    throw QueryException.exceptionWhileUsingConstructorExpression(exc, query);
-                } catch (java.lang.reflect.InvocationTargetException exc){
-                    throw QueryException.exceptionWhileUsingConstructorExpression(exc, query);
-                } catch (InstantiationException exc){
-                    throw QueryException.exceptionWhileUsingConstructorExpression(exc, query);
-                }
-
+                Object result = processConstructorItem(query, row, toManyData, (ConstructorReportItem) item);
+                results.add(result);
             } else if (item.getAttributeExpression()!=null && item.getAttributeExpression().isClassTypeExpression()){
                 Object value = processItem(query, row, toManyData, item);
                 ClassDescriptor descriptor = ((org.eclipse.persistence.internal.expressions.ClassTypeExpression)item.getAttributeExpression()).getContainingDescriptor(query);
@@ -149,6 +122,40 @@ public class ReportQueryResult implements Serializable, Map {
         }
 
         setResults(results);
+    }
+
+    private Object processConstructorItem(ReportQuery query, AbstractRecord row, Vector toManyData, ConstructorReportItem constructorItem) {
+        // For constructor items need to process each constructor argument.
+        Class[] constructorArgTypes = constructorItem.getConstructorArgTypes();
+        int numberOfArguments = constructorItem.getReportItems().size();
+        Object[] constructorArgs = new Object[numberOfArguments];
+
+        for (int argumentIndex = 0; argumentIndex < numberOfArguments; argumentIndex++) {
+            ReportItem argumentItem = constructorItem.getReportItems().get(argumentIndex);
+            Object result = null;
+            if(argumentItem.isConstructorItem()) {
+                result = processConstructorItem(query, row, toManyData, (ConstructorReportItem) argumentItem);
+            } else {
+                result = processItem(query, row, toManyData, argumentItem);
+            }
+            constructorArgs[argumentIndex] = ConversionManager.getDefaultManager().convertObject(result, constructorArgTypes[argumentIndex]);
+        }
+        try {
+            Constructor constructor = constructorItem.getConstructor();
+            Object returnValue = null;
+            if (PrivilegedAccessHelper.shouldUsePrivilegedAccess()){
+                try {
+                    returnValue = AccessController.doPrivileged(new PrivilegedInvokeConstructor(constructor, constructorArgs));
+                } catch (PrivilegedActionException exception) {
+                    throw QueryException.exceptionWhileUsingConstructorExpression(exception.getException(), query);
+                }
+            } else {
+                returnValue = PrivilegedAccessHelper.invokeConstructor(constructor, constructorArgs);
+            }
+            return returnValue;
+        } catch (ReflectiveOperationException exc) {
+            throw QueryException.exceptionWhileUsingConstructorExpression(exc, query);
+        }
     }
 
     /**

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/criteria/TestCriteriaBuilder.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/criteria/TestCriteriaBuilder.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018 IBM Corporation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     10/01/2018: Will Dazey
+//       - #253: Add support for embedded constructor results with CriteriaBuilder
+package org.eclipse.persistence.jpa.test.criteria;
+
+import java.util.List;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.CompoundSelection;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Join;
+import javax.persistence.criteria.Root;
+
+import org.eclipse.persistence.jpa.test.criteria.model.L1;
+import org.eclipse.persistence.jpa.test.criteria.model.L1Model;
+import org.eclipse.persistence.jpa.test.criteria.model.L1_;
+import org.eclipse.persistence.jpa.test.criteria.model.L2;
+import org.eclipse.persistence.jpa.test.criteria.model.L2Model;
+import org.eclipse.persistence.jpa.test.criteria.model.L2_;
+import org.eclipse.persistence.jpa.test.framework.DDLGen;
+import org.eclipse.persistence.jpa.test.framework.Emf;
+import org.eclipse.persistence.jpa.test.framework.EmfRunner;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(EmfRunner.class)
+public class TestCriteriaBuilder {
+
+    @Emf(createTables = DDLGen.DROP_CREATE, classes = { L1.class, L2.class })
+    private EntityManagerFactory emf;
+
+    /**
+     * Merging ElementCollections on Oracle fails when EclipseLink generates 
+     * a DELETE SQL statement with a WHERE clause containing a CLOB.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testCriteriaCompoundSelectionModel() throws Exception {
+        //Populate the database
+        EntityManager em = emf.createEntityManager();
+
+        em.getTransaction().begin();
+
+        L2 l2 = new L2(1, "L2-1");
+        L2 l2_2 = new L2(2, "L2-2");
+
+        L1 l1 = new L1(1, "L1-1", l2);
+        L1 l1_2 = new L1(2, "L1-2", l2_2);
+
+        em.persist(l2);
+        em.persist(l2_2);
+        em.persist(l1);
+        em.persist(l1_2);
+
+        em.getTransaction().commit();
+        em.clear();
+
+        em = emf.createEntityManager();
+
+        //Test CriteriaBuilder
+        final CriteriaBuilder builder = em.getCriteriaBuilder();
+        final CriteriaQuery<L1Model> query = builder.createQuery(L1Model.class);
+        final Root<L1> root = query.from(L1.class);
+        final Join<L1, L2> l1ToL2 = root.join(L1_.l2);
+        final CompoundSelection<L2Model> selection_l2 = builder.construct(L2Model.class, l1ToL2.get(L2_.id), l1ToL2.get(L2_.name));
+        final CompoundSelection<L1Model> selection = builder.construct(L1Model.class, root.get(L1_.id), root.get(L1_.name), selection_l2);
+        query.select(selection);
+
+        TypedQuery<L1Model> q = em.createQuery(query);
+        List<L1Model> l1List = q.getResultList();
+        if (l1List != null && !l1List.isEmpty()) {
+            for (L1Model l1m : l1List) {
+                Assert.assertNotNull(l1m.getL2());
+            }
+        }
+
+        em.close();
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/criteria/model/L1.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/criteria/model/L1.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018 IBM Corporation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     10/01/2018: Will Dazey
+//       - #253: Add support for embedded constructor results with CriteriaBuilder
+package org.eclipse.persistence.jpa.test.criteria.model;
+
+import javax.persistence.*;
+
+@Entity
+public class L1 {
+
+    @Id @Column(name="ID")
+    private Integer id;
+    
+    @Column(name="NAME")
+    private String name;
+
+    @ManyToOne
+    @JoinColumn(name="ID_L2", referencedColumnName="ID")
+    private L2 l2;
+
+    public L1() {}
+
+    public L1(Integer id, String name, L2 l2) {
+        this.id = id;
+        this.name = name;
+        this.l2 = l2;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public L2 getL2() {
+        return l2;
+    }
+
+    public void setL2(L2 l2) {
+        this.l2 = l2;
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/criteria/model/L1Model.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/criteria/model/L1Model.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018 IBM Corporation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     10/01/2018: Will Dazey
+//       - #253: Add support for embedded constructor results with CriteriaBuilder
+package org.eclipse.persistence.jpa.test.criteria.model;
+
+public class L1Model {
+
+    private Integer id;
+    private String name;
+    private L2Model l2;
+
+    public L1Model(final Integer id, final String name, final L2Model l2) {
+        this.id = id;
+        this.name = name;
+        this.l2 = l2;
+    }
+
+    public L2Model getL2() {
+        return l2;
+    }
+
+    public void setL2(L2Model l2) {
+        this.l2 = l2;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/criteria/model/L1_.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/criteria/model/L1_.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018 IBM Corporation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     10/01/2018: Will Dazey
+//       - #253: Add support for embedded constructor results with CriteriaBuilder
+package org.eclipse.persistence.jpa.test.criteria.model;
+
+import javax.persistence.metamodel.SingularAttribute;
+import javax.persistence.metamodel.StaticMetamodel;
+
+@StaticMetamodel(L1.class)
+public class L1_ {
+    public static volatile SingularAttribute<L1, Integer> id;
+    public static volatile SingularAttribute<L1, String> name;
+    public static volatile SingularAttribute<L1, L2> l2;
+}

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/criteria/model/L2.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/criteria/model/L2.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018 IBM Corporation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     10/01/2018: Will Dazey
+//       - #253: Add support for embedded constructor results with CriteriaBuilder
+package org.eclipse.persistence.jpa.test.criteria.model;
+
+import javax.persistence.*;
+
+@Entity
+public class L2 {
+
+    @Id @Column(name="ID")
+    private Integer id;
+
+    @Column(name="NAME")
+    private String name;
+
+    public L2() {}
+
+    public L2(Integer id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/criteria/model/L2Model.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/criteria/model/L2Model.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018 IBM Corporation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     10/01/2018: Will Dazey
+//       - #253: Add support for embedded constructor results with CriteriaBuilder
+package org.eclipse.persistence.jpa.test.criteria.model;
+
+public class L2Model {
+
+    private Integer id;
+    private String name;
+
+    public L2Model(final Integer id, final String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/criteria/model/L2_.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/criteria/model/L2_.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018 IBM Corporation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     10/01/2018: Will Dazey
+//       - #253: Add support for embedded constructor results with CriteriaBuilder
+package org.eclipse.persistence.jpa.test.criteria.model;
+
+import javax.persistence.metamodel.SingularAttribute;
+import javax.persistence.metamodel.StaticMetamodel;
+
+@StaticMetamodel(L2.class)
+public class L2_ {
+    public static volatile SingularAttribute<L2, Integer> id;
+    public static volatile SingularAttribute<L2, String> name;
+}

--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/querydef/CriteriaQueryImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/querydef/CriteriaQueryImpl.java
@@ -12,8 +12,8 @@
 
 // Contributors:
 //     Gordon Yorke - Initial development
-//
-
+//     10/01/2018: Will Dazey
+//       - #253: Add support for embedded constructor results with CriteriaBuilder
 package org.eclipse.persistence.internal.jpa.querydef;
 
 import java.lang.reflect.Constructor;
@@ -401,6 +401,11 @@ public class CriteriaQueryImpl<T> extends AbstractQueryImpl<T> implements Criter
         Class[] constructorArgs = new Class[selections.length];
         int count = 0;
         for (Selection select : selections) {
+            if(select instanceof ConstructorSelectionImpl) {
+                ConstructorSelectionImpl constructorSelect = (ConstructorSelectionImpl)select;
+                Selection[] selectArray = constructorSelect.getCompoundSelectionItems().toArray(new Selection[constructorSelect.getCompoundSelectionItems().size()]);
+                populateAndSetConstructorSelection(constructorSelect, constructorSelect.getJavaType(), selectArray);
+            }
             constructorArgs[count++] = select.getJavaType();
         }
         Constructor constructor = null;


### PR DESCRIPTION
for #253 

Most of these changes revolve around adding support for recursively processing the ReportItems/ConstructorReportItems. We now process the `reportItems` for ConstructorReportItem recursively instead of just 1 level down:

```
ConstructorReportItem(null -> [
    ReportItem(null0 -> Query Key id Base model.L1),
    ReportItem(null1 -> Query Key name Base model.L1),
    ConstructorReportItem(null -> [
        ReportQueryItem(null0 -> Query Key id Query Key l2 Base model.L1),
        ReportQueryItem(null1 -> Query Key name Query Key l2 Base model.L1)
    ])
])
```

Signed-off-by: Will Dazey <dazeydev.3@gmail.com>