### PR TITLE
[2.6_WAS] Bug 537795: Change missed in the port to 2.6_WAS

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/expressions/ConstantExpression.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/expressions/ConstantExpression.java
@@ -142,7 +142,9 @@ public class ConstantExpression extends Expression {
      */
     protected void postCopyIn(Map alreadyDone) {
         super.postCopyIn(alreadyDone);
-        this.localBase = this.localBase.copiedVersionFrom(alreadyDone);
+        if(this.localBase != null) {
+            this.localBase = this.localBase.copiedVersionFrom(alreadyDone);
+        }
     }
 
     /**


### PR DESCRIPTION
for #212

This change was apparently missing from #219 and causes a NPE test failure in the jpa.jse test bucket

Signed-off-by: Will Dazey <dazeydev.3@gmail.com>