### PR TITLE
Bug411013 - 2nd attempt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ addons:
 
 env:
   global:
-    - ANT_HOME=$HOME/apache-ant-1.10.2
+    - ANT_HOME=$HOME/apache-ant-1.10.5
     - M2_HOME=/usr/local/maven-3.5.2
   matrix:
     - TEST_TARGET=test-core
@@ -62,9 +62,9 @@ install:
   - wget -nc http://repo1.maven.org/maven2/org/jboss/logging/jboss-logging/3.3.0.Final/jboss-logging-3.3.0.Final.jar -O $HOME/extension.lib.external/jboss-logging-3.3.0.Final.jar || true
   - wget -nc http://repo1.maven.org/maven2/org/glassfish/javax.el/3.0.1-b08/javax.el-3.0.1-b08.jar -O $HOME/extension.lib.external/javax.el-3.0.1-b08.jar || true
   - wget -nc http://repo1.maven.org/maven2/com/fasterxml/classmate/1.3.1/classmate-1.3.1.jar -O $HOME/extension.lib.external/classmate-1.3.1.jar || true
-  - wget -nc http://apache.belnet.be/ant/binaries/apache-ant-1.10.2-bin.tar.gz -O $HOME/extension.lib.external/apache-ant-1.10.2-bin.tar.gz || true
-  - wget -nc http://download.jboss.org/wildfly/12.0.0.Final/wildfly-12.0.0.Final.tar.gz -O $HOME/extension.lib.external/wildfly-12.0.0.Final.tar.gz || true
-  - tar -x -z -C $HOME -f $HOME/extension.lib.external/apache-ant-1.10.2-bin.tar.gz
+  - wget -nc http://apache.belnet.be/ant/binaries/apache-ant-1.10.5-bin.tar.gz -O $HOME/extension.lib.external/apache-ant-1.10.5-bin.tar.gz || true
+  - wget -nc http://download.jboss.org/wildfly/14.0.1.Final/wildfly-14.0.1.Final.tar.gz -O $HOME/extension.lib.external/wildfly-14.0.1.Final.tar.gz || true
+  - tar -x -z -C $HOME -f $HOME/extension.lib.external/apache-ant-1.10.5-bin.tar.gz
 
 before_script:
   - env | sort
@@ -77,13 +77,13 @@ before_script:
   - echo 'db.pwd=root' >> $HOME/build.properties
   - echo 'db.platform=org.eclipse.persistence.platform.database.MySQLPlatform' >> $HOME/build.properties
   - echo 'server.name=wildfly' >> $HOME/build.properties
-  - echo "wildfly.home=$HOME/wildfly-12.0.0.Final" >> $HOME/build.properties
-  - echo 'wildfly.config=standalone-ee8.xml' >> $HOME/build.properties
+  - echo "wildfly.home=$HOME/wildfly-14.0.1.Final" >> $HOME/build.properties
+  - echo 'wildfly.config=standalone-full.xml' >> $HOME/build.properties
 
 script:
   - cat $HOME/build.properties
   - $ANT_HOME/bin/ant -f antbuild.xml build -Dfail.on.error=true
   - echo 'RUNNING TESTS, BE PATIENT...'
-  - if [ "$TEST_TARGET" == "test-lrg-server" ]; then tar -x -z -C $HOME -f $HOME/extension.lib.external/wildfly-12.0.0.Final.tar.gz; fi
+  - if [ "$TEST_TARGET" == "test-lrg-server" ]; then tar -x -z -C $HOME -f $HOME/extension.lib.external/wildfly-14.0.1.Final.tar.gz; fi
   - set -o pipefail
   - $ANT_HOME/bin/ant -f antbuild.xml -Dtest.fail.fast=true -Dfail.on.error=true $TEST_TARGET | grep -E "\] Running |\] Tests run:"

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,4 +86,4 @@ script:
   - echo 'RUNNING TESTS, BE PATIENT...'
   - if [ "$TEST_TARGET" == "test-lrg-server" ]; then tar -x -z -C $HOME -f $HOME/extension.lib.external/wildfly-12.0.0.Final.tar.gz; fi
   - set -o pipefail
-  - $ANT_HOME/bin/ant -f antbuild.xml -Dtest.fail.fast=true $TEST_TARGET | grep -E "\] Running |\] Tests run:"
+  - $ANT_HOME/bin/ant -f antbuild.xml -Dtest.fail.fast=true -Dfail.on.error=true $TEST_TARGET | grep -E "\] Running |\] Tests run:"

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/descriptors/changetracking/DeferredChangeDetectionPolicy.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/descriptors/changetracking/DeferredChangeDetectionPolicy.java
@@ -78,26 +78,25 @@ public class DeferredChangeDetectionPolicy implements ObjectChangePolicy, java.i
      */
     @Override
     public ObjectChangeSet calculateChanges(Object clone, Object backUp, boolean isNew, UnitOfWorkChangeSet changeSet, UnitOfWorkImpl unitOfWork, ClassDescriptor descriptor, boolean shouldRaiseEvent) {
-        ObjectChangeSet changes = createObjectChangeSet(clone, backUp, changeSet, isNew, unitOfWork, descriptor);
-        if(changes.hasChanges()) {
-            // PERF: Avoid events if no listeners.
-            if (descriptor.getEventManager().hasAnyEventListeners() && shouldRaiseEvent) {
-                // The query is built for compatibility to old event mechanism.
-                WriteObjectQuery writeQuery = new WriteObjectQuery(clone.getClass());
-                writeQuery.setObject(clone);
-                writeQuery.setBackupClone(backUp);
-                writeQuery.setSession(unitOfWork);
-                writeQuery.setDescriptor(descriptor);
+        // PERF: Avoid events if no listeners.
+        if (descriptor.getEventManager().hasAnyEventListeners() && shouldRaiseEvent) {
+            WriteObjectQuery writeQuery = new WriteObjectQuery(clone.getClass());
+            writeQuery.setObject(clone);
+            writeQuery.setBackupClone(backUp);
+            writeQuery.setSession(unitOfWork);
+            writeQuery.setDescriptor(descriptor);
 
-                descriptor.getEventManager().executeEvent(new DescriptorEvent(DescriptorEventManager.PreWriteEvent, writeQuery));
+            descriptor.getEventManager().executeEvent(new DescriptorEvent(DescriptorEventManager.PreWriteEvent, writeQuery));
 
-                if (isNew) {
-                    descriptor.getEventManager().executeEvent(new DescriptorEvent(DescriptorEventManager.PreInsertEvent, writeQuery));
-                } else {
-                    descriptor.getEventManager().executeEvent(new DescriptorEvent(DescriptorEventManager.PreUpdateEvent, writeQuery));
-                }
+            if (isNew) {
+                descriptor.getEventManager().executeEvent(new DescriptorEvent(DescriptorEventManager.PreInsertEvent, writeQuery));
+            } else {
+                descriptor.getEventManager().executeEvent(new DescriptorEvent(DescriptorEventManager.PreUpdateEvent, writeQuery));
             }
+        }
 
+        ObjectChangeSet changes = createObjectChangeSet(clone, backUp, changeSet, isNew, unitOfWork, descriptor);
+        if (changes.hasChanges()) {
             if (descriptor.hasMappingsPostCalculateChanges() && ! changes.isNew() && ! unitOfWork.getCommitManager().isActive() && !unitOfWork.isNestedUnitOfWork()) {
                 // if we are in the commit because of an event skip this postCalculateChanges step as we have already executed it.
                 int size = descriptor.getMappingsPostCalculateChanges().size();

--- a/jpa/eclipselink.jpa.test/antbuild.xml
+++ b/jpa/eclipselink.jpa.test/antbuild.xml
@@ -1829,6 +1829,8 @@
             <attribute name="testname"/>
             <attribute name="earname" default="@{testname}"/>
             <attribute name="classpath" default="compile.jpa22.server.path"/>
+            <attribute name="modulepath" default="jpatest.compile.module.path"/>
+            <attribute name="upgrademodulepath" default="jpatest.upgrade.module.path"/>
             <sequential>
                 <local name="junit.failed"/>
                 <ant antfile="${jpatest.basedir}/${server.name}.xml" target="${server.name}-deploy" inheritRefs="true">
@@ -1864,6 +1866,8 @@
                 <echo message="  additional.jvmargs           ='${additional.jvmargs}'"/>
                 <echo message="  maxmemory                    ='${max.heap.memory}'"/>
                 <echo message="  java args                    ='${test.junit.jvm.modules.prop}'"/>
+                <echo message="  module-path                  ='${toString:@{modulepath}}'"/>
+                <echo message="  upgrade-module-path          ='${toString:@{upgrademodulepath}}'"/>
                 <echo message="  class-path                   ='${toString:@{testname}.run.path}'"/>
                 <mkdir dir="${jpatest.run.dir}"/>
                 <mkdir dir="${jpatest.report.dir}"/>
@@ -1871,6 +1875,8 @@
                        dir="${jpatest.run.dir}" showoutput="true" printsummary="yes" failureproperty="junit.failed">
                     <!--haltonfailure="${test.haltonfailure}" logfailedtests="true" forkmode="once"-->
                     <classpath refid="@{testname}.run.path"/>
+                    <modulepath refid="@{modulepath}"/>
+                    <upgrademodulepath refid="@{upgrademodulepath}"/>
                     <jvmarg line="${test.junit.jvm.modules.prop}"/>
                     <jvmarg line="${additional.jvmargs}"/>
                     <sysproperty key="proxy.user.name" value="${pa.connection.user}"/>

--- a/jpa/eclipselink.jpa.test/wildfly.properties
+++ b/jpa/eclipselink.jpa.test/wildfly.properties
@@ -27,7 +27,7 @@ server.pwd=admin
 
 ## WildFly specific properties.
 wildfly.home=/Users/lukas/java/wildfly-11.0.0.Final
-wildfly.config=standalone-ee8.xml
+wildfly.config=standalone-full.xml
 
 server.testrunner=TestRunner!org.eclipse.persistence.testing.framework.server.TestRunner
 server.testrunner1=TestRunner1!org.eclipse.persistence.testing.framework.server.TestRunner1

--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/metadata/listeners/BeanValidationListener.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/metadata/listeners/BeanValidationListener.java
@@ -21,6 +21,13 @@
 
 package org.eclipse.persistence.internal.jpa.metadata.listeners;
 
+import java.lang.annotation.ElementType;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
 import javax.validation.Path;
@@ -30,22 +37,15 @@ import javax.validation.ValidatorFactory;
 import javax.validation.groups.Default;
 
 import org.eclipse.persistence.config.PersistenceUnitProperties;
-import org.eclipse.persistence.descriptors.DescriptorEventAdapter;
-import org.eclipse.persistence.descriptors.DescriptorEvent;
 import org.eclipse.persistence.descriptors.ClassDescriptor;
+import org.eclipse.persistence.descriptors.DescriptorEvent;
+import org.eclipse.persistence.descriptors.DescriptorEventAdapter;
 import org.eclipse.persistence.descriptors.FetchGroupManager;
 import org.eclipse.persistence.internal.localization.ExceptionLocalization;
 import org.eclipse.persistence.internal.security.PrivilegedAccessHelper;
 import org.eclipse.persistence.internal.sessions.UnitOfWorkImpl;
 import org.eclipse.persistence.mappings.DatabaseMapping;
 import org.eclipse.persistence.mappings.ForeignReferenceMapping;
-
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.lang.annotation.ElementType;
 
 /**
  * Responsible for performing automatic bean validation on call back events.
@@ -87,7 +87,7 @@ public class BeanValidationListener extends DescriptorEventAdapter {
     }
 
     @Override
-    public void preUpdate (DescriptorEvent event) {
+    public void aboutToUpdate(DescriptorEvent event) {
         Object source = event.getSource();
         UnitOfWorkImpl unitOfWork = (UnitOfWorkImpl )event.getSession();
         // preUpdate is also generated for deleted objects that were modified in this UOW.
@@ -117,7 +117,7 @@ public class BeanValidationListener extends DescriptorEventAdapter {
                 // Throw a ConstrainViolationException as required by the spec.
                 // The transaction would be rolled back automatically
                 throw new ConstraintViolationException(
-                        ExceptionLocalization.buildMessage("bean_validation_constraint_violated", 
+                        ExceptionLocalization.buildMessage("bean_validation_constraint_violated",
                                 new Object[]{callbackEventName, source.getClass().getName()}),
                         (Set<ConstraintViolation<?>>) (Object) constraintViolations); /* Do not remove the explicit
                         cast. This issue is related to capture#a not being instance of capture#b. */


### PR DESCRIPTION
Original fix in #248 caused regressions in core tests (as can be seen on nightly downloads page :-/ )

Problem with the original fix is that it did not take into account that user may have custom event listener bound to say 'preUpdate' event where he wants to alter to be modified object somehow. In this case, it is expected that the update event is fired even for unchanged objects and that is not happening after my original fix :-/

Better fix seems to be to bind internal bean validation 'preUpdate' check to the 'aboutToUpdateEvent' - this event is fired only for to be updated objects just before sending the update statement to the DB. In this case, it is also expected to be guaranteed that all user-defined listeners, even those altering the object being changed in ie 'preUpdateWithChangesEvent', were run and validation runs against the real, up-to-date to be updated object.

This also revealed one issue in travis test runs where it did not fail the build if there were failures/errors in core/jpa tests, that is fixed by the second commit.