### PR TITLE
Bug 540203 - Wrong characters in SQL script dbsetup_alltests.sql

### DIFF
--- a/utils/eclipselink.dbws.builder.test.oracle/etc/dbsetup_alltests.sql
+++ b/utils/eclipselink.dbws.builder.test.oracle/etc/dbsetup_alltests.sql
@@ -1,5 +1,5 @@
 --
--- Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+-- Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 --
 -- This program and the accompanying materials are made available under the
 -- terms of the Eclipse Public License v. 2.0 which is available at

--- a/utils/eclipselink.dbws.builder.test.oracle/etc/dbsetup_alltests.sql
+++ b/utils/eclipselink.dbws.builder.test.oracle/etc/dbsetup_alltests.sql
@@ -129,7 +129,7 @@ CREATE OR REPLACE FUNCTION SF_TBL1(NUM IN INTEGER) RETURN SOMEPACKAGE_TBL1 AS
   BEGIN
       FOR I IN 1 .. NUM LOOP
          L_DATA.EXTEND;
-         L_DATA(I) := 'entry ' || i;
+         L_DATA(I) := CONCAT('entry ', TO_CHAR(i));
       END LOOP;
      RETURN L_DATA;
 END;
@@ -197,7 +197,7 @@ CREATE OR REPLACE PACKAGE BODY ANOTHER_ADVANCED_DEMO AS
   BEGIN
       FOR I IN 1 .. NUM LOOP
          L_DATA.EXTEND;
-         L_DATA(I) := EMP_INFO(I, 'entry ' || i);
+         L_DATA(I) := EMP_INFO(I, CONCAT('entry ', TO_CHAR(i)));
       END LOOP;
      RETURN L_DATA;
   END BUILDEMPARRAY;


### PR DESCRIPTION
Bug 540203 - Wrong characters in SQL script dbsetup_alltests.sql

This fix rewrites string concatenation expressions with "||" operator to SQL function CONCAT(…).

See https://bugs.eclipse.org/bugs/show_bug.cgi?id=540203

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>