### PR TITLE
SQL Server: if possible, use OFFSET and FETCH instead of JDBC methods

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/SQLServerPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/SQLServerPlatform.java
@@ -45,8 +45,8 @@ import org.eclipse.persistence.queries.*;
  * @since TOPLink/Java 1.0
  */
 public class SQLServerPlatform extends org.eclipse.persistence.platform.database.DatabasePlatform {
-    /** Support for sequence objects added in SQL Server 2012 */
-    private boolean supportsSequenceObjects;
+    /** Support for sequence objects and OFFSET FETCH NEXT added in SQL Server 2012 */
+    private boolean isVersion11OrHigher;
     private boolean isConnectionDataInitialized;
 
     public SQLServerPlatform(){
@@ -62,7 +62,7 @@ public class SQLServerPlatform extends org.eclipse.persistence.platform.database
         }
         DatabaseMetaData dmd = connection.getMetaData();
         int databaseVersion = dmd.getDatabaseMajorVersion();
-        supportsSequenceObjects = databaseVersion >= 11;
+        isVersion11OrHigher = databaseVersion >= 11;
         isConnectionDataInitialized = true;
         this.driverSupportsNationalCharacterVarying = Helper.compareVersions(dmd.getDriverVersion(), "4.0.0") >= 0;
     }
@@ -690,7 +690,7 @@ public class SQLServerPlatform extends org.eclipse.persistence.platform.database
      */
     @Override
     public boolean supportsSequenceObjects() {
-        return supportsSequenceObjects;
+        return isVersion11OrHigher;
     }
 
     /**
@@ -731,5 +731,48 @@ public class SQLServerPlatform extends org.eclipse.persistence.platform.database
         writer.write(", ");
         writer.write(tempTableName);
         writeAutoJoinWhereClause(writer, tableName, tempTableName, pkFields, this);
+    }
+
+    @Override
+    public void printSQLSelectStatement(DatabaseCall call, ExpressionSQLPrinter printer, SQLSelectStatement statement) {
+        ReadQuery query = statement.getQuery();
+        if (query == null || !isVersion11OrHigher || !shouldUseRownumFiltering()) {
+            super.printSQLSelectStatement(call, printer, statement);
+            return;
+        }
+        
+        int max = Math.max(0, query.getMaxRows());
+        int first = Math.max(0, query.getFirstResult());
+        
+        if (max == 0 && first == 0) {
+            super.printSQLSelectStatement(call, printer, statement);
+            return;
+        }
+        
+        // OFFSET + FETCH NEXT requires ORDER BY, so add an ordering if there are none
+        // this SQL will satisfy the query parser without actually changing the ordering of the rows
+        List<Expression> orderBy = statement.getOrderByExpressions();
+        if (orderBy.isEmpty()) {
+            orderBy.add(statement.getBuilder().literal("ROW_NUMBER() OVER (ORDER BY (SELECT null))"));
+        }
+        
+        // decide exact syntax to use, depending on whether a limit is specified (could just have an offset)
+        String offsetFetchSql;
+        List<?> offsetFetchArgs;
+        if (max == 0) {
+            offsetFetchSql = "? OFFSET ? ROWS";
+            offsetFetchArgs = Arrays.asList(first);
+        } else {
+            offsetFetchSql = "? OFFSET ? ROWS FETCH NEXT ? ROWS ONLY";
+            offsetFetchArgs = Arrays.asList(first, max - first);
+        }
+        
+        // append to the last ORDER BY clause
+        orderBy.add(orderBy.remove(orderBy.size() - 1).sql(offsetFetchSql, offsetFetchArgs));
+        
+        super.printSQLSelectStatement(call, printer, statement);
+        
+        call.setIgnoreFirstRowSetting(true);
+        call.setIgnoreMaxResultsSetting(true);
     }
 }


### PR DESCRIPTION
Currently, EclipseLink uses Statement#setMaxRows() to apply a result limit when the target database is MS SQL Server. This is dangerous because mssql-jdbc implements setMaxRows() by executing SET ROWCOUNT, which applies to all queries made on the connection until SET ROWCOUNT is executed again.

Normally, that is not an issue, but it can become a problem if, for example, your query includes a call to a user-defined function that executes another query. When that happens, it creates truly baffling bugs that are very difficult to track down. mssql-jdbc acknowledges that SET ROWCOUNT is not an appropriate way to implement setMaxRows() but currently has no ability to replace it with something better; see https://github.com/Microsoft/mssql-jdbc/issues/176.

This PR alters SQLServerPlatform to add the OFFSET and FETCH NEXT clauses to the query, if the version of SQL Server in use supports them. This avoids EclipseLink calling setMaxRows(), and may improve query performance.

This PR is for 2.7. If it looks okay to whoever reviews it, I will open another PR for master.