### PR TITLE
[master] Bug 540929: jdbc.sql-cast property does not apply - fix

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
@@ -28,6 +28,8 @@
 //       - 458877 : Add national character support
 //     02/23/2015-2.6 Dalia Abo Sheasha
 //       - 460607: Change DatabasePlatform StoredProcedureTerminationToken to be configurable
+//     11/12/2018 - Will Dazey
+//       - 540929 : 'jdbc.sql-cast' property does not copy
 package org.eclipse.persistence.internal.databaseaccess;
 
 // javase imports
@@ -992,6 +994,7 @@ public class DatabasePlatform extends DatasourcePlatform {
         //use the variable directly to avoid custom platform strings - only want to copy user set values.
         //specifically used for login platform detection
         databasePlatform.setTableCreationSuffix(this.tableCreationSuffix);
+        databasePlatform.setIsCastRequired(isCastRequired());
     }
 
     /**

--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
@@ -84,8 +84,6 @@
 //       - 526419: Modify EclipseLink to reflect changes in JTA 1.1.
 //     01/16/2018-2.7 Joe Grassel
 //       - 529907: EntityManagerSetupImpl.addBeanValidationListeners() should fall back on old method for finding helperClass
-//     11/12/2018 - Will Dazey
-//       - 540929 : 'jdbc.sql-cast' property does not apply
 package org.eclipse.persistence.internal.jpa;
 
 import static org.eclipse.persistence.config.PersistenceUnitProperties.DDL_GENERATION;
@@ -814,10 +812,6 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
 
                             // Generate the DDL using the correct connection.
                             writeDDL(deployProperties, getDatabaseSession(deployProperties), classLoaderToUse);
-                        }
-                        //Setting this requires login to have occurred
-                        if(!session.isBroker()) {
-                            updateSQLCastSetting(deployProperties);
                         }
                     }
                     // Initialize platform specific identity sequences.
@@ -2876,6 +2870,7 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
             updateSequencing(m);
             updateSequencingStart(m);
             updateAllowNativeSQLQueriesSetting(m);
+            updateSQLCastSetting(m);
             updateUppercaseSetting(m);
             updateCacheStatementSettings(m);
             updateTemporalMutableSetting(m);


### PR DESCRIPTION
for #283

I think the fix for #284 was incorrect. I stumbled across DatabasePlatform.copyInto() and realized that this is where the Cast value is supposed to be copied over at. 

Signed-off-by: Will Dazey <dazeydev.3@gmail.com>