### PR TITLE
Bug 391279: fix the case when existing object is being updated

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/mappings/OneToManyMapping.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/mappings/OneToManyMapping.java
@@ -929,18 +929,13 @@ public class OneToManyMapping extends CollectionMapping implements RelationalMap
                 } else {
                     ContainerPolicy cp = getContainerPolicy();
                     prepareTranslationRow(query.getTranslationRow(), query.getObject(), query.getDescriptor(), query.getSession());
-                    AbstractRecord databaseRow = buildKeyRowForTargetUpdate(query);
+                    AbstractRecord keyRow = buildKeyRowForTargetUpdate(query);
 
                     // Extract target field and its value. Construct insert statement and execute it
-                    int size = targetPrimaryKeyFields.size();
                     ClassDescriptor referenceDesc = getReferenceDescriptor();
                     AbstractSession session = query.getSession();
-                    for (int index = 0; index < size; index++) {
-                        DatabaseField targetPrimaryKey = targetPrimaryKeyFields.get(index);
-                        Object targetKeyValue = getReferenceDescriptor().getObjectBuilder().extractValueFromObjectForField(cp.unwrapIteratorResult(objectAdded), targetPrimaryKey, query.getSession());
-                        databaseRow.put(targetPrimaryKey, targetKeyValue);
-                    }
 
+                    AbstractRecord databaseRow = referenceDesc.getObjectBuilder().buildRow(keyRow, objectAdded, session, WriteType.INSERT);
                     ContainerPolicy.copyMapDataToRow(cp.getKeyMappingDataForWriteQuery(objectAdded, query.getSession()), databaseRow);
                     if(listOrderField != null && extraData != null) {
                         databaseRow.put(listOrderField, extraData.get(listOrderField));
@@ -1068,7 +1063,6 @@ public class OneToManyMapping extends CollectionMapping implements RelationalMap
 
                         // Extract target field and its value. Construct insert
                         // statement and execute it
-                        int size = targetPrimaryKeyFields.size();
                         ClassDescriptor referenceDesc = getReferenceDescriptor();
                         AbstractSession session = query.getSession();
                         int objectIndex = 0;

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/mapping/TestUnidirectionalOneToMany.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/mapping/TestUnidirectionalOneToMany.java
@@ -116,9 +116,9 @@ public class TestUnidirectionalOneToMany {
 
         PostB post = new PostB(new ComplexIdB(3, 4));
         post.setComments(new ArrayList<CommentB>());
-        post.getComments().add(new CommentB());
-        post.getComments().add(new CommentB());
-        post.getComments().add(new CommentB());
+        post.getComments().add(new CommentB("a"));
+        post.getComments().add(new CommentB("b"));
+        post.getComments().add(new CommentB("c"));
 
         em.persist(post);
 
@@ -137,9 +137,9 @@ public class TestUnidirectionalOneToMany {
         em.flush();
 
         post.setComments(new ArrayList<CommentB>());
-        post.getComments().add(new CommentB());
-        post.getComments().add(new CommentB());
-        post.getComments().add(new CommentB());
+        post.getComments().add(new CommentB("d"));
+        post.getComments().add(new CommentB("e"));
+        post.getComments().add(new CommentB("f"));
 
         em.persist(post);
 

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/mapping/TestUnidirectionalOneToMany.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/mapping/TestUnidirectionalOneToMany.java
@@ -46,10 +46,11 @@ import org.junit.runner.RunWith;
 public class TestUnidirectionalOneToMany {
     @Emf(createTables = DDLGen.DROP_CREATE,
             classes = { CommentA.class, CommentB.class, ComplexIdA.class, ComplexIdB.class, PostA.class, PostB.class },
-            properties = { @Property(name = "eclipselink.cache.shared.default", value = "false"),
-                    @Property(name = "eclipselink.logging.parameters", value = "true"),
-                    @Property(name = "eclipselink.logging.exceptions", value = "true"),
-@Property(name = "eclipselink.logging.level.sql", value = "FINEST")})
+            properties = {
+                @Property(name = "eclipselink.cache.shared.default", value = "false"),
+                @Property(name = "eclipselink.logging.parameters", value = "true"),
+                @Property(name = "eclipselink.logging.exceptions", value = "true"),
+                @Property(name = "eclipselink.logging.level.sql", value = "FINEST")})
     private EntityManagerFactory emf;
 
     /**

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/mapping/model/CommentB.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/mapping/model/CommentB.java
@@ -15,6 +15,7 @@
 //       - 391279: Add support for Unidirectional OneToMany mappings with non-nullable values
 package org.eclipse.persistence.jpa.test.mapping.model;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -27,6 +28,21 @@ public class CommentB {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
+    @Column(nullable=false)
+    private String content;
+
     public CommentB() {
+    }
+
+    public CommentB(String content) {
+        this.content = content;
+    }
+
+    public void setContent(String s) {
+        content = s;
+    }
+
+    public String getContent() {
+        return content;
     }
 }


### PR DESCRIPTION
during update of unidirectional 1-m relationship only relationship constraint related fields are being inserted to the DB, so if there are additional fields then these additional fields never get stored into DB.