### PR TITLE
[2.6] Bug #542491: Add new property to force parameter binding

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/PersistenceUnitProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/PersistenceUnitProperties.java
@@ -39,6 +39,8 @@
  *       - 456067 : Added support for defining query timeout units
  *     09/28/2015 - Will Dazey
  *       - 478331 : Added support for defining local or server as the default locale for obtaining timestamps
+ *     12/06/2018 - Will Dazey
+ *       - 542491: Add new 'eclipselink.jdbc.force-bind-parameters' property to force enable binding
  ******************************************************************************/
 package org.eclipse.persistence.config;
 
@@ -1015,6 +1017,22 @@ public class PersistenceUnitProperties {
      * </ul>
      */
     public static final String JDBC_BIND_PARAMETERS = "eclipselink.jdbc.bind-parameters";
+
+    /**
+     * Property "<code>eclipselink.jdbc.force-bind-parameters</code>" enables parameter binding 
+     * in the creation of JDBC prepared statements. Some database platforms disable parameter binding 
+     * on certain functions and relations. This property allows the user to force parameter binding 
+     * to be enabled regardless. 
+     * <p>
+     * <b>Allowed Values:</b>
+     * <ul>
+     * <li>"<code>false</code>" (DEFAULT) - values will default to platform specific logic
+     * <li>"<code>true</code>" - bindings will use platform default
+     * </ul>
+     * 
+     * @see org.eclipse.persistence.config.PersistenceUnitProperties.JDBC_BIND_PARAMETERS
+    */
+   public static final String JDBC_FORCE_BIND_PARAMETERS = "eclipselink.jdbc.force-bind-parameters";
 
     /**
      * The "<code>eclipselink.jdbc.exclusive-connection.mode</code>" property

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
@@ -24,6 +24,8 @@
  *       - 458877 : Add national character support
  *     02/23/2015-2.6 Dalia Abo Sheasha
  *       - 460607: Change DatabasePlatform StoredProcedureTerminationToken to be configurable
+ *     12/06/2018 - Will Dazey
+ *       - 542491: Add new 'eclipselink.jdbc.force-bind-parameters' property to force enable binding
  ******************************************************************************/
 package org.eclipse.persistence.internal.databaseaccess;
 
@@ -128,6 +130,9 @@ public class DatabasePlatform extends DatasourcePlatform {
 
     /** Bind all arguments to any SQL statement. */
     protected boolean shouldBindAllParameters;
+
+    /** Bind all arguments to any SQL statement. */
+    protected boolean shouldForceBindAllParameters;
 
     /** Cache all prepared statements, this requires full parameter binding as well. */
     protected boolean shouldCacheAllStatements;
@@ -272,6 +277,7 @@ public class DatabasePlatform extends DatasourcePlatform {
         this.stringBindingSize = 255;
         this.shouldTrimStrings = true;
         this.shouldBindAllParameters = true;
+        this.shouldForceBindAllParameters = false;
         this.shouldCacheAllStatements = false;
         this.shouldOptimizeDataConversion = true;
         this.statementCacheSize = 50;
@@ -957,6 +963,7 @@ public class DatabasePlatform extends DatasourcePlatform {
         databasePlatform.setUsesByteArrayBinding(usesByteArrayBinding());
         databasePlatform.setUsesStringBinding(usesStringBinding());
         databasePlatform.setShouldBindAllParameters(shouldBindAllParameters());
+        databasePlatform.setShouldForceBindAllParameters(shouldForceBindAllParameters());
         databasePlatform.setShouldCacheAllStatements(shouldCacheAllStatements());
         databasePlatform.setStatementCacheSize(getStatementCacheSize());
         databasePlatform.setTransactionIsolation(getTransactionIsolation());
@@ -1917,6 +1924,13 @@ public class DatabasePlatform extends DatasourcePlatform {
     }
 
     /**
+     * Used to enable parameter binding and override the platform default
+     */
+    public void setShouldForceBindAllParameters(boolean shouldForceBindAllParameters) {
+        this.shouldForceBindAllParameters = shouldForceBindAllParameters;
+    }
+
+    /**
      * Can be used if the app expects upper case but the database is not return consistent case, i.e. different databases.
      */
     public void setShouldForceFieldNamesToUpperCase(boolean shouldForceFieldNamesToUpperCase) {
@@ -2130,6 +2144,13 @@ public class DatabasePlatform extends DatasourcePlatform {
      */
     public void setShouldCreateIndicesOnForeignKeys(boolean shouldCreateIndicesOnForeignKeys) {
         this.shouldCreateIndicesOnForeignKeys = shouldCreateIndicesOnForeignKeys;
+    }
+
+    /**
+     * Used to enable parameter binding and override platform default
+     */
+    public boolean shouldForceBindAllParameters() {
+        return this.shouldForceBindAllParameters;
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/DB2Platform.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/DB2Platform.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2015 Oracle and/or its affiliates, IBM Corporation. All rights reserved.
+ * Copyright (c) 1998, 201* Oracle and/or its affiliates, IBM Corporation. All rights reserved.
  * This program and the accompanying materials are made available under the 
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0 
  * which accompanies this distribution. 
@@ -15,6 +15,8 @@
  *       - 458877 : Add national character support
  *     02/24/2016-2.6.0 Rick Curtis
  *       - 460740: Fix pessimistic locking with setFirst/Max results on DB2
+ *     12/06/2018 - Will Dazey
+ *       - 542491: Add new 'eclipselink.jdbc.force-bind-parameters' property to force enable binding
  *****************************************************************************/
 package org.eclipse.persistence.platform.database;
 
@@ -51,7 +53,7 @@ import org.eclipse.persistence.tools.schemaframework.FieldDefinition;
  * <li>Support for identity sequencing.
  * <li>Support for SEQUENCE sequencing.
  * </ul>
- * 
+ *
  * @since TOPLink/Java 1.0
  */
 public class DB2Platform extends org.eclipse.persistence.platform.database.DatabasePlatform {
@@ -60,7 +62,7 @@ public class DB2Platform extends org.eclipse.persistence.platform.database.Datab
         super();
         this.pingSQL = "VALUES(1)";
     }
-    
+
     @Override
     public void initializeConnectionData(Connection connection) throws SQLException {
         // DB2 database doesn't support NVARCHAR column types and as such doesn't support calling
@@ -290,7 +292,7 @@ public class DB2Platform extends org.eclipse.persistence.platform.database.Datab
         if(getUseNationalCharacterVaryingTypeForString()){
             fieldTypeMapping.put(String.class, new FieldTypeDefinition("VARCHAR", DEFAULT_VARCHAR_SIZE, "FOR MIXED DATA"));
         }else {
-            fieldTypeMapping.put(String.class, new FieldTypeDefinition("VARCHAR", DEFAULT_VARCHAR_SIZE));   
+            fieldTypeMapping.put(String.class, new FieldTypeDefinition("VARCHAR", DEFAULT_VARCHAR_SIZE));
         }
         fieldTypeMapping.put(Character.class, new FieldTypeDefinition("CHAR", 1));
         fieldTypeMapping.put(Byte[].class, new FieldTypeDefinition("BLOB", 64000));
@@ -324,7 +326,7 @@ public class DB2Platform extends org.eclipse.persistence.platform.database.Datab
     public int getMaxForeignKeyNameSize() {
         return 18;
     }
-    
+
     /**
      * INTERNAL:
      * returns the maximum number of characters that can be used in a unique key
@@ -333,7 +335,7 @@ public class DB2Platform extends org.eclipse.persistence.platform.database.Datab
     @Override
     public int getMaxUniqueKeyNameSize() {
         return 18;
-    }    
+    }
 
     /**
      * INTERNAL:
@@ -624,7 +626,7 @@ public class DB2Platform extends org.eclipse.persistence.platform.database.Datab
             throw ValidationException.fileError(ioException);
         }
     }
-    
+
     @Override
     protected void printFieldTypeSize(Writer writer, FieldDefinition field, FieldTypeDefinition ftd) throws IOException {
         super.printFieldTypeSize(writer, field, ftd);
@@ -708,7 +710,7 @@ public class DB2Platform extends org.eclipse.persistence.platform.database.Datab
     public boolean isNullAllowedInSelectClause() {
         return false;
     }
-    
+
     /**
      * INTERNAL
      * DB2 has some issues with using parameters on certain functions and relations.
@@ -717,6 +719,9 @@ public class DB2Platform extends org.eclipse.persistence.platform.database.Datab
      */
     @Override
     public boolean isDynamicSQLRequiredForFunctions() {
+        if(shouldForceBindAllParameters()) {
+            return false;
+        }
         return !isCastRequired();
     }
 
@@ -790,7 +795,7 @@ public class DB2Platform extends org.eclipse.persistence.platform.database.Datab
     public boolean isAlterSequenceObjectSupported() {
         return true;
     }
-    
+
     @Override
     public boolean shouldPrintForUpdateClause() {
         return false;
@@ -799,7 +804,7 @@ public class DB2Platform extends org.eclipse.persistence.platform.database.Datab
      * INTERNAL:
      * Print the SQL representation of the statement on a stream, storing the fields
      * in the DatabaseCall.  This implementation works MaxRows and FirstResult into the SQL using
-     * DB2's ROWNUMBER() OVER() to filter values if shouldUseRownumFiltering is true.  
+     * DB2's ROWNUMBER() OVER() to filter values if shouldUseRownumFiltering is true.
      */
     @Override
     public void printSQLSelectStatement(DatabaseCall call, ExpressionSQLPrinter printer, SQLSelectStatement statement){
@@ -810,7 +815,7 @@ public class DB2Platform extends org.eclipse.persistence.platform.database.Datab
             max = statement.getQuery().getMaxRows();
             firstRow = statement.getQuery().getFirstResult();
         }
-        
+
         if ( !(this.shouldUseRownumFiltering()) || ( !(max>0) && !(firstRow>0) ) ){
             super.printSQLSelectStatement(call, printer, statement);
             statement.appendForUpdateClause(printer);
@@ -837,5 +842,5 @@ public class DB2Platform extends org.eclipse.persistence.platform.database.Datab
         call.setIgnoreFirstRowSetting(true);
         call.setIgnoreMaxResultsSetting(true);
     }
-    
+
 }

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/property/TestParameterBinding.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/property/TestParameterBinding.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018 IBM Corporation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     12/06/2018 - Will Dazey
+//       - 542491: Add new 'eclipselink.jdbc.force-bind-parameters' property to force enable binding
+package org.eclipse.persistence.jpa.test.property;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.TypedQuery;
+
+import org.eclipse.persistence.jpa.JpaQuery;
+import org.eclipse.persistence.jpa.test.framework.DDLGen;
+import org.eclipse.persistence.jpa.test.framework.Emf;
+import org.eclipse.persistence.jpa.test.framework.EmfRunner;
+import org.eclipse.persistence.jpa.test.framework.Property;
+import org.eclipse.persistence.jpa.test.property.model.AbstractParent;
+import org.eclipse.persistence.jpa.test.property.model.Child;
+import org.eclipse.persistence.jpa.test.property.model.Parent;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(EmfRunner.class)
+public class TestParameterBinding {
+
+    @Emf(createTables = DDLGen.DROP_CREATE, classes = { AbstractParent.class, Parent.class, Child.class }, properties = {
+            @Property(name = "eclipselink.jdbc.force-bind-parameters", value = "true") })
+    private EntityManagerFactory emf;
+
+    /**
+     * Tests the 'eclipselink.jdbc.force-bind-parameters' persistence property. 
+     */
+    @Test
+    public void testForceBindAllFunctionParameters() {
+        EntityManager em = emf.createEntityManager();
+
+        TypedQuery<Child> query = em.createQuery("SELECT c FROM Child c WHERE c.id = abs(?1)", Child.class);
+        query.setParameter(1, 12);
+        //query.setHint("eclipselink.jdbc.bind-parameters", true);
+        query.getResultList();
+
+        Assert.assertFalse("Expected query parameter binding to not be set for the DatabaseCall", ((JpaQuery)query).getDatabaseQuery().getCall().isUsesBindingSet());
+    }
+}

--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
@@ -66,6 +66,8 @@
  *       - 478331 : Added support for defining local or server as the default locale for obtaining timestamps
  *     11/05/2015 - Dalia Abo Sheasha
  *       - 480787 : Wrap several privileged method calls with a doPrivileged block
+ *     12/06/2018 - Will Dazey
+ *       - 542491: Add new 'eclipselink.jdbc.force-bind-parameters' property to force enable binding
  *****************************************************************************/  
 package org.eclipse.persistence.internal.jpa;
 
@@ -2751,6 +2753,12 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
             if (shouldBindString != null) {
                 session.getPlatform().setShouldBindAllParameters(Boolean.parseBoolean(shouldBindString));
             }
+
+            String shouldForceBindString = getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.JDBC_FORCE_BIND_PARAMETERS, m, session);
+            if(shouldForceBindString != null) {
+                session.getPlatform().setShouldForceBindAllParameters(Boolean.parseBoolean(shouldForceBindString));
+            }
+
             updateLogins(m);
         }
         if (!session.getDatasourceLogin().shouldUseExternalTransactionController()) {


### PR DESCRIPTION
backport to 2.6