### PR TITLE
Bug 536947 v 3.0 – XmlDiscriminatorNode with JSON in MoxyBindings File Is not applied to Root Elements

### DIFF
--- a/foundation/org.eclipse.persistence.core/core.iml
+++ b/foundation/org.eclipse.persistence.core/core.iml
@@ -15,7 +15,7 @@
       <src_folder value="file://$MODULE_DIR$/resource" expected_position="1" />
     </src_description>
   </component>
-  <component name="NewModuleRootManager" inherit-compiler-output="false">
+  <component name="NewModuleRootManager">
     <output url="file://$MODULE_DIR$/target/classes" />
     <exclude-output />
     <content url="file://$MODULE_DIR$">
@@ -48,12 +48,10 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/../../plugins/org.glassfish.javax.json_1.0.4.v201311181159.jar!/" />
+          <root url="jar://$MODULE_DIR$/../../plugins/org.glassfish.jakarta.json.jar!/" />
         </CLASSES>
         <JAVADOC />
-        <SOURCES>
-          <root url="jar://$MODULE_DIR$/../../plugins/org.glassfish.javax.json.source_1.0.4.v201311181159.jar!/" />
-        </SOURCES>
+        <SOURCES />
       </library>
     </orderEntry>
     <orderEntry type="module-library">

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLRelationshipMappingNodeValue.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLRelationshipMappingNodeValue.java
@@ -77,7 +77,8 @@ public abstract class XMLRelationshipMappingNodeValue extends MappingNodeValue {
                 // if xsi:type is overriden by JSON_TYPE_ATTRIBUTE_NAME unmarshall property
                 if (classValue == null && unmarshalRecord.getUnmarshaller().isApplicationJSON() &&
                         unmarshalRecord.getUnmarshaller().getJsonTypeConfiguration().getJsonTypeAttributeName() != null && atts.getValue(unmarshalRecord.getUnmarshaller().getJsonTypeConfiguration().getJsonTypeAttributeName()) != null) {
-                    classValue = (Class)xmlDescriptor.getInheritancePolicy().getClassIndicatorMapping().get(new QName(atts.getValue(unmarshalRecord.getUnmarshaller().getJsonTypeConfiguration().getJsonTypeAttributeName())));
+                    QName qname = new QName(xmlDescriptor.getSchemaReference().getSchemaContextAsQName().getNamespaceURI(), atts.getValue(unmarshalRecord.getUnmarshaller().getJsonTypeConfiguration().getJsonTypeAttributeName()));
+                    classValue = (Class)xmlDescriptor.getInheritancePolicy().getClassIndicatorMapping().get(qname);
                 }
             }
             if (classValue != null) {

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/record/SAXUnmarshallerHandler.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/record/SAXUnmarshallerHandler.java
@@ -205,7 +205,8 @@ public class SAXUnmarshallerHandler implements ExtendedContentHandler {
             Descriptor xmlDescriptor = xmlContext.getDescriptor(rootQName);
 
             //if no match on root element look for xsi:type
-            if(xmlDescriptor == null){
+            if (xmlDescriptor == null || (unmarshaller.getMediaType() == MediaType.APPLICATION_JSON && unmarshaller.getJsonTypeConfiguration().getJsonTypeAttributeName() != null &&
+                    !Constants.SCHEMA_TYPE_ATTRIBUTE.equals(unmarshaller.getJsonTypeConfiguration().getJsonTypeAttributeName()))) {
                 boolean isPrimitiveType = false;
                 String type = null;
                 if(xmlReader.isNamespaceAware()){

--- a/moxy/eclipselink.moxy.test/moxy.test.iml
+++ b/moxy/eclipselink.moxy.test/moxy.test.iml
@@ -17,7 +17,7 @@
       <src_folder value="file://$MODULE_DIR$/resource" expected_position="1" />
     </src_description>
   </component>
-  <component name="NewModuleRootManager" inherit-compiler-output="false">
+  <component name="NewModuleRootManager">
     <output url="file://$MODULE_DIR$/classes" />
     <exclude-output />
     <content url="file://$MODULE_DIR$">
@@ -80,12 +80,10 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/../../plugins/org.glassfish.javax.json_1.0.4.v201311181159.jar!/" />
+          <root url="jar://$MODULE_DIR$/../../plugins/org.glassfish.jakarta.json.jar!/" />
         </CLASSES>
         <JAVADOC />
-        <SOURCES>
-          <root url="jar://$MODULE_DIR$/../../plugins/org.glassfish.javax.json.source_1.0.4.v201311181159.jar!/" />
-        </SOURCES>
+        <SOURCES />
       </library>
     </orderEntry>
     <orderEntry type="module-library">
@@ -149,7 +147,6 @@
           <root url="file://$MODULE_DIR$/resource" />
         </JAVADOC>
         <SOURCES>
-          <root url="file://$MODULE_DIR$/resource" />
           <root url="file://$MODULE_DIR$/resource" />
         </SOURCES>
         <jarDirectory url="file://$MODULE_DIR$/resource" recursive="false" type="SOURCES" />

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/JSONTestSuite.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/JSONTestSuite.java
@@ -96,6 +96,7 @@ public class JSONTestSuite extends TestSuite {
           suite.addTestSuite(TypeNameValueTestCases.class);
           suite.addTestSuite(TypePrefixTestCases.class);
           suite.addTestSuite(TypePropertyCustomNameTestCases.class);
+          suite.addTestSuite(TypePropertyCustomNameNamespaceTestCases.class);
           suite.addTestSuite(TypePropertyInheritanceTestCases.class);
           suite.addTestSuite(TypePropertyTestCases.class);
           suite.addTestSuite(JsonUnmappedTestCases.class);

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/type/TypePropertyCustomNameNamespaceTestCases.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/type/TypePropertyCustomNameNamespaceTestCases.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Radek Felcman - 2.7.4 - initial implementation
+package org.eclipse.persistence.testing.jaxb.json.type;
+
+import org.eclipse.persistence.jaxb.JAXBContextFactory;
+import org.eclipse.persistence.jaxb.JAXBContextProperties;
+import org.eclipse.persistence.testing.jaxb.json.type.modelns.*;
+import org.junit.Test;
+
+import javax.xml.bind.*;
+import java.io.ByteArrayInputStream;
+import java.io.StringWriter;
+import java.util.*;
+
+/**
+ * Tests to marshall, unmarshal JSON with JSON_TYPE_ATTRIBUTE_NAME marshall and unmarshall property.
+ * Package with entity classes contains package-info.java file with namespaces declaration.
+ *
+ * @author Radek Felcman
+ */
+public class TypePropertyCustomNameNamespaceTestCases extends junit.framework.TestCase {
+
+    private static final ObjectFactory OF = new ObjectFactory();
+
+    private static final JAXBElement<KooSuper> KOO_SUPER = OF.createKoo(new KooSuper());
+    private static final JAXBElement<KooSuper> KOO_1 = OF.createKoo(new Koo1());
+    private static final JAXBElement<Tel> TEL_KOO_SUPER = OF.createTel(new Tel(new KooSuper()));
+    private static final JAXBElement<Tel> TEL_KOO_1 = OF.createTel(new Tel(new Koo1()));
+
+    private static final String JSON_ROOT_KOO_SUPER_WITH = "{\"koo-Root\":{\"_type\":\"KS\"}}";
+    private static final String JSON_ROOT_KOO_SUPER_WITHOUT = "{\"koo-Root\":{}}";
+    private static final String JSON_ROOT_KOO_1 = "{\"koo-Root\":{\"_type\":\"K1\"}}";
+    private static final String JSON_TEL_KOO_SUPER_WITH = "{\"tel-Root\":{\"koo\":{\"_type\":\"KS\"}}}";
+    private static final String JSON_TEL_KOO_SUPER_WITHOUT = "{\"tel-Root\":{\"koo\":{}}}";
+    private static final String JSON_TEL_KOO_1 = "{\"tel-Root\":{\"koo\":{\"_type\":\"K1\"}}}";
+
+
+    public TypePropertyCustomNameNamespaceTestCases() {
+        super(TypePropertyCustomNameNamespaceTestCases.class.getSimpleName());
+    }
+
+    @Test
+    public void testMarshallJsonRootKooSuperWithout() throws Exception {
+        assertEquals(JSON_ROOT_KOO_SUPER_WITHOUT, marshal(KOO_SUPER));
+    }
+
+    @Test
+    public void testMarshallJsonRootKoo1() throws Exception {
+        assertEquals(JSON_ROOT_KOO_1, marshal(KOO_1));
+    }
+
+    @Test
+    public void testMarshallJsonTelKooSuperWithout() throws Exception {
+        assertEquals(JSON_TEL_KOO_SUPER_WITHOUT, marshal(TEL_KOO_SUPER));
+    }
+
+    @Test
+    public void testMarshallJsonTelKoo1() throws Exception {
+        assertEquals(JSON_TEL_KOO_1, marshal(TEL_KOO_1));
+    }
+
+    @Test
+    public void testUnmarshallJsonRootKooSuperWith() throws Exception {
+        assertEquals(KooSuper.class.getName(), unmarshal(JSON_ROOT_KOO_SUPER_WITH).getValue().getClass().getName());
+    }
+
+    @Test
+    public void testUnmarshallJsonRootKooSuperWithout() throws Exception {
+        assertEquals(KooSuper.class.getName(), unmarshal(JSON_ROOT_KOO_SUPER_WITHOUT).getValue().getClass().getName());
+    }
+
+    @Test
+    public void testUnmarshallJsonRootKoo1() throws Exception {
+        assertEquals(Koo1.class.getName(), unmarshal(JSON_ROOT_KOO_1).getValue().getClass().getName());
+    }
+
+    @Test
+    public void testUnmarshallJsonTelKooSuperWith() throws Exception {
+        assertEquals(KooSuper.class.getName(), Tel.class.cast(unmarshal(JSON_TEL_KOO_SUPER_WITH).getValue()).getKoo().getClass().getName());
+    }
+
+    @Test
+    public void testUnmarshallJsonTelKooSuperWithout() throws Exception {
+        assertEquals(KooSuper.class.getName(), Tel.class.cast(unmarshal(JSON_TEL_KOO_SUPER_WITHOUT).getValue()).getKoo().getClass().getName());
+    }
+
+    @Test
+    public void testUnmarshallJsonTelKoo1() throws Exception {
+        assertEquals(Koo1.class.getName(), Tel.class.cast(unmarshal(JSON_TEL_KOO_1).getValue()).getKoo().getClass().getName());
+    }
+
+    private static String marshal(final JAXBElement<?> value) throws Exception {
+        final StringWriter stringWriter = new StringWriter();
+        final Class<?>[] types = new Class<?>[]{ObjectFactory.class, Tel.class, KooSuper.class, Koo1.class};
+        final Map<Object, Object> conf = new LinkedHashMap<>();
+        conf.put(JAXBContextProperties.MEDIA_TYPE, "application/json");
+        final JAXBContext innerCtx = JAXBContextFactory.createContext(types, conf);
+        final Marshaller marshaller = innerCtx.createMarshaller();
+        marshaller.setProperty(JAXBContextProperties.JSON_TYPE_ATTRIBUTE_NAME, "_type");
+        marshaller.marshal(value, stringWriter);
+        return stringWriter.toString();
+    }
+
+    private static JAXBElement<?> unmarshal(final String value) throws Exception {
+        final Class<?>[] types = new Class<?>[]{ObjectFactory.class, Tel.class, KooSuper.class, Koo1.class};
+        final Map<Object, Object> conf = new LinkedHashMap<>();
+        conf.put(JAXBContextProperties.MEDIA_TYPE, "application/json");
+        final JAXBContext innerCtx = JAXBContextFactory.createContext(types, conf);
+        final Unmarshaller unmarshaller = innerCtx.createUnmarshaller();
+        unmarshaller.setProperty(JAXBContextProperties.JSON_TYPE_ATTRIBUTE_NAME, "_type");
+        return (JAXBElement<?>) unmarshaller.unmarshal(new ByteArrayInputStream(value.getBytes()));
+    }
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/type/TypePropertyCustomNameTestCases.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/type/TypePropertyCustomNameTestCases.java
@@ -14,6 +14,7 @@
 //     Radek Felcman - 2.7.4 - initial implementation
 package org.eclipse.persistence.testing.jaxb.json.type;
 
+import org.eclipse.persistence.jaxb.JAXBContextProperties;
 import org.eclipse.persistence.jaxb.MarshallerProperties;
 import org.eclipse.persistence.jaxb.UnmarshallerProperties;
 import org.eclipse.persistence.testing.jaxb.json.JSONMarshalUnmarshalTestCases;
@@ -22,7 +23,9 @@ import org.eclipse.persistence.testing.jaxb.json.type.model.*;
 import javax.xml.bind.JAXBElement;
 import javax.xml.namespace.QName;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Tests to marshall, unmarshal JSON with JSON_TYPE_ATTRIBUTE_NAME marshall and unmarshall property.
@@ -41,12 +44,24 @@ public class TypePropertyCustomNameTestCases extends JSONMarshalUnmarshalTestCas
 
     public void setUp() throws Exception{
         super.setUp();
+    }
 
-        jsonMarshaller.setProperty(MarshallerProperties.JSON_INCLUDE_ROOT, false);
-        jsonMarshaller.setProperty(MarshallerProperties.JSON_TYPE_ATTRIBUTE_NAME, "mytype");
+    @Override
+    public Map getProperties() {
+        Map<String, Object> properties = new HashMap<String, Object>(3);
+        properties.put(JAXBContextProperties.JSON_INCLUDE_ROOT, false);
+        properties.put(JAXBContextProperties.JSON_TYPE_ATTRIBUTE_NAME, "mytype");
+        return properties;
+    }
 
-        jsonUnmarshaller.setProperty(UnmarshallerProperties.JSON_INCLUDE_ROOT, false);
-        jsonUnmarshaller.setProperty(UnmarshallerProperties.JSON_TYPE_ATTRIBUTE_NAME, "mytype");
+    public void testMarshallerProperty() throws Exception {
+        assertFalse((Boolean) jsonMarshaller.getProperty(MarshallerProperties.JSON_INCLUDE_ROOT));
+        assertEquals("mytype", jsonMarshaller.getProperty(MarshallerProperties.JSON_TYPE_ATTRIBUTE_NAME));
+    }
+
+    public void testUnmarshallerProperty() throws Exception {
+        assertFalse((Boolean) jsonUnmarshaller.getProperty(UnmarshallerProperties.JSON_INCLUDE_ROOT));
+        assertEquals("mytype", jsonUnmarshaller.getProperty(MarshallerProperties.JSON_TYPE_ATTRIBUTE_NAME));
     }
 
     protected Object getControlObject() {

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/type/modelns/Koo1.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/type/modelns/Koo1.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Radek Felcman - 2.7.4 - initial implementation
+package org.eclipse.persistence.testing.jaxb.json.type.modelns;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlType(name = "K1")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Koo1 extends KooSuper {}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/type/modelns/KooSuper.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/type/modelns/KooSuper.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Radek Felcman - 2.7.4 - initial implementation
+package org.eclipse.persistence.testing.jaxb.json.type.modelns;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlType(name = "KS")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class KooSuper {}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/type/modelns/Namespace.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/type/modelns/Namespace.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Radek Felcman - 2.7.4 - initial implementation
+package org.eclipse.persistence.testing.jaxb.json.type.modelns;
+
+public interface Namespace {
+
+  String NAME = "http://NS";
+
+  String PREFIX = "nsp";
+
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/type/modelns/ObjectFactory.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/type/modelns/ObjectFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Radek Felcman - 2.7.4 - initial implementation
+package org.eclipse.persistence.testing.jaxb.json.type.modelns;
+
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.annotation.XmlElementDecl;
+import javax.xml.bind.annotation.XmlRegistry;
+import javax.xml.namespace.QName;
+
+@XmlRegistry
+public class ObjectFactory {
+  
+  @XmlElementDecl(namespace = Namespace.NAME, name = "koo-Root")
+  public JAXBElement<KooSuper> createKoo(KooSuper value) {
+    return new JAXBElement<KooSuper>(new QName(Namespace.NAME, "koo-Root"), KooSuper.class, null, value);
+  }
+  
+  @XmlElementDecl(namespace = Namespace.NAME, name = "tel-Root")
+  public JAXBElement<Tel> createTel(Tel value) {
+    return new JAXBElement<Tel>(new QName(Namespace.NAME, "tel-Root"), Tel.class, null, value);
+  }
+  
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/type/modelns/Tel.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/type/modelns/Tel.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Radek Felcman - 2.7.4 - initial implementation
+package org.eclipse.persistence.testing.jaxb.json.type.modelns;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Tel {
+  
+  private KooSuper koo;
+  
+  public Tel() {}
+  
+  public Tel(final KooSuper koo) {
+    this.koo = koo;
+  }
+  
+  public KooSuper getKoo() {
+    return this.koo;
+  }
+  
+  public void setKoo(final KooSuper koo) {
+    this.koo = koo;
+  }
+  
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/type/modelns/package-info.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/type/modelns/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Radek Felcman - 2.7.4 - initial implementation
+@XmlSchema(
+  namespace = Namespace.NAME, elementFormDefault = XmlNsForm.QUALIFIED,
+  xmlns = {
+    @XmlNs(namespaceURI = Namespace.NAME, prefix = Namespace.PREFIX),
+    @XmlNs(namespaceURI = "http://www.w3.org/2001/XMLSchema-instance", prefix = "xsi") })
+package org.eclipse.persistence.testing.jaxb.json.type.modelns;
+
+import javax.xml.bind.annotation.XmlNs;
+import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBContext.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBContext.java
@@ -1604,6 +1604,7 @@ public class JAXBContext extends javax.xml.bind.JAXBContext {
                 setPropertyOnMarshaller(JAXBContextProperties.BEAN_VALIDATION_NO_OPTIMISATION, marshaller);
                 setPropertyOnMarshaller(JAXBContextProperties.JSON_TYPE_COMPATIBILITY, marshaller);
                 setPropertyOnMarshaller(JAXBContextProperties.JSON_USE_XSD_TYPES_WITH_PREFIX, marshaller);
+                setPropertyOnMarshaller(JAXBContextProperties.JSON_TYPE_ATTRIBUTE_NAME, marshaller);
             }
 
             return marshaller;
@@ -1637,6 +1638,7 @@ public class JAXBContext extends javax.xml.bind.JAXBContext {
                 setPropertyOnUnmarshaller(JAXBContextProperties.BEAN_VALIDATION_NO_OPTIMISATION, unmarshaller);
                 setPropertyOnUnmarshaller(JAXBContextProperties.JSON_TYPE_COMPATIBILITY, unmarshaller);
                 setPropertyOnUnmarshaller(JAXBContextProperties.JSON_USE_XSD_TYPES_WITH_PREFIX, unmarshaller);
+                setPropertyOnUnmarshaller(JAXBContextProperties.JSON_TYPE_ATTRIBUTE_NAME, unmarshaller);
             }
             return unmarshaller;
         }


### PR DESCRIPTION
This is fix v 3.0 for bug 536947 – XmlDiscriminatorNode with JSON in MoxyBindings File Is not applied to Root Elements

This fix cover additional test cases described in bug [attachment](https://bugs.eclipse.org/bugs/attachment.cgi?id=276944)
This fix extends Unit tests with test case from bugzilla.