### PR TITLE
Bug 543036 – <xsd:simpleType> generates unnecessary NotNull annotation

### DIFF
--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/beanvalidation/sgen_xjc/rich_schema.xsd
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/beanvalidation/sgen_xjc/rich_schema.xsd
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -28,6 +28,14 @@
             <xsd:element nillable="false" name="byteArray" type="rs:byteArray"/>
             <xsd:element name="someCollection" minOccurs="1" maxOccurs="unbounded"/>
             <xsd:element name="optionalElement" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element minOccurs="0" name="optionalElementWithSimpleType">
+                <xsd:simpleType>
+                    <xsd:restriction base="xsd:int">
+                        <xsd:minInclusive value="1"/>
+                        <xsd:maxInclusive value="31"/>
+                    </xsd:restriction>
+                </xsd:simpleType>
+            </xsd:element>
         </xsd:sequence>
     </xsd:complexType>
 

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/beanvalidation/BeanValidationBindingsTestCase.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/beanvalidation/BeanValidationBindingsTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -242,6 +242,13 @@ public class BeanValidationBindingsTestCase extends junit.framework.TestCase {
         assertTrue(size.min() == 0);
         assertNotNull(optionalElement.getAnnotation(Valid.class));
         assertNull(optionalElement.getAnnotation(NotNull.class));
+
+        Field optionalElementWithSimpleType = Main.getDeclaredField("optionalElementWithSimpleType");
+        assertNull(optionalElementWithSimpleType.getAnnotation(NotNull.class));
+        decimalMin = optionalElementWithSimpleType.getAnnotation(DecimalMin.class);
+        assertEquals(decimalMin.value(), "1");
+        decimalMax = optionalElementWithSimpleType.getAnnotation(DecimalMax.class);
+        assertEquals(decimalMax.value(), "31");
 
         /* Numbers.class */
         Field minInclusive = Numbers.getDeclaredField("minInclusive");


### PR DESCRIPTION
Fix for the bug 543036 and extended bean validation test.
Before this fix MOXy xjc extension in _BeanValidationPlugin.java_ enabled by _-XBeanVal_ switch generated unnecessary `@NotNull` annotation.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>