### PR TITLE
Bug 543063 - JSON cannot be validated against XSD schema when uses namespaces

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/record/XMLReaderAdapter.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/record/XMLReaderAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -12,6 +12,7 @@
 
 // Contributors:
 //     Blaise Doughan = 2.1 - Initial implementation
+//     Juan Pablo Gardella = 2.7.4 - Fix for the bug #543063
 package org.eclipse.persistence.internal.oxm.record;
 
 import javax.xml.validation.Schema;
@@ -148,7 +149,7 @@ public abstract class XMLReaderAdapter extends XMLReader {
     /**
      * Convert a ContentHandler to an ExtendedContentHandler
      */
-    private static class ExtendedContentHandlerAdapter implements ExtendedContentHandler {
+    public static class ExtendedContentHandlerAdapter implements ExtendedContentHandler {
 
         private ContentHandler contentHandler;
 
@@ -156,50 +157,66 @@ public abstract class XMLReaderAdapter extends XMLReader {
             this.contentHandler = contentHandler;
         }
 
+        public ContentHandler getContentHandler() {
+            return contentHandler;
+        }
+
+        @Override
         public void setDocumentLocator(Locator locator) {
             contentHandler.setDocumentLocator(locator);
         }
 
+        @Override
         public void startDocument() throws SAXException {
             contentHandler.startDocument();
         }
 
+        @Override
         public void endDocument() throws SAXException {
             contentHandler.endDocument();
         }
 
+        @Override
         public void startPrefixMapping(String prefix, String uri) throws SAXException {
             contentHandler.startPrefixMapping(prefix, uri);
         }
 
+        @Override
         public void endPrefixMapping(String prefix) throws SAXException {
             contentHandler.endPrefixMapping(prefix);
         }
 
+        @Override
         public void startElement(String uri, String localName, String qName, Attributes atts) throws SAXException {
             contentHandler.startElement(uri, localName, qName, atts);
         }
 
+        @Override
         public void endElement(String uri, String localName, String qName) throws SAXException {
             contentHandler.endElement(uri, localName, qName);
         }
 
+        @Override
         public void characters(char[] ch, int start, int length) throws SAXException {
             contentHandler.characters(ch, start, length);
         }
 
+        @Override
         public void ignorableWhitespace(char[] ch, int start, int length) throws SAXException {
             contentHandler.ignorableWhitespace(ch, start, length);
         }
 
+        @Override
         public void processingInstruction(String target, String data) throws SAXException {
             contentHandler.processingInstruction(target, data);
         }
 
+        @Override
         public void skippedEntity(String name) throws SAXException {
             contentHandler.skippedEntity(name);
         }
 
+        @Override
         public void characters(CharSequence characters) throws SAXException {
             if(null == characters) {
                 return;
@@ -220,6 +237,7 @@ public abstract class XMLReaderAdapter extends XMLReader {
 
         protected abstract Attribute[] attributes();
 
+        @Override
         public int getIndex(String qName) {
             if(null == qName) {
                 return -1;
@@ -234,6 +252,7 @@ public abstract class XMLReaderAdapter extends XMLReader {
             return -1;
         }
 
+        @Override
         public int getIndex(String uri, String localName) {
             if(null == localName) {
                 return -1;
@@ -248,38 +267,47 @@ public abstract class XMLReaderAdapter extends XMLReader {
             return -1;
         }
 
+        @Override
         public int getLength() {
             return attributes().length;
         }
 
+        @Override
         public String getLocalName(int index) {
             return attributes()[index].getLocalName();
         }
 
+        @Override
         public String getQName(int index) {
             return attributes()[index].getName();
         }
 
+        @Override
         public String getType(int index) {
             return Constants.CDATA;
         }
 
+        @Override
         public String getType(String name) {
             return Constants.CDATA;
         }
 
+        @Override
         public String getType(String uri, String localName) {
             return Constants.CDATA;
         }
 
+        @Override
         public String getURI(int index) {
             return attributes()[index].getUri();
         }
 
+        @Override
         public String getValue(int index) {
             return attributes()[index].getValue();
         }
 
+        @Override
         public String getValue(String qName) {
             int index = getIndex(qName);
             if(-1 == index) {
@@ -288,6 +316,7 @@ public abstract class XMLReaderAdapter extends XMLReader {
             return attributes()[index].getValue();
         }
 
+        @Override
         public String getValue(String uri, String localName) {
             int index = getIndex(uri, localName);
             if(-1 == index) {

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/record/json/JsonStructureReader.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/record/json/JsonStructureReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -12,6 +12,7 @@
 
 // Contributors:
 //     Denise Smith - 2.6 - initial implementation
+//     Juan Pablo Gardella = 2.7.4 - Fix for the bug #543063
 package org.eclipse.persistence.internal.oxm.record.json;
 
 import java.io.FileInputStream;
@@ -307,7 +308,7 @@ public class JsonStructureReader extends XMLReaderAdapter {
                         String prefix = parentLocalName.substring(0, nsIndex);
                         uri = namespaces.resolveNamespacePrefix(prefix);
                     }
-                    if (uri == null) {
+                    if (uri == null || uri == Constants.EMPTY_STRING) {
                         uri = namespaces.getDefaultNamespaceURI();
                     } else {
                         parentLocalName = parentLocalName.substring(nsIndex + 1);
@@ -320,8 +321,8 @@ public class JsonStructureReader extends XMLReaderAdapter {
             boolean isTextValue;
             int arraySize = jsonArray.size();
             if (arraySize == 0) {
-                if (contentHandler instanceof UnmarshalRecord) {
-                    UnmarshalRecord ur = (UnmarshalRecord) contentHandler;
+                if (contentHandler instanceof UnmarshalRecord || isUnmarshalRecordWithinAdapter()) {
+                    final UnmarshalRecord ur = this.contentHandler instanceof UnmarshalRecord ? (UnmarshalRecord) this.contentHandler : getUnmarshalRecordFromAdapter();
                     XPathNode node = ur.getNonAttributeXPathNode(uri, parentLocalName, parentLocalName, null);
                     if (node != null) {
                         NodeValue nv = node.getNodeValue();
@@ -338,9 +339,10 @@ public class JsonStructureReader extends XMLReaderAdapter {
 
             XPathFragment groupingXPathFragment = null;
             XPathFragment itemXPathFragment = null;
-            if (contentHandler instanceof UnmarshalRecord) {
-                isTextValue = isTextValue(parentLocalName);
-                UnmarshalRecord unmarshalRecord = (UnmarshalRecord) contentHandler;
+            if (contentHandler instanceof UnmarshalRecord || isUnmarshalRecordWithinAdapter()) {
+                final UnmarshalRecord contentHandler_ = contentHandler instanceof UnmarshalRecord ? (UnmarshalRecord) contentHandler : getUnmarshalRecordFromAdapter();
+                isTextValue = isTextValue(parentLocalName, contentHandler_);
+                UnmarshalRecord unmarshalRecord = contentHandler_;
                 if (unmarshalRecord.getUnmarshaller().isWrapperAsCollectionName()) {
                     XPathNode unmarshalRecordXPathNode = unmarshalRecord.getXPathNode();
                     if (null != unmarshalRecordXPathNode) {
@@ -352,7 +354,7 @@ public class JsonStructureReader extends XMLReaderAdapter {
                         if (groupingXPathNode != null) {
                             if (groupingXPathNode.getUnmarshalNodeValue() instanceof CollectionGroupingElementNodeValue) {
                                 groupingXPathFragment = groupingXPathNode.getXPathFragment();
-                                contentHandler.startElement(uri, parentLocalName, parentLocalName, new AttributesImpl());
+                                contentHandler_.startElement(uri, parentLocalName, parentLocalName, new AttributesImpl());
                                 XPathNode itemXPathNode = groupingXPathNode.getNonAttributeChildren().get(0);
                                 itemXPathFragment = itemXPathNode.getXPathFragment();
                             } else if (groupingXPathNode.getUnmarshalNodeValue() == null) {
@@ -360,7 +362,7 @@ public class JsonStructureReader extends XMLReaderAdapter {
                                 if (itemXPathNode != null) {
                                     if ((itemXPathNode.getUnmarshalNodeValue()).isContainerValue()) {
                                         groupingXPathFragment = groupingXPathNode.getXPathFragment();
-                                        contentHandler.startElement(uri, parentLocalName, parentLocalName, new AttributesImpl());
+                                        contentHandler_.startElement(uri, parentLocalName, parentLocalName, new AttributesImpl());
                                         itemXPathFragment = itemXPathNode.getXPathFragment();
                                     }
                                 }
@@ -376,24 +378,24 @@ public class JsonStructureReader extends XMLReaderAdapter {
 
                     if (!isTextValue) {
                         if (null != itemXPathFragment) {
-                            contentHandler.startElement(itemXPathFragment.getNamespaceURI(), itemXPathFragment.getLocalName(), itemXPathFragment.getLocalName(), attributes.setValue(nextArrayValue, attributePrefix,namespaces, getNamespaceSeparator(), isNamespaceAware()));
+                            contentHandler.startElement(itemXPathFragment.getNamespaceURI(), itemXPathFragment.getLocalName(), itemXPathFragment.getLocalName(), attributes.setValue(nextArrayValue, attributePrefix, namespaces, getNamespaceSeparator(), isNamespaceAware()));
                         } else {
-                            contentHandler.startElement(uri, parentLocalName,parentLocalName, attributes.setValue(nextArrayValue, attributePrefix,namespaces, getNamespaceSeparator(), isNamespaceAware()));
+                            contentHandler.startElement(uri, parentLocalName, parentLocalName, attributes.setValue(nextArrayValue, attributePrefix, namespaces, getNamespaceSeparator(), isNamespaceAware()));
                         }
 
                     }
                     parseValue(nextArrayValue);
                     if (!isTextValue) {
                         if (null != itemXPathFragment) {
-                            contentHandler.endElement(itemXPathFragment.getNamespaceURI(),itemXPathFragment.getLocalName(),itemXPathFragment.getLocalName());
+                            contentHandler.endElement(itemXPathFragment.getNamespaceURI(), itemXPathFragment.getLocalName(), itemXPathFragment.getLocalName());
                         } else {
-                            contentHandler.endElement(uri, parentLocalName,parentLocalName);
+                            contentHandler.endElement(uri, parentLocalName, parentLocalName);
                         }
                     }
                 }
             }
             if (null != groupingXPathFragment) {
-                contentHandler.endElement(uri,groupingXPathFragment.getLocalName(),groupingXPathFragment.getLocalName());
+                contentHandler.endElement(uri, groupingXPathFragment.getLocalName(), groupingXPathFragment.getLocalName());
             }
             endCollection();
         } else {
@@ -410,7 +412,7 @@ public class JsonStructureReader extends XMLReaderAdapter {
                         prefix = localName.substring(0, nsIndex);
                     }
                     uri = namespaces.resolveNamespacePrefix(prefix);
-                    if (uri == null) {
+                    if (uri == null || uri == Constants.EMPTY_STRING) {
                         uri = namespaces.getDefaultNamespaceURI();
                     } else {
                         localName = localName.substring(nsIndex + 1);
@@ -441,16 +443,33 @@ public class JsonStructureReader extends XMLReaderAdapter {
                         return;
                     }
                 }
-                boolean isTextValue = isTextValue(localName);
+                boolean isTextValue = isTextValue(localName, (UnmarshalRecord) contentHandler);
                 if (isTextValue) {
                     parseValue(jsonValue);
                     return;
                 }
-                NodeValue nv = ((UnmarshalRecord)contentHandler).getAttributeChildNodeValue(uri, localName);
-                if(attributePrefix == null && nv !=null ){
-                  return;
+                NodeValue nv = ((UnmarshalRecord) contentHandler).getAttributeChildNodeValue(uri, localName);
+                if (attributePrefix == null && nv != null) {
+                    return;
+                }
+            } else if (isUnmarshalRecordWithinAdapter()) {
+                @SuppressWarnings("rawtypes") final UnmarshalRecord contentHandler_ = getUnmarshalRecordFromAdapter();
+                if (jsonTypeCompatibility) {
+                    if (!isNamespaceAware() && localName.equals(Constants.SCHEMA_TYPE_ATTRIBUTE) && !contentHandler_.getXPathNode().hasTypeChild()) {
+                        return;
+                    }
+                }
+                boolean isTextValue = isTextValue(localName, contentHandler_);
+                if (isTextValue) {
+                    parseValue(jsonValue);
+                    return;
+                }
+                NodeValue nv = contentHandler_.getAttributeChildNodeValue(uri, localName);
+                if (attributePrefix == null && nv != null) {
+                    return;
                 }
             }
+
             if (jsonValue.getValueType() == ValueType.NULL) {
                 contentHandler.setNil(true);
             }
@@ -461,6 +480,19 @@ public class JsonStructureReader extends XMLReaderAdapter {
 
         }
 
+    }
+
+    private UnmarshalRecord getUnmarshalRecordFromAdapter() {
+        return (UnmarshalRecord) ((ValidatingContentHandler) ((ExtendedContentHandlerAdapter) contentHandler)
+                .getContentHandler()).getContentHandler();
+    }
+
+    private boolean isUnmarshalRecordWithinAdapter() {
+        return contentHandler instanceof ExtendedContentHandlerAdapter
+                && ((ExtendedContentHandlerAdapter) contentHandler)
+                .getContentHandler() instanceof ValidatingContentHandler
+                && ((ValidatingContentHandler) ((ExtendedContentHandlerAdapter) contentHandler).getContentHandler())
+                .getContentHandler() instanceof UnmarshalRecord;
     }
 
     public boolean isNullRepresentedByXsiNil(AbstractNullPolicy nullPolicy) {
@@ -475,23 +507,25 @@ public class JsonStructureReader extends XMLReaderAdapter {
         isInCollection = false;
     }
 
+    @Override
     public boolean isInCollection() {
         return isInCollection;
     }
 
-    private boolean isTextValue(String localName) {
-        XPathNode currentNode = ((UnmarshalRecord) contentHandler).getXPathNode();
+    private boolean isTextValue(String localName, UnmarshalRecord contentHandler_) {
+        XPathNode currentNode = ((UnmarshalRecord) contentHandler_).getXPathNode();
         if (currentNode == null) {
             return textWrapper != null && textWrapper.equals(localName);
         }
 
         return ((currentNode.getNonAttributeChildrenMap() == null
-                        || currentNode.getNonAttributeChildrenMap().size() == 0
-                        || (currentNode.getNonAttributeChildrenMap().size() == 1
-                                && currentNode.getTextNode() != null)
-                ) && textWrapper != null && textWrapper.equals(localName)
+                || currentNode.getNonAttributeChildrenMap().size() == 0
+                || (currentNode.getNonAttributeChildrenMap().size() == 1
+                && currentNode.getTextNode() != null)
+        ) && textWrapper != null && textWrapper.equals(localName)
         );
     }
+
 
     @Override
     public Object convertValueBasedOnSchemaType(Field xmlField, Object value, ConversionManager conversionManager, AbstractUnmarshalRecord record) {
@@ -580,6 +614,7 @@ public class JsonStructureReader extends XMLReaderAdapter {
             }
         }
 
+        @Override
         public int getIndex(String uri, String localName) {
             if (null == localName) {
                 return -1;

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/json/namespaces/purchase_order.json
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/json/namespaces/purchase_order.json
@@ -1,0 +1,20 @@
+{
+   "PurchaseOrder":{
+      "ShipTo":[
+         {
+            "name":"Oracle Czech",
+            "street":"U Trezorky",
+            "city":"Prague",
+            "state":"Czech Republic",
+            "zip":15800
+         }
+      ],
+      "BillTo":{
+         "name":"Oracle US",
+         "street":"Oracle Parkway",
+         "city":"Redwood Shores",
+         "state":"California",
+         "zip":94065
+      }
+   }
+}

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/json/namespaces/purchase_order.xml
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/json/namespaces/purchase_order.xml
@@ -1,0 +1,30 @@
+﻿<!--
+
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0,
+    or the Eclipse Distribution License v. 1.0 which is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+
+    SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+-->
+
+<PurchaseOrder xmlns="http://tempuri.org/PurchaseOrderSchema.xsd">
+    <ShipTo>
+        <name>Oracle Czech</name>
+        <street>U Trezorky</street>
+        <city>Prague</city>
+        <state>Czech Republic</state>
+        <zip>15800</zip>
+    </ShipTo>
+    <BillTo>
+        <name>Oracle US</name>
+        <street>Oracle Parkway</street>
+        <city>Redwood Shores</city>
+        <state>California</state>
+        <zip>94065</zip>
+    </BillTo>
+</PurchaseOrder>

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/json/namespaces/purchase_order.xsd
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/json/namespaces/purchase_order.xsd
@@ -1,0 +1,36 @@
+<!--
+
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0,
+    or the Eclipse Distribution License v. 1.0 which is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+
+    SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+-->
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://tempuri.org/PurchaseOrderSchema.xsd"
+            targetNamespace="http://tempuri.org/PurchaseOrderSchema.xsd"
+            elementFormDefault="qualified">
+    <xsd:element name="PurchaseOrder" type="tns:PurchaseOrderType"/>
+    <xsd:complexType name="PurchaseOrderType">
+        <xsd:sequence>
+            <xsd:element name="ShipTo" type="tns:USAddress" maxOccurs="2"/>
+            <xsd:element name="BillTo" type="tns:USAddress"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="USAddress">
+        <xsd:sequence>
+            <xsd:element name="name" type="xsd:string"/>
+            <xsd:element name="street" type="xsd:string"/>
+            <xsd:element name="city" type="xsd:string"/>
+            <xsd:element name="state" type="xsd:string"/>
+            <xsd:element name="zip" type="xsd:integer"/>
+        </xsd:sequence>
+    </xsd:complexType>
+</xsd:schema>

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/JSONTestSuite.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/JSONTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -37,6 +37,7 @@ import org.eclipse.persistence.testing.jaxb.json.namespaces.DifferentNamespacesT
 import org.eclipse.persistence.testing.jaxb.json.namespaces.NamespaceInheritanceSeparatorContextTestCases;
 import org.eclipse.persistence.testing.jaxb.json.namespaces.NamespaceInheritanceSeparatorTestCases;
 import org.eclipse.persistence.testing.jaxb.json.namespaces.NamespaceInheritanceTestCases;
+import org.eclipse.persistence.testing.jaxb.json.namespaces.NamespaceOnXMLOnlyTestCases;
 import org.eclipse.persistence.testing.jaxb.json.namespaces.NamespacesOnContextTestCases;
 import org.eclipse.persistence.testing.jaxb.json.namespaces.NamespacesOnUnmarshalOnlyTestCases;
 import org.eclipse.persistence.testing.jaxb.json.namespaces.SeparatorInNameTestCases;
@@ -68,6 +69,7 @@ public class JSONTestSuite extends TestSuite {
           suite.addTestSuite(JSONAttributeNoXmlRootElementJAXBElementTestCases.class);
           suite.addTestSuite(SimpleBeanAttrNullTestCases.class);
           suite.addTestSuite(DifferentNamespacesTestCases.class);
+          suite.addTestSuite(NamespaceOnXMLOnlyTestCases.class);
           suite.addTestSuite(NamespacesOnContextTestCases.class);
           suite.addTestSuite(NamespacesOnUnmarshalOnlyTestCases.class);
           suite.addTestSuite(NoRootElementTestCases.class);

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/namespaces/NamespaceOnXMLOnlyTestCases.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/namespaces/NamespaceOnXMLOnlyTestCases.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Radek Felcman - January 2019 - Initial implementation
+package org.eclipse.persistence.testing.jaxb.json.namespaces;
+
+import org.eclipse.persistence.jaxb.JAXBContextProperties;
+import org.eclipse.persistence.testing.jaxb.JAXBWithJSONTestCases;
+import org.eclipse.persistence.testing.jaxb.json.namespaces.model.PurchaseOrderType;
+import org.eclipse.persistence.testing.jaxb.json.namespaces.model.USAddress;
+
+import javax.xml.XMLConstants;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class NamespaceOnXMLOnlyTestCases extends JAXBWithJSONTestCases {
+
+    private static final String NAMESPACE = "http://tempuri.org/PurchaseOrderSchema.xsd";
+    private final static String XML_RESOURCE = "org/eclipse/persistence/testing/jaxb/json/namespaces/purchase_order.xml";
+    private final static String JSON_RESOURCE = "org/eclipse/persistence/testing/jaxb/json/namespaces/purchase_order.json";
+    private final static String XML_SCHEMA_RESOURCE = "org/eclipse/persistence/testing/jaxb/json/namespaces/purchase_order.xsd";
+
+    private Schema schema;
+
+    public NamespaceOnXMLOnlyTestCases(String name) throws Exception {
+        super(name);
+        setControlDocument(XML_RESOURCE);
+        setControlJSON(JSON_RESOURCE);
+        setClasses(new Class[]{PurchaseOrderType.class, USAddress.class});
+    }
+
+    @Override
+    protected Object getControlObject() {
+        USAddress shipTo = new USAddress();
+        shipTo.setName("Oracle Czech");
+        shipTo.setStreet("U Trezorky");
+        shipTo.setCity("Prague");
+        shipTo.setState("Czech Republic");
+        shipTo.setZip(15800);
+        List<USAddress> shipToList = new ArrayList<USAddress>();
+        shipToList.add(shipTo);
+
+        USAddress billTo = new USAddress();
+        billTo.setName("Oracle US");
+        billTo.setStreet("Oracle Parkway");
+        billTo.setCity("Redwood Shores");
+        billTo.setState("California");
+        billTo.setZip(94065);
+
+        PurchaseOrderType purchaseOrder = new PurchaseOrderType();
+        purchaseOrder.setShipTo(shipToList);
+        purchaseOrder.setBillTo(billTo);
+        return purchaseOrder;
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        SchemaFactory sf = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        schema = sf.newSchema(Thread.currentThread().getContextClassLoader().getResource(XML_SCHEMA_RESOURCE));
+    }
+
+    @Override
+    public Map getProperties() {
+        Map props = new HashMap();
+        Map<String, String> namespaceMap = new HashMap<>();
+        namespaceMap.put(NAMESPACE, "");
+        props.put(JAXBContextProperties.NAMESPACE_PREFIX_MAPPER, namespaceMap);
+        props.put(JAXBContextProperties.JSON_ATTRIBUTE_PREFIX, "@");
+        props.put(JAXBContextProperties.JSON_WRAPPER_AS_ARRAY_NAME, true);
+        return props;
+    }
+
+    @Override
+    public Unmarshaller getJAXBUnmarshaller() {
+        Unmarshaller unmarshaller = super.getJAXBUnmarshaller();
+        unmarshaller.setSchema(schema);
+        return unmarshaller;
+    }
+
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/namespaces/model/ObjectFactory.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/namespaces/model/ObjectFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Radek Felcman - January 2019 - Initial implementation
+package org.eclipse.persistence.testing.jaxb.json.namespaces.model;
+
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.annotation.XmlElementDecl;
+import javax.xml.bind.annotation.XmlRegistry;
+import javax.xml.namespace.QName;
+
+@XmlRegistry
+public class ObjectFactory {
+
+    private final static QName _PurchaseOrder_QNAME = new QName("http://tempuri.org/PurchaseOrderSchema.xsd", "PurchaseOrder");
+
+    public ObjectFactory() {
+    }
+
+    public PurchaseOrderType createPurchaseOrderType() {
+        return new PurchaseOrderType();
+    }
+
+    public USAddress createUSAddress() {
+        return new USAddress();
+    }
+
+    @XmlElementDecl(namespace = "http://tempuri.org/PurchaseOrderSchema.xsd", name = "PurchaseOrder")
+    public JAXBElement<PurchaseOrderType> createPurchaseOrder(PurchaseOrderType value) {
+        return new JAXBElement<PurchaseOrderType>(_PurchaseOrder_QNAME, PurchaseOrderType.class, null, value);
+    }
+
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/namespaces/model/PurchaseOrderType.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/namespaces/model/PurchaseOrderType.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Radek Felcman - January 2019 - Initial implementation
+package org.eclipse.persistence.testing.jaxb.json.namespaces.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import javax.xml.bind.annotation.*;
+
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "PurchaseOrderType", propOrder = {
+        "shipTo",
+        "billTo"
+})
+@XmlRootElement(name = "PurchaseOrder")
+public class PurchaseOrderType {
+
+    @XmlElement(name = "ShipTo", required = true)
+    protected List<USAddress> shipTo;
+    @XmlElement(name = "BillTo", required = true)
+    protected USAddress billTo;
+
+    public List<USAddress> getShipTo() {
+        if (shipTo == null) {
+            shipTo = new ArrayList<USAddress>();
+        }
+        return this.shipTo;
+    }
+
+    public USAddress getBillTo() {
+        return billTo;
+    }
+
+    public void setBillTo(USAddress value) {
+        this.billTo = value;
+    }
+
+    public void setShipTo(List<USAddress> shipTo) {
+        this.shipTo = shipTo;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PurchaseOrderType that = (PurchaseOrderType) o;
+        return Objects.equals(getShipTo(), that.getShipTo()) &&
+                Objects.equals(getBillTo(), that.getBillTo());
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(getShipTo(), getBillTo());
+    }
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/namespaces/model/USAddress.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/namespaces/model/USAddress.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Radek Felcman - January 2019 - Initial implementation
+package org.eclipse.persistence.testing.jaxb.json.namespaces.model;
+
+import java.util.Objects;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "USAddress", propOrder = {
+        "name",
+        "street",
+        "city",
+        "state",
+        "zip"
+})
+public class USAddress {
+
+    @XmlElement(required = true)
+    protected String name;
+    @XmlElement(required = true)
+    protected String street;
+    @XmlElement(required = true)
+    protected String city;
+    @XmlElement(required = true)
+    protected String state;
+    @XmlElement(required = true)
+    protected Integer zip;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String value) {
+        this.name = value;
+    }
+
+    public String getStreet() {
+        return street;
+    }
+
+    public void setStreet(String value) {
+        this.street = value;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(String value) {
+        this.city = value;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String value) {
+        this.state = value;
+    }
+
+    public Integer getZip() {
+        return zip;
+    }
+
+    public void setZip(Integer value) {
+        this.zip = value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        USAddress usAddress = (USAddress) o;
+        return Objects.equals(getName(), usAddress.getName()) &&
+                Objects.equals(getStreet(), usAddress.getStreet()) &&
+                Objects.equals(getCity(), usAddress.getCity()) &&
+                Objects.equals(getState(), usAddress.getState()) &&
+                Objects.equals(getZip(), usAddress.getZip());
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(getName(), getStreet(), getCity(), getState(), getZip());
+    }
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/namespaces/model/package-info.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/namespaces/model/package-info.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Radek Felcman - January 2019 - Initial implementation
+@javax.xml.bind.annotation.XmlSchema(namespace = "http://tempuri.org/PurchaseOrderSchema.xsd", elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
+package org.eclipse.persistence.testing.jaxb.json.namespaces.model;


### PR DESCRIPTION
Bug 543063 - JSON cannot be validated against XSD schema when uses namespaces

Fix for the bug 543063 and unit test test.
Before this fix MOXy threw error in case of conversion between JSON and XML, when XML schema validation was used there and XML namespaces was there.
Patch comes from https://bugs.eclipse.org/bugs/attachment.cgi?id=277013

Signed-off-by: Radek Felcman radek.felcman@oracle.com

(cherry picked from commit d5596e9)
Signed-off-by: Radek Felcman <radek.felcman@oracle.com>