### PR TITLE
Bug 543339 - jaxb-compiler.(cmd|sh) script error in Java 9 and higher

### DIFF
--- a/antbuild.properties
+++ b/antbuild.properties
@@ -205,6 +205,7 @@ jms-api.jar=jakarta.jms-api.jar
 transaction-api.jar=jakarta.transaction-api.jar
 wsrs-api.jar=jakarta.ws.rs-api.jar
 jgroups.jar=jgroups.jar
+activation.jar=jakarta.activation.jar
 annotation-api.jar=jakarta.annotation-api.jar
 cdi-api.jar=jakarta.enterprise.cdi-api.jar
 inject.jar=jakarta.inject.jar

--- a/antbuild.xml
+++ b/antbuild.xml
@@ -610,6 +610,7 @@
         <copy-plugin from="ch.qos.logback.classic*.jar" to="${logback-classic.jar}"/>
         <copy-plugin from="ch.qos.logback.core*.jar" to="${logback-core.jar}"/>
         <copy-plugin from="com.sun.xml.bind.jaxb-osgi*.jar" to="${jaxb-core.jar}"/>
+        <copy-plugin from="com.sun.activation.jakarta.activation*.jar" to="${activation.jar}"/>
         <copy-plugin from="jakarta.annotation-api*.jar" to="${annotation-api.jar}"/>
         <copy-plugin from="jakarta.ejb-api*.jar" to="${ejb-api.jar}"/>
         <copy-plugin from="org.glassfish.hk2.external.jakarta.inject*.jar" to="${inject.jar}"/>
@@ -1446,6 +1447,7 @@
             <zipfileset dir="${eclipselink.plugins}/" prefix="eclipselink/jlib/moxy">
                 <include name="${mail.jar}"/>
                 <include name="${jaxb-core.jar}"/>
+                <include name="${activation.jar}"/>
                 <include name="${validation-api.jar}"/>
                 <include name="${json.jar}"/>
             </zipfileset>

--- a/moxy/bin/jaxb-compiler.cmd
+++ b/moxy/bin/jaxb-compiler.cmd
@@ -27,7 +27,9 @@ call :fixpath "%~dp0"
 set THIS=%_FIXPATH:~1%
 set EL_PATH=%THIS%..\jlib\moxy\jakarta.json.jar
 set EL_PATH=%EL_PATH%;%THIS%..\jlib\moxy\jaxb-osgi.jar
+set EL_PATH=%EL_PATH%;%THIS%..\jlib\moxy\jakarta.activation.jar
 set EL_PATH=%EL_PATH%;%THIS%..\jlib\moxy\jakarta.validation-api.jar
+set EL_PATH=%EL_PATH%;%THIS%..\jlib\moxy\api\jakarta.xml.bind-api.jar
 set EL_PATH=%EL_PATH%;%THIS%..\jlib\eclipselink.jar
 set JAXB_API_PATH=%THIS%..\jlib\moxy\api\jakarta.xml.bind-api.jar
 set MAIN_CLASS=org.eclipse.persistence.jaxb.xjc.MOXyXJC

--- a/moxy/bin/jaxb-compiler.cmd
+++ b/moxy/bin/jaxb-compiler.cmd
@@ -25,13 +25,13 @@ set JVM_ARGS=-Xmx256m
 set _FIXPATH=
 call :fixpath "%~dp0"
 set THIS=%_FIXPATH:~1%
-set EL_PATH=%THIS%..\jlib\moxy\jakarta.json.jar
-set EL_PATH=%EL_PATH%;%THIS%..\jlib\moxy\jaxb-osgi.jar
-set EL_PATH=%EL_PATH%;%THIS%..\jlib\moxy\jakarta.activation.jar
-set EL_PATH=%EL_PATH%;%THIS%..\jlib\moxy\jakarta.validation-api.jar
-set EL_PATH=%EL_PATH%;%THIS%..\jlib\moxy\api\jakarta.xml.bind-api.jar
-set EL_PATH=%EL_PATH%;%THIS%..\jlib\eclipselink.jar
-set JAXB_API_PATH=%THIS%..\jlib\moxy\api\jakarta.xml.bind-api.jar
+set CLASSPATH=%THIS%..\jlib\moxy\jakarta.json.jar
+set CLASSPATH=%CLASSPATH%;%THIS%..\jlib\moxy\jaxb-osgi.jar
+set CLASSPATH=%CLASSPATH%;%THIS%..\jlib\moxy\jakarta.activation.jar
+set CLASSPATH=%CLASSPATH%;%THIS%..\jlib\moxy\jakarta.validation-api.jar
+set CLASSPATH=%CLASSPATH%;%THIS%..\jlib\moxy\api\jakarta.xml.bind-api.jar
+set CLASSPATH=%CLASSPATH%;%THIS%..\jlib\eclipselink.jar
+set ENDORSED_DIR=..\jlib\moxy\api
 set MAIN_CLASS=org.eclipse.persistence.jaxb.xjc.MOXyXJC
 set JAVA_ARGS=%*
 
@@ -52,21 +52,14 @@ for /f "delims=-" %%i in ('echo %JAVA_VERSION2%') do set JAVA_VERSION=%%i
 echo Java major version: %JAVA_VERSION%
 
 if %JAVA_VERSION% GEQ 9 goto JDK9_OR_GREATER
-rem classpath (Java 8)
-%JAVA_HOME%\bin\java.exe %JVM_ARGS% -cp %EL_PATH% -Djava.endorsed.dirs=..\jlib\moxy\api %MAIN_CLASS% %JAVA_ARGS%
+rem Java 8
+%JAVA_HOME%\bin\java.exe %JVM_ARGS% -cp %CLASSPATH% -Djava.endorsed.dirs=%ENDORSED_DIR% %MAIN_CLASS% %JAVA_ARGS%
 @endlocal
 goto :EOF
 
 :JDK9_OR_GREATER
-if %JAVA_VERSION% GTR 10 goto JDK11_OR_GREATER
-rem module path + upgrade (Java 9,10)
-%JAVA_HOME%\bin\java.exe %JVM_ARGS% -cp %EL_PATH% --add-modules java.activation --upgrade-module-path %JAXB_API_PATH% %MAIN_CLASS% %JAVA_ARGS%
-@endlocal
-goto :EOF
-
-:JDK11_OR_GREATER
-rem module path (Java 11)
-%JAVA_HOME%\bin\java.exe %JVM_ARGS% -cp %EL_PATH% --module-path %JAXB_API_PATH% %MAIN_CLASS% %JAVA_ARGS%
+rem Java
+%JAVA_HOME%\bin\java.exe %JVM_ARGS% -cp %CLASSPATH% %MAIN_CLASS% %JAVA_ARGS%
 @endlocal
 goto :EOF
 

--- a/moxy/bin/jaxb-compiler.cmd
+++ b/moxy/bin/jaxb-compiler.cmd
@@ -29,8 +29,8 @@ set CLASSPATH=%THIS%..\jlib\moxy\jakarta.json.jar
 set CLASSPATH=%CLASSPATH%;%THIS%..\jlib\moxy\jaxb-osgi.jar
 set CLASSPATH=%CLASSPATH%;%THIS%..\jlib\moxy\jakarta.activation.jar
 set CLASSPATH=%CLASSPATH%;%THIS%..\jlib\moxy\jakarta.validation-api.jar
-set CLASSPATH=%CLASSPATH%;%THIS%..\jlib\moxy\api\jakarta.xml.bind-api.jar
 set CLASSPATH=%CLASSPATH%;%THIS%..\jlib\eclipselink.jar
+set JAXB_API=%THIS%..\jlib\moxy\api\jakarta.xml.bind-api.jar
 set ENDORSED_DIR=..\jlib\moxy\api
 set MAIN_CLASS=org.eclipse.persistence.jaxb.xjc.MOXyXJC
 set JAVA_ARGS=%*
@@ -59,7 +59,7 @@ goto :EOF
 
 :JDK9_OR_GREATER
 rem Java
-%JAVA_HOME%\bin\java.exe %JVM_ARGS% -cp %CLASSPATH% %MAIN_CLASS% %JAVA_ARGS%
+%JAVA_HOME%\bin\java.exe %JVM_ARGS% -cp %CLASSPATH%;%JAXB_API% %MAIN_CLASS% %JAVA_ARGS%
 @endlocal
 goto :EOF
 

--- a/moxy/bin/jaxb-compiler.cmd
+++ b/moxy/bin/jaxb-compiler.cmd
@@ -25,14 +25,46 @@ set JVM_ARGS=-Xmx256m
 set _FIXPATH=
 call :fixpath "%~dp0"
 set THIS=%_FIXPATH:~1%
-set CLASSPATH=%THIS%..\jlib\moxy\jakarta.json.jar
-set CLASSPATH=%CLASSPATH%;%THIS%..\jlib\moxy\jaxb-osgi.jar
-set CLASSPATH=%CLASSPATH%;%THIS%..\jlib\moxy\jakarta.validation-api.jar
-set CLASSPATH=%CLASSPATH%;%THIS%..\jlib\eclipselink.jar
+set EL_PATH=%THIS%..\jlib\moxy\jakarta.json.jar
+set EL_PATH=%EL_PATH%;%THIS%..\jlib\moxy\jaxb-osgi.jar
+set EL_PATH=%EL_PATH%;%THIS%..\jlib\moxy\jakarta.validation-api.jar
+set EL_PATH=%EL_PATH%;%THIS%..\jlib\eclipselink.jar
+set JAXB_API_PATH=%THIS%..\jlib\moxy\api\jakarta.xml.bind-api.jar
+set MAIN_CLASS=org.eclipse.persistence.jaxb.xjc.MOXyXJC
 set JAVA_ARGS=%*
 
-%JAVA_HOME%\bin\java.exe %JVM_ARGS% -cp %CLASSPATH% -Djava.endorsed.dirs=..\jlib\moxy\api org.eclipse.persistence.jaxb.xjc.MOXyXJC %JAVA_ARGS%
+rem Set Java Version
+for /f "tokens=3" %%i in ('java -version 2^>^&1 ^| %SystemRoot%\system32\find.exe "version"') do (
+  set JAVA_VERSION1=%%i
+)
+for /f "tokens=1,2 delims=." %%j in ('echo %JAVA_VERSION1:~1,-1%') do (
+  if "1" EQU "%%j" (
+    set JAVA_VERSION2=%%k
+  ) else (
+    set JAVA_VERSION2=%%j
+  )
+)
 
+rem Remove -ea
+for /f "delims=-" %%i in ('echo %JAVA_VERSION2%') do set JAVA_VERSION=%%i
+echo Java major version: %JAVA_VERSION%
+
+if %JAVA_VERSION% GEQ 9 goto JDK9_OR_GREATER
+rem classpath (Java 8)
+%JAVA_HOME%\bin\java.exe %JVM_ARGS% -cp %EL_PATH% -Djava.endorsed.dirs=..\jlib\moxy\api %MAIN_CLASS% %JAVA_ARGS%
+@endlocal
+goto :EOF
+
+:JDK9_OR_GREATER
+if %JAVA_VERSION% GTR 10 goto JDK11_OR_GREATER
+rem module path + upgrade (Java 9,10)
+%JAVA_HOME%\bin\java.exe %JVM_ARGS% -cp %EL_PATH% --add-modules java.activation --upgrade-module-path %JAXB_API_PATH% %MAIN_CLASS% %JAVA_ARGS%
+@endlocal
+goto :EOF
+
+:JDK11_OR_GREATER
+rem module path (Java 11)
+%JAVA_HOME%\bin\java.exe %JVM_ARGS% -cp %EL_PATH% --module-path %JAXB_API_PATH% %MAIN_CLASS% %JAVA_ARGS%
 @endlocal
 goto :EOF
 

--- a/moxy/bin/jaxb-compiler.sh
+++ b/moxy/bin/jaxb-compiler.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 #
@@ -20,10 +20,27 @@ JVM_ARGS="-Xmx256m"
 # JVM_ARGS="${JVM_ARGS} -DproxySet=true -Dhttp.proxyHost= -Dhttp.proxyPort="
 
 # Please do not change any of the following lines:
-CLASSPATH=`dirname $0`/../jlib/moxy/jaxb-osgi.jar:\
+EL_PATH=`dirname $0`/../jlib/moxy/jaxb-osgi.jar:\
 `dirname $0`/../jlib/moxy/jakarta.json.jar:\
 `dirname $0`/../jlib/moxy/jakarta.validation-api.jar:\
 `dirname $0`/../jlib/eclipselink.jar
+JAXB_API_PATH=`dirname $0`/../jlib/moxy/api/jakarta.xml.bind-api.jar
+MAIN_CLASS=org.eclipse.persistence.jaxb.xjc.MOXyXJC
 JAVA_ARGS="$@"
 
-${JAVA_HOME}/bin/java ${JVM_ARGS} -cp ${CLASSPATH} -Djava.endorsed.dirs=../jlib/moxy/api org.eclipse.persistence.jaxb.xjc.MOXyXJC ${JAVA_ARGS}
+JAVA_VERSION=`${JAVA_HOME}/bin/java -version 2>&1 | head -n 1 | cut -d'"' -f2 | sed -E 's/^(1\.)?([0-9]+).+$/\2/'`
+echo "Java major version: ${JAVA_VERSION}"
+
+# Check if supports module path
+if [[ ${JAVA_VERSION} -lt 9 ]] ;
+then
+    #classpath (Java 8)
+    ${JAVA_HOME}/bin/java ${JVM_ARGS} -cp ${EL_PATH} -Djava.endorsed.dirs=../jlib/moxy/api ${MAIN_CLASS} ${JAVA_ARGS}
+elif [[ ${JAVA_VERSION} -ge 9 && ${JAVA_VERSION} -le 10 ]] ;
+then
+    #module path + upgrade (Java 9,10)
+    ${JAVA_HOME}/bin/java ${JVM_ARGS} -cp ${EL_PATH} --upgrade-module-path ${JAXB_API_PATH} ${MAIN_CLASS} ${JAVA_ARGS}
+else
+    #module path (Java 11)
+    ${JAVA_HOME}/bin/java ${JVM_ARGS} -cp ${EL_PATH} --module-path ${JAXB_API_PATH} ${MAIN_CLASS} ${JAVA_ARGS}
+fi

--- a/moxy/bin/jaxb-compiler.sh
+++ b/moxy/bin/jaxb-compiler.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 #
@@ -20,13 +20,13 @@ JVM_ARGS="-Xmx256m"
 # JVM_ARGS="${JVM_ARGS} -DproxySet=true -Dhttp.proxyHost= -Dhttp.proxyPort="
 
 # Please do not change any of the following lines:
-EL_PATH=`dirname $0`/../jlib/moxy/jaxb-osgi.jar:\
+CLASSPATH=`dirname $0`/../jlib/moxy/jaxb-osgi.jar:\
 `dirname $0`/../jlib/moxy/jakarta.activation.jar:\
 `dirname $0`/../jlib/moxy/jakarta.json.jar:\
 `dirname $0`/../jlib/moxy/jakarta.validation-api.jar:\
 `dirname $0`/../jlib/moxy/api/jakarta.xml.bind-api.jar:\
 `dirname $0`/../jlib/eclipselink.jar
-JAXB_API_PATH=`dirname $0`/../jlib/moxy/api/jakarta.xml.bind-api.jar
+ENDORSED_DIR=../jlib/moxy/api
 MAIN_CLASS=org.eclipse.persistence.jaxb.xjc.MOXyXJC
 JAVA_ARGS="$@"
 
@@ -34,15 +34,11 @@ JAVA_VERSION=`${JAVA_HOME}/bin/java -version 2>&1 | head -n 1 | cut -d'"' -f2 | 
 echo "Java major version: ${JAVA_VERSION}"
 
 # Check if supports module path
-if [[ ${JAVA_VERSION} -lt 9 ]] ;
+if [ ${JAVA_VERSION} -lt 9 ];
 then
-    #classpath (Java 8)
-    ${JAVA_HOME}/bin/java ${JVM_ARGS} -cp ${EL_PATH} -Djava.endorsed.dirs=../jlib/moxy/api ${MAIN_CLASS} ${JAVA_ARGS}
-elif [[ ${JAVA_VERSION} -ge 9 && ${JAVA_VERSION} -le 10 ]] ;
-then
-    #module path + upgrade (Java 9,10)
-    ${JAVA_HOME}/bin/java ${JVM_ARGS} -cp ${EL_PATH} --upgrade-module-path ${JAXB_API_PATH} ${MAIN_CLASS} ${JAVA_ARGS}
+    #Java 8
+    ${JAVA_HOME}/bin/java ${JVM_ARGS} -cp ${CLASSPATH} -Djava.endorsed.dirs=${ENDORSED_DIR} ${MAIN_CLASS} ${JAVA_ARGS}
 else
-    #module path (Java 11)
-    ${JAVA_HOME}/bin/java ${JVM_ARGS} -cp ${EL_PATH} --module-path ${JAXB_API_PATH} ${MAIN_CLASS} ${JAVA_ARGS}
+    #Java >8
+    ${JAVA_HOME}/bin/java ${JVM_ARGS} -cp ${CLASSPATH} ${MAIN_CLASS} ${JAVA_ARGS}
 fi

--- a/moxy/bin/jaxb-compiler.sh
+++ b/moxy/bin/jaxb-compiler.sh
@@ -24,8 +24,8 @@ CLASSPATH=`dirname $0`/../jlib/moxy/jaxb-osgi.jar:\
 `dirname $0`/../jlib/moxy/jakarta.activation.jar:\
 `dirname $0`/../jlib/moxy/jakarta.json.jar:\
 `dirname $0`/../jlib/moxy/jakarta.validation-api.jar:\
-`dirname $0`/../jlib/moxy/api/jakarta.xml.bind-api.jar:\
 `dirname $0`/../jlib/eclipselink.jar
+JAXB_API=`dirname $0`/../jlib/moxy/api/jakarta.xml.bind-api.jar
 ENDORSED_DIR=../jlib/moxy/api
 MAIN_CLASS=org.eclipse.persistence.jaxb.xjc.MOXyXJC
 JAVA_ARGS="$@"
@@ -40,5 +40,5 @@ then
     ${JAVA_HOME}/bin/java ${JVM_ARGS} -cp ${CLASSPATH} -Djava.endorsed.dirs=${ENDORSED_DIR} ${MAIN_CLASS} ${JAVA_ARGS}
 else
     #Java >8
-    ${JAVA_HOME}/bin/java ${JVM_ARGS} -cp ${CLASSPATH} ${MAIN_CLASS} ${JAVA_ARGS}
+    ${JAVA_HOME}/bin/java ${JVM_ARGS} -cp ${CLASSPATH}:${JAXB_API} ${MAIN_CLASS} ${JAVA_ARGS}
 fi

--- a/moxy/bin/jaxb-compiler.sh
+++ b/moxy/bin/jaxb-compiler.sh
@@ -21,8 +21,10 @@ JVM_ARGS="-Xmx256m"
 
 # Please do not change any of the following lines:
 EL_PATH=`dirname $0`/../jlib/moxy/jaxb-osgi.jar:\
+`dirname $0`/../jlib/moxy/jakarta.activation.jar:\
 `dirname $0`/../jlib/moxy/jakarta.json.jar:\
 `dirname $0`/../jlib/moxy/jakarta.validation-api.jar:\
+`dirname $0`/../jlib/moxy/api/jakarta.xml.bind-api.jar:\
 `dirname $0`/../jlib/eclipselink.jar
 JAXB_API_PATH=`dirname $0`/../jlib/moxy/api/jakarta.xml.bind-api.jar
 MAIN_CLASS=org.eclipse.persistence.jaxb.xjc.MOXyXJC


### PR DESCRIPTION
Bug 543339 - jaxb-compiler.(cmd|sh) script error in Java 9 and higher

This is fix for jaxb-compiler.(cmd|sh) script. After this fix will be possible to call this script in Java 8,9,10,11 (before only Java 8).
There is some change in dependencies. _jakarta.activation.jar_ is added there (due Java 11).