### PR TITLE
Bug 543339 - jaxb-compiler.(cmd|sh) script error in Java 9 and higher

### DIFF
--- a/antbuild.properties
+++ b/antbuild.properties
@@ -208,6 +208,7 @@ jms-api.jar=jakarta.jms-api.jar
 transaction-api.jar=jakarta.transaction-api.jar
 wsrs-api.jar=jakarta.ws.rs-api.jar
 jgroups.jar=jgroups.jar
+activation.jar=jakarta.activation.jar
 annotation-api.jar=jakarta.annotation-api.jar
 cdi-api.jar=jakarta.enterprise.cdi-api.jar
 inject.jar=jakarta.inject.jar

--- a/antbuild.xml
+++ b/antbuild.xml
@@ -618,6 +618,7 @@
         <copy-plugin from="ch.qos.logback.classic*.jar" to="${logback-classic.jar}"/>
         <copy-plugin from="ch.qos.logback.core*.jar" to="${logback-core.jar}"/>
         <copy-plugin from="com.sun.xml.bind.jaxb-osgi*.jar" to="${jaxb-core.jar}"/>
+        <copy-plugin from="com.sun.activation.jakarta.activation*.jar" to="${activation.jar}"/>
         <copy-plugin from="jakarta.annotation-api*.jar" to="${annotation-api.jar}"/>
         <copy-plugin from="jakarta.ejb-api*.jar" to="${ejb-api.jar}"/>
         <copy-plugin from="org.glassfish.hk2.external.jakarta.inject*.jar" to="${inject.jar}"/>
@@ -1587,6 +1588,7 @@
             <zipfileset dir="${eclipselink.plugins}/" prefix="eclipselink/jlib/moxy">
                 <include name="${mail.jar}"/>
                 <include name="${jaxb-core.jar}"/>
+                <include name="${activation.jar}"/>
                 <include name="${validation-api.jar}"/>
                 <include name="${json.jar}"/>
             </zipfileset>

--- a/moxy/bin/jaxb-compiler.cmd
+++ b/moxy/bin/jaxb-compiler.cmd
@@ -27,12 +27,39 @@ call :fixpath "%~dp0"
 set THIS=%_FIXPATH:~1%
 set CLASSPATH=%THIS%..\jlib\moxy\jakarta.json.jar
 set CLASSPATH=%CLASSPATH%;%THIS%..\jlib\moxy\jaxb-osgi.jar
+set CLASSPATH=%CLASSPATH%;%THIS%..\jlib\moxy\jakarta.activation.jar
 set CLASSPATH=%CLASSPATH%;%THIS%..\jlib\moxy\jakarta.validation-api.jar
 set CLASSPATH=%CLASSPATH%;%THIS%..\jlib\eclipselink.jar
+set JAXB_API=%THIS%..\jlib\moxy\api\jakarta.xml.bind-api.jar
+set ENDORSED_DIR=..\jlib\moxy\api
+set MAIN_CLASS=org.eclipse.persistence.jaxb.xjc.MOXyXJC
 set JAVA_ARGS=%*
 
-%JAVA_HOME%\bin\java.exe %JVM_ARGS% -cp %CLASSPATH% -Djava.endorsed.dirs=..\jlib\moxy\api org.eclipse.persistence.jaxb.xjc.MOXyXJC %JAVA_ARGS%
+rem Set Java Version
+for /f "tokens=3" %%i in ('java -version 2^>^&1 ^| %SystemRoot%\system32\find.exe "version"') do (
+  set JAVA_VERSION1=%%i
+)
+for /f "tokens=1,2 delims=." %%j in ('echo %JAVA_VERSION1:~1,-1%') do (
+  if "1" EQU "%%j" (
+    set JAVA_VERSION2=%%k
+  ) else (
+    set JAVA_VERSION2=%%j
+  )
+)
 
+rem Remove -ea
+for /f "delims=-" %%i in ('echo %JAVA_VERSION2%') do set JAVA_VERSION=%%i
+echo Java major version: %JAVA_VERSION%
+
+if %JAVA_VERSION% GEQ 9 goto JDK9_OR_GREATER
+rem Java 8
+%JAVA_HOME%\bin\java.exe %JVM_ARGS% -cp %CLASSPATH% -Djava.endorsed.dirs=%ENDORSED_DIR% %MAIN_CLASS% %JAVA_ARGS%
+@endlocal
+goto :EOF
+
+:JDK9_OR_GREATER
+rem Java
+%JAVA_HOME%\bin\java.exe %JVM_ARGS% -cp %CLASSPATH%;%JAXB_API% %MAIN_CLASS% %JAVA_ARGS%
 @endlocal
 goto :EOF
 

--- a/moxy/bin/jaxb-compiler.sh
+++ b/moxy/bin/jaxb-compiler.sh
@@ -21,9 +21,24 @@ JVM_ARGS="-Xmx256m"
 
 # Please do not change any of the following lines:
 CLASSPATH=`dirname $0`/../jlib/moxy/jaxb-osgi.jar:\
+`dirname $0`/../jlib/moxy/jakarta.activation.jar:\
 `dirname $0`/../jlib/moxy/jakarta.json.jar:\
 `dirname $0`/../jlib/moxy/jakarta.validation-api.jar:\
 `dirname $0`/../jlib/eclipselink.jar
+JAXB_API=`dirname $0`/../jlib/moxy/api/jakarta.xml.bind-api.jar
+ENDORSED_DIR=../jlib/moxy/api
+MAIN_CLASS=org.eclipse.persistence.jaxb.xjc.MOXyXJC
 JAVA_ARGS="$@"
 
-${JAVA_HOME}/bin/java ${JVM_ARGS} -cp ${CLASSPATH} -Djava.endorsed.dirs=../jlib/moxy/api org.eclipse.persistence.jaxb.xjc.MOXyXJC ${JAVA_ARGS}
+JAVA_VERSION=`${JAVA_HOME}/bin/java -version 2>&1 | head -n 1 | cut -d'"' -f2 | sed -E 's/^(1\.)?([0-9]+).+$/\2/'`
+echo "Java major version: ${JAVA_VERSION}"
+
+# Check if supports module path
+if [ ${JAVA_VERSION} -lt 9 ];
+then
+    #Java 8
+    ${JAVA_HOME}/bin/java ${JVM_ARGS} -cp ${CLASSPATH} -Djava.endorsed.dirs=${ENDORSED_DIR} ${MAIN_CLASS} ${JAVA_ARGS}
+else
+    #Java >8
+    ${JAVA_HOME}/bin/java ${JVM_ARGS} -cp ${CLASSPATH}:${JAXB_API} ${MAIN_CLASS} ${JAVA_ARGS}
+fi


### PR DESCRIPTION
Bug 543339 - jaxb-compiler.(cmd|sh) script error in Java 9 and higher

This is fix for jaxb-compiler.(cmd|sh) script. After this fix will be possible to call this script in Java 8,9,10,11 (before only Java 8).
There is some change in dependencies. jakarta.activation.jar is added there (due Java 11).

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>

(cherry picked from commit eb98ed2)
Signed-off-by: Radek Felcman <radek.felcman@oracle.com>