### PR TITLE
 Bug 543265 - WSDL namespace order is different on ITEMSERVICEPORT?WSDL

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/schema/model/SchemaCompareByNamespace.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/schema/model/SchemaCompareByNamespace.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Radek Felcman (Oracle) - initial implementation
+package org.eclipse.persistence.internal.oxm.schema.model;
+
+import java.util.Comparator;
+
+public class SchemaCompareByNamespace implements Comparator<Schema>{
+
+    @Override
+    public int compare(Schema arg1, Schema arg2) {
+        String targetNamespace1 = arg1.getTargetNamespace() != null ? arg1.getTargetNamespace() : "";
+        String targetNamespace2 = arg2.getTargetNamespace() != null ? arg2.getTargetNamespace() : "";
+        return targetNamespace1.compareTo(targetNamespace2);
+    }
+}

--- a/moxy/eclipselink.moxy.test/moxy.test.iml
+++ b/moxy/eclipselink.moxy.test/moxy.test.iml
@@ -42,7 +42,7 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/../../plugins/com.sun.xml.bind.jaxb-osgi.jar!/" />
+          <root url="jar://$MODULE_DIR$/../../plugins/jaxb-osgi.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES />

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/beanvalidation/generator/schema_with_facets.xsd
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/beanvalidation/generator/schema_with_facets.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,6 +14,11 @@
 -->
 
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+   <xsd:complexType name="drivingLicense">
+      <xsd:sequence/>
+      <xsd:attribute name="id" type="xsd:int" use="required"/>
+      <xsd:attribute name="validThrough" type="xsd:dateTime"/>
+   </xsd:complexType>
    <xsd:complexType name="employee">
       <xsd:sequence>
          <xsd:element name="personalName" minOccurs="0">
@@ -37,13 +42,8 @@
       <xsd:attribute name="id" type="xsd:int"/>
       <xsd:attribute name="age" type="xsd:int" use="required"/>
    </xsd:complexType>
-   <xsd:complexType name="drivingLicense">
-      <xsd:sequence/>
-      <xsd:attribute name="id" type="xsd:int" use="required"/>
-      <xsd:attribute name="validThrough" type="xsd:dateTime"/>
-   </xsd:complexType>
-   <xsd:element name="employee" type="employee"/>
    <xsd:element name="department" type="department"/>
+   <xsd:element name="employee" type="employee"/>
    <xsd:simpleType name="department">
       <xsd:restriction base="xsd:string">
          <xsd:enumeration value="RDBMS"/>

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/beanvalidation/sgen_xjc/golden_file.xsd
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/beanvalidation/sgen_xjc/golden_file.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -35,6 +35,14 @@
          </xsd:element>
          <xsd:element name="someCollection" type="xsd:anyType" maxOccurs="unbounded"/>
       </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="NumberWithHiddenValueAttribute">
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:string">
+            <xsd:attribute name="code" type="xsd:string" use="required"/>
+            <xsd:attribute name="whatNumber" type="xsd:long" use="required"/>
+         </xsd:extension>
+      </xsd:simpleContent>
    </xsd:complexType>
    <xsd:complexType name="Numbers">
       <xsd:sequence>
@@ -76,14 +84,6 @@
          </xsd:element>
          <xsd:element name="NumberWithHiddenValueAttribute" type="ns0:NumberWithHiddenValueAttribute"/>
       </xsd:sequence>
-   </xsd:complexType>
-   <xsd:complexType name="NumberWithHiddenValueAttribute">
-      <xsd:simpleContent>
-         <xsd:extension base="xsd:string">
-            <xsd:attribute name="code" type="xsd:string" use="required"/>
-            <xsd:attribute name="whatNumber" type="xsd:long" use="required"/>
-         </xsd:extension>
-      </xsd:simpleContent>
    </xsd:complexType>
    <xsd:complexType name="Strings">
       <xsd:sequence>

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/MultiDimensionalArrayNonRoot1.xsd
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/MultiDimensionalArrayNonRoot1.xsd
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,45 +13,20 @@
 
 -->
 
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:ns0="http://jaxb.dev.java.net/array" xmlns:x="listOfObjectsNamespace" targetNamespace="listOfObjectsNamespace">
-   <xsd:complexType name="multiDimensionalArrayRoot">
+<xsd:schema xmlns:ns0="http://jaxb.dev.java.net/array" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://jaxb.dev.java.net/array">
+   <xsd:complexType name="intArray">
       <xsd:sequence>
-         <xsd:element nillable="true" maxOccurs="unbounded" minOccurs="0" name="char2dArray" type="ns0:stringArray"/>
-         <xsd:element nillable="true" maxOccurs="unbounded" minOccurs="0" name="employee2dArray" type="x:employeeArray"/>
-         <xsd:element nillable="true" maxOccurs="unbounded" minOccurs="0" name="innerClass2dArray" type="x:myInnerArray"/>
-         <xsd:element nillable="true" maxOccurs="unbounded" minOccurs="0" name="int2dArray" type="ns0:intArray"/>
-         <xsd:element nillable="true" maxOccurs="unbounded" minOccurs="0" name="int3dArray" type="ns0:intArrayArray"/>
+         <xsd:element name="item" type="xsd:int" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
       </xsd:sequence>
    </xsd:complexType>
-   <xsd:complexType name="myInner">
+   <xsd:complexType name="intArrayArray">
       <xsd:sequence>
-         <xsd:element minOccurs="0" name="innerName" type="xsd:string"/>
+         <xsd:element name="item" type="ns0:intArray" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
       </xsd:sequence>
    </xsd:complexType>
-   <xsd:complexType name="employeeArray">
+   <xsd:complexType name="stringArray">
       <xsd:sequence>
-         <xsd:element nillable="true" maxOccurs="unbounded" minOccurs="0" name="item" type="x:employee"/>
+         <xsd:element name="item" type="xsd:string" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
       </xsd:sequence>
    </xsd:complexType>
-   <xsd:complexType name="employee">
-      <xsd:sequence>
-         <xsd:element minOccurs="0" name="firstName" type="xsd:string"/>
-         <xsd:element minOccurs="0" name="lastName" type="xsd:string"/>
-         <xsd:element minOccurs="0" name="birthday" type="xsd:dateTime"/>
-         <xsd:element minOccurs="0" name="responsibilities">
-            <xsd:complexType>
-               <xsd:sequence>
-                  <xsd:element maxOccurs="unbounded" minOccurs="0" name="responsibility" type="xsd:anyType"/>
-               </xsd:sequence>
-            </xsd:complexType>
-         </xsd:element>
-      </xsd:sequence>
-      <xsd:attribute name="id" type="xsd:int" use="required"/>
-   </xsd:complexType>
-   <xsd:complexType name="myInnerArray">
-      <xsd:sequence>
-         <xsd:element nillable="true" maxOccurs="unbounded" minOccurs="0" name="item" type="x:myInner"/>
-      </xsd:sequence>
-   </xsd:complexType>
-   <xsd:element name="employee-data" type="x:employee"/>
 </xsd:schema>

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/MultiDimensionalArrayNonRoot2.xsd
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/MultiDimensionalArrayNonRoot2.xsd
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,7 +13,45 @@
 
 -->
 
-<xsd:schema xmlns:ns0="urn:example" xmlns:ns1="listOfObjectsNamespace" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:example">
-   <xsd:import schemaLocation="schema1.xsd" namespace="listOfObjectsNamespace"/>
-   <xsd:element name="root" type="ns1:multiDimensionalArrayRoot"/>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:ns0="http://jaxb.dev.java.net/array" xmlns:x="listOfObjectsNamespace" targetNamespace="listOfObjectsNamespace">
+   <xsd:complexType name="employeeArray">
+      <xsd:sequence>
+         <xsd:element nillable="true" maxOccurs="unbounded" minOccurs="0" name="item" type="x:employee"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="myInnerArray">
+      <xsd:sequence>
+         <xsd:element nillable="true" maxOccurs="unbounded" minOccurs="0" name="item" type="x:myInner"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="myInner">
+      <xsd:sequence>
+         <xsd:element minOccurs="0" name="innerName" type="xsd:string"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="employee">
+      <xsd:sequence>
+         <xsd:element minOccurs="0" name="firstName" type="xsd:string"/>
+         <xsd:element minOccurs="0" name="lastName" type="xsd:string"/>
+         <xsd:element minOccurs="0" name="birthday" type="xsd:dateTime"/>
+         <xsd:element minOccurs="0" name="responsibilities">
+            <xsd:complexType>
+               <xsd:sequence>
+                  <xsd:element maxOccurs="unbounded" minOccurs="0" name="responsibility" type="xsd:anyType"/>
+               </xsd:sequence>
+            </xsd:complexType>
+         </xsd:element>
+      </xsd:sequence>
+      <xsd:attribute name="id" type="xsd:int" use="required"/>
+   </xsd:complexType>
+   <xsd:complexType name="multiDimensionalArrayRoot">
+      <xsd:sequence>
+         <xsd:element nillable="true" maxOccurs="unbounded" minOccurs="0" name="char2dArray" type="ns0:stringArray"/>
+         <xsd:element nillable="true" maxOccurs="unbounded" minOccurs="0" name="employee2dArray" type="x:employeeArray"/>
+         <xsd:element nillable="true" maxOccurs="unbounded" minOccurs="0" name="innerClass2dArray" type="x:myInnerArray"/>
+         <xsd:element nillable="true" maxOccurs="unbounded" minOccurs="0" name="int2dArray" type="ns0:intArray"/>
+         <xsd:element nillable="true" maxOccurs="unbounded" minOccurs="0" name="int3dArray" type="ns0:intArrayArray"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:element name="employee-data" type="x:employee"/>
 </xsd:schema>

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/MultiDimensionalArrayNonRoot3.xsd
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/MultiDimensionalArrayNonRoot3.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,20 +13,7 @@
 
 -->
 
-<xsd:schema xmlns:ns0="http://jaxb.dev.java.net/array" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://jaxb.dev.java.net/array">
-   <xsd:complexType name="intArrayArray">
-      <xsd:sequence>
-         <xsd:element name="item" type="ns0:intArray" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-   </xsd:complexType>
-   <xsd:complexType name="stringArray">
-      <xsd:sequence>
-         <xsd:element name="item" type="xsd:string" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-   </xsd:complexType>
-   <xsd:complexType name="intArray">
-      <xsd:sequence>
-         <xsd:element name="item" type="xsd:int" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-   </xsd:complexType>
+<xsd:schema xmlns:ns0="urn:example" xmlns:ns1="listOfObjectsNamespace" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:example">
+   <xsd:import schemaLocation="schema2.xsd" namespace="listOfObjectsNamespace"/>
+   <xsd:element name="root" type="ns1:multiDimensionalArrayRoot"/>
 </xsd:schema>

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/employeeCollision1.xsd
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/employeeCollision1.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,7 +13,12 @@
 
 -->
 
-<xsd:schema targetNamespace="listOfObjectsNamespace" xmlns:x="listOfObjectsNamespace" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<xsd:schema targetNamespace="examplenamespace" xmlns:x="examplenamespace" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+   <xsd:complexType name="employeeArray">
+      <xsd:sequence>
+         <xsd:element name="item" nillable="true" type="x:employee" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
    <xsd:complexType name="employee">
       <xsd:sequence>
          <xsd:element name="firstName" type="xsd:string" minOccurs="0"/>
@@ -28,11 +33,6 @@
          </xsd:element>
       </xsd:sequence>
       <xsd:attribute name="id" type="xsd:int" use="required"/>
-   </xsd:complexType>
-   <xsd:complexType name="listOfEmployee">
-      <xsd:sequence>
-         <xsd:element name="item" nillable="true" type="x:employee" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
    </xsd:complexType>
    <xsd:element name="employee-data" type="x:employee"/>
 </xsd:schema>

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/employeeCollision2.xsd
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/employeeCollision2.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,12 +13,7 @@
 
 -->
 
-<xsd:schema targetNamespace="examplenamespace" xmlns:x="examplenamespace" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-   <xsd:complexType name="employeeArray">
-      <xsd:sequence>
-         <xsd:element name="item" nillable="true" type="x:employee" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-   </xsd:complexType>
+<xsd:schema targetNamespace="listOfObjectsNamespace" xmlns:x="listOfObjectsNamespace" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
    <xsd:complexType name="employee">
       <xsd:sequence>
          <xsd:element name="firstName" type="xsd:string" minOccurs="0"/>
@@ -33,6 +28,11 @@
          </xsd:element>
       </xsd:sequence>
       <xsd:attribute name="id" type="xsd:int" use="required"/>
+   </xsd:complexType>
+   <xsd:complexType name="listOfEmployee">
+      <xsd:sequence>
+         <xsd:element name="item" nillable="true" type="x:employee" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
    </xsd:complexType>
    <xsd:element name="employee-data" type="x:employee"/>
 </xsd:schema>

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/employeesAndIntegers1.xsd
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/employeesAndIntegers1.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,26 +13,10 @@
 
 -->
 
-<xsd:schema targetNamespace="listOfObjectsNamespace" xmlns:x="listOfObjectsNamespace" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-   <xsd:complexType name="employeeArray">
+<xsd:schema targetNamespace="http://jaxb.dev.java.net/array" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:ns0="http://jaxb.dev.java.net/array">
+   <xsd:complexType name="intArray">
       <xsd:sequence>
-         <xsd:element name="item" nillable="true" type="x:employee" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element name="item" nillable="true" type="xsd:int" minOccurs="0" maxOccurs="unbounded"/>
       </xsd:sequence>
    </xsd:complexType>
-   <xsd:complexType name="employee">
-      <xsd:sequence>
-         <xsd:element name="firstName" type="xsd:string" minOccurs="0"/>
-         <xsd:element name="lastName" type="xsd:string" minOccurs="0"/>
-         <xsd:element name="birthday" type="xsd:dateTime" minOccurs="0"/>
-         <xsd:element name="responsibilities" minOccurs="0">
-            <xsd:complexType>
-               <xsd:sequence>
-                  <xsd:element name="responsibility" type="xsd:anyType" minOccurs="0" maxOccurs="unbounded"/>
-               </xsd:sequence>
-            </xsd:complexType>
-         </xsd:element>
-      </xsd:sequence>
-      <xsd:attribute name="id" type="xsd:int" use="required"/>
-   </xsd:complexType>
-   <xsd:element name="employee-data" type="x:employee"/>
 </xsd:schema>

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/employeesAndIntegers2.xsd
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/employeesAndIntegers2.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,16 +13,26 @@
 
 -->
 
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:ns0="listOfObjectsNamespace">
-   <xsd:import namespace="listOfObjectsNamespace" schemaLocation="schema2.xsd"/>
-   <xsd:complexType name="listOfInteger">
+<xsd:schema targetNamespace="listOfObjectsNamespace" xmlns:x="listOfObjectsNamespace" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+   <xsd:complexType name="employeeArray">
       <xsd:sequence>
-         <xsd:element name="item" nillable="true" type="xsd:int" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element name="item" nillable="true" type="x:employee" minOccurs="0" maxOccurs="unbounded"/>
       </xsd:sequence>
    </xsd:complexType>
-   <xsd:complexType name="listOfEmployee">
+   <xsd:complexType name="employee">
       <xsd:sequence>
-         <xsd:element name="item" nillable="true" type="ns0:employee" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element name="firstName" type="xsd:string" minOccurs="0"/>
+         <xsd:element name="lastName" type="xsd:string" minOccurs="0"/>
+         <xsd:element name="birthday" type="xsd:dateTime" minOccurs="0"/>
+         <xsd:element name="responsibilities" minOccurs="0">
+            <xsd:complexType>
+               <xsd:sequence>
+                  <xsd:element name="responsibility" type="xsd:anyType" minOccurs="0" maxOccurs="unbounded"/>
+               </xsd:sequence>
+            </xsd:complexType>
+         </xsd:element>
       </xsd:sequence>
+      <xsd:attribute name="id" type="xsd:int" use="required"/>
    </xsd:complexType>
+   <xsd:element name="employee-data" type="x:employee"/>
 </xsd:schema>

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/employeesAndIntegers3.xsd
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/employeesAndIntegers3.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,10 +13,16 @@
 
 -->
 
-<xsd:schema targetNamespace="http://jaxb.dev.java.net/array" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:ns0="http://jaxb.dev.java.net/array">
-   <xsd:complexType name="intArray">
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:ns0="listOfObjectsNamespace">
+   <xsd:import namespace="listOfObjectsNamespace" schemaLocation="schema3.xsd"/>
+   <xsd:complexType name="listOfInteger">
       <xsd:sequence>
          <xsd:element name="item" nillable="true" type="xsd:int" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="listOfEmployee">
+      <xsd:sequence>
+         <xsd:element name="item" nillable="true" type="ns0:employee" minOccurs="0" maxOccurs="unbounded"/>
       </xsd:sequence>
    </xsd:complexType>
 </xsd:schema>

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/listEmployee2.xsd
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/listEmployee2.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,11 +13,21 @@
 
 -->
 
-<xsd:schema xmlns:ns0="listOfObjectsNamespace" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-   <xsd:import namespace="listOfObjectsNamespace" schemaLocation="schema1.xsd"/>
-   <xsd:complexType name="listOfEmployee">
+<xsd:schema targetNamespace="listOfObjectsNamespace" xmlns:x="listOfObjectsNamespace" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+   <xsd:complexType name="employee">
       <xsd:sequence>
-         <xsd:element name="item" nillable="true" type="ns0:employee" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element name="firstName" type="xsd:string" minOccurs="0"/>
+         <xsd:element name="lastName" type="xsd:string" minOccurs="0"/>
+         <xsd:element name="birthday" type="xsd:dateTime" minOccurs="0"/>
+         <xsd:element name="responsibilities" minOccurs="0">
+            <xsd:complexType>
+               <xsd:sequence>
+                  <xsd:element name="responsibility" type="xsd:anyType" minOccurs="0" maxOccurs="unbounded"/>
+               </xsd:sequence>
+            </xsd:complexType>
+         </xsd:element>
       </xsd:sequence>
+      <xsd:attribute name="id" type="xsd:int" use="required"/>
    </xsd:complexType>
+   <xsd:element name="employee-data" type="x:employee"/>
 </xsd:schema>

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/multipleMaps.xsd
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/multipleMaps.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,52 +13,7 @@
 
 -->
 
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:ns0="myns">
-   <xsd:import namespace="myns" schemaLocation="schema1.xsd"/>
-   <xsd:complexType name="stringIntegerMap">
-      <xsd:sequence>
-         <xsd:element maxOccurs="unbounded" minOccurs="0" name="entry">
-            <xsd:complexType>
-               <xsd:sequence>
-                  <xsd:element minOccurs="0" name="key" type="xsd:string"/>
-                  <xsd:element minOccurs="0" name="value" type="xsd:int"/>
-               </xsd:sequence>
-            </xsd:complexType>
-         </xsd:element>
-      </xsd:sequence>
-   </xsd:complexType>
-   <xsd:complexType name="calendarFloatMap">
-      <xsd:sequence>
-         <xsd:element maxOccurs="unbounded" minOccurs="0" name="entry">
-            <xsd:complexType>
-               <xsd:sequence>
-                  <xsd:element minOccurs="0" name="key" type="xsd:dateTime"/>
-                  <xsd:element minOccurs="0" name="value" type="xsd:float"/>
-               </xsd:sequence>
-            </xsd:complexType>
-         </xsd:element>
-      </xsd:sequence>
-   </xsd:complexType>
-   <xsd:complexType name="listOfString">
-      <xsd:sequence>
-         <xsd:element name="item" type="xsd:string" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-   </xsd:complexType>
-   <xsd:complexType name="personJobMap">
-      <xsd:sequence>
-         <xsd:element maxOccurs="unbounded" minOccurs="0" name="entry">
-            <xsd:complexType>
-               <xsd:sequence>
-                  <xsd:element minOccurs="0" name="key" type="ns0:person"/>
-                  <xsd:element minOccurs="0" name="value" type="ns0:job"/>
-               </xsd:sequence>
-            </xsd:complexType>
-         </xsd:element>
-      </xsd:sequence>
-   </xsd:complexType>
-   <xsd:complexType name="listOfPerson">
-      <xsd:sequence>
-         <xsd:element name="item" type="ns0:person" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-   </xsd:complexType>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:ns0="myns" targetNamespace="myns">
+   <xsd:complexType name="person"/>
+   <xsd:complexType name="job"/>
 </xsd:schema>

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/multipleMaps2.xsd
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/multipleMaps2.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,7 +13,52 @@
 
 -->
 
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:ns0="myns" targetNamespace="myns">
-   <xsd:complexType name="person"/>
-   <xsd:complexType name="job"/>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:ns0="myns">
+   <xsd:import namespace="myns" schemaLocation="schema2.xsd"/>
+   <xsd:complexType name="calendarFloatMap">
+      <xsd:sequence>
+         <xsd:element maxOccurs="unbounded" minOccurs="0" name="entry">
+            <xsd:complexType>
+               <xsd:sequence>
+                  <xsd:element minOccurs="0" name="key" type="xsd:dateTime"/>
+                  <xsd:element minOccurs="0" name="value" type="xsd:float"/>
+               </xsd:sequence>
+            </xsd:complexType>
+         </xsd:element>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="stringIntegerMap">
+      <xsd:sequence>
+         <xsd:element maxOccurs="unbounded" minOccurs="0" name="entry">
+            <xsd:complexType>
+               <xsd:sequence>
+                  <xsd:element minOccurs="0" name="key" type="xsd:string"/>
+                  <xsd:element minOccurs="0" name="value" type="xsd:int"/>
+               </xsd:sequence>
+            </xsd:complexType>
+         </xsd:element>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="listOfString">
+      <xsd:sequence>
+         <xsd:element name="item" type="xsd:string" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="listOfPerson">
+      <xsd:sequence>
+         <xsd:element name="item" type="ns0:person" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="personJobMap">
+      <xsd:sequence>
+         <xsd:element maxOccurs="unbounded" minOccurs="0" name="entry">
+            <xsd:complexType>
+               <xsd:sequence>
+                  <xsd:element minOccurs="0" name="key" type="ns0:person"/>
+                  <xsd:element minOccurs="0" name="value" type="ns0:job"/>
+               </xsd:sequence>
+            </xsd:complexType>
+         </xsd:element>
+      </xsd:sequence>
+   </xsd:complexType>
 </xsd:schema>

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/multipleMapsNamespace.xsd
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/multipleMapsNamespace.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,52 +13,7 @@
 
 -->
 
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:ns0="java.util" xmlns:ns1="myns" targetNamespace="java.util">
-   <xsd:import namespace="myns" schemaLocation="schema1.xsd"/>
-   <xsd:complexType name="personJobMap">
-      <xsd:sequence>
-         <xsd:element maxOccurs="unbounded" minOccurs="0" name="entry">
-            <xsd:complexType>
-               <xsd:sequence>
-                  <xsd:element minOccurs="0" name="key" type="ns1:person"/>
-                  <xsd:element minOccurs="0" name="value" type="ns1:job"/>
-               </xsd:sequence>
-            </xsd:complexType>
-         </xsd:element>
-      </xsd:sequence>
-   </xsd:complexType>
-   <xsd:complexType name="listOfPerson">
-      <xsd:sequence>
-         <xsd:element name="item" type="ns1:person" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-   </xsd:complexType>
-   <xsd:complexType name="stringIntegerMap">
-      <xsd:sequence>
-         <xsd:element maxOccurs="unbounded" minOccurs="0" name="entry">
-            <xsd:complexType>
-               <xsd:sequence>
-                  <xsd:element minOccurs="0" name="key" type="xsd:string"/>
-                  <xsd:element minOccurs="0" name="value" type="xsd:int"/>
-               </xsd:sequence>
-            </xsd:complexType>
-         </xsd:element>
-      </xsd:sequence>
-   </xsd:complexType>
-   <xsd:complexType name="calendarFloatMap">
-      <xsd:sequence>
-         <xsd:element maxOccurs="unbounded" minOccurs="0" name="entry">
-            <xsd:complexType>
-               <xsd:sequence>
-                  <xsd:element minOccurs="0" name="key" type="xsd:dateTime"/>
-                  <xsd:element minOccurs="0" name="value" type="xsd:float"/>
-               </xsd:sequence>
-            </xsd:complexType>
-         </xsd:element>
-      </xsd:sequence>
-   </xsd:complexType>
-   <xsd:complexType name="listOfString">
-      <xsd:sequence>
-         <xsd:element name="item" type="xsd:string" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
-      </xsd:sequence>
-   </xsd:complexType>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:ns0="myns" targetNamespace="myns">
+   <xsd:complexType name="person"/>
+   <xsd:complexType name="job"/>
 </xsd:schema>

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/multipleMapsNamespace2.xsd
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/multipleMapsNamespace2.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,7 +13,52 @@
 
 -->
 
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:ns0="myns" targetNamespace="myns">
-   <xsd:complexType name="person"/>
-   <xsd:complexType name="job"/>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:ns0="java.util" xmlns:ns1="myns" targetNamespace="java.util">
+   <xsd:import namespace="myns" schemaLocation="schema2.xsd"/>
+   <xsd:complexType name="calendarFloatMap">
+      <xsd:sequence>
+         <xsd:element maxOccurs="unbounded" minOccurs="0" name="entry">
+            <xsd:complexType>
+               <xsd:sequence>
+                  <xsd:element minOccurs="0" name="key" type="xsd:dateTime"/>
+                  <xsd:element minOccurs="0" name="value" type="xsd:float"/>
+               </xsd:sequence>
+            </xsd:complexType>
+         </xsd:element>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="stringIntegerMap">
+      <xsd:sequence>
+         <xsd:element maxOccurs="unbounded" minOccurs="0" name="entry">
+            <xsd:complexType>
+               <xsd:sequence>
+                  <xsd:element minOccurs="0" name="key" type="xsd:string"/>
+                  <xsd:element minOccurs="0" name="value" type="xsd:int"/>
+               </xsd:sequence>
+            </xsd:complexType>
+         </xsd:element>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="listOfString">
+      <xsd:sequence>
+         <xsd:element name="item" type="xsd:string" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="listOfPerson">
+      <xsd:sequence>
+         <xsd:element name="item" type="ns1:person" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="personJobMap">
+      <xsd:sequence>
+         <xsd:element maxOccurs="unbounded" minOccurs="0" name="entry">
+            <xsd:complexType>
+               <xsd:sequence>
+                  <xsd:element minOccurs="0" name="key" type="ns1:person"/>
+                  <xsd:element minOccurs="0" name="value" type="ns1:job"/>
+               </xsd:sequence>
+            </xsd:complexType>
+         </xsd:element>
+      </xsd:sequence>
+   </xsd:complexType>
 </xsd:schema>

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/objectCollections.xsd
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/objectCollections.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,8 +13,20 @@
 
 -->
 
-<xsd:schema targetNamespace="http://jaxb.dev.java.net/array" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:ns0="http://jaxb.dev.java.net/array">
-   <xsd:complexType name="anyTypeArray">
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+   <xsd:complexType name="objectObjectMap">
+      <xsd:sequence>
+         <xsd:element name="entry" minOccurs="0" maxOccurs="unbounded">
+            <xsd:complexType>
+               <xsd:sequence>
+                  <xsd:element name="key" type="xsd:anyType" minOccurs="0"/>
+                  <xsd:element name="value" type="xsd:anyType" minOccurs="0"/>
+               </xsd:sequence>
+            </xsd:complexType>
+         </xsd:element>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="arrayListOfObject">
       <xsd:sequence>
          <xsd:element name="item" type="xsd:anyType" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
       </xsd:sequence>

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/objectCollections2.xsd
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/objectCollections2.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,20 +13,8 @@
 
 -->
 
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-   <xsd:complexType name="objectObjectMap">
-      <xsd:sequence>
-         <xsd:element name="entry" minOccurs="0" maxOccurs="unbounded">
-            <xsd:complexType>
-               <xsd:sequence>
-                  <xsd:element name="key" type="xsd:anyType" minOccurs="0"/>
-                  <xsd:element name="value" type="xsd:anyType" minOccurs="0"/>
-               </xsd:sequence>
-            </xsd:complexType>
-         </xsd:element>
-      </xsd:sequence>
-   </xsd:complexType>
-   <xsd:complexType name="arrayListOfObject">
+<xsd:schema targetNamespace="http://jaxb.dev.java.net/array" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:ns0="http://jaxb.dev.java.net/array">
+   <xsd:complexType name="anyTypeArray">
       <xsd:sequence>
          <xsd:element name="item" type="xsd:anyType" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
       </xsd:sequence>

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/stringEmployeeHashtable.xsd
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/stringEmployeeHashtable.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,21 +13,18 @@
 
 -->
 
-<xsd:schema targetNamespace="listOfObjectsNamespace" xmlns:x="listOfObjectsNamespace" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-   <xsd:complexType name="employee">
+<xsd:schema xmlns:x="listOfObjectsNamespace" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+   <xsd:import schemaLocation="schema2.xsd" namespace="listOfObjectsNamespace"/>
+   <xsd:complexType name="stringEmployeeHashtable">
       <xsd:sequence>
-         <xsd:element name="firstName" type="xsd:string" minOccurs="0"/>
-         <xsd:element name="lastName" type="xsd:string" minOccurs="0"/>
-         <xsd:element name="birthday" type="xsd:dateTime" minOccurs="0"/>
-         <xsd:element name="responsibilities" minOccurs="0">
+         <xsd:element name="entry" minOccurs="0" maxOccurs="unbounded">
             <xsd:complexType>
                <xsd:sequence>
-                  <xsd:element name="responsibility" type="xsd:anyType" minOccurs="0" maxOccurs="unbounded"/>
+                  <xsd:element name="key" type="xsd:string" minOccurs="0"/>
+                  <xsd:element name="value" type="x:employee" minOccurs="0"/>
                </xsd:sequence>
             </xsd:complexType>
          </xsd:element>
       </xsd:sequence>
-      <xsd:attribute name="id" type="xsd:int" use="required"/>
    </xsd:complexType>
-   <xsd:element name="employee-data" type="x:employee"/>
 </xsd:schema>

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/stringEmployeeHashtable2.xsd
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/stringEmployeeHashtable2.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,18 +13,21 @@
 
 -->
 
-<xsd:schema xmlns:x="listOfObjectsNamespace" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-   <xsd:import schemaLocation="schema1.xsd" namespace="listOfObjectsNamespace"/>
-   <xsd:complexType name="stringEmployeeHashtable">
+<xsd:schema targetNamespace="listOfObjectsNamespace" xmlns:x="listOfObjectsNamespace" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+   <xsd:complexType name="employee">
       <xsd:sequence>
-         <xsd:element name="entry" minOccurs="0" maxOccurs="unbounded">
+         <xsd:element name="firstName" type="xsd:string" minOccurs="0"/>
+         <xsd:element name="lastName" type="xsd:string" minOccurs="0"/>
+         <xsd:element name="birthday" type="xsd:dateTime" minOccurs="0"/>
+         <xsd:element name="responsibilities" minOccurs="0">
             <xsd:complexType>
                <xsd:sequence>
-                  <xsd:element name="key" type="xsd:string" minOccurs="0"/>
-                  <xsd:element name="value" type="x:employee" minOccurs="0"/>
+                  <xsd:element name="responsibility" type="xsd:anyType" minOccurs="0" maxOccurs="unbounded"/>
                </xsd:sequence>
             </xsd:complexType>
          </xsd:element>
       </xsd:sequence>
+      <xsd:attribute name="id" type="xsd:int" use="required"/>
    </xsd:complexType>
+   <xsd:element name="employee-data" type="x:employee"/>
 </xsd:schema>

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/stringEmployeeMap.xsd
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/stringEmployeeMap.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,21 +13,18 @@
 
 -->
 
-<xsd:schema xmlns:x="listOfObjectsNamespace" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="listOfObjectsNamespace">
-   <xsd:complexType name="employee">
+<xsd:schema xmlns:x="listOfObjectsNamespace" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+   <xsd:import schemaLocation="schema2.xsd" namespace="listOfObjectsNamespace"/>
+   <xsd:complexType name="stringEmployeeMap">
       <xsd:sequence>
-         <xsd:element name="firstName" type="xsd:string" minOccurs="0"/>
-         <xsd:element name="lastName" type="xsd:string" minOccurs="0"/>
-         <xsd:element name="birthday" type="xsd:dateTime" minOccurs="0"/>
-         <xsd:element name="responsibilities" minOccurs="0">
+         <xsd:element name="entry" minOccurs="0" maxOccurs="unbounded">
             <xsd:complexType>
                <xsd:sequence>
-                  <xsd:element name="responsibility" type="xsd:anyType" minOccurs="0" maxOccurs="unbounded"/>
+                  <xsd:element name="key" type="xsd:string" minOccurs="0"/>
+                  <xsd:element name="value" type="x:employee" minOccurs="0"/>
                </xsd:sequence>
             </xsd:complexType>
          </xsd:element>
       </xsd:sequence>
-      <xsd:attribute name="id" type="xsd:int" use="required"/>
    </xsd:complexType>
-   <xsd:element name="employee-data" type="x:employee"/>
 </xsd:schema>

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/stringEmployeeMap2.xsd
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/listofobjects/stringEmployeeMap2.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,18 +13,21 @@
 
 -->
 
-<xsd:schema xmlns:x="listOfObjectsNamespace" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-   <xsd:import schemaLocation="schema1.xsd" namespace="listOfObjectsNamespace"/>
-   <xsd:complexType name="stringEmployeeMap">
+<xsd:schema xmlns:x="listOfObjectsNamespace" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="listOfObjectsNamespace">
+   <xsd:complexType name="employee">
       <xsd:sequence>
-         <xsd:element name="entry" minOccurs="0" maxOccurs="unbounded">
+         <xsd:element name="firstName" type="xsd:string" minOccurs="0"/>
+         <xsd:element name="lastName" type="xsd:string" minOccurs="0"/>
+         <xsd:element name="birthday" type="xsd:dateTime" minOccurs="0"/>
+         <xsd:element name="responsibilities" minOccurs="0">
             <xsd:complexType>
                <xsd:sequence>
-                  <xsd:element name="key" type="xsd:string" minOccurs="0"/>
-                  <xsd:element name="value" type="x:employee" minOccurs="0"/>
+                  <xsd:element name="responsibility" type="xsd:anyType" minOccurs="0" maxOccurs="unbounded"/>
                </xsd:sequence>
             </xsd:complexType>
          </xsd:element>
       </xsd:sequence>
+      <xsd:attribute name="id" type="xsd:int" use="required"/>
    </xsd:complexType>
+   <xsd:element name="employee-data" type="x:employee"/>
 </xsd:schema>

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/schemagen/deploymentxml/schema1.xsd
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/schemagen/deploymentxml/schema1.xsd
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0,
+    or the Eclipse Distribution License v. 1.0 which is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+
+    SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+-->
+
+<xsd:schema xmlns:ns0="http://first.temp.com/" xmlns:ns1="http://second.temp.com/" xmlns:ns2="http://third.temp.com/" xmlns:ns3="http://fourth.temp.com/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+   <xsd:import schemaLocation="schema2.xsd" namespace="http://first.temp.com/"/>
+   <xsd:import schemaLocation="schema4.xsd" namespace="http://second.temp.com/"/>
+   <xsd:import schemaLocation="schema5.xsd" namespace="http://third.temp.com/"/>
+   <xsd:import schemaLocation="schema3.xsd" namespace="http://fourth.temp.com/"/>
+   <xsd:complexType name="WithoutNamespaceType">
+      <xsd:sequence>
+         <xsd:element name="WithoutNamespaceSubElement" type="xsd:string"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:element name="RootElement">
+      <xsd:complexType>
+         <xsd:sequence>
+            <xsd:element name="FirstElement" type="ns0:FirstType"/>
+            <xsd:element name="SecondElement" type="ns1:SecondType"/>
+            <xsd:element name="ThirdElement" type="ns2:ThirdType"/>
+            <xsd:element name="FourthElement" type="ns3:FourthType"/>
+            <xsd:element name="WithoutNamespaceSubElement" type="WithoutNamespaceType"/>
+         </xsd:sequence>
+      </xsd:complexType>
+   </xsd:element>
+</xsd:schema>

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/schemagen/deploymentxml/schema2.xsd
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/schemagen/deploymentxml/schema2.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,11 +13,10 @@
 
 -->
 
-<xsd:schema xmlns:ns0="listOfObjectsNamespace" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-   <xsd:import namespace="listOfObjectsNamespace" schemaLocation="schema2.xsd"/>
-   <xsd:complexType name="listOfEmployee">
+<xsd:schema xmlns:ns0="http://first.temp.com/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://first.temp.com/">
+   <xsd:complexType name="FirstType">
       <xsd:sequence>
-         <xsd:element name="item" nillable="true" type="ns0:employee" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element name="FirstSubElement" type="xsd:string" form="qualified"/>
       </xsd:sequence>
    </xsd:complexType>
 </xsd:schema>

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/schemagen/deploymentxml/schema3.xsd
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/schemagen/deploymentxml/schema3.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,11 +13,10 @@
 
 -->
 
-<xsd:schema xmlns:ns0="listOfObjectsNamespace" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-   <xsd:import namespace="listOfObjectsNamespace" schemaLocation="schema2.xsd"/>
-   <xsd:complexType name="listOfEmployee">
+<xsd:schema xmlns:ns0="http://fourth.temp.com/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://fourth.temp.com/">
+   <xsd:complexType name="FourthType">
       <xsd:sequence>
-         <xsd:element name="item" nillable="true" type="ns0:employee" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element name="FourthSubElement" type="xsd:string" form="qualified"/>
       </xsd:sequence>
    </xsd:complexType>
 </xsd:schema>

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/schemagen/deploymentxml/schema4.xsd
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/schemagen/deploymentxml/schema4.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,11 +13,10 @@
 
 -->
 
-<xsd:schema xmlns:ns0="listOfObjectsNamespace" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-   <xsd:import namespace="listOfObjectsNamespace" schemaLocation="schema2.xsd"/>
-   <xsd:complexType name="listOfEmployee">
+<xsd:schema xmlns:ns0="http://second.temp.com/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://second.temp.com/">
+   <xsd:complexType name="SecondType">
       <xsd:sequence>
-         <xsd:element name="item" nillable="true" type="ns0:employee" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element name="SecondSubElement" type="xsd:string" form="qualified"/>
       </xsd:sequence>
    </xsd:complexType>
 </xsd:schema>

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/schemagen/deploymentxml/schema5.xsd
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/schemagen/deploymentxml/schema5.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,11 +13,10 @@
 
 -->
 
-<xsd:schema xmlns:ns0="listOfObjectsNamespace" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-   <xsd:import namespace="listOfObjectsNamespace" schemaLocation="schema2.xsd"/>
-   <xsd:complexType name="listOfEmployee">
+<xsd:schema xmlns:ns0="http://third.temp.com/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://third.temp.com/">
+   <xsd:complexType name="ThirdType">
       <xsd:sequence>
-         <xsd:element name="item" nillable="true" type="ns0:employee" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element name="ThirdSubElement" type="xsd:string" form="qualified"/>
       </xsd:sequence>
    </xsd:complexType>
 </xsd:schema>

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/xmlattribute/imports.xsd
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/xmlattribute/imports.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,13 +13,12 @@
 
 -->
 
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:ns0="testNamespace" elementFormDefault="qualified" targetNamespace="testNamespace">
-   <xsd:import schemaLocation="schema2.xsd"/>
-   <xsd:complexType name="person">
-      <xsd:sequence>
-         <xsd:element minOccurs="0" name="name" type="xsd:string"/>
-      </xsd:sequence>
-      <xsd:attribute name="id" type="identifierType"/>
-   </xsd:complexType>
-   <xsd:element name="person" type="ns0:person"/>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+   <xsd:simpleType name="identifierType">
+      <xsd:restriction base="xsd:string">
+         <xsd:enumeration value="firstThing"/>
+         <xsd:enumeration value="secondThing"/>
+         <xsd:enumeration value="thirdThing"/>
+      </xsd:restriction>
+   </xsd:simpleType>
 </xsd:schema>

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/xmlattribute/imports2.xsd
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/xmlattribute/imports2.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,12 +13,13 @@
 
 -->
 
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-   <xsd:simpleType name="identifierType">
-      <xsd:restriction base="xsd:string">
-         <xsd:enumeration value="firstThing"/>
-         <xsd:enumeration value="secondThing"/>
-         <xsd:enumeration value="thirdThing"/>
-      </xsd:restriction>
-   </xsd:simpleType>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:ns0="testNamespace" elementFormDefault="qualified" targetNamespace="testNamespace">
+   <xsd:import schemaLocation="schema1.xsd"/>
+   <xsd:complexType name="person">
+      <xsd:sequence>
+         <xsd:element minOccurs="0" name="name" type="xsd:string"/>
+      </xsd:sequence>
+      <xsd:attribute name="id" type="identifierType"/>
+   </xsd:complexType>
+   <xsd:element name="person" type="ns0:person"/>
 </xsd:schema>

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/schemagen/classarray/FirstType.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/schemagen/classarray/FirstType.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+// Radek Felcman - 02/2019 - Initial implementation
+package org.eclipse.persistence.testing.jaxb.schemagen.classarray;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "FirstType", namespace = "http://first.temp.com/", propOrder = {
+        "firstSubElement"
+})
+public class FirstType {
+
+    @XmlElement(name = "FirstSubElement", namespace = "http://first.temp.com/", required = true)
+    protected String firstSubElement;
+
+    public String getFirstSubElement() {
+        return firstSubElement;
+    }
+
+    public void setFirstSubElement(String value) {
+        this.firstSubElement = value;
+    }
+
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/schemagen/classarray/FourthType.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/schemagen/classarray/FourthType.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+// Radek Felcman - 02/2019 - Initial implementation
+package org.eclipse.persistence.testing.jaxb.schemagen.classarray;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "FourthType", namespace = "http://fourth.temp.com/", propOrder = {
+        "fourthSubElement"
+})
+public class FourthType {
+
+    @XmlElement(name = "FourthSubElement", namespace = "http://fourth.temp.com/", required = true)
+    protected String fourthSubElement;
+
+    public String getFourthSubElement() {
+        return fourthSubElement;
+    }
+
+    public void setFourthSubElement(String value) {
+        this.fourthSubElement = value;
+    }
+
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/schemagen/classarray/RootElement.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/schemagen/classarray/RootElement.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+// Radek Felcman - 02/2019 - Initial implementation
+package org.eclipse.persistence.testing.jaxb.schemagen.classarray;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "firstElement",
+    "secondElement",
+    "thirdElement",
+    "fourthElement",
+    "withoutNamespaceSubElement"
+})
+@XmlRootElement(name = "RootElement")
+public class RootElement {
+
+    @XmlElement(name = "FirstElement", required = true)
+    @Valid
+    @NotNull
+    protected FirstType firstElement;
+    @XmlElement(name = "SecondElement", required = true)
+    @Valid
+    @NotNull
+    protected SecondType secondElement;
+    @XmlElement(name = "ThirdElement", required = true)
+    @Valid
+    @NotNull
+    protected ThirdType thirdElement;
+    @XmlElement(name = "FourthElement", required = true)
+    @Valid
+    @NotNull
+    protected FourthType fourthElement;
+    @XmlElement(name = "WithoutNamespaceSubElement", required = true)
+    @Valid
+    @NotNull
+    protected WithoutNamespaceType withoutNamespaceSubElement;
+
+    public FirstType getFirstElement() {
+        return firstElement;
+    }
+
+    public void setFirstElement(FirstType value) {
+        this.firstElement = value;
+    }
+
+    public SecondType getSecondElement() {
+        return secondElement;
+    }
+
+    public void setSecondElement(SecondType value) {
+        this.secondElement = value;
+    }
+
+    public ThirdType getThirdElement() {
+        return thirdElement;
+    }
+
+    public void setThirdElement(ThirdType value) {
+        this.thirdElement = value;
+    }
+
+    public FourthType getFourthElement() {
+        return fourthElement;
+    }
+
+    public void setFourthElement(FourthType value) {
+        this.fourthElement = value;
+    }
+
+    public WithoutNamespaceType getWithoutNamespaceSubElement() {
+        return withoutNamespaceSubElement;
+    }
+
+    public void setWithoutNamespaceSubElement(WithoutNamespaceType value) {
+        this.withoutNamespaceSubElement = value;
+    }
+
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/schemagen/classarray/SecondType.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/schemagen/classarray/SecondType.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+// Radek Felcman - 02/2019 - Initial implementation
+package org.eclipse.persistence.testing.jaxb.schemagen.classarray;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "SecondType", namespace = "http://second.temp.com/", propOrder = {
+        "secondSubElement"
+})
+public class SecondType {
+
+    @XmlElement(name = "SecondSubElement", namespace = "http://second.temp.com/", required = true)
+    protected String secondSubElement;
+
+    public String getSecondSubElement() {
+        return secondSubElement;
+    }
+
+    public void setSecondSubElement(String value) {
+        this.secondSubElement = value;
+    }
+
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/schemagen/classarray/ThirdType.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/schemagen/classarray/ThirdType.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+// Radek Felcman - 02/2019 - Initial implementation
+package org.eclipse.persistence.testing.jaxb.schemagen.classarray;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "ThirdType", namespace = "http://third.temp.com/", propOrder = {
+    "thirdSubElement"
+})
+public class ThirdType {
+
+    @XmlElement(name = "ThirdSubElement", namespace = "http://third.temp.com/", required = true)
+    protected String thirdSubElement;
+
+    public String getThirdSubElement() {
+        return thirdSubElement;
+    }
+
+    public void setThirdSubElement(String value) {
+        this.thirdSubElement = value;
+    }
+
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/schemagen/classarray/WithoutNamespaceType.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/schemagen/classarray/WithoutNamespaceType.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+// Radek Felcman - 02/2019 - Initial implementation
+package org.eclipse.persistence.testing.jaxb.schemagen.classarray;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "WithoutNamespaceType", propOrder = {
+    "withoutNamespaceSubElement"
+})
+public class WithoutNamespaceType {
+
+    @XmlElement(name = "WithoutNamespaceSubElement", required = true)
+    protected String withoutNamespaceSubElement;
+
+    public String getWithoutNamespaceSubElement() {
+        return withoutNamespaceSubElement;
+    }
+
+    public void setWithoutNamespaceSubElement(String value) {
+        this.withoutNamespaceSubElement = value;
+    }
+
+}

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/compiler/Generator.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/compiler/Generator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/compiler/Generator.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/compiler/Generator.java
@@ -19,6 +19,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -31,6 +32,7 @@ import org.eclipse.persistence.internal.oxm.Constants;
 import org.eclipse.persistence.internal.oxm.mappings.Descriptor;
 import org.eclipse.persistence.internal.oxm.schema.SchemaModelProject;
 import org.eclipse.persistence.internal.oxm.schema.model.Schema;
+import org.eclipse.persistence.internal.oxm.schema.model.SchemaCompareByNamespace;
 import org.eclipse.persistence.jaxb.TypeMappingInfo;
 import org.eclipse.persistence.jaxb.javamodel.Helper;
 import org.eclipse.persistence.jaxb.javamodel.JavaClass;
@@ -231,6 +233,10 @@ public class Generator {
         Descriptor schemaDescriptor = (Descriptor)proj.getDescriptor(Schema.class);
 
         java.util.Collection<Schema> schemas = schemaGenerator.getAllSchemas();
+        // make sure that schemas will be passed to the output in specified order
+        if (schemas instanceof List) {
+            ((List)schemas).sort(new SchemaCompareByNamespace());
+        }
         for(Schema schema : schemas) {
             try {
                 NamespaceResolver schemaNamespaces = schema.getNamespaceResolver();

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/compiler/SchemaGenerator.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/compiler/SchemaGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/compiler/SchemaGenerator.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/compiler/SchemaGenerator.java
@@ -76,6 +76,7 @@ import org.eclipse.persistence.jaxb.compiler.facets.PatternListFacet;
 import org.eclipse.persistence.jaxb.compiler.facets.SizeFacet;
 import org.eclipse.persistence.jaxb.javamodel.Helper;
 import org.eclipse.persistence.jaxb.javamodel.JavaClass;
+import org.eclipse.persistence.jaxb.javamodel.JavaClassCompareByNamespace;
 import org.eclipse.persistence.jaxb.xmlmodel.XmlElementWrapper;
 import org.eclipse.persistence.jaxb.xmlmodel.XmlJoinNodes.XmlJoinNode;
 import org.eclipse.persistence.jaxb.xmlmodel.XmlVirtualAccessMethodsSchema;
@@ -152,6 +153,8 @@ public class SchemaGenerator {
         this.schemaTypeInfo = new HashMap<String, SchemaTypeInfo>(typeInfo.size());
         this.arrayClassesToGeneratedClasses = arrayClassesToGeneratedClasses;
 
+        //sort input classes before schema name (like schema1.xsd, schema2.xsd....) is generated and assigned
+        typeInfoClasses.sort(new JavaClassCompareByNamespace(typeInfo));
         for (JavaClass javaClass : typeInfoClasses) {
             addSchemaComponents(javaClass);
         }

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/javamodel/JavaClassCompareByNamespace.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/javamodel/JavaClassCompareByNamespace.java
@@ -21,9 +21,9 @@ import java.util.Map;
 
 public class JavaClassCompareByNamespace implements Comparator<JavaClass>{
 
-    Map<String, TypeInfo> typeInfo;
+    private final Map<String, TypeInfo> typeInfo;
 
-    public JavaClassCompareByNamespace(Map<String, TypeInfo> typeInfo) {
+    public JavaClassCompareByNamespace(final Map<String, TypeInfo> typeInfo) {
         this.typeInfo = typeInfo;
     }
 

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/javamodel/JavaClassCompareByNamespace.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/javamodel/JavaClassCompareByNamespace.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Radek Felcman (Oracle) - initial implementation
+package org.eclipse.persistence.jaxb.javamodel;
+
+import org.eclipse.persistence.jaxb.compiler.TypeInfo;
+
+import java.util.Comparator;
+import java.util.Map;
+
+public class JavaClassCompareByNamespace implements Comparator<JavaClass>{
+
+    Map<String, TypeInfo> typeInfo;
+
+    public JavaClassCompareByNamespace(Map<String, TypeInfo> typeInfo) {
+        this.typeInfo = typeInfo;
+    }
+
+    @Override
+    public int compare(JavaClass arg1, JavaClass arg2) {
+        int result;
+        String namespaceUri1 = this.typeInfo.get(arg1.getQualifiedName()).getClassNamespace();
+        String namespaceUri2 = this.typeInfo.get(arg2.getQualifiedName()).getClassNamespace();
+        result = namespaceUri1.compareTo(namespaceUri2);
+        if (result != 0) {
+            return result;
+        } else {
+            return arg1.getQualifiedName().compareTo(arg2.getQualifiedName());
+        }
+    }
+}
+


### PR DESCRIPTION
 Bug 543265 - WSDL namespace order is different on ITEMSERVICEPORT?WSDL

This is fix for this bug with unit test _ClassArraySchemaGenTestCases.testSchemaGenFromClassArrayVerifyOrder()_
There are two sort calls.
First sort in _SchemaGenerator.java_ to sort input classes before schema name (like schema1.xsd, schema2.xsd....) is generated and assigned.
Second sort in _Generator.java_ to ensure that schemas will be passed to the output in specified order (by namespace).
This fix leads into some changes in current unit tests in MOXy (schema generation), because some schemes are generated in different order. In some cases there are changes in order of _complexType_ definition inside schemes.