### PR TITLE
[Non bug] OSGi tests - ASM version parameter

### DIFF
--- a/moxy/eclipselink.moxy.test/antbuild.properties
+++ b/moxy/eclipselink.moxy.test/antbuild.properties
@@ -39,6 +39,7 @@ ejb.jar=jakarta.ejb-api.jar
 jms.jar=jakarta.jms-api.jar
 transaction.jar=jakarta.transaction-api.jar
 asm.jar=org.eclipse.persistence.asm_7.0.0.v201811131354.jar
+asm.version=7.0.0.v201811131354
 
 eclipselink.core.depend=${resource.jar},${ejb.jar},${jms.jar},${transaction.jar},${mail.jar},${javax.validation.jar}
 

--- a/moxy/eclipselink.moxy.test/antbuild.xml
+++ b/moxy/eclipselink.moxy.test/antbuild.xml
@@ -380,6 +380,7 @@
             <arg line="-Djaxb-api.jar=${jaxb-api.jar}"/>
             <arg line="-Djaxrs.jar=${jaxrs.jar}"/>
             <arg line="-Dasm.jar=${asm.jar}"/>
+            <arg line="-Dasm.version=${asm.version}"/>
             <arg line="-Dtest.junit.jvm=${test.junit.jvm}"/>
             <arg line="-DargLine='${test.junit.osgi.jvm.modules.prop}'"/>
             <classpath>

--- a/moxy/eclipselink.moxy.test/antbuild.xml
+++ b/moxy/eclipselink.moxy.test/antbuild.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/osgi/OSGITestHelper.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/osgi/OSGITestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/osgi/OSGITestHelper.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/osgi/OSGITestHelper.java
@@ -21,6 +21,7 @@ import static org.ops4j.pax.exam.CoreOptions.cleanCaches;
 import static org.ops4j.pax.exam.CoreOptions.junitBundles;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.CoreOptions.options;
+import static org.ops4j.pax.exam.CoreOptions.systemProperty;
 import static org.ops4j.pax.exam.CoreOptions.vmOptions;
 import static org.ops4j.pax.exam.CoreOptions.when;
 
@@ -40,11 +41,13 @@ public class OSGITestHelper {
     private static final String JAXB_API_JAR = System.getProperty("jaxb-api.jar", "jakarta.xml.bind-api.jar");
     private static final String JAXRS_JAR = System.getProperty("jaxrs.jar", "javax.ws.rs_1.1.1.v20101004-1200.jar");
     private static final String ASM_JAR = System.getProperty("asm.jar", "org.eclipse.persistence.asm_7.0.0.v201811131354.jar");
+    private static final String ASM_VERSION = System.getProperty("asm.version", "7.0.0.v201811131354");
     private static final String BEAN_VALIDATION_LIB = System.getProperty("javax.validation.lib", "jakarta.validation-api.jar");
 
     public static Option[] getDefaultOptions() {
         return options(
                 when(JavaSEPlatform.CURRENT.getMajor() >= 9).useOptions(vmOptions("--add-modules", "java.sql,java.xml.bind")),
+                systemProperty("asm.version").value(ASM_VERSION),
                 // JAXB API
                 bundle("file:" + PLUGINS_DIR + JAXB_API_JAR),
 

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/osgi/OSGiBundleTest.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/osgi/OSGiBundleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/osgi/OSGiBundleTest.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/osgi/OSGiBundleTest.java
@@ -41,6 +41,9 @@ import org.osgi.framework.Version;
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
 public class OSGiBundleTest {
+    // ASM bundle symbolic name
+    private static final String ASM_BUNDLE_NAME = "org.eclipse.persistence.asm";
+
     // MOXy bundle symbolic name
     private static final String MOXY_BUNDLE_NAME = "org.eclipse.persistence.moxy";
 
@@ -58,7 +61,7 @@ public class OSGiBundleTest {
     @Test
     public void testAsmVersion() {
         Class<?> c = loadClass("org.eclipse.persistence.internal.libraries.asm.AnnotationVisitor");
-        assertClassLoadedByBundle(c, "org.eclipse.persistence.asm", "7.0.0.v201811131354");
+        assertClassLoadedByBundle(c, ASM_BUNDLE_NAME, System.getProperty("asm.version", "7.0.0.v201811131354"));
     }
 
     @Test


### PR DESCRIPTION
ASM version parameter used in OSGi test now should be passed as a Ant/Maven parameter (system property). Before this patch ASM version was hard coded in source file _OSGiBundleTest.java_  => every ASM update required to update this test.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>