### PR TITLE
Bug 545221 - org.eclipse.persistence.moxy removed from EclipseLink update site after 2.7.3

### DIFF
--- a/features/antbuild.xml
+++ b/features/antbuild.xml
@@ -340,7 +340,7 @@
         <selectbundle basename="${sun.xml.bind.prefix}"  directory="${local.p2.repo.dir}"
                       criterion="${sun.xml.bind.criteria}" property="sun.xml.bind.version" versiononly="true"
         />
-        <selectbundle basename="${mongodb.prefix}" directory="${feature.2.common.plugins.dir}"
+        <selectbundle basename="${mongodb.prefix}" directory="${local.p2.repo.dir}"
                      criterion="${mongodb.criteria}" property="mongodb.version" versiononly="true"
         />
         <selectbundle basename="${jaxrs.prefix}" directory="${local.p2.repo.dir}"


### PR DESCRIPTION
Bug 545221 - org.eclipse.persistence.moxy removed from EclipseLink update site after 2.7.3 ?

P2 site generation fails with eclipse-SDK-4.8M7. After upgrade to eclipse-SDK-4.10 it is OK.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>