### PR TITLE
Bug 535431 - Fix support of JSR-310 date/time types with PostgreSQL

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/PostgreSQLPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/PostgreSQLPlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,6 +15,8 @@
 //     Phillip Ross - LIMIT/OFFSET syntax support
 //     09/14/2011-2.3.1 Guy Pelletier
 //       - 357533: Allow DDL queries to execute even when Multitenant entities are part of the PU
+//     18/03/2019 Joni Syri
+//       - 535431: Handle JSR-310 date/time types properly
 package org.eclipse.persistence.platform.database;
 
 import java.io.*;
@@ -331,6 +333,12 @@ public class PostgreSQLPlatform extends DatabasePlatform {
         fieldTypeMapping.put(java.sql.Date.class, new FieldTypeDefinition("DATE", false));
         fieldTypeMapping.put(java.sql.Time.class, new FieldTypeDefinition("TIME", false));
         fieldTypeMapping.put(java.sql.Timestamp.class, new FieldTypeDefinition("TIMESTAMP", false));
+
+        fieldTypeMapping.put(java.time.LocalDate.class, new FieldTypeDefinition("DATE", false));
+        fieldTypeMapping.put(java.time.LocalDateTime.class, new FieldTypeDefinition("TIMESTAMP", false));
+        fieldTypeMapping.put(java.time.LocalTime.class, new FieldTypeDefinition("TIMESTAMP", false));
+        fieldTypeMapping.put(java.time.OffsetDateTime.class, new FieldTypeDefinition("TIMESTAMP", false));
+        fieldTypeMapping.put(java.time.OffsetTime.class, new FieldTypeDefinition("TIMESTAMP", false));
 
         return fieldTypeMapping;
     }


### PR DESCRIPTION
Fix for https://bugs.eclipse.org/bugs/show_bug.cgi?id=535431

This should probably include some kind of test, but I'm not sure where it should be located. There's no much point testing the changes against non-PostgreSQL server and I couldn't easily locate Postgres specific tests. Additionally at least on my own environment, I have problems running test-lrg against Postgres even without changes, so I'm not sure if tests are supposed to work with Postgres.

If anyone can provide guidance how tests should be implemented, I can add those to this request.