### PR TITLE
Fix javadoc errors in Core Test Framework classes.

### DIFF
--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/framework/LoadBuildSummary.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/framework/LoadBuildSummary.java
@@ -84,7 +84,7 @@ public class LoadBuildSummary {
 
     /**
      *
-     * @param summary org.eclipse.persistence.testing.framework.TestResultsSummary
+     * @param result org.eclipse.persistence.testing.framework.TestResults
      */
     public void addResult(TestResult result) {
         if (results == null) {
@@ -114,10 +114,6 @@ public class LoadBuildSummary {
         getSummaries().addElement(summary);
     }
 
-    /**
-     *
-     * @return int
-     */
     public void computeNumberOfTestsAndErrors() {
         Vector<TestResultsSummary> rootSummaries = new Vector<>();
         numberOfTests = 0;
@@ -247,10 +243,6 @@ public class LoadBuildSummary {
         results = holder;
     }
 
-    /**
-     *
-     * @return java.util.Vector
-     */
     public void setSummaries(Vector<TestResultsSummary> theSummaries) {
         summaries.setValue(theSummaries);
     }

--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/framework/PerformanceComparisonTestResult.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/framework/PerformanceComparisonTestResult.java
@@ -142,7 +142,7 @@ public class PerformanceComparisonTestResult extends TestResult {
     }
 
     /**
-     * Return the & difference between the current test average time and the
+     * Return the &amp; difference between the current test average time and the
      * average of the last 3 successful runs of the test on the baseline version.
      */
     public double getPercentageDifferenceAverage() {

--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/framework/SessionEventTracker.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/framework/SessionEventTracker.java
@@ -24,6 +24,7 @@ import org.eclipse.persistence.internal.sessions.DatabaseSessionImpl;
 import org.eclipse.persistence.sessions.Session;
 import org.eclipse.persistence.sessions.SessionEvent;
 import org.eclipse.persistence.sessions.SessionEventListener;
+import org.eclipse.persistence.sessions.SessionEventManager;
 
 /**
  * <p><b>Purpose</b>: Used to test handling of session events.
@@ -60,7 +61,7 @@ import org.eclipse.persistence.sessions.SessionEventListener;
  *   It's possible to set error on a Handling (see examples preLogin and postLogin) -
  *   that sends the erroneous Handling to errors list (still kept on handlings list, too).
  *
- * @see "SessionEventManager#addListener(SessionEventListener)"
+ * @see SessionEventManager#addListener(SessionEventListener)
  * @see Session#getEventManager()
  * @see SessionEvent
  */

--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/framework/SessionEventTracker.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/framework/SessionEventTracker.java
@@ -60,7 +60,7 @@ import org.eclipse.persistence.sessions.SessionEventListener;
  *   It's possible to set error on a Handling (see examples preLogin and postLogin) -
  *   that sends the erroneous Handling to errors list (still kept on handlings list, too).
  *
- * @see SessionEventManager#addListener(SessionEventListener)
+ * @see "SessionEventManager#addListener(SessionEventListener)"
  * @see Session#getEventManager()
  * @see SessionEvent
  */

--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/framework/TogglingFastTableCreator.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/framework/TogglingFastTableCreator.java
@@ -45,19 +45,19 @@ import org.eclipse.persistence.tools.schemaframework.TableDefinition;
  * the tests tables are dropped and recreated. If the tables were created in a
  * previous test and the connection used to create it is still open, Symfoware
  * complains that the tables are locked when it tries to drop them.
- * <p/>
+ * <p>
  *
  * This class sets a flag before the subsequent recreation of the tables to
  * delete the rows instead. The first time it is called it does not set the
  * flag, to allow the tables to be initially created.
- * <p/>
+ * <p>
  *
  * To enable this functionality, the system property
  * "eclipselink.test.toggle-fast-table-creator" needs to be set to "true".
- * <p/>
+ * <p>
  *
  * This class should be positioned between the test's table creator class and
- * TableCreator by making the's test table creator extend this class.<br/>
+ * TableCreator by making the's test table creator extend this class.
  *
  * @author Dies Koper, Tomas Kraus
  *
@@ -262,9 +262,7 @@ public class TogglingFastTableCreator extends TableCreator {
      * with given name, size of {@code 15}, with {@code null} value allowed and
      * without any additional constraints.
      * @param name Column name.
-     * @param size Column numeric type size of {@code 15} with .
      * @return Initialized {@link FieldDefinition} instance.
-     * @param allowNull Allow {@code null} values for column.
      */
     protected static FieldDefinition createNumericColumn(
             final String name) {

--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/framework/UniversalSessionTestAdapter.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/framework/UniversalSessionTestAdapter.java
@@ -21,7 +21,7 @@ import org.eclipse.persistence.sessions.*;
  *  on any session configuration.
  *  @author  Stephen McRitchie
  *  @since   10 used for testing flashback queries on different sessions.
- *  @see "org.eclipse.persistence.testing.ClientServerTests.ClientSessionTestAdapter"
+ *  @see "org.eclipse.persistence.testing.tests.clientserver.ClientSessionTestAdapter"
  *  @see "org.eclipse.persistence.testing.tests.sessionbroker.ClientSessionBrokerTestAdapter"
  *  @see "org.eclipse.persistence.testing.tests.flashback.HistoricalSessionTest"
  */

--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/framework/UniversalSessionTestAdapter.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/framework/UniversalSessionTestAdapter.java
@@ -21,9 +21,9 @@ import org.eclipse.persistence.sessions.*;
  *  on any session configuration.
  *  @author  Stephen McRitchie
  *  @since   10 used for testing flashback queries on different sessions.
- *  @see org.eclipse.persistence.testing.ClientServerTests.ClientSessionTestAdapter
- *  @see org.eclipse.persistence.testing.tests.sessionbroker.ClientSessionBrokerTestAdapter
- *  @see org.eclipse.persistence.testing.tests.flashback.HistoricalSessionTest
+ *  @see "org.eclipse.persistence.testing.ClientServerTests.ClientSessionTestAdapter"
+ *  @see "org.eclipse.persistence.testing.tests.sessionbroker.ClientSessionBrokerTestAdapter"
+ *  @see "org.eclipse.persistence.testing.tests.flashback.HistoricalSessionTest"
  */
 public abstract class UniversalSessionTestAdapter extends TestAdapter {
     protected Session oldSession;

--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/performance/emulateddb/EmulatedConnection.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/performance/emulateddb/EmulatedConnection.java
@@ -314,7 +314,7 @@ public class EmulatedConnection implements Connection {
      * @exception SQLException if a database access error occurs or this
      *            method is called during a transaction
      */
-    public void setReadOnly(boolean readOnly) {
+    public void setReadOnly(boolean readOnly) throws SQLException {
     }
 
     /**
@@ -325,7 +325,7 @@ public class EmulatedConnection implements Connection {
      *         is read-only; <code>false</code> otherwise
      * @exception SQLException if a database access error occurs
      */
-    public boolean isReadOnly() {
+    public boolean isReadOnly() throws SQLException {
         return false;
     }
 
@@ -342,7 +342,7 @@ public class EmulatedConnection implements Connection {
      * @exception SQLException if a database access error occurs
      * @see #getCatalog
      */
-    public void setCatalog(String catalog) {
+    public void setCatalog(String catalog) throws SQLException {
     }
 
     /**
@@ -352,7 +352,7 @@ public class EmulatedConnection implements Connection {
      * @exception SQLException if a database access error occurs
      * @see #setCatalog
      */
-    public String getCatalog() {
+    public String getCatalog() throws SQLException {
         return null;
     }
 
@@ -378,7 +378,7 @@ public class EmulatedConnection implements Connection {
      * @see DatabaseMetaData#supportsTransactionIsolationLevel
      * @see #getTransactionIsolation
      */
-    public void setTransactionIsolation(int level) {
+    public void setTransactionIsolation(int level) throws SQLException {
     }
 
     /**
@@ -395,7 +395,7 @@ public class EmulatedConnection implements Connection {
      * @exception SQLException if a database access error occurs
      * @see #setTransactionIsolation
      */
-    public int getTransactionIsolation() {
+    public int getTransactionIsolation() throws SQLException {
         return 0;
     }
 
@@ -420,7 +420,7 @@ public class EmulatedConnection implements Connection {
      *            this method is called on a closed connection
      * @see SQLWarning
      */
-    public SQLWarning getWarnings() {
+    public SQLWarning getWarnings() throws SQLException {
         return null;
     }
 
@@ -432,7 +432,7 @@ public class EmulatedConnection implements Connection {
      *
      * @exception SQLException if a database access error occurs
      */
-    public void clearWarnings() {
+    public void clearWarnings() throws SQLException {
     }
 
     //--------------------------JDBC 2.0-----------------------------
@@ -533,7 +533,7 @@ public class EmulatedConnection implements Connection {
      * @since 1.2
      * @see #setTypeMap
      */
-    public java.util.Map getTypeMap() {
+    public java.util.Map getTypeMap() throws SQLException {
         return null;
     }
 
@@ -551,7 +551,7 @@ public class EmulatedConnection implements Connection {
      * @since 1.2
      * @see #getTypeMap
      */
-    public void setTypeMap(java.util.Map map) {
+    public void setTypeMap(java.util.Map map) throws SQLException {
     }
 
     //--------------------------JDBC 3.0-----------------------------
@@ -571,7 +571,7 @@ public class EmulatedConnection implements Connection {
      * @see ResultSet
      * @since 1.4
      */
-    public void setHoldability(int holdability) {
+    public void setHoldability(int holdability) throws SQLException {
     }
 
     /**
@@ -586,7 +586,7 @@ public class EmulatedConnection implements Connection {
      * @see ResultSet
      * @since 1.4
      */
-    public int getHoldability() {
+    public int getHoldability() throws SQLException {
         return 0;
     }
 
@@ -601,7 +601,7 @@ public class EmulatedConnection implements Connection {
      * @see Savepoint
      * @since 1.4
      */
-    public Savepoint setSavepoint() {
+    public Savepoint setSavepoint() throws SQLException {
         return null;
     }
 
@@ -617,7 +617,7 @@ public class EmulatedConnection implements Connection {
      * @see Savepoint
      * @since 1.4
      */
-    public Savepoint setSavepoint(String name) {
+    public Savepoint setSavepoint(String name) throws SQLException {
         return null;
     }
 
@@ -636,7 +636,7 @@ public class EmulatedConnection implements Connection {
      * @see #rollback
      * @since 1.4
      */
-    public void rollback(Savepoint savepoint) {
+    public void rollback(Savepoint savepoint) throws SQLException {
         return;
     }
 
@@ -651,7 +651,7 @@ public class EmulatedConnection implements Connection {
      *            savepoint in the current transaction
      * @since 1.4
      */
-    public void releaseSavepoint(Savepoint savepoint) {
+    public void releaseSavepoint(Savepoint savepoint)throws SQLException  {
         return;
     }
 
@@ -941,13 +941,13 @@ public class EmulatedConnection implements Connection {
         return iFace.cast(this);
     }
 
-    public int getNetworkTimeout(){return 0;}
+    public int getNetworkTimeout() throws SQLException {return 0;}
 
-    public void setNetworkTimeout(Executor executor, int milliseconds){}
+    public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException{}
 
-    public void abort(Executor executor){}
+    public void abort(Executor executor) throws SQLException {}
 
-    public String getSchema(){return null;}
+    public String getSchema() throws SQLException {return null;}
 
-    public void setSchema(String schema){}
+    public void setSchema(String schema) throws SQLException {}
 }

--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/performance/emulateddb/EmulatedConnection.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/performance/emulateddb/EmulatedConnection.java
@@ -72,6 +72,7 @@ public class EmulatedConnection implements Connection {
      * @return a new default <code>Statement</code> object
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public Statement createStatement() throws SQLException {
         if (!EmulatedDriver.emulate) {
             return connection.createStatement();
@@ -108,6 +109,7 @@ public class EmulatedConnection implements Connection {
      * pre-compiled SQL statement
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public PreparedStatement prepareStatement(String sql) throws SQLException {
         if (!EmulatedDriver.emulate || (sql.indexOf("DUAL") != -1) || (sql.indexOf("dual") != -1)) {
             return connection.prepareStatement(sql);
@@ -142,6 +144,7 @@ public class EmulatedConnection implements Connection {
      * pre-compiled SQL statement
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public CallableStatement prepareCall(String sql) throws SQLException {
         return null;
     }
@@ -157,6 +160,7 @@ public class EmulatedConnection implements Connection {
      * @return the native form of this statement
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public String nativeSQL(String sql) throws SQLException {
         return sql;
     }
@@ -189,6 +193,7 @@ public class EmulatedConnection implements Connection {
      * @exception SQLException if a database access error occurs
      * @see #getAutoCommit
      */
+    @Override
     public void setAutoCommit(boolean autoCommit) throws SQLException {
         if (!EmulatedDriver.emulate) {
             connection.setAutoCommit(autoCommit);
@@ -204,6 +209,7 @@ public class EmulatedConnection implements Connection {
      * @exception SQLException if a database access error occurs
      * @see #setAutoCommit
      */
+    @Override
     public boolean getAutoCommit() throws SQLException {
         if (!EmulatedDriver.emulate) {
             connection.getAutoCommit();
@@ -222,6 +228,7 @@ public class EmulatedConnection implements Connection {
      *            <code>Connection</code> object is in auto-commit mode
      * @see #setAutoCommit
      */
+    @Override
     public void commit() throws SQLException {
         if (!EmulatedDriver.emulate) {
             connection.commit();
@@ -238,6 +245,7 @@ public class EmulatedConnection implements Connection {
      *            <code>Connection</code> object is in auto-commit mode
      * @see #setAutoCommit
      */
+    @Override
     public void rollback() throws SQLException {
         if (!EmulatedDriver.emulate) {
             connection.rollback();
@@ -257,6 +265,7 @@ public class EmulatedConnection implements Connection {
      *
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public void close() throws SQLException {
     }
 
@@ -277,6 +286,7 @@ public class EmulatedConnection implements Connection {
      *         is closed; <code>false</code> if it is still open
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public boolean isClosed() throws SQLException {
         return false;
     }
@@ -296,6 +306,7 @@ public class EmulatedConnection implements Connection {
      *         <code>Connection</code> object
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public DatabaseMetaData getMetaData() throws SQLException {
         if (connection != null) {
             return connection.getMetaData();
@@ -314,6 +325,7 @@ public class EmulatedConnection implements Connection {
      * @exception SQLException if a database access error occurs or this
      *            method is called during a transaction
      */
+    @Override
     public void setReadOnly(boolean readOnly) throws SQLException {
     }
 
@@ -325,6 +337,7 @@ public class EmulatedConnection implements Connection {
      *         is read-only; <code>false</code> otherwise
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public boolean isReadOnly() throws SQLException {
         return false;
     }
@@ -342,6 +355,7 @@ public class EmulatedConnection implements Connection {
      * @exception SQLException if a database access error occurs
      * @see #getCatalog
      */
+    @Override
     public void setCatalog(String catalog) throws SQLException {
     }
 
@@ -352,6 +366,7 @@ public class EmulatedConnection implements Connection {
      * @exception SQLException if a database access error occurs
      * @see #setCatalog
      */
+    @Override
     public String getCatalog() throws SQLException {
         return null;
     }
@@ -378,6 +393,7 @@ public class EmulatedConnection implements Connection {
      * @see DatabaseMetaData#supportsTransactionIsolationLevel
      * @see #getTransactionIsolation
      */
+    @Override
     public void setTransactionIsolation(int level) throws SQLException {
     }
 
@@ -395,6 +411,7 @@ public class EmulatedConnection implements Connection {
      * @exception SQLException if a database access error occurs
      * @see #setTransactionIsolation
      */
+    @Override
     public int getTransactionIsolation() throws SQLException {
         return 0;
     }
@@ -420,6 +437,7 @@ public class EmulatedConnection implements Connection {
      *            this method is called on a closed connection
      * @see SQLWarning
      */
+    @Override
     public SQLWarning getWarnings() throws SQLException {
         return null;
     }
@@ -432,6 +450,7 @@ public class EmulatedConnection implements Connection {
      *
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public void clearWarnings() throws SQLException {
     }
 
@@ -459,6 +478,7 @@ public class EmulatedConnection implements Connection {
      *         constants indicating type and concurrency
      * @since 1.2
      */
+    @Override
     public Statement createStatement(int resultSetType, int resultSetConcurrency) throws SQLException {
         return new EmulatedStatement(this);
     }
@@ -489,6 +509,7 @@ public class EmulatedConnection implements Connection {
      *         constants indicating type and concurrency
      * @since 1.2
      */
+    @Override
     public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
         return prepareStatement(sql);
     }
@@ -517,6 +538,7 @@ public class EmulatedConnection implements Connection {
      *         constants indicating type and concurrency
      * @since 1.2
      */
+    @Override
     public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
         return null;
     }
@@ -533,6 +555,7 @@ public class EmulatedConnection implements Connection {
      * @since 1.2
      * @see #setTypeMap
      */
+    @Override
     public java.util.Map getTypeMap() throws SQLException {
         return null;
     }
@@ -551,6 +574,7 @@ public class EmulatedConnection implements Connection {
      * @since 1.2
      * @see #getTypeMap
      */
+    @Override
     public void setTypeMap(java.util.Map map) throws SQLException {
     }
 
@@ -571,6 +595,7 @@ public class EmulatedConnection implements Connection {
      * @see ResultSet
      * @since 1.4
      */
+    @Override
     public void setHoldability(int holdability) throws SQLException {
     }
 
@@ -586,6 +611,7 @@ public class EmulatedConnection implements Connection {
      * @see ResultSet
      * @since 1.4
      */
+    @Override
     public int getHoldability() throws SQLException {
         return 0;
     }
@@ -601,6 +627,7 @@ public class EmulatedConnection implements Connection {
      * @see Savepoint
      * @since 1.4
      */
+    @Override
     public Savepoint setSavepoint() throws SQLException {
         return null;
     }
@@ -617,6 +644,7 @@ public class EmulatedConnection implements Connection {
      * @see Savepoint
      * @since 1.4
      */
+    @Override
     public Savepoint setSavepoint(String name) throws SQLException {
         return null;
     }
@@ -636,6 +664,7 @@ public class EmulatedConnection implements Connection {
      * @see #rollback
      * @since 1.4
      */
+    @Override
     public void rollback(Savepoint savepoint) throws SQLException {
         return;
     }
@@ -651,6 +680,7 @@ public class EmulatedConnection implements Connection {
      *            savepoint in the current transaction
      * @since 1.4
      */
+    @Override
     public void releaseSavepoint(Savepoint savepoint)throws SQLException  {
         return;
     }
@@ -685,6 +715,7 @@ public class EmulatedConnection implements Connection {
      * @see ResultSet
      * @since 1.4
      */
+    @Override
     public Statement createStatement(int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
         return new EmulatedStatement(this);
     }
@@ -724,6 +755,7 @@ public class EmulatedConnection implements Connection {
      * @see ResultSet
      * @since 1.4
      */
+    @Override
     public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
         return prepareStatement(sql);
     }
@@ -760,6 +792,7 @@ public class EmulatedConnection implements Connection {
      * @see ResultSet
      * @since 1.4
      */
+    @Override
     public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
         return null;
     }
@@ -800,6 +833,7 @@ public class EmulatedConnection implements Connection {
      *         returned
      * @since 1.4
      */
+    @Override
     public PreparedStatement prepareStatement(String sql, int autoGeneratedKeys) throws SQLException {
         return prepareStatement(sql);
     }
@@ -843,6 +877,7 @@ public class EmulatedConnection implements Connection {
      *
      * @since 1.4
      */
+    @Override
     public PreparedStatement prepareStatement(String sql, int[] columnIndexes) throws SQLException {
         return prepareStatement(sql);
     }
@@ -886,68 +921,87 @@ public class EmulatedConnection implements Connection {
      *
      * @since 1.4
      */
+    @Override
     public PreparedStatement prepareStatement(String sql, String[] columnNames) throws SQLException {
         return prepareStatement(sql);
     }
 
     // 236070: Methods introduced in JDK 1.6
+    @Override
     public Array createArrayOf(String typeName, Object[] elements)  throws SQLException {
         return null;
     }
 
+    @Override
     public Blob createBlob()  throws SQLException {
         return null;
     }
 
+    @Override
     public Clob createClob()  throws SQLException {
         return null;
     }
 
+    @Override
     public NClob createNClob()  throws SQLException {
         return null;
     }
 
+    @Override
     public SQLXML createSQLXML()  throws SQLException {
         return null;
     }
 
+    @Override
     public Struct createStruct(String typeName, Object[] attributes)  throws SQLException {
         return null;
     }
 
+    @Override
     public Properties getClientInfo()  throws SQLException {
         return null;
     }
 
+    @Override
     public String getClientInfo(String name)  throws SQLException {
         return null;
     }
 
+    @Override
     public boolean isValid(int timeout)  throws SQLException {
         return true;
     }
 
+    @Override
     public void setClientInfo(String name, String value) {
     }
 
+    @Override
     public void setClientInfo(Properties properties) {
     }
 
+    @Override
     public boolean isWrapperFor(Class<?> iFace) throws SQLException{
         return false;
     }
 
+    @Override
     public <T>T unwrap(Class<T> iFace)  throws SQLException {
         return iFace.cast(this);
     }
 
+    @Override
     public int getNetworkTimeout() throws SQLException {return 0;}
 
+    @Override
     public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException{}
 
+    @Override
     public void abort(Executor executor) throws SQLException {}
 
+    @Override
     public String getSchema() throws SQLException {return null;}
 
+    @Override
     public void setSchema(String schema) throws SQLException {}
 }

--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/performance/emulateddb/EmulatedDriver.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/performance/emulateddb/EmulatedDriver.java
@@ -56,6 +56,7 @@ public class EmulatedDriver implements Driver {
      *         connection to the URL
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public Connection connect(String url, java.util.Properties info) throws SQLException {
         if (! acceptsURL(url)) {
             return null;
@@ -77,6 +78,7 @@ public class EmulatedDriver implements Driver {
      *         <code>false</code> otherwise
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public boolean acceptsURL(String url) throws SQLException {
         return url.indexOf("emulate:") != -1;
     }
@@ -100,6 +102,7 @@ public class EmulatedDriver implements Driver {
      *          no properties are required.
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public DriverPropertyInfo[] getPropertyInfo(String url, java.util.Properties info) throws SQLException {
         return null;
     }
@@ -109,6 +112,7 @@ public class EmulatedDriver implements Driver {
      *
      * @return this driver's major version number
      */
+    @Override
     public int getMajorVersion() {
         return 1;
     }
@@ -117,6 +121,7 @@ public class EmulatedDriver implements Driver {
      * Gets the driver's minor version number. Initially this should be 0.
      * @return this driver's minor version number
      */
+    @Override
     public int getMinorVersion() {
         return 0;
     }
@@ -140,9 +145,11 @@ public class EmulatedDriver implements Driver {
      * @return <code>true</code> if this driver is JDBC Compliant; <code>false</code>
      *         otherwise
      */
+    @Override
     public boolean jdbcCompliant() {
         return true;
     }
 
+    @Override
     public Logger getParentLogger(){return null;}
 }

--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/performance/emulateddb/EmulatedDriver.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/performance/emulateddb/EmulatedDriver.java
@@ -77,7 +77,7 @@ public class EmulatedDriver implements Driver {
      *         <code>false</code> otherwise
      * @exception SQLException if a database access error occurs
      */
-    public boolean acceptsURL(String url) {
+    public boolean acceptsURL(String url) throws SQLException {
         return url.indexOf("emulate:") != -1;
     }
 
@@ -100,7 +100,7 @@ public class EmulatedDriver implements Driver {
      *          no properties are required.
      * @exception SQLException if a database access error occurs
      */
-    public DriverPropertyInfo[] getPropertyInfo(String url, java.util.Properties info) {
+    public DriverPropertyInfo[] getPropertyInfo(String url, java.util.Properties info) throws SQLException {
         return null;
     }
 

--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/performance/emulateddb/EmulatedResultSet.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/performance/emulateddb/EmulatedResultSet.java
@@ -57,7 +57,8 @@ public class EmulatedResultSet implements ResultSet {
      * <code>false</code> if there are no more rows
      * @exception SQLException if a database access error occurs
      */
-    public boolean next() {
+    @Override
+    public boolean next() throws SQLException {
         this.index++;
         return this.index <= this.rows.size();
     }
@@ -77,7 +78,8 @@ public class EmulatedResultSet implements ResultSet {
      *
      * @exception SQLException if a database access error occurs
      */
-    public void close() {
+    @Override
+    public void close() throws SQLException {
     }
 
     /**
@@ -92,7 +94,8 @@ public class EmulatedResultSet implements ResultSet {
      *         <code>NULL</code> and <code>false</code> otherwise
      * @exception SQLException if a database access error occurs
      */
-    public boolean wasNull() {
+    @Override
+    public boolean wasNull() throws SQLException {
         return false;
     }
 
@@ -110,7 +113,8 @@ public class EmulatedResultSet implements ResultSet {
      * value returned is <code>null</code>
      * @exception SQLException if a database access error occurs
      */
-    public String getString(int columnIndex) {
+    @Override
+    public String getString(int columnIndex) throws SQLException {
         return (String)getObject(columnIndex);
     }
 
@@ -124,7 +128,8 @@ public class EmulatedResultSet implements ResultSet {
      * value returned is <code>false</code>
      * @exception SQLException if a database access error occurs
      */
-    public boolean getBoolean(int columnIndex) {
+    @Override
+    public boolean getBoolean(int columnIndex) throws SQLException {
         return ((Boolean)getObject(columnIndex)).booleanValue();
     }
 
@@ -138,7 +143,8 @@ public class EmulatedResultSet implements ResultSet {
      * value returned is <code>0</code>
      * @exception SQLException if a database access error occurs
      */
-    public byte getByte(int columnIndex) {
+    @Override
+    public byte getByte(int columnIndex) throws SQLException {
         return ((Number)getObject(columnIndex)).byteValue();
     }
 
@@ -152,7 +158,8 @@ public class EmulatedResultSet implements ResultSet {
      * value returned is <code>0</code>
      * @exception SQLException if a database access error occurs
      */
-    public short getShort(int columnIndex) {
+    @Override
+    public short getShort(int columnIndex) throws SQLException {
         return ((Number)getObject(columnIndex)).shortValue();
     }
 
@@ -166,7 +173,8 @@ public class EmulatedResultSet implements ResultSet {
      * value returned is <code>0</code>
      * @exception SQLException if a database access error occurs
      */
-    public int getInt(int columnIndex) {
+    @Override
+    public int getInt(int columnIndex) throws SQLException {
         Number value = (Number)getObject(columnIndex);
         if (value == null) {
             return 0;
@@ -185,7 +193,8 @@ public class EmulatedResultSet implements ResultSet {
      * value returned is <code>0</code>
      * @exception SQLException if a database access error occurs
      */
-    public long getLong(int columnIndex) {
+    @Override
+    public long getLong(int columnIndex) throws SQLException {
         Number value = (Number)getObject(columnIndex);
         if (value == null) {
             return 0;
@@ -204,7 +213,8 @@ public class EmulatedResultSet implements ResultSet {
      * value returned is <code>0</code>
      * @exception SQLException if a database access error occurs
      */
-    public float getFloat(int columnIndex) {
+    @Override
+    public float getFloat(int columnIndex) throws SQLException {
         Number value = (Number)getObject(columnIndex);
         if (value == null) {
             return 0;
@@ -223,7 +233,8 @@ public class EmulatedResultSet implements ResultSet {
      * value returned is <code>0</code>
      * @exception SQLException if a database access error occurs
      */
-    public double getDouble(int columnIndex) {
+    @Override
+    public double getDouble(int columnIndex) throws SQLException {
         Number value = (Number)getObject(columnIndex);
         if (value == null) {
             return 0;
@@ -244,7 +255,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @deprecated
      */
-    public BigDecimal getBigDecimal(int columnIndex, int scale) {
+    @Override
+    public BigDecimal getBigDecimal(int columnIndex, int scale)throws SQLException {
         return (BigDecimal)getObject(columnIndex);
     }
 
@@ -259,7 +271,8 @@ public class EmulatedResultSet implements ResultSet {
      * value returned is <code>null</code>
      * @exception SQLException if a database access error occurs
      */
-    public byte[] getBytes(int columnIndex) {
+    @Override
+    public byte[] getBytes(int columnIndex) throws SQLException {
         return (byte[])getObject(columnIndex);
     }
 
@@ -273,7 +286,8 @@ public class EmulatedResultSet implements ResultSet {
      * value returned is <code>null</code>
      * @exception SQLException if a database access error occurs
      */
-    public java.sql.Date getDate(int columnIndex) {
+    @Override
+    public java.sql.Date getDate(int columnIndex) throws SQLException {
         java.util.Date date = (java.util.Date)getObject(columnIndex);
         if ((date != null) && (!(date instanceof java.sql.Date))) {
             date = new java.sql.Date(date.getTime());
@@ -291,7 +305,8 @@ public class EmulatedResultSet implements ResultSet {
      * value returned is <code>null</code>
      * @exception SQLException if a database access error occurs
      */
-    public java.sql.Time getTime(int columnIndex) {
+    @Override
+    public java.sql.Time getTime(int columnIndex) throws SQLException {
         return (java.sql.Time)getObject(columnIndex);
     }
 
@@ -305,7 +320,8 @@ public class EmulatedResultSet implements ResultSet {
      * value returned is <code>null</code>
      * @exception SQLException if a database access error occurs
      */
-    public java.sql.Timestamp getTimestamp(int columnIndex) {
+    @Override
+    public java.sql.Timestamp getTimestamp(int columnIndex) throws SQLException {
         return (java.sql.Timestamp)getObject(columnIndex);
     }
 
@@ -314,7 +330,7 @@ public class EmulatedResultSet implements ResultSet {
      * of this <code>ResultSet</code> object as
      * a stream of ASCII characters. The value can then be read in chunks from the
      * stream. This method is particularly
-     * suitable for retrieving large <char>LONGVARCHAR</char> values.
+     * suitable for retrieving large <code>LONGVARCHAR</code> values.
      * The JDBC driver will
      * do any necessary conversion from the database format into ASCII.
      *
@@ -332,7 +348,8 @@ public class EmulatedResultSet implements ResultSet {
      * value returned is <code>null</code>
      * @exception SQLException if a database access error occurs
      */
-    public java.io.InputStream getAsciiStream(int columnIndex) {
+    @Override
+    public java.io.InputStream getAsciiStream(int columnIndex) throws SQLException {
         return (java.io.InputStream)getObject(columnIndex);
     }
 
@@ -365,7 +382,8 @@ public class EmulatedResultSet implements ResultSet {
      * @deprecated use <code>getCharacterStream</code> in place of
      *              <code>getUnicodeStream</code>
      */
-    public java.io.InputStream getUnicodeStream(int columnIndex) {
+    @Override
+    public java.io.InputStream getUnicodeStream(int columnIndex) throws SQLException {
         return (java.io.InputStream)getObject(columnIndex);
     }
 
@@ -390,7 +408,8 @@ public class EmulatedResultSet implements ResultSet {
      *         <code>null</code>
      * @exception SQLException if a database access error occurs
      */
-    public java.io.InputStream getBinaryStream(int columnIndex) {
+    @Override
+    public java.io.InputStream getBinaryStream(int columnIndex) throws SQLException {
         return (java.io.InputStream)getObject(columnIndex);
     }
 
@@ -408,7 +427,8 @@ public class EmulatedResultSet implements ResultSet {
      * value returned is <code>null</code>
      * @exception SQLException if a database access error occurs
      */
-    public String getString(String columnName) {
+    @Override
+    public String getString(String columnName) throws SQLException {
         return (String)getObject(columnName);
     }
 
@@ -422,7 +442,8 @@ public class EmulatedResultSet implements ResultSet {
      * value returned is <code>false</code>
      * @exception SQLException if a database access error occurs
      */
-    public boolean getBoolean(String columnName) {
+    @Override
+    public boolean getBoolean(String columnName) throws SQLException {
         return ((Boolean)getObject(columnName)).booleanValue();
     }
 
@@ -436,7 +457,8 @@ public class EmulatedResultSet implements ResultSet {
      * value returned is <code>0</code>
      * @exception SQLException if a database access error occurs
      */
-    public byte getByte(String columnName) {
+    @Override
+    public byte getByte(String columnName) throws SQLException {
         return ((Number)getObject(columnName)).byteValue();
     }
 
@@ -450,7 +472,8 @@ public class EmulatedResultSet implements ResultSet {
      * value returned is <code>0</code>
      * @exception SQLException if a database access error occurs
      */
-    public short getShort(String columnName) {
+    @Override
+    public short getShort(String columnName) throws SQLException {
         return ((Number)getObject(columnName)).shortValue();
     }
 
@@ -464,7 +487,8 @@ public class EmulatedResultSet implements ResultSet {
      * value returned is <code>0</code>
      * @exception SQLException if a database access error occurs
      */
-    public int getInt(String columnName) {
+    @Override
+    public int getInt(String columnName) throws SQLException {
         Number value = (Number)getObject(columnName);
         if (value == null) {
             return 0;
@@ -483,7 +507,8 @@ public class EmulatedResultSet implements ResultSet {
      * value returned is <code>0</code>
      * @exception SQLException if a database access error occurs
      */
-    public long getLong(String columnName) {
+    @Override
+    public long getLong(String columnName) throws SQLException {
         Number value = (Number)getObject(columnName);
         if (value == null) {
             return 0;
@@ -502,7 +527,8 @@ public class EmulatedResultSet implements ResultSet {
      * value returned is <code>0</code>
      * @exception SQLException if a database access error occurs
      */
-    public float getFloat(String columnName) {
+    @Override
+    public float getFloat(String columnName) throws SQLException {
         Number value = (Number)getObject(columnName);
         if (value == null) {
             return 0;
@@ -521,7 +547,8 @@ public class EmulatedResultSet implements ResultSet {
      * value returned is <code>0</code>
      * @exception SQLException if a database access error occurs
      */
-    public double getDouble(String columnName) {
+    @Override
+    public double getDouble(String columnName) throws SQLException {
         Number value = (Number)getObject(columnName);
         if (value == null) {
             return 0;
@@ -542,7 +569,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @deprecated
      */
-    public BigDecimal getBigDecimal(String columnName, int scale) {
+    @Override
+    public BigDecimal getBigDecimal(String columnName, int scale) throws SQLException {
         return (BigDecimal)getObject(columnName);
     }
 
@@ -557,7 +585,8 @@ public class EmulatedResultSet implements ResultSet {
      * value returned is <code>null</code>
      * @exception SQLException if a database access error occurs
      */
-    public byte[] getBytes(String columnName) {
+    @Override
+    public byte[] getBytes(String columnName) throws SQLException {
         return (byte[])getObject(columnName);
     }
 
@@ -571,7 +600,8 @@ public class EmulatedResultSet implements ResultSet {
      * value returned is <code>null</code>
      * @exception SQLException if a database access error occurs
      */
-    public java.sql.Date getDate(String columnName) {
+    @Override
+    public java.sql.Date getDate(String columnName) throws SQLException {
         java.util.Date date = (java.util.Date)getObject(columnName);
         if ((date != null) && (!(date instanceof java.sql.Date))) {
             date = new java.sql.Date(date.getTime());
@@ -590,7 +620,8 @@ public class EmulatedResultSet implements ResultSet {
      * the value returned is <code>null</code>
      * @exception SQLException if a database access error occurs
      */
-    public java.sql.Time getTime(String columnName) {
+    @Override
+    public java.sql.Time getTime(String columnName) throws SQLException {
         return (java.sql.Time)getObject(columnName);
     }
 
@@ -604,7 +635,8 @@ public class EmulatedResultSet implements ResultSet {
      * value returned is <code>null</code>
      * @exception SQLException if a database access error occurs
      */
-    public java.sql.Timestamp getTimestamp(String columnName) {
+    @Override
+    public java.sql.Timestamp getTimestamp(String columnName) throws SQLException {
         return (java.sql.Timestamp)getObject(columnName);
     }
 
@@ -630,7 +662,8 @@ public class EmulatedResultSet implements ResultSet {
      * the value returned is <code>null</code>.
      * @exception SQLException if a database access error occurs
      */
-    public java.io.InputStream getAsciiStream(String columnName) {
+    @Override
+    public java.io.InputStream getAsciiStream(String columnName) throws SQLException {
         return (java.io.InputStream)getObject(columnName);
     }
 
@@ -661,7 +694,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @deprecated use <code>getCharacterStream</code> instead
      */
-    public java.io.InputStream getUnicodeStream(String columnName) {
+    @Override
+    public java.io.InputStream getUnicodeStream(String columnName) throws SQLException {
         return (java.io.InputStream)getObject(columnName);
     }
 
@@ -686,7 +720,8 @@ public class EmulatedResultSet implements ResultSet {
      * if the value is SQL <code>NULL</code>, the result is <code>null</code>
      * @exception SQLException if a database access error occurs
      */
-    public java.io.InputStream getBinaryStream(String columnName) {
+    @Override
+    public java.io.InputStream getBinaryStream(String columnName) throws SQLException {
         return (java.io.InputStream)getObject(columnName);
     }
 
@@ -717,7 +752,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs or this method is
      *            called on a closed result set
      */
-    public SQLWarning getWarnings() {
+    @Override
+    public SQLWarning getWarnings() throws SQLException {
         return null;
     }
 
@@ -729,7 +765,8 @@ public class EmulatedResultSet implements ResultSet {
      *
      * @exception SQLException if a database access error occurs
      */
-    public void clearWarnings() {
+    @Override
+    public void clearWarnings() throws SQLException {
     }
 
     /**
@@ -755,7 +792,8 @@ public class EmulatedResultSet implements ResultSet {
      * @return the SQL name for this <code>ResultSet</code> object's cursor
      * @exception SQLException if a database access error occurs
      */
-    public String getCursorName() {
+    @Override
+    public String getCursorName() throws SQLException {
         return null;
     }
 
@@ -766,7 +804,8 @@ public class EmulatedResultSet implements ResultSet {
      * @return the description of this <code>ResultSet</code> object's columns
      * @exception SQLException if a database access error occurs
      */
-    public ResultSetMetaData getMetaData() {
+    @Override
+    public ResultSetMetaData getMetaData() throws SQLException {
         return new EmulatedResultSetMetaData(this);
     }
 
@@ -796,7 +835,8 @@ public class EmulatedResultSet implements ResultSet {
      * @return a <code>java.lang.Object</code> holding the column value
      * @exception SQLException if a database access error occurs
      */
-    public Object getObject(int columnIndex) {
+    @Override
+    public Object getObject(int columnIndex) throws SQLException {
         return this.rows.get(this.index - 1).getValues().get(columnIndex - 1);
     }
 
@@ -826,7 +866,8 @@ public class EmulatedResultSet implements ResultSet {
      * @return a <code>java.lang.Object</code> holding the column value
      * @exception SQLException if a database access error occurs
      */
-    public Object getObject(String columnName) {
+    @Override
+    public Object getObject(String columnName) throws SQLException {
         return this.rows.get(this.index - 1).get(columnName);
     }
 
@@ -841,7 +882,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if the <code>ResultSet</code> object
      * does not contain <code>columnName</code> or a database access error occurs
      */
-    public int findColumn(String columnName) {
+    @Override
+    public int findColumn(String columnName) throws SQLException {
         return 0;
     }
 
@@ -861,7 +903,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public java.io.Reader getCharacterStream(int columnIndex) {
+    @Override
+    public java.io.Reader getCharacterStream(int columnIndex) throws SQLException {
         return (java.io.Reader)getObject(columnIndex);
     }
 
@@ -877,7 +920,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public java.io.Reader getCharacterStream(String columnName) {
+    @Override
+    public java.io.Reader getCharacterStream(String columnName) throws SQLException {
         return (java.io.Reader)getObject(columnName);
     }
 
@@ -893,7 +937,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public BigDecimal getBigDecimal(int columnIndex) {
+    @Override
+    public BigDecimal getBigDecimal(int columnIndex) throws SQLException {
         return (BigDecimal)getObject(columnIndex);
     }
 
@@ -910,7 +955,8 @@ public class EmulatedResultSet implements ResultSet {
      * @since 1.2
      *
      */
-    public BigDecimal getBigDecimal(String columnName) {
+    @Override
+    public BigDecimal getBigDecimal(String columnName) throws SQLException {
         return (BigDecimal)getObject(columnName);
     }
 
@@ -928,7 +974,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public boolean isBeforeFirst() {
+    @Override
+    public boolean isBeforeFirst() throws SQLException {
         return this.index == 0;
     }
 
@@ -942,7 +989,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public boolean isAfterLast() {
+    @Override
+    public boolean isAfterLast() throws SQLException {
         return (this.index - 1) == this.rows.size();
     }
 
@@ -955,7 +1003,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public boolean isFirst() {
+    @Override
+    public boolean isFirst() throws SQLException {
         return this.index == 1;
     }
 
@@ -972,7 +1021,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public boolean isLast() {
+    @Override
+    public boolean isLast() throws SQLException {
         return this.index == this.rows.size();
     }
 
@@ -985,7 +1035,8 @@ public class EmulatedResultSet implements ResultSet {
      * occurs or the result set type is <code>TYPE_FORWARD_ONLY</code>
      * @since 1.2
      */
-    public void beforeFirst() {
+    @Override
+    public void beforeFirst() throws SQLException {
         this.index = 0;
     }
 
@@ -997,7 +1048,8 @@ public class EmulatedResultSet implements ResultSet {
      * occurs or the result set type is <code>TYPE_FORWARD_ONLY</code>
      * @since 1.2
      */
-    public void afterLast() {
+    @Override
+    public void afterLast() throws SQLException {
         this.index = this.rows.size() + 1;
     }
 
@@ -1011,7 +1063,8 @@ public class EmulatedResultSet implements ResultSet {
      * occurs or the result set type is <code>TYPE_FORWARD_ONLY</code>
      * @since 1.2
      */
-    public boolean first() {
+    @Override
+    public boolean first() throws SQLException {
         this.index = 1;
         return true;
     }
@@ -1026,7 +1079,8 @@ public class EmulatedResultSet implements ResultSet {
      * occurs or the result set type is <code>TYPE_FORWARD_ONLY</code>
      * @since 1.2
      */
-    public boolean last() {
+    @Override
+    public boolean last() throws SQLException {
         this.index = this.rows.size();
         return true;
     }
@@ -1039,7 +1093,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public int getRow() {
+    @Override
+    public int getRow() throws SQLException {
         return index;
     }
 
@@ -1077,7 +1132,8 @@ public class EmulatedResultSet implements ResultSet {
      * occurs, or the result set type is <code>TYPE_FORWARD_ONLY</code>
      * @since 1.2
      */
-    public boolean absolute(int row) {
+    @Override
+    public boolean absolute(int row) throws SQLException {
         this.index = row;
         return true;
     }
@@ -1104,7 +1160,8 @@ public class EmulatedResultSet implements ResultSet {
      *            <code>TYPE_FORWARD_ONLY</code>
      * @since 1.2
      */
-    public boolean relative(int rows) {
+    @Override
+    public boolean relative(int rows) throws SQLException {
         this.index = index + rows;
         return true;
     }
@@ -1119,7 +1176,8 @@ public class EmulatedResultSet implements ResultSet {
      * occurs or the result set type is <code>TYPE_FORWARD_ONLY</code>
      * @since 1.2
      */
-    public boolean previous() {
+    @Override
+    public boolean previous() throws SQLException {
         this.index--;
         return true;
     }
@@ -1147,7 +1205,8 @@ public class EmulatedResultSet implements ResultSet {
      * @see Statement#setFetchDirection
      * @see #getFetchDirection
      */
-    public void setFetchDirection(int direction) {
+    @Override
+    public void setFetchDirection(int direction) throws SQLException {
     }
 
     /**
@@ -1159,7 +1218,8 @@ public class EmulatedResultSet implements ResultSet {
      * @since 1.2
      * @see #setFetchDirection
      */
-    public int getFetchDirection() {
+    @Override
+    public int getFetchDirection() throws SQLException {
         return 0;
     }
 
@@ -1175,11 +1235,12 @@ public class EmulatedResultSet implements ResultSet {
      *
      * @param rows the number of rows to fetch
      * @exception SQLException if a database access error occurs or the
-     * condition <code>0 <= rows <= Statement.getMaxRows()</code> is not satisfied
+     * condition <code>0 &lt;= rows &lt;= Statement.getMaxRows()</code> is not satisfied
      * @since 1.2
      * @see #getFetchSize
      */
-    public void setFetchSize(int rows) {
+    @Override
+    public void setFetchSize(int rows) throws SQLException {
     }
 
     /**
@@ -1191,7 +1252,8 @@ public class EmulatedResultSet implements ResultSet {
      * @since 1.2
      * @see #setFetchSize
      */
-    public int getFetchSize() {
+    @Override
+    public int getFetchSize() throws SQLException {
         return 0;
     }
 
@@ -1206,7 +1268,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public int getType() {
+    @Override
+    public int getType() throws SQLException {
         return 0;
     }
 
@@ -1221,7 +1284,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public int getConcurrency() {
+    @Override
+    public int getConcurrency() throws SQLException {
         return 0;
     }
 
@@ -1239,7 +1303,8 @@ public class EmulatedResultSet implements ResultSet {
      * @see DatabaseMetaData#updatesAreDetected
      * @since 1.2
      */
-    public boolean rowUpdated() {
+    @Override
+    public boolean rowUpdated() throws SQLException {
         return false;
     }
 
@@ -1255,7 +1320,8 @@ public class EmulatedResultSet implements ResultSet {
      * @see DatabaseMetaData#insertsAreDetected
      * @since 1.2
      */
-    public boolean rowInserted() {
+    @Override
+    public boolean rowInserted() throws SQLException {
         return false;
     }
 
@@ -1272,7 +1338,8 @@ public class EmulatedResultSet implements ResultSet {
      * @see DatabaseMetaData#deletesAreDetected
      * @since 1.2
      */
-    public boolean rowDeleted() {
+    @Override
+    public boolean rowDeleted() throws SQLException {
         return false;
     }
 
@@ -1288,7 +1355,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateNull(int columnIndex) {
+    @Override
+    public void updateNull(int columnIndex) throws SQLException {
     }
 
     /**
@@ -1303,7 +1371,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateBoolean(int columnIndex, boolean x) {
+    @Override
+    public void updateBoolean(int columnIndex, boolean x) throws SQLException {
     }
 
     /**
@@ -1319,7 +1388,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateByte(int columnIndex, byte x) {
+    @Override
+    public void updateByte(int columnIndex, byte x) throws SQLException {
     }
 
     /**
@@ -1334,7 +1404,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateShort(int columnIndex, short x) {
+    @Override
+    public void updateShort(int columnIndex, short x) throws SQLException {
     }
 
     /**
@@ -1349,7 +1420,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateInt(int columnIndex, int x) {
+    @Override
+    public void updateInt(int columnIndex, int x) throws SQLException {
     }
 
     /**
@@ -1364,7 +1436,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateLong(int columnIndex, long x) {
+    @Override
+    public void updateLong(int columnIndex, long x) throws SQLException {
     }
 
     /**
@@ -1379,7 +1452,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateFloat(int columnIndex, float x) {
+    @Override
+    public void updateFloat(int columnIndex, float x) throws SQLException {
     }
 
     /**
@@ -1394,7 +1468,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateDouble(int columnIndex, double x) {
+    @Override
+    public void updateDouble(int columnIndex, double x) throws SQLException {
     }
 
     /**
@@ -1410,7 +1485,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateBigDecimal(int columnIndex, BigDecimal x) {
+    @Override
+    public void updateBigDecimal(int columnIndex, BigDecimal x) throws SQLException {
     }
 
     /**
@@ -1425,7 +1501,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateString(int columnIndex, String x) {
+    @Override
+    public void updateString(int columnIndex, String x) throws SQLException {
     }
 
     /**
@@ -1440,7 +1517,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateBytes(int columnIndex, byte[] x) {
+    @Override
+    public void updateBytes(int columnIndex, byte[] x) throws SQLException {
     }
 
     /**
@@ -1455,7 +1533,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateDate(int columnIndex, java.sql.Date x) {
+    @Override
+    public void updateDate(int columnIndex, java.sql.Date x) throws SQLException {
     }
 
     /**
@@ -1470,7 +1549,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateTime(int columnIndex, java.sql.Time x) {
+    @Override
+    public void updateTime(int columnIndex, java.sql.Time x) throws SQLException {
     }
 
     /**
@@ -1486,7 +1566,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateTimestamp(int columnIndex, java.sql.Timestamp x) {
+    @Override
+    public void updateTimestamp(int columnIndex, java.sql.Timestamp x) throws SQLException {
     }
 
     /**
@@ -1502,7 +1583,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateAsciiStream(int columnIndex, java.io.InputStream x, int length) {
+    @Override
+    public void updateAsciiStream(int columnIndex, java.io.InputStream x, int length) throws SQLException {
     }
 
     /**
@@ -1518,7 +1600,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateBinaryStream(int columnIndex, java.io.InputStream x, int length) {
+    @Override
+    public void updateBinaryStream(int columnIndex, java.io.InputStream x, int length) throws SQLException {
     }
 
     /**
@@ -1534,7 +1617,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateCharacterStream(int columnIndex, java.io.Reader x, int length) {
+    @Override
+    public void updateCharacterStream(int columnIndex, java.io.Reader x, int length) throws SQLException {
     }
 
     /**
@@ -1553,7 +1637,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateObject(int columnIndex, Object x, int scale) {
+    @Override
+    public void updateObject(int columnIndex, Object x, int scale) throws SQLException {
     }
 
     /**
@@ -1568,7 +1653,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateObject(int columnIndex, Object x) {
+    @Override
+    public void updateObject(int columnIndex, Object x) throws SQLException {
     }
 
     /**
@@ -1582,7 +1668,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateNull(String columnName) {
+    @Override
+    public void updateNull(String columnName) throws SQLException {
     }
 
     /**
@@ -1597,7 +1684,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateBoolean(String columnName, boolean x) {
+    @Override
+    public void updateBoolean(String columnName, boolean x) throws SQLException {
     }
 
     /**
@@ -1612,7 +1700,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateByte(String columnName, byte x) {
+    @Override
+    public void updateByte(String columnName, byte x) throws SQLException {
     }
 
     /**
@@ -1627,7 +1716,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateShort(String columnName, short x) {
+    @Override
+    public void updateShort(String columnName, short x) throws SQLException {
     }
 
     /**
@@ -1642,7 +1732,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateInt(String columnName, int x) {
+    @Override
+    public void updateInt(String columnName, int x) throws SQLException {
     }
 
     /**
@@ -1657,7 +1748,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateLong(String columnName, long x) {
+    @Override
+    public void updateLong(String columnName, long x) throws SQLException {
     }
 
     /**
@@ -1672,7 +1764,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateFloat(String columnName, float x) {
+    @Override
+    public void updateFloat(String columnName, float x) throws SQLException {
     }
 
     /**
@@ -1687,7 +1780,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateDouble(String columnName, double x) {
+    @Override
+    public void updateDouble(String columnName, double x) throws SQLException {
     }
 
     /**
@@ -1703,7 +1797,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateBigDecimal(String columnName, BigDecimal x) {
+    @Override
+    public void updateBigDecimal(String columnName, BigDecimal x) throws SQLException {
     }
 
     /**
@@ -1718,7 +1813,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateString(String columnName, String x) {
+    @Override
+    public void updateString(String columnName, String x) throws SQLException {
     }
 
     /**
@@ -1734,7 +1830,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateBytes(String columnName, byte[] x) {
+    @Override
+    public void updateBytes(String columnName, byte[] x) throws SQLException {
     }
 
     /**
@@ -1749,7 +1846,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateDate(String columnName, java.sql.Date x) {
+    @Override
+    public void updateDate(String columnName, java.sql.Date x) throws SQLException {
     }
 
     /**
@@ -1764,7 +1862,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateTime(String columnName, java.sql.Time x) {
+    @Override
+    public void updateTime(String columnName, java.sql.Time x) throws SQLException {
     }
 
     /**
@@ -1780,7 +1879,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateTimestamp(String columnName, java.sql.Timestamp x) {
+    @Override
+    public void updateTimestamp(String columnName, java.sql.Timestamp x) throws SQLException {
     }
 
     /**
@@ -1796,7 +1896,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateAsciiStream(String columnName, java.io.InputStream x, int length) {
+    @Override
+    public void updateAsciiStream(String columnName, java.io.InputStream x, int length) throws SQLException {
     }
 
     /**
@@ -1812,7 +1913,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateBinaryStream(String columnName, java.io.InputStream x, int length) {
+    @Override
+    public void updateBinaryStream(String columnName, java.io.InputStream x, int length) throws SQLException {
     }
 
     /**
@@ -1829,7 +1931,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateCharacterStream(String columnName, java.io.Reader reader, int length) {
+    @Override
+    public void updateCharacterStream(String columnName, java.io.Reader reader, int length) throws SQLException {
     }
 
     /**
@@ -1848,7 +1951,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateObject(String columnName, Object x, int scale) {
+    @Override
+    public void updateObject(String columnName, Object x, int scale) throws SQLException {
     }
 
     /**
@@ -1863,7 +1967,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void updateObject(String columnName, Object x) {
+    @Override
+    public void updateObject(String columnName, Object x) throws SQLException {
     }
 
     /**
@@ -1877,7 +1982,8 @@ public class EmulatedResultSet implements ResultSet {
      * the insert row have been given a value
      * @since 1.2
      */
-    public void insertRow() {
+    @Override
+    public void insertRow() throws SQLException {
     }
 
     /**
@@ -1889,7 +1995,8 @@ public class EmulatedResultSet implements ResultSet {
      * if this method is called when the cursor is on the insert row
      * @since 1.2
      */
-    public void updateRow() {
+    @Override
+    public void updateRow() throws SQLException {
     }
 
     /**
@@ -1901,7 +2008,8 @@ public class EmulatedResultSet implements ResultSet {
      * or if this method is called when the cursor is on the insert row
      * @since 1.2
      */
-    public void deleteRow() {
+    @Override
+    public void deleteRow() throws SQLException {
     }
 
     /**
@@ -1929,7 +2037,8 @@ public class EmulatedResultSet implements ResultSet {
      * occurs or if this method is called when the cursor is on the insert row
      * @since 1.2
      */
-    public void refreshRow() {
+    @Override
+    public void refreshRow() throws SQLException {
     }
 
     /**
@@ -1947,7 +2056,8 @@ public class EmulatedResultSet implements ResultSet {
      *            on the insert row
      * @since 1.2
      */
-    public void cancelRowUpdates() {
+    @Override
+    public void cancelRowUpdates() throws SQLException {
     }
 
     /**
@@ -1971,7 +2081,8 @@ public class EmulatedResultSet implements ResultSet {
      * or the result set is not updatable
      * @since 1.2
      */
-    public void moveToInsertRow() {
+    @Override
+    public void moveToInsertRow() throws SQLException {
     }
 
     /**
@@ -1983,7 +2094,8 @@ public class EmulatedResultSet implements ResultSet {
      * or the result set is not updatable
      * @since 1.2
      */
-    public void moveToCurrentRow() {
+    @Override
+    public void moveToCurrentRow() throws SQLException {
     }
 
     /**
@@ -1999,7 +2111,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public Statement getStatement() {
+    @Override
+    public Statement getStatement() throws SQLException {
         return null;
     }
 
@@ -2021,7 +2134,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public Object getObject(int i, java.util.Map map) {
+    @Override
+    public Object getObject(int i, java.util.Map map) throws SQLException {
         return getObject(i);
     }
 
@@ -2036,7 +2150,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public Ref getRef(int i) {
+    @Override
+    public Ref getRef(int i) throws SQLException {
         return null;
     }
 
@@ -2051,7 +2166,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public Blob getBlob(int i) {
+    @Override
+    public Blob getBlob(int i) throws SQLException {
         return (Blob)getObject(i);
     }
 
@@ -2066,7 +2182,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public Clob getClob(int i) {
+    @Override
+    public Clob getClob(int i) throws SQLException {
         return (Clob)getObject(i);
     }
 
@@ -2081,7 +2198,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public Array getArray(int i) {
+    @Override
+    public Array getArray(int i) throws SQLException {
         return null;
     }
 
@@ -2102,7 +2220,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public Object getObject(String colName, java.util.Map map) {
+    @Override
+    public Object getObject(String colName, java.util.Map map) throws SQLException {
         return getObject(colName);
     }
 
@@ -2117,7 +2236,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public Ref getRef(String colName) {
+    @Override
+    public Ref getRef(String colName) throws SQLException {
         return null;
     }
 
@@ -2132,7 +2252,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public Blob getBlob(String colName) {
+    @Override
+    public Blob getBlob(String colName) throws SQLException {
         return (Blob)getObject(colName);
     }
 
@@ -2147,7 +2268,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public Clob getClob(String colName) {
+    @Override
+    public Clob getClob(String colName) throws SQLException {
         return (Clob)getObject(colName);
     }
 
@@ -2162,7 +2284,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public Array getArray(String colName) {
+    @Override
+    public Array getArray(String colName) throws SQLException {
         return null;
     }
 
@@ -2183,7 +2306,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public java.sql.Date getDate(int columnIndex, Calendar cal) {
+    @Override
+    public java.sql.Date getDate(int columnIndex, Calendar cal) throws SQLException {
         return getDate(columnIndex);
     }
 
@@ -2204,7 +2328,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public java.sql.Date getDate(String columnName, Calendar cal) {
+    @Override
+    public java.sql.Date getDate(String columnName, Calendar cal) throws SQLException {
         return getDate(columnName);
     }
 
@@ -2225,7 +2350,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public java.sql.Time getTime(int columnIndex, Calendar cal) {
+    @Override
+    public java.sql.Time getTime(int columnIndex, Calendar cal) throws SQLException {
         return null;
     }
 
@@ -2246,7 +2372,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public java.sql.Time getTime(String columnName, Calendar cal) {
+    @Override
+    public java.sql.Time getTime(String columnName, Calendar cal) throws SQLException {
         return null;
     }
 
@@ -2267,7 +2394,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public java.sql.Timestamp getTimestamp(int columnIndex, Calendar cal) {
+    @Override
+    public java.sql.Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException {
         return getTimestamp(columnIndex);
     }
 
@@ -2288,7 +2416,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public java.sql.Timestamp getTimestamp(String columnName, Calendar cal) {
+    @Override
+    public java.sql.Timestamp getTimestamp(String columnName, Calendar cal) throws SQLException {
         return getTimestamp(columnName);
     }
 
@@ -2307,7 +2436,8 @@ public class EmulatedResultSet implements ResultSet {
      *            or if a URL is malformed
      * @since 1.4
      */
-    public java.net.URL getURL(int columnIndex) {
+    @Override
+    public java.net.URL getURL(int columnIndex) throws SQLException {
         return null;
     }
 
@@ -2324,7 +2454,8 @@ public class EmulatedResultSet implements ResultSet {
      *            or if a URL is malformed
      * @since 1.4
      */
-    public java.net.URL getURL(String columnName) {
+    @Override
+    public java.net.URL getURL(String columnName) throws SQLException {
         return null;
     }
 
@@ -2340,7 +2471,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.4
      */
-    public void updateRef(int columnIndex, java.sql.Ref x) {
+    @Override
+    public void updateRef(int columnIndex, java.sql.Ref x) throws SQLException {
     }
 
     /**
@@ -2355,7 +2487,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.4
      */
-    public void updateRef(String columnName, java.sql.Ref x) {
+    @Override
+    public void updateRef(String columnName, java.sql.Ref x) throws SQLException {
     }
 
     /**
@@ -2370,7 +2503,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.4
      */
-    public void updateBlob(int columnIndex, java.sql.Blob x) {
+    @Override
+    public void updateBlob(int columnIndex, java.sql.Blob x) throws SQLException {
     }
 
     /**
@@ -2385,7 +2519,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.4
      */
-    public void updateBlob(String columnName, java.sql.Blob x) {
+    @Override
+    public void updateBlob(String columnName, java.sql.Blob x) throws SQLException {
     }
 
     /**
@@ -2400,7 +2535,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.4
      */
-    public void updateClob(int columnIndex, java.sql.Clob x) {
+    @Override
+    public void updateClob(int columnIndex, java.sql.Clob x) throws SQLException {
     }
 
     /**
@@ -2415,7 +2551,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.4
      */
-    public void updateClob(String columnName, java.sql.Clob x) {
+    @Override
+    public void updateClob(String columnName, java.sql.Clob x) throws SQLException {
     }
 
     /**
@@ -2430,7 +2567,8 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.4
      */
-    public void updateArray(int columnIndex, java.sql.Array x) {
+    @Override
+    public void updateArray(int columnIndex, java.sql.Array x) throws SQLException {
     }
 
     /**
@@ -2445,175 +2583,228 @@ public class EmulatedResultSet implements ResultSet {
      * @exception SQLException if a database access error occurs
      * @since 1.4
      */
-    public void updateArray(String columnName, java.sql.Array x) {
+    @Override
+    public void updateArray(String columnName, java.sql.Array x) throws SQLException {
     }
 
     // 236070: Methods introduced in JDK 1.6
+    @Override
     public int getHoldability()  throws SQLException {
         return 0;
     }
 
+    @Override
     public Reader getNCharacterStream(int columnIndex)  throws SQLException {
         return null;
     }
 
+    @Override
     public Reader getNCharacterStream(String columnLabel)  throws SQLException {
         return null;
     }
 
+    @Override
     public NClob getNClob(int columnIndex)  throws SQLException {
         return null;
     }
 
+   @Override
    public NClob getNClob(String columnLabel)  throws SQLException {
         return null;
     }
 
+   @Override
    public String getNString(int columnIndex)  throws SQLException {
        return null;
    }
 
+   @Override
    public String getNString(String columnLabel)  throws SQLException {
        return null;
    }
 
+   @Override
    public RowId getRowId(int columnIndex)  throws SQLException {
        return null;
    }
 
+   @Override
    public RowId getRowId(String columnLabel)  throws SQLException {
        return null;
    }
 
+   @Override
    public SQLXML getSQLXML(int columnIndex)  throws SQLException {
        return null;
    }
 
+   @Override
    public SQLXML getSQLXML(String columnLabel)  throws SQLException {
        return null;
    }
 
+   @Override
    public boolean isClosed()  throws SQLException {
        return false;
    }
 
+    @Override
    public void updateAsciiStream(int columnIndex, InputStream stream, long length)  throws SQLException {
    }
 
+    @Override
    public void updateAsciiStream(int columnIndex, InputStream stream)  throws SQLException {
    }
 
+    @Override
    public void updateAsciiStream(String columnLabel, InputStream stream, long length)  throws SQLException {
    }
 
+    @Override
    public void updateAsciiStream(String columnLabel, InputStream stream)  throws SQLException {
    }
 
+    @Override
    public void updateBlob(int columnIndex, InputStream stream, long length)  throws SQLException {
    }
 
+    @Override
    public void updateBlob(int columnIndex, InputStream stream)  throws SQLException {
    }
 
+    @Override
    public void updateBlob(String columnLabel, InputStream stream, long length)  throws SQLException {
    }
 
+    @Override
    public void updateBlob(String columnLabel, InputStream stream)  throws SQLException {
    }
 
+    @Override
    public void updateBinaryStream(int columnIndex, InputStream stream, long length)  throws SQLException {
    }
 
+    @Override
    public void updateBinaryStream(int columnIndex, InputStream stream)  throws SQLException {
    }
 
+    @Override
    public void updateBinaryStream(String columnLabel, InputStream stream, long length)  throws SQLException {
    }
 
+    @Override
    public void updateBinaryStream(String columnLabel, InputStream stream)  throws SQLException {
    }
 
+    @Override
    public void updateCharacterStream(int columnIndex, Reader reader, long length)  throws SQLException {
    }
 
+    @Override
    public void updateCharacterStream(int columnIndex, Reader reader)  throws SQLException {
    }
 
+    @Override
    public void updateCharacterStream(String columnLabel, Reader reader, long length)  throws SQLException {
    }
 
+    @Override
    public void updateCharacterStream(String columnLabel, Reader reader)  throws SQLException {
    }
 
+    @Override
    public void updateClob(int columnIndex, Reader reader, long length)  throws SQLException {
    }
 
+    @Override
    public void updateClob(int columnIndex, Reader reader)  throws SQLException {
    }
 
+    @Override
    public void updateClob(String columnLabel, Reader reader, long length)  throws SQLException {
    }
 
+    @Override
    public void updateClob(String columnLabel, Reader reader)  throws SQLException {
    }
 
+    @Override
    public void updateNCharacterStream(int columnIndex, Reader reader, long length)  throws SQLException {
    }
 
+    @Override
    public void updateNCharacterStream(int columnIndex, Reader reader)  throws SQLException {
    }
 
+    @Override
    public void updateNCharacterStream(String columnLabel, Reader reader, long length)  throws SQLException {
    }
 
+    @Override
    public void updateNCharacterStream(String columnLabel, Reader reader)  throws SQLException {
    }
 
+    @Override
    public void updateNClob(int columnIndex, Reader reader, long length)  throws SQLException {
    }
 
+    @Override
    public void updateNClob(int columnIndex, Reader reader)  throws SQLException {
    }
 
+    @Override
    public void updateNClob(String columnLabel, Reader reader, long length)  throws SQLException {
    }
 
+    @Override
    public void updateNClob(String columnLabel, Reader reader)  throws SQLException {
    }
 
+    @Override
    public void updateNClob(int columnIndex, NClob nclob)  throws SQLException {
    }
 
+    @Override
    public void updateNClob(String columnLabel, NClob nclob)  throws SQLException {
    }
 
+    @Override
    public void updateNString(int columnIndex, String nString)  throws SQLException {
    }
 
+    @Override
    public void updateNString(String columnLabel, String nString)  throws SQLException {
    }
 
+    @Override
    public void updateSQLXML(String columnLabel, SQLXML sqlxml)  throws SQLException {
    }
 
+    @Override
    public void updateSQLXML(int columnIndex, SQLXML sqlxml)  throws SQLException {
    }
 
+    @Override
    public void updateRowId(int columnIndex, RowId rowid)  throws SQLException {
    }
 
+    @Override
    public void updateRowId(String columnLabel, RowId rowid)  throws SQLException {
    }
 
+    @Override
    public boolean isWrapperFor(Class<?> iFace) throws SQLException{
        return false;
    }
 
+    @Override
    public <T>T unwrap(Class<T> iFace)  throws SQLException {
        return iFace.cast(this);
    }
 
+    @Override
    public <T> T getObject(String columnLabel, Class<T> type){return null;}
 
+    @Override
    public <T> T getObject(int columnIndex, Class<T> type){return null;}
 }

--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/performance/emulateddb/EmulatedResultSetMetaData.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/performance/emulateddb/EmulatedResultSetMetaData.java
@@ -36,6 +36,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * @return the number of columns
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public int getColumnCount() throws SQLException {
         if (resultSet.getRows().isEmpty()) {
             return 1;
@@ -50,6 +51,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * @return <code>true</code> if so; <code>false</code> otherwise
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public boolean isAutoIncrement(int column) throws SQLException {
         return false;
     }
@@ -61,6 +63,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * @return <code>true</code> if so; <code>false</code> otherwise
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public boolean isCaseSensitive(int column) throws SQLException {
         return true;
     }
@@ -72,6 +75,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * @return <code>true</code> if so; <code>false</code> otherwise
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public boolean isSearchable(int column) throws SQLException {
         return true;
     }
@@ -83,6 +87,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * @return <code>true</code> if so; <code>false</code> otherwise
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public boolean isCurrency(int column) throws SQLException {
         return false;
     }
@@ -95,6 +100,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      *          <code>columnNullable</code> or <code>columnNullableUnknown</code>
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public int isNullable(int column) throws SQLException {
         return 0;
     }
@@ -106,6 +112,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * @return <code>true</code> if so; <code>false</code> otherwise
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public boolean isSigned(int column) throws SQLException {
         return true;
     }
@@ -118,6 +125,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      *          of the designated column
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public int getColumnDisplaySize(int column) throws SQLException {
         return 0;
     }
@@ -130,6 +138,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * @return the suggested column title
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public String getColumnLabel(int column) throws SQLException {
         return "";
     }
@@ -141,6 +150,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * @return column name
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public String getColumnName(int column) throws SQLException {
         return ((DatabaseField)((DatabaseRecord)resultSet.getRows().get(0)).getFields().get(column - 1)).getName();
     }
@@ -152,6 +162,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * @return schema name or "" if not applicable
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public String getSchemaName(int column) throws SQLException {
         return "";
     }
@@ -163,6 +174,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * @return precision
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public int getPrecision(int column) throws SQLException {
         return 0;
     }
@@ -174,6 +186,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * @return scale
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public int getScale(int column) throws SQLException {
         return 0;
     }
@@ -185,6 +198,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * @return table name or "" if not applicable
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public String getTableName(int column) throws SQLException {
         return "";
     }
@@ -197,6 +211,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      *          appears or "" if not applicable
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public String getCatalogName(int column) throws SQLException {
         return "";
     }
@@ -209,6 +224,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * @exception SQLException if a database access error occurs
      * @see Types
      */
+    @Override
     public int getColumnType(int column) throws SQLException {
         return 0;
     }
@@ -221,6 +237,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * a user-defined type, then a fully-qualified type name is returned.
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public String getColumnTypeName(int column) throws SQLException {
         return "";
     }
@@ -232,6 +249,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * @return <code>true</code> if so; <code>false</code> otherwise
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public boolean isReadOnly(int column) throws SQLException {
         return false;
     }
@@ -243,6 +261,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * @return <code>true</code> if so; <code>false</code> otherwise
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public boolean isWritable(int column) throws SQLException {
         return true;
     }
@@ -254,6 +273,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * @return <code>true</code> if so; <code>false</code> otherwise
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public boolean isDefinitelyWritable(int column) throws SQLException {
         return true;
     }
@@ -275,14 +295,17 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
+    @Override
     public String getColumnClassName(int column) throws SQLException {
         return "";
     }
 
+    @Override
     public boolean isWrapperFor(Class<?> iFace) throws SQLException{
         return false;
     }
 
+    @Override
     public <T>T unwrap(Class<T> iFace)  throws SQLException {
         return iFace.cast(this);
     }

--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/performance/emulateddb/EmulatedResultSetMetaData.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/performance/emulateddb/EmulatedResultSetMetaData.java
@@ -36,7 +36,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * @return the number of columns
      * @exception SQLException if a database access error occurs
      */
-    public int getColumnCount() {
+    public int getColumnCount() throws SQLException {
         if (resultSet.getRows().isEmpty()) {
             return 1;
         }
@@ -50,7 +50,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * @return <code>true</code> if so; <code>false</code> otherwise
      * @exception SQLException if a database access error occurs
      */
-    public boolean isAutoIncrement(int column) {
+    public boolean isAutoIncrement(int column) throws SQLException {
         return false;
     }
 
@@ -61,7 +61,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * @return <code>true</code> if so; <code>false</code> otherwise
      * @exception SQLException if a database access error occurs
      */
-    public boolean isCaseSensitive(int column) {
+    public boolean isCaseSensitive(int column) throws SQLException {
         return true;
     }
 
@@ -72,7 +72,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * @return <code>true</code> if so; <code>false</code> otherwise
      * @exception SQLException if a database access error occurs
      */
-    public boolean isSearchable(int column) {
+    public boolean isSearchable(int column) throws SQLException {
         return true;
     }
 
@@ -83,7 +83,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * @return <code>true</code> if so; <code>false</code> otherwise
      * @exception SQLException if a database access error occurs
      */
-    public boolean isCurrency(int column) {
+    public boolean isCurrency(int column) throws SQLException {
         return false;
     }
 
@@ -95,7 +95,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      *          <code>columnNullable</code> or <code>columnNullableUnknown</code>
      * @exception SQLException if a database access error occurs
      */
-    public int isNullable(int column) {
+    public int isNullable(int column) throws SQLException {
         return 0;
     }
 
@@ -106,7 +106,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * @return <code>true</code> if so; <code>false</code> otherwise
      * @exception SQLException if a database access error occurs
      */
-    public boolean isSigned(int column) {
+    public boolean isSigned(int column) throws SQLException {
         return true;
     }
 
@@ -118,7 +118,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      *          of the designated column
      * @exception SQLException if a database access error occurs
      */
-    public int getColumnDisplaySize(int column) {
+    public int getColumnDisplaySize(int column) throws SQLException {
         return 0;
     }
 
@@ -130,7 +130,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * @return the suggested column title
      * @exception SQLException if a database access error occurs
      */
-    public String getColumnLabel(int column) {
+    public String getColumnLabel(int column) throws SQLException {
         return "";
     }
 
@@ -141,7 +141,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * @return column name
      * @exception SQLException if a database access error occurs
      */
-    public String getColumnName(int column) {
+    public String getColumnName(int column) throws SQLException {
         return ((DatabaseField)((DatabaseRecord)resultSet.getRows().get(0)).getFields().get(column - 1)).getName();
     }
 
@@ -152,7 +152,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * @return schema name or "" if not applicable
      * @exception SQLException if a database access error occurs
      */
-    public String getSchemaName(int column) {
+    public String getSchemaName(int column) throws SQLException {
         return "";
     }
 
@@ -163,7 +163,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * @return precision
      * @exception SQLException if a database access error occurs
      */
-    public int getPrecision(int column) {
+    public int getPrecision(int column) throws SQLException {
         return 0;
     }
 
@@ -174,7 +174,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * @return scale
      * @exception SQLException if a database access error occurs
      */
-    public int getScale(int column) {
+    public int getScale(int column) throws SQLException {
         return 0;
     }
 
@@ -185,7 +185,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * @return table name or "" if not applicable
      * @exception SQLException if a database access error occurs
      */
-    public String getTableName(int column) {
+    public String getTableName(int column) throws SQLException {
         return "";
     }
 
@@ -197,7 +197,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      *          appears or "" if not applicable
      * @exception SQLException if a database access error occurs
      */
-    public String getCatalogName(int column) {
+    public String getCatalogName(int column) throws SQLException {
         return "";
     }
 
@@ -209,7 +209,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * @exception SQLException if a database access error occurs
      * @see Types
      */
-    public int getColumnType(int column) {
+    public int getColumnType(int column) throws SQLException {
         return 0;
     }
 
@@ -221,7 +221,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * a user-defined type, then a fully-qualified type name is returned.
      * @exception SQLException if a database access error occurs
      */
-    public String getColumnTypeName(int column) {
+    public String getColumnTypeName(int column) throws SQLException {
         return "";
     }
 
@@ -232,7 +232,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * @return <code>true</code> if so; <code>false</code> otherwise
      * @exception SQLException if a database access error occurs
      */
-    public boolean isReadOnly(int column) {
+    public boolean isReadOnly(int column) throws SQLException {
         return false;
     }
 
@@ -243,7 +243,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * @return <code>true</code> if so; <code>false</code> otherwise
      * @exception SQLException if a database access error occurs
      */
-    public boolean isWritable(int column) {
+    public boolean isWritable(int column) throws SQLException {
         return true;
     }
 
@@ -254,7 +254,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * @return <code>true</code> if so; <code>false</code> otherwise
      * @exception SQLException if a database access error occurs
      */
-    public boolean isDefinitelyWritable(int column) {
+    public boolean isDefinitelyWritable(int column) throws SQLException {
         return true;
     }
 
@@ -275,7 +275,7 @@ public class EmulatedResultSetMetaData implements ResultSetMetaData {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public String getColumnClassName(int column) {
+    public String getColumnClassName(int column) throws SQLException {
         return "";
     }
 

--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/performance/emulateddb/EmulatedStatement.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/performance/emulateddb/EmulatedStatement.java
@@ -108,7 +108,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @param sqlType the SQL type code defined in <code>java.sql.Types</code>
      * @exception SQLException if a database access error occurs
      */
-    public void setNull(int parameterIndex, int sqlType) {
+    public void setNull(int parameterIndex, int sqlType) throws SQLException {
         setObject(parameterIndex, null);
     }
 
@@ -121,7 +121,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setBoolean(int parameterIndex, boolean x) {
+    public void setBoolean(int parameterIndex, boolean x) throws SQLException {
     }
 
     /**
@@ -133,7 +133,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setByte(int parameterIndex, byte x) {
+    public void setByte(int parameterIndex, byte x) throws SQLException {
     }
 
     /**
@@ -145,7 +145,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setShort(int parameterIndex, short x) {
+    public void setShort(int parameterIndex, short x) throws SQLException {
     }
 
     /**
@@ -157,7 +157,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setInt(int parameterIndex, int x) {
+    public void setInt(int parameterIndex, int x) throws SQLException {
         setObject(parameterIndex, x);
     }
 
@@ -170,7 +170,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setLong(int parameterIndex, long x) {
+    public void setLong(int parameterIndex, long x) throws SQLException {
         setObject(parameterIndex, x);
     }
 
@@ -183,7 +183,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setFloat(int parameterIndex, float x) {
+    public void setFloat(int parameterIndex, float x) throws SQLException {
         setObject(parameterIndex, x);
     }
 
@@ -196,7 +196,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setDouble(int parameterIndex, double x) {
+    public void setDouble(int parameterIndex, double x) throws SQLException {
         setObject(parameterIndex, x);
     }
 
@@ -209,7 +209,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setBigDecimal(int parameterIndex, BigDecimal x) {
+    public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException {
     }
 
     /**
@@ -224,7 +224,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setString(int parameterIndex, String x) {
+    public void setString(int parameterIndex, String x) throws SQLException {
         setObject(parameterIndex, x);
     }
 
@@ -238,7 +238,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setBytes(int parameterIndex, byte[] x) {
+    public void setBytes(int parameterIndex, byte[] x) throws SQLException {
         setObject(parameterIndex, x);
     }
 
@@ -251,7 +251,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setDate(int parameterIndex, java.sql.Date x) {
+    public void setDate(int parameterIndex, java.sql.Date x) throws SQLException {
         setObject(parameterIndex, x);
     }
 
@@ -264,7 +264,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setTime(int parameterIndex, java.sql.Time x) {
+    public void setTime(int parameterIndex, java.sql.Time x) throws SQLException {
         setObject(parameterIndex, x);
     }
 
@@ -278,7 +278,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
-    public void setTimestamp(int parameterIndex, java.sql.Timestamp x) {
+    public void setTimestamp(int parameterIndex, java.sql.Timestamp x) throws SQLException {
         setObject(parameterIndex, x);
     }
 
@@ -300,7 +300,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @param length the number of bytes in the stream
      * @exception SQLException if a database access error occurs
      */
-    public void setAsciiStream(int parameterIndex, java.io.InputStream x, int length) {
+    public void setAsciiStream(int parameterIndex, java.io.InputStream x, int length) throws SQLException {
     }
 
     /**
@@ -326,7 +326,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @deprecated
      */
-    public void setUnicodeStream(int parameterIndex, java.io.InputStream x, int length) {
+    public void setUnicodeStream(int parameterIndex, java.io.InputStream x, int length) throws SQLException {
     }
 
     /**
@@ -346,7 +346,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @param length the number of bytes in the stream
      * @exception SQLException if a database access error occurs
      */
-    public void setBinaryStream(int parameterIndex, java.io.InputStream x, int length) {
+    public void setBinaryStream(int parameterIndex, java.io.InputStream x, int length) throws SQLException {
     }
 
     /**
@@ -359,7 +359,7 @@ public class EmulatedStatement implements PreparedStatement {
      *
      * @exception SQLException if a database access error occurs
      */
-    public void clearParameters() {
+    public void clearParameters() throws SQLException {
     }
 
     //----------------------------------------------------------------------
@@ -395,7 +395,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @see Types
      */
-    public void setObject(int parameterIndex, Object x, int targetSqlType, int scale) {
+    public void setObject(int parameterIndex, Object x, int targetSqlType, int scale) throws SQLException {
         setObject(parameterIndex, x);
     }
 
@@ -410,7 +410,7 @@ public class EmulatedStatement implements PreparedStatement {
     *                      sent to the database
     * @exception SQLException if a database access error occurs
     */
-    public void setObject(int parameterIndex, Object x, int targetSqlType) {
+    public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException {
         setObject(parameterIndex, x);
     }
 
@@ -444,7 +444,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs or the type
      *            of the given object is ambiguous
      */
-    public void setObject(int parameterIndex, Object x) {
+    public void setObject(int parameterIndex, Object x) throws SQLException {
         while (this.parameters.size() < parameterIndex) {
             this.parameters.add(null);
         }
@@ -490,7 +490,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @see Statement#addBatch
      * @since 1.2
      */
-    public void addBatch() {
+    public void addBatch() throws SQLException {
         this.batch++;
     }
 
@@ -514,7 +514,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void setCharacterStream(int parameterIndex, java.io.Reader reader, int length) {
+    public void setCharacterStream(int parameterIndex, java.io.Reader reader, int length) throws SQLException {
     }
 
     /**
@@ -528,7 +528,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void setRef(int i, Ref x) {
+    public void setRef(int i, Ref x) throws SQLException {
     }
 
     /**
@@ -541,7 +541,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void setBlob(int i, Blob x) {
+    public void setBlob(int i, Blob x) throws SQLException {
         setObject(i, x);
     }
 
@@ -555,7 +555,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void setClob(int i, Clob x) {
+    public void setClob(int i, Clob x) throws SQLException {
         setObject(i, x);
     }
 
@@ -569,7 +569,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void setArray(int i, Array x) {
+    public void setArray(int i, Array x) throws SQLException {
         setObject(i, x);
     }
 
@@ -596,7 +596,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public ResultSetMetaData getMetaData() {
+    public ResultSetMetaData getMetaData() throws SQLException {
         return null;
     }
 
@@ -617,7 +617,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void setDate(int parameterIndex, java.sql.Date x, Calendar cal) {
+    public void setDate(int parameterIndex, java.sql.Date x, Calendar cal) throws SQLException {
         setObject(parameterIndex, x);
     }
 
@@ -638,7 +638,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void setTime(int parameterIndex, java.sql.Time x, Calendar cal) {
+    public void setTime(int parameterIndex, java.sql.Time x, Calendar cal) throws SQLException {
         setObject(parameterIndex, x);
     }
 
@@ -659,7 +659,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void setTimestamp(int parameterIndex, java.sql.Timestamp x, Calendar cal) {
+    public void setTimestamp(int parameterIndex, java.sql.Timestamp x, Calendar cal) throws SQLException {
         setObject(parameterIndex, x);
     }
 
@@ -691,7 +691,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public void setNull(int paramIndex, int sqlType, String typeName) {
+    public void setNull(int paramIndex, int sqlType, String typeName) throws SQLException {
         setObject(paramIndex, null);
     }
 
@@ -707,7 +707,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @since 1.4
      */
-    public void setURL(int parameterIndex, java.net.URL x) {
+    public void setURL(int parameterIndex, java.net.URL x) throws SQLException {
     }
 
     /**
@@ -721,7 +721,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @see ParameterMetaData
      * @since 1.4
      */
-    public ParameterMetaData getParameterMetaData() {
+    public ParameterMetaData getParameterMetaData() throws SQLException {
         return null;
     }
 
@@ -776,7 +776,7 @@ public class EmulatedStatement implements PreparedStatement {
      *
      * @exception SQLException if a database access error occurs
      */
-    public void close() {
+    public void close() throws SQLException {
     }
 
     //----------------------------------------------------------------------
@@ -796,7 +796,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @see #setMaxFieldSize
      */
-    public int getMaxFieldSize() {
+    public int getMaxFieldSize() throws SQLException {
         return 0;
     }
 
@@ -812,10 +812,10 @@ public class EmulatedStatement implements PreparedStatement {
      *
      * @param max the new column size limit in bytes; zero means there is no limit
      * @exception SQLException if a database access error occurs
-     *            or the condition max >= 0 is not satisfied
+     *            or the condition max &gt;= 0 is not satisfied
      * @see #getMaxFieldSize
      */
-    public void setMaxFieldSize(int max) {
+    public void setMaxFieldSize(int max) throws SQLException {
     }
 
     /**
@@ -830,7 +830,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @see #setMaxRows
      */
-    public int getMaxRows() {
+    public int getMaxRows() throws SQLException {
         return 0;
     }
 
@@ -842,10 +842,10 @@ public class EmulatedStatement implements PreparedStatement {
      *
      * @param max the new max rows limit; zero means there is no limit
      * @exception SQLException if a database access error occurs
-     *            or the condition max >= 0 is not satisfied
+     *            or the condition max &gt;= 0 is not satisfied
      * @see #getMaxRows
      */
-    public void setMaxRows(int max) {
+    public void setMaxRows(int max) throws SQLException {
     }
 
     /**
@@ -861,7 +861,7 @@ public class EmulatedStatement implements PreparedStatement {
      *       <code>false</code> to disable it
      * @exception SQLException if a database access error occurs
      */
-    public void setEscapeProcessing(boolean enable) {
+    public void setEscapeProcessing(boolean enable) throws SQLException {
     }
 
     /**
@@ -874,7 +874,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @see #setQueryTimeout
      */
-    public int getQueryTimeout() {
+    public int getQueryTimeout() throws SQLException {
         return 0;
     }
 
@@ -886,10 +886,10 @@ public class EmulatedStatement implements PreparedStatement {
      * @param seconds the new query timeout limit in seconds; zero means
      *        there is no limit
      * @exception SQLException if a database access error occurs
-     *            or the condition seconds >= 0 is not satisfied
+     *            or the condition seconds &gt;= 0 is not satisfied
      * @see #getQueryTimeout
      */
-    public void setQueryTimeout(int seconds) {
+    public void setQueryTimeout(int seconds) throws SQLException {
     }
 
     /**
@@ -900,7 +900,7 @@ public class EmulatedStatement implements PreparedStatement {
      *
      * @exception SQLException if a database access error occurs
      */
-    public void cancel() {
+    public void cancel() throws SQLException {
     }
 
     /**
@@ -923,7 +923,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs or this
      *            method is called on a closed statement
      */
-    public SQLWarning getWarnings() {
+    public SQLWarning getWarnings() throws SQLException {
         return null;
     }
 
@@ -936,7 +936,7 @@ public class EmulatedStatement implements PreparedStatement {
      *
      * @exception SQLException if a database access error occurs
      */
-    public void clearWarnings() {
+    public void clearWarnings() throws SQLException {
     }
 
     /**
@@ -960,7 +960,7 @@ public class EmulatedStatement implements PreparedStatement {
      *             a connection
      * @exception SQLException if a database access error occurs
      */
-    public void setCursorName(String name) {
+    public void setCursorName(String name) throws SQLException {
     }
 
     //----------------------- Multiple Results --------------------------
@@ -1001,7 +1001,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @see #execute
      */
-    public ResultSet getResultSet() {
+    public ResultSet getResultSet() throws SQLException {
         return null;
     }
 
@@ -1015,7 +1015,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @see #execute
      */
-    public int getUpdateCount() {
+    public int getUpdateCount() throws SQLException {
         return 0;
     }
 
@@ -1028,7 +1028,7 @@ public class EmulatedStatement implements PreparedStatement {
      * <P>There are no more results when the following is true:
      * <PRE>
      *     // stmt is a Statement object
-     *     ((stmt.getMoreResults() == false) && (stmt.getUpdateCount() == -1))
+     *     ((stmt.getMoreResults() == false) &amp;&amp; (stmt.getUpdateCount() == -1))
      * </PRE>
      *
      * @return <code>true</code> if the next result is a <code>ResultSet</code>
@@ -1037,7 +1037,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @see #execute
      */
-    public boolean getMoreResults() {
+    public boolean getMoreResults() throws SQLException {
         return false;
     }
 
@@ -1062,7 +1062,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @since 1.2
      * @see #getFetchDirection
      */
-    public void setFetchDirection(int direction) {
+    public void setFetchDirection(int direction) throws SQLException {
     }
 
     /**
@@ -1079,7 +1079,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @since 1.2
      * @see #setFetchDirection
      */
-    public int getFetchDirection() {
+    public int getFetchDirection() throws SQLException {
         return 0;
     }
 
@@ -1092,12 +1092,12 @@ public class EmulatedStatement implements PreparedStatement {
      *
      * @param rows the number of rows to fetch
      * @exception SQLException if a database access error occurs, or the
-     *        condition 0 <= <code>rows</code> <= <code>this.getMaxRows()</code>
+     *        condition 0 &lt;= <code>rows</code> &lt;= <code>this.getMaxRows()</code>
      *        is not satisfied.
      * @since 1.2
      * @see #getFetchSize
      */
-    public void setFetchSize(int rows) {
+    public void setFetchSize(int rows) throws SQLException {
     }
 
     /**
@@ -1114,7 +1114,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @since 1.2
      * @see #setFetchSize
      */
-    public int getFetchSize() {
+    public int getFetchSize() throws SQLException {
         return 0;
     }
 
@@ -1127,7 +1127,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public int getResultSetConcurrency() {
+    public int getResultSetConcurrency() throws SQLException {
         return 0;
     }
 
@@ -1141,7 +1141,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public int getResultSetType() {
+    public int getResultSetType() throws SQLException {
         return 0;
     }
 
@@ -1159,7 +1159,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @see #executeBatch
      * @since 1.2
      */
-    public void addBatch(String sql) {
+    public void addBatch(String sql) throws SQLException {
     }
 
     /**
@@ -1173,7 +1173,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @see #addBatch
      * @since 1.2
      */
-    public void clearBatch() {
+    public void clearBatch() throws SQLException {
     }
 
     /**
@@ -1224,7 +1224,7 @@ public class EmulatedStatement implements PreparedStatement {
      * database fails to execute properly or attempts to return a result set.
      * @since 1.3
      */
-    public int[] executeBatch(){
+    public int[] executeBatch() throws SQLException {
         int result[] = new int[this.batch];
         for (int index = 0; index < this.batch; index++) {
             result[index] = 1;
@@ -1240,7 +1240,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
-    public Connection getConnection() {
+    public Connection getConnection() throws SQLException {
         return connection;
     }
 
@@ -1255,7 +1255,7 @@ public class EmulatedStatement implements PreparedStatement {
      * <P>There are no more results when the following is true:
      * <PRE>
      *     // stmt is a Statement object
-     *     ((stmt.getMoreResults() == false) && (stmt.getUpdateCount() == -1))
+     *     ((stmt.getMoreResults() == false) &amp;&amp; (stmt.getUpdateCount() == -1))
      * </PRE>
      *
      * @param current one of the following <code>Statement</code>
@@ -1276,7 +1276,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @since 1.4
      * @see #execute
      */
-    public boolean getMoreResults(int current) {
+    public boolean getMoreResults(int current) throws SQLException {
         return false;
     }
 
@@ -1291,7 +1291,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @since 1.4
      */
-    public ResultSet getGeneratedKeys() {
+    public ResultSet getGeneratedKeys() throws SQLException {
         return null;
     }
 
@@ -1505,7 +1505,7 @@ public class EmulatedStatement implements PreparedStatement {
      *
      * @since 1.4
      */
-    public int getResultSetHoldability() {
+    public int getResultSetHoldability() throws SQLException {
         return 0;
     }
 

--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/performance/emulateddb/EmulatedStatement.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/performance/emulateddb/EmulatedStatement.java
@@ -79,6 +79,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs or the SQL
      *            statement does not return a <code>ResultSet</code> object
      */
+    @Override
     public ResultSet executeQuery() throws SQLException {
         return new EmulatedResultSet(fetchRows());
     }
@@ -95,6 +96,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs or the SQL
      *            statement returns a <code>ResultSet</code> object
      */
+    @Override
     public int executeUpdate() throws SQLException {
         return 1;
     }
@@ -108,6 +110,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @param sqlType the SQL type code defined in <code>java.sql.Types</code>
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public void setNull(int parameterIndex, int sqlType) throws SQLException {
         setObject(parameterIndex, null);
     }
@@ -121,6 +124,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public void setBoolean(int parameterIndex, boolean x) throws SQLException {
     }
 
@@ -133,6 +137,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public void setByte(int parameterIndex, byte x) throws SQLException {
     }
 
@@ -145,6 +150,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public void setShort(int parameterIndex, short x) throws SQLException {
     }
 
@@ -157,6 +163,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public void setInt(int parameterIndex, int x) throws SQLException {
         setObject(parameterIndex, x);
     }
@@ -170,6 +177,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public void setLong(int parameterIndex, long x) throws SQLException {
         setObject(parameterIndex, x);
     }
@@ -183,6 +191,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public void setFloat(int parameterIndex, float x) throws SQLException {
         setObject(parameterIndex, x);
     }
@@ -196,6 +205,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public void setDouble(int parameterIndex, double x) throws SQLException {
         setObject(parameterIndex, x);
     }
@@ -209,6 +219,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException {
     }
 
@@ -224,6 +235,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public void setString(int parameterIndex, String x) throws SQLException {
         setObject(parameterIndex, x);
     }
@@ -238,6 +250,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public void setBytes(int parameterIndex, byte[] x) throws SQLException {
         setObject(parameterIndex, x);
     }
@@ -251,6 +264,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public void setDate(int parameterIndex, java.sql.Date x) throws SQLException {
         setObject(parameterIndex, x);
     }
@@ -264,6 +278,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public void setTime(int parameterIndex, java.sql.Time x) throws SQLException {
         setObject(parameterIndex, x);
     }
@@ -278,6 +293,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @param x the parameter value
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public void setTimestamp(int parameterIndex, java.sql.Timestamp x) throws SQLException {
         setObject(parameterIndex, x);
     }
@@ -300,6 +316,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @param length the number of bytes in the stream
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public void setAsciiStream(int parameterIndex, java.io.InputStream x, int length) throws SQLException {
     }
 
@@ -326,6 +343,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @deprecated
      */
+    @Override
     public void setUnicodeStream(int parameterIndex, java.io.InputStream x, int length) throws SQLException {
     }
 
@@ -346,6 +364,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @param length the number of bytes in the stream
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public void setBinaryStream(int parameterIndex, java.io.InputStream x, int length) throws SQLException {
     }
 
@@ -359,6 +378,7 @@ public class EmulatedStatement implements PreparedStatement {
      *
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public void clearParameters() throws SQLException {
     }
 
@@ -395,6 +415,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @see Types
      */
+    @Override
     public void setObject(int parameterIndex, Object x, int targetSqlType, int scale) throws SQLException {
         setObject(parameterIndex, x);
     }
@@ -410,6 +431,7 @@ public class EmulatedStatement implements PreparedStatement {
     *                      sent to the database
     * @exception SQLException if a database access error occurs
     */
+    @Override
     public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException {
         setObject(parameterIndex, x);
     }
@@ -444,6 +466,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs or the type
      *            of the given object is ambiguous
      */
+    @Override
     public void setObject(int parameterIndex, Object x) throws SQLException {
         while (this.parameters.size() < parameterIndex) {
             this.parameters.add(null);
@@ -476,6 +499,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @see Statement#getMoreResults
 
      */
+    @Override
     public boolean execute() throws SQLException{
         return true;
     }
@@ -490,6 +514,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @see Statement#addBatch
      * @since 1.2
      */
+    @Override
     public void addBatch() throws SQLException {
         this.batch++;
     }
@@ -514,6 +539,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
+    @Override
     public void setCharacterStream(int parameterIndex, java.io.Reader reader, int length) throws SQLException {
     }
 
@@ -528,6 +554,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
+    @Override
     public void setRef(int i, Ref x) throws SQLException {
     }
 
@@ -541,6 +568,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
+    @Override
     public void setBlob(int i, Blob x) throws SQLException {
         setObject(i, x);
     }
@@ -555,6 +583,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
+    @Override
     public void setClob(int i, Clob x) throws SQLException {
         setObject(i, x);
     }
@@ -569,6 +598,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
+    @Override
     public void setArray(int i, Array x) throws SQLException {
         setObject(i, x);
     }
@@ -596,6 +626,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
+    @Override
     public ResultSetMetaData getMetaData() throws SQLException {
         return null;
     }
@@ -617,6 +648,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
+    @Override
     public void setDate(int parameterIndex, java.sql.Date x, Calendar cal) throws SQLException {
         setObject(parameterIndex, x);
     }
@@ -638,6 +670,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
+    @Override
     public void setTime(int parameterIndex, java.sql.Time x, Calendar cal) throws SQLException {
         setObject(parameterIndex, x);
     }
@@ -659,6 +692,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
+    @Override
     public void setTimestamp(int parameterIndex, java.sql.Timestamp x, Calendar cal) throws SQLException {
         setObject(parameterIndex, x);
     }
@@ -691,6 +725,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
+    @Override
     public void setNull(int paramIndex, int sqlType, String typeName) throws SQLException {
         setObject(paramIndex, null);
     }
@@ -707,6 +742,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @since 1.4
      */
+    @Override
     public void setURL(int parameterIndex, java.net.URL x) throws SQLException {
     }
 
@@ -721,6 +757,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @see ParameterMetaData
      * @since 1.4
      */
+    @Override
     public ParameterMetaData getParameterMetaData() throws SQLException {
         return null;
     }
@@ -737,6 +774,7 @@ public class EmulatedStatement implements PreparedStatement {
      *            SQL statement produces anything other than a single
      *            <code>ResultSet</code> object
      */
+    @Override
     public ResultSet executeQuery(String sql) throws SQLException {
         return new EmulatedResultSet(this.connection.getRows(sql));
     }
@@ -754,6 +792,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs or the given
      *            SQL statement produces a <code>ResultSet</code> object
      */
+    @Override
     public int executeUpdate(String sql) throws SQLException {
         return 1;
     }
@@ -776,6 +815,7 @@ public class EmulatedStatement implements PreparedStatement {
      *
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public void close() throws SQLException {
     }
 
@@ -796,6 +836,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @see #setMaxFieldSize
      */
+    @Override
     public int getMaxFieldSize() throws SQLException {
         return 0;
     }
@@ -815,6 +856,7 @@ public class EmulatedStatement implements PreparedStatement {
      *            or the condition max &gt;= 0 is not satisfied
      * @see #getMaxFieldSize
      */
+    @Override
     public void setMaxFieldSize(int max) throws SQLException {
     }
 
@@ -830,6 +872,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @see #setMaxRows
      */
+    @Override
     public int getMaxRows() throws SQLException {
         return 0;
     }
@@ -845,6 +888,7 @@ public class EmulatedStatement implements PreparedStatement {
      *            or the condition max &gt;= 0 is not satisfied
      * @see #getMaxRows
      */
+    @Override
     public void setMaxRows(int max) throws SQLException {
     }
 
@@ -861,6 +905,7 @@ public class EmulatedStatement implements PreparedStatement {
      *       <code>false</code> to disable it
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public void setEscapeProcessing(boolean enable) throws SQLException {
     }
 
@@ -874,6 +919,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @see #setQueryTimeout
      */
+    @Override
     public int getQueryTimeout() throws SQLException {
         return 0;
     }
@@ -889,6 +935,7 @@ public class EmulatedStatement implements PreparedStatement {
      *            or the condition seconds &gt;= 0 is not satisfied
      * @see #getQueryTimeout
      */
+    @Override
     public void setQueryTimeout(int seconds) throws SQLException {
     }
 
@@ -900,6 +947,7 @@ public class EmulatedStatement implements PreparedStatement {
      *
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public void cancel() throws SQLException {
     }
 
@@ -923,6 +971,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs or this
      *            method is called on a closed statement
      */
+    @Override
     public SQLWarning getWarnings() throws SQLException {
         return null;
     }
@@ -936,6 +985,7 @@ public class EmulatedStatement implements PreparedStatement {
      *
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public void clearWarnings() throws SQLException {
     }
 
@@ -960,6 +1010,7 @@ public class EmulatedStatement implements PreparedStatement {
      *             a connection
      * @exception SQLException if a database access error occurs
      */
+    @Override
     public void setCursorName(String name) throws SQLException {
     }
 
@@ -988,6 +1039,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @see #getUpdateCount
      * @see #getMoreResults
      */
+    @Override
     public boolean execute(String sql) throws SQLException {
         return true;
     }
@@ -1001,6 +1053,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @see #execute
      */
+    @Override
     public ResultSet getResultSet() throws SQLException {
         return null;
     }
@@ -1015,6 +1068,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @see #execute
      */
+    @Override
     public int getUpdateCount() throws SQLException {
         return 0;
     }
@@ -1037,6 +1091,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @see #execute
      */
+    @Override
     public boolean getMoreResults() throws SQLException {
         return false;
     }
@@ -1062,6 +1117,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @since 1.2
      * @see #getFetchDirection
      */
+    @Override
     public void setFetchDirection(int direction) throws SQLException {
     }
 
@@ -1079,6 +1135,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @since 1.2
      * @see #setFetchDirection
      */
+    @Override
     public int getFetchDirection() throws SQLException {
         return 0;
     }
@@ -1097,6 +1154,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @since 1.2
      * @see #getFetchSize
      */
+    @Override
     public void setFetchSize(int rows) throws SQLException {
     }
 
@@ -1114,6 +1172,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @since 1.2
      * @see #setFetchSize
      */
+    @Override
     public int getFetchSize() throws SQLException {
         return 0;
     }
@@ -1127,6 +1186,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
+    @Override
     public int getResultSetConcurrency() throws SQLException {
         return 0;
     }
@@ -1141,6 +1201,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
+    @Override
     public int getResultSetType() throws SQLException {
         return 0;
     }
@@ -1159,6 +1220,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @see #executeBatch
      * @since 1.2
      */
+    @Override
     public void addBatch(String sql) throws SQLException {
     }
 
@@ -1173,6 +1235,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @see #addBatch
      * @since 1.2
      */
+    @Override
     public void clearBatch() throws SQLException {
     }
 
@@ -1224,6 +1287,7 @@ public class EmulatedStatement implements PreparedStatement {
      * database fails to execute properly or attempts to return a result set.
      * @since 1.3
      */
+    @Override
     public int[] executeBatch() throws SQLException {
         int result[] = new int[this.batch];
         for (int index = 0; index < this.batch; index++) {
@@ -1240,6 +1304,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @since 1.2
      */
+    @Override
     public Connection getConnection() throws SQLException {
         return connection;
     }
@@ -1276,6 +1341,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @since 1.4
      * @see #execute
      */
+    @Override
     public boolean getMoreResults(int current) throws SQLException {
         return false;
     }
@@ -1291,6 +1357,7 @@ public class EmulatedStatement implements PreparedStatement {
      * @exception SQLException if a database access error occurs
      * @since 1.4
      */
+    @Override
     public ResultSet getGeneratedKeys() throws SQLException {
         return null;
     }
@@ -1317,6 +1384,7 @@ public class EmulatedStatement implements PreparedStatement {
      *            the given constant is not one of those allowed
      * @since 1.4
      */
+    @Override
     public int executeUpdate(String sql, int autoGeneratedKeys) throws SQLException {
         return 1;
     }
@@ -1341,6 +1409,7 @@ public class EmulatedStatement implements PreparedStatement {
      *            whose elements are valid column indexes
      * @since 1.4
      */
+    @Override
     public int executeUpdate(String sql, int[] columnIndexes) throws SQLException {
         return 1;
     }
@@ -1365,6 +1434,7 @@ public class EmulatedStatement implements PreparedStatement {
      *
      * @since 1.4
      */
+    @Override
     public int executeUpdate(String sql, String[] columnNames) throws SQLException {
         return 1;
     }
@@ -1408,6 +1478,7 @@ public class EmulatedStatement implements PreparedStatement {
      *
      * @since 1.4
      */
+    @Override
     public boolean execute(String sql, int autoGeneratedKeys) throws SQLException {
         return true;
     }
@@ -1449,6 +1520,7 @@ public class EmulatedStatement implements PreparedStatement {
      *
      * @since 1.4
      */
+    @Override
     public boolean execute(String sql, int[] columnIndexes) throws SQLException {
         return true;
     }
@@ -1491,6 +1563,7 @@ public class EmulatedStatement implements PreparedStatement {
      *
      * @since 1.4
      */
+    @Override
     public boolean execute(String sql, String[] columnNames) throws SQLException {
         return true;
     }
@@ -1505,15 +1578,18 @@ public class EmulatedStatement implements PreparedStatement {
      *
      * @since 1.4
      */
+    @Override
     public int getResultSetHoldability() throws SQLException {
         return 0;
     }
 
     // 236070: Methods introduced in JDK 1.6
 
+    @Override
     public void setAsciiStream(int columnIndex, InputStream stream, long length)  throws SQLException {
     }
 
+    @Override
     public void setAsciiStream(int columnIndex, InputStream stream)  throws SQLException {
     }
 
@@ -1523,9 +1599,11 @@ public class EmulatedStatement implements PreparedStatement {
     public void setAsciiStream(String columnLabel, InputStream stream)  throws SQLException {
     }
 
+    @Override
     public void setBlob(int columnIndex, InputStream stream, long length)  throws SQLException {
     }
 
+    @Override
     public void setBlob(int columnIndex, InputStream stream)  throws SQLException {
     }
 
@@ -1535,9 +1613,11 @@ public class EmulatedStatement implements PreparedStatement {
     public void setBlob(String columnLabel, InputStream stream)  throws SQLException {
     }
 
+    @Override
     public void setBinaryStream(int columnIndex, InputStream stream, long length)  throws SQLException {
     }
 
+    @Override
     public void setBinaryStream(int columnIndex, InputStream stream)  throws SQLException {
     }
 
@@ -1547,9 +1627,11 @@ public class EmulatedStatement implements PreparedStatement {
     public void setBinaryStream(String columnLabel, InputStream stream)  throws SQLException {
     }
 
+    @Override
     public void setCharacterStream(int columnIndex, Reader reader, long length)  throws SQLException {
     }
 
+    @Override
     public void setCharacterStream(int columnIndex, Reader reader)  throws SQLException {
     }
 
@@ -1559,9 +1641,11 @@ public class EmulatedStatement implements PreparedStatement {
     public void setCharacterStream(String columnLabel, Reader reader)  throws SQLException {
     }
 
+    @Override
     public void setClob(int columnIndex, Reader reader, long length)  throws SQLException {
     }
 
+    @Override
     public void setClob(int columnIndex, Reader reader)  throws SQLException {
     }
 
@@ -1571,9 +1655,11 @@ public class EmulatedStatement implements PreparedStatement {
     public void setClob(String columnLabel, Reader reader)  throws SQLException {
     }
 
+    @Override
     public void setNCharacterStream(int columnIndex, Reader reader, long length)  throws SQLException {
     }
 
+    @Override
     public void setNCharacterStream(int columnIndex, Reader reader)  throws SQLException {
     }
 
@@ -1583,9 +1669,11 @@ public class EmulatedStatement implements PreparedStatement {
     public void setNCharacterStream(String columnLabel, Reader reader)  throws SQLException {
     }
 
+    @Override
     public void setNClob(int columnIndex, Reader reader, long length)  throws SQLException {
     }
 
+    @Override
     public void setNClob(int columnIndex, Reader reader)  throws SQLException {
     }
 
@@ -1595,12 +1683,14 @@ public class EmulatedStatement implements PreparedStatement {
     public void setNClob(String columnLabel, Reader reader)  throws SQLException {
     }
 
+    @Override
     public void setNClob(int columnIndex, NClob nclob)  throws SQLException {
     }
 
     public void setNClob(String columnLabel, NClob nclob)  throws SQLException {
     }
 
+    @Override
     public void setNString(int columnIndex, String nString)  throws SQLException {
     }
 
@@ -1610,36 +1700,45 @@ public class EmulatedStatement implements PreparedStatement {
     public void setSQLXML(String columnLabel, SQLXML sqlxml)  throws SQLException {
     }
 
+    @Override
     public void setSQLXML(int columnIndex, SQLXML sqlxml)  throws SQLException {
     }
 
+    @Override
     public void setRowId(int columnIndex, RowId rowid)  throws SQLException {
     }
 
     public void setRowId(String columnLabel, RowId rowid)  throws SQLException {
     }
 
+    @Override
     public boolean isClosed()  throws SQLException {
         return false;
     }
 
+    @Override
     public boolean isPoolable()  throws SQLException {
         return false;
     }
 
+    @Override
     public void setPoolable(boolean poolable)  throws SQLException {
     }
 
     // From java.sql.Wrapper
+    @Override
     public boolean isWrapperFor(Class<?> iFace) throws SQLException{
         return false;
     }
 
+    @Override
     public <T>T unwrap(Class<T> iFace)  throws SQLException {
         return iFace.cast(this);
     }
 
+    @Override
     public boolean isCloseOnCompletion(){return false;}
 
+    @Override
     public void closeOnCompletion(){}
 }

--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/tools/beans/MessageDialog.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/tools/beans/MessageDialog.java
@@ -114,7 +114,7 @@ public class MessageDialog extends JDialog {
 
     /**
      * main entrypoint - starts the part when it is run as an application
-     * @param args java.lang.String[]
+     * @param exception java.lang.Throwable
      */
     public static void displayException(Throwable exception) {
         displayMessage(exception.toString());
@@ -122,7 +122,8 @@ public class MessageDialog extends JDialog {
 
     /**
      * main entrypoint - starts the part when it is run as an application
-     * @param args java.lang.String[]
+     * @param exception java.lang.Throwable
+     * @param parent java.awt.Container
      */
     public static void displayException(Throwable exception,
                                         java.awt.Container parent) {
@@ -131,7 +132,7 @@ public class MessageDialog extends JDialog {
 
     /**
      * main entrypoint - starts the part when it is run as an application
-     * @param args java.lang.String[]
+     * @param message java.lang.String
      */
     public static void displayMessage(String message) {
         try {
@@ -147,7 +148,8 @@ public class MessageDialog extends JDialog {
 
     /**
      * main entrypoint - starts the part when it is run as an application
-     * @param args java.lang.String[]
+     * @param message java.lang.String
+     * @param parent java.awt.Container
      */
     public static void displayMessage(String message,
                                       java.awt.Container parent) {


### PR DESCRIPTION
Fix javadoc errors in Core Test Framework classes.

Modified classes are part of Core Test Framework in Maven version in the main scope.
This fix removes build blockers for "oss-release" profile.
Mainly it is about Javadoc comments, but in org/eclipse/persistence/testing/tests/performance/emulateddb/Emulated*.java classes are some required method signature (add ` throws SQLException {`) changes.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>