### PR TITLE
[master] Bug 533724: Set the default to MILLISECONDS

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/PersistenceUnitProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/PersistenceUnitProperties.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 1998, 2018 IBM Corporation. All rights reserved.
+ * Copyright (c) 1998, 2019 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -3153,8 +3153,8 @@ public class PersistenceUnitProperties {
      * <p>
      * <b>Allowed Values:</b>
      * <ul>
-     * <li>"<code>java.util.concurrent.TimeUnit.MILLISECONDS</code>",
-     * <li>"<code>java.util.concurrent.TimeUnit.SECONDS</code>" (DEFAULT),
+     * <li>"<code>java.util.concurrent.TimeUnit.MILLISECONDS</code>" (DEFAULT), 
+     * <li>"<code>java.util.concurrent.TimeUnit.SECONDS</code>", 
      * <li>"<code>java.util.concurrent.TimeUnit.MINUTES</code>".
      * </ul>
      * @see #PESSIMISTIC_LOCK_TIMEOUT_UNIT
@@ -3181,8 +3181,8 @@ public class PersistenceUnitProperties {
      * <p>
      * <b>Allowed Values:</b>
      * <ul>
-     * <li>"<code>java.util.concurrent.TimeUnit.MILLISECONDS</code>",
-     * <li>"<code>java.util.concurrent.TimeUnit.SECONDS</code>" (DEFAULT),
+     * <li>"<code>java.util.concurrent.TimeUnit.MILLISECONDS</code>" (DEFAULT), 
+     * <li>"<code>java.util.concurrent.TimeUnit.SECONDS</code>", 
      * <li>"<code>java.util.concurrent.TimeUnit.MINUTES</code>".
      * </ul>
      * @see #QUERY_TIMEOUT

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/QueryHints.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/QueryHints.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -245,14 +246,14 @@ public class QueryHints {
      * @see org.eclipse.persistence.queries.ObjectLevelReadQuery#setWaitTimeout(Integer)
      */
     public static final String PESSIMISTIC_LOCK_TIMEOUT = "javax.persistence.lock.timeout";
-    
+
     /**
      * "eclipselink.pessimistic.lock.timeout.unit"
      * <p>Configures the pessimistic lock timeout unit value. Allows users more refinement.
      * <b>Valid Values:</b>
      * <ul>
-     * <li>"<code>java.util.concurrent.TimeUnit.MILLISECONDS</code>",
-     * <li>"<code>java.util.concurrent.TimeUnit.SECONDS</code>" (DEFAULT),
+     * <li>"<code>java.util.concurrent.TimeUnit.MILLISECONDS</code>" (DEFAULT), 
+     * <li>"<code>java.util.concurrent.TimeUnit.SECONDS</code>", 
      * <li>"<code>java.util.concurrent.TimeUnit.MINUTES</code>".
      * </ul>
      * @see org.eclipse.persistence.queries.ObjectLevelReadQuery#setWaitTimeoutUnit(TimeUnit)
@@ -380,8 +381,8 @@ public class QueryHints {
      * <p>Configures the query timeout unit value. Allows users more refinement.
      * <b>Valid Values:</b>
      * <ul>
-     * <li>"<code>java.util.concurrent.TimeUnit.MILLISECONDS</code>",
-     * <li>"<code>java.util.concurrent.TimeUnit.SECONDS</code>" (DEFAULT),
+     * <li>"<code>java.util.concurrent.TimeUnit.MILLISECONDS</code>" (DEFAULT), 
+     * <li>"<code>java.util.concurrent.TimeUnit.SECONDS</code>", 
      * <li>"<code>java.util.concurrent.TimeUnit.MINUTES</code>".
      * </ul>
      * @see org.eclipse.persistence.queries.DatabaseQuery#setQueryTimeoutUnit(TimeUnit)

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/descriptors/DescriptorQueryManager.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/descriptors/DescriptorQueryManager.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -131,7 +132,7 @@ public class DescriptorQueryManager implements Cloneable, Serializable {
     public static final int DefaultTimeout = -1;
     protected int queryTimeout;
 
-    public static final TimeUnit DefaultTimeoutUnit = TimeUnit.SECONDS;
+    public static final TimeUnit DefaultTimeoutUnit = TimeUnit.MILLISECONDS;
     protected TimeUnit queryTimeoutUnit;
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 1998, 2018 IBM Corporation. All rights reserved.
+ * Copyright (c) 1998, 2019 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -1523,6 +1523,8 @@ public class DatabasePlatform extends DatasourcePlatform {
     /**
      * Platforms that support the WAIT option should override this method.
      * By default the wait timeout is ignored.
+     * 
+     *  @see DatabasePlatform#supportsWaitForUpdate()
      */
     public String getSelectForUpdateWaitString(Integer waitTimeout) {
         return getSelectForUpdateString();
@@ -2333,6 +2335,16 @@ public class DatabasePlatform extends DatasourcePlatform {
      * this method.
      */
     public boolean supportsVPD() {
+        return false;
+    }
+
+    /**
+     *  INTERNAL:
+     *  Indicates whether the platform supports timeouts on For Update
+     *  
+     *  @see DatabasePlatform#getSelectForUpdateWaitString(Integer waitTimeout)
+     */
+    public boolean supportsWaitForUpdate() {
         return false;
     }
 

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/sessions/PropertiesHandler.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/sessions/PropertiesHandler.java
@@ -717,7 +717,7 @@ public class PropertiesHandler {
             };
         }
     }
-    
+
     protected static class PessimisticLockTimeoutUnitProp extends Prop {
         PessimisticLockTimeoutUnitProp() {
             super(PersistenceUnitProperties.PESSIMISTIC_LOCK_TIMEOUT_UNIT, DescriptorQueryManager.DefaultTimeoutUnit.toString());

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/OraclePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/OraclePlatform.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 1998, 2018 IBM Corporation. All rights reserved.
+ * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -885,6 +885,11 @@ public class OraclePlatform extends org.eclipse.persistence.platform.database.Da
      */
     @Override
     public boolean supportsVPD() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsWaitForUpdate() {
         return true;
     }
 

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/DatabaseQuery.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/DatabaseQuery.java
@@ -1839,7 +1839,7 @@ public abstract class DatabaseQuery implements Cloneable, Serializable {
         if (this.queryTimeout == DescriptorQueryManager.DefaultTimeout) {
             if (this.descriptor == null) {
                 setQueryTimeout(this.session.getQueryTimeoutDefault());
-                if(this.session.getQueryTimeoutUnitDefault() == null){
+                if(this.session.getQueryTimeoutUnitDefault() == null) {
                     this.session.setQueryTimeoutUnitDefault(DescriptorQueryManager.DefaultTimeoutUnit);
                 }
                 setQueryTimeoutUnit(this.session.getQueryTimeoutUnitDefault());
@@ -1850,10 +1850,10 @@ public abstract class DatabaseQuery implements Cloneable, Serializable {
                     timeout = this.session.getQueryTimeoutDefault();
                 }
                 setQueryTimeout(timeout);
-                
+
                 //Bug #456067
                 TimeUnit timeoutUnit = this.descriptor.getQueryManager().getQueryTimeoutUnit();
-                if(timeoutUnit == DescriptorQueryManager.DefaultTimeoutUnit){
+                if(timeoutUnit == DescriptorQueryManager.DefaultTimeoutUnit) {
                     timeoutUnit = this.session.getQueryTimeoutUnitDefault();
                 }
                 setQueryTimeoutUnit(timeoutUnit);

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/ObjectLevelReadQuery.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/ObjectLevelReadQuery.java
@@ -2200,10 +2200,10 @@ public abstract class ObjectLevelReadQuery extends ObjectBuildingQuery {
                         convertedTimeout = TimeUnit.SECONDS.convert(timeout, timeoutUnit);
                         if(convertedTimeout > Integer.MAX_VALUE){
                             timeout = Integer.MAX_VALUE;
-                        }else {
+                        } else {
                             timeout = convertedTimeout.intValue();
                         }
-                      //Round up the timeout if SECONDS are larger than the given units
+                        //Round up the timeout if SECONDS are larger than the given units
                         if(TimeUnit.SECONDS.compareTo(timeoutUnit) > 0 && timeout % 1000 > 0){
                             timeout += 1;
                         }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/sessions/factories/ProjectClassGenerator.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/sessions/factories/ProjectClassGenerator.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -1046,6 +1047,9 @@ public class ProjectClassGenerator {
         }
         if (query.getQueryTimeout() != DescriptorQueryManager.DefaultTimeout) {
             method.addLine(queryIdentifier + ".setQueryTimeout(" + String.valueOf(query.getQueryTimeout()) + ");");
+        }
+        if (query.getQueryTimeoutUnit() != DescriptorQueryManager.DefaultTimeoutUnit) {
+            method.addLine(queryIdentifier + ".setQueryTimeoutUnit(" + query.getQueryTimeoutUnit() + ");");
         }
         if (!query.shouldUseWrapperPolicy()) {
             method.addLine(queryIdentifier + ".setShouldUseWrapperPolicy(" + String.valueOf(query.shouldUseWrapperPolicy()) + ");");

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQueryHints.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQueryHints.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2017 IBM Corporation. All rights reserved.
+ * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -42,13 +42,13 @@ import org.eclipse.persistence.jpa.test.framework.DDLGen;
 import org.eclipse.persistence.jpa.test.framework.Emf;
 import org.eclipse.persistence.jpa.test.framework.EmfRunner;
 import org.eclipse.persistence.jpa.test.framework.PUPropertiesProvider;
-import org.eclipse.persistence.jpa.test.framework.Property;
 import org.eclipse.persistence.queries.ScrollableCursor;
 import org.eclipse.persistence.sessions.Connector;
 import org.eclipse.persistence.sessions.DatabaseLogin;
 import org.eclipse.persistence.sessions.Session;
 import org.eclipse.persistence.sessions.SessionEvent;
 import org.eclipse.persistence.sessions.SessionEventAdapter;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -56,26 +56,16 @@ import org.junit.runner.RunWith;
 @RunWith(EmfRunner.class)
 public class TestQueryHints implements PUPropertiesProvider {
 
-    private static int setTimeout;
+    private static int statementTimeout;
 
-    private final static int realTimeout = 3099;
+    private final static int propertyTimeout = 3099;
 
     @Emf(name = "defaultEMF", classes = { Employee.class }, createTables = DDLGen.DROP_CREATE)
     private EntityManagerFactory emf;
 
-    @Emf(name = "TimeoutPropertiesEMF", classes = { Employee.class }, createTables = DDLGen.DROP_CREATE, properties = {
-            @Property(name = PersistenceUnitProperties.QUERY_TIMEOUT, value = "" + TestQueryHints.realTimeout),
-            @Property(name = PersistenceUnitProperties.QUERY_TIMEOUT_UNIT, value = "MINUTES") })
-    private EntityManagerFactory emfTimeoutProperties;
-
     /**
-     * Test that setting the Query Hint: QueryHints.JDBC_TIMEOUT sets the
-     * timeout accordingly on the executed java.sql.Statement.
-     *
-     * QueryHints.JDBC_TIMEOUT expects seconds by default.
-     * java.sql.Statement.getQueryTimeout() will return a value in seconds.
-     *
-     * @throws Exception
+     * Test that setting the Query Hint: QueryHints.JDBC_TIMEOUT to the default value
+     *  will see the expected value of seconds being set on the statement
      */
     @Test
     public void testJDBCQueryTimeout() throws Exception {
@@ -84,15 +74,51 @@ public class TestQueryHints implements PUPropertiesProvider {
             em = emf.createEntityManager();
 
             em.getTransaction().begin();
-            Query q = em.createQuery("SELECT x FROM Employee x").setHint(QueryHints.JDBC_TIMEOUT, TestQueryHints.realTimeout);
-            q.getResultList();
+            em.createQuery("SELECT x FROM Employee x")
+                .setHint(QueryHints.QUERY_TIMEOUT, TestQueryHints.propertyTimeout)
+                .getResultList();
 
-            Assert.assertEquals(TestQueryHints.realTimeout, TestQueryHints.setTimeout);
+            //Convert the timeout set (MILLISECONDS) to what is expected by the JDBC layer (SECONDS)
+            double queryTimeoutSeconds = TestQueryHints.propertyTimeout / 1000d;
+            //if there was a remainder, it should round up
+            if(queryTimeoutSeconds % 1 > 0) {
+                queryTimeoutSeconds += 1;
+            }
 
-            em.getTransaction().rollback();
+            Assert.assertEquals((int)queryTimeoutSeconds, TestQueryHints.statementTimeout);
         } catch (Exception e) {
             Assert.fail(e.getLocalizedMessage());
         } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if (em != null) {
+                em.close();
+            }
+        }
+
+        try {
+            em = emf.createEntityManager();
+
+            em.getTransaction().begin();
+            em.createQuery("SELECT x FROM Employee x")
+                .setHint(QueryHints.JDBC_TIMEOUT, TestQueryHints.propertyTimeout)
+                .getResultList();
+
+            //Convert the timeout set (MILLISECONDS) to what is expected by the JDBC layer (SECONDS)
+            double queryTimeoutSeconds = TestQueryHints.propertyTimeout / 1000d;
+            //if there was a remainder, it should round up
+            if(queryTimeoutSeconds % 1 > 0) {
+                queryTimeoutSeconds += 1;
+            }
+
+            Assert.assertEquals((int)queryTimeoutSeconds, TestQueryHints.statementTimeout);
+        } catch (Exception e) {
+            Assert.fail(e.getLocalizedMessage());
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
             if (em != null) {
                 em.close();
             }
@@ -100,59 +126,107 @@ public class TestQueryHints implements PUPropertiesProvider {
     }
 
     /**
-     * Test that setting the Query Hint: QueryHints.JDBC_TIMEOUT_UNIT sets the
-     * timeout accordingly on the executed java.sql.Statement.
-     *
-     * QueryHints.JDBC_TIMEOUT expects seconds by default.
-     * java.sql.Statement.getQueryTimeout() will return a value in seconds.
-     *
-     * @throws Exception
+     * Test that setting the Query Hint: QueryHints.JDBC_TIMEOUT_UNIT to the "SECONDS" value
+     *  will see the expected value of seconds being set on the statement
      */
     @Test
-    public void testQueryTimeoutUnit() throws Exception {
+    public void testQueryTimeoutUnitSeconds() throws Exception {
         EntityManager em = null;
         try {
             em = emf.createEntityManager();
 
-            /*
-             * Default Case: Seconds
-             * Without being set, the units should be in seconds already.
-             */
             em.getTransaction().begin();
-            Query q = em.createQuery("SELECT x FROM Employee x").setHint(QueryHints.JDBC_TIMEOUT, TestQueryHints.realTimeout);
-            q.getResultList();
-            int queryTimeoutSeconds = TestQueryHints.realTimeout;
-            Assert.assertEquals(queryTimeoutSeconds, TestQueryHints.setTimeout);
-            em.getTransaction().rollback();
+            em.createQuery("SELECT x FROM Employee x")
+                .setHint(QueryHints.QUERY_TIMEOUT, TestQueryHints.propertyTimeout)
+                .setHint(QueryHints.QUERY_TIMEOUT_UNIT, TimeUnit.SECONDS.toString()).getResultList();
 
-            /*
-             * Case 2: Minutes
-             * Setting units to Minutes, value should come back converted to Seconds
-             */
-            em.getTransaction().begin();
-            q = em.createQuery("SELECT x FROM Employee x").setHint(QueryHints.JDBC_TIMEOUT, TestQueryHints.realTimeout).setHint(QueryHints.QUERY_TIMEOUT_UNIT, TimeUnit.MINUTES.toString());
-            q.getResultList();
-            queryTimeoutSeconds = TestQueryHints.realTimeout * 60;
-            Assert.assertEquals(queryTimeoutSeconds, TestQueryHints.setTimeout);
-            em.getTransaction().rollback();
+            //Convert the timeout set (SECONDS) to what is expected by the JDBC layer (SECONDS)
+            int queryTimeoutSecondsDouble = TestQueryHints.propertyTimeout;
 
-            /*
-             * Case 3: Milliseconds
-             * Setting units to Milliseconds, value should come back converted to Seconds
-             */
-            em.getTransaction().begin();
-            q = em.createQuery("SELECT x FROM Employee x").setHint(QueryHints.JDBC_TIMEOUT, TestQueryHints.realTimeout).setHint(QueryHints.QUERY_TIMEOUT_UNIT, TimeUnit.MILLISECONDS.toString());
-            q.getResultList();
-            double queryTimeoutSecondsDouble = TestQueryHints.realTimeout / 1000d;
-            //if there was a remainder, it should round up
-            if(queryTimeoutSecondsDouble % 1 > 0){
-                queryTimeoutSecondsDouble += 1;
-            }
-            Assert.assertEquals((int)queryTimeoutSecondsDouble, TestQueryHints.setTimeout);
-            em.getTransaction().rollback();
+            Assert.assertEquals(queryTimeoutSecondsDouble, TestQueryHints.statementTimeout);
         } catch (Exception e) {
             Assert.fail(e.getLocalizedMessage());
         } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if (em != null) {
+                em.close();
+            }
+        }
+
+        try {
+            em = emf.createEntityManager();
+
+            em.getTransaction().begin();
+            em.createQuery("SELECT x FROM Employee x")
+                .setHint(QueryHints.JDBC_TIMEOUT, TestQueryHints.propertyTimeout)
+                .setHint(QueryHints.QUERY_TIMEOUT_UNIT, TimeUnit.SECONDS.toString()).getResultList();
+
+            //Convert the timeout set (SECONDS) to what is expected by the JDBC layer (SECONDS)
+            int queryTimeoutSecondsDouble = TestQueryHints.propertyTimeout;
+
+            Assert.assertEquals(queryTimeoutSecondsDouble, TestQueryHints.statementTimeout);
+        } catch (Exception e) {
+            Assert.fail(e.getLocalizedMessage());
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if (em != null) {
+                em.close();
+            }
+        }
+    }
+
+    /**
+     * Test that setting the Query Hint: QueryHints.JDBC_TIMEOUT_UNIT to the "MINUTES" value
+     *  will see the expected value of seconds being set on the statement
+     */
+    @Test
+    public void testQueryTimeoutUnitMinutes() throws Exception {
+        EntityManager em = null;
+        try {
+            em = emf.createEntityManager();
+
+            em.getTransaction().begin();
+            em.createQuery("SELECT x FROM Employee x")
+                .setHint(QueryHints.QUERY_TIMEOUT, TestQueryHints.propertyTimeout)
+                .setHint(QueryHints.QUERY_TIMEOUT_UNIT, TimeUnit.MINUTES.toString()).getResultList();
+
+            //Convert the timeout set (MINUTES) to what is expected by the JDBC layer (SECONDS)
+            int queryTimeoutSeconds = TestQueryHints.propertyTimeout * 60;
+
+            Assert.assertEquals(queryTimeoutSeconds, TestQueryHints.statementTimeout);
+        } catch (Exception e) {
+            Assert.fail(e.getLocalizedMessage());
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if (em != null) {
+                em.close();
+            }
+        }
+
+        try {
+            em = emf.createEntityManager();
+
+            em.getTransaction().begin();
+            em.createQuery("SELECT x FROM Employee x")
+                .setHint(QueryHints.JDBC_TIMEOUT, TestQueryHints.propertyTimeout)
+                .setHint(QueryHints.QUERY_TIMEOUT_UNIT, TimeUnit.MINUTES.toString()).getResultList();
+
+            //Convert the timeout set (MINUTES) to what is expected by the JDBC layer (SECONDS)
+            int queryTimeoutSeconds = TestQueryHints.propertyTimeout * 60;
+
+            Assert.assertEquals(queryTimeoutSeconds, TestQueryHints.statementTimeout);
+        } catch (Exception e) {
+            Assert.fail(e.getLocalizedMessage());
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
             if (em != null) {
                 em.close();
             }
@@ -270,9 +344,11 @@ public class TestQueryHints implements PUPropertiesProvider {
         }
 
         public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            //Get the query timeout being set on the statement
+            //This value should be in seconds, since that is what the Statement expects
             if (method.getName().equals("setQueryTimeout") && proxy instanceof PreparedStatement) {
-                if(args.length > 0){
-                    TestQueryHints.setTimeout = (Integer)args[0];
+                if(args.length > 0) {
+                    TestQueryHints.statementTimeout = (Integer)args[0];
                 }
             }
             return method.invoke(wrappedStatement, args);

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQueryProperties.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQueryProperties.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015 IBM Corporation. All rights reserved.
+ * Copyright (c) 2015, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -28,7 +28,6 @@ import java.util.Map;
 
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
-import javax.persistence.Query;
 
 import org.eclipse.persistence.config.PersistenceUnitProperties;
 import org.eclipse.persistence.config.SessionCustomizer;
@@ -43,6 +42,7 @@ import org.eclipse.persistence.sessions.DatabaseLogin;
 import org.eclipse.persistence.sessions.Session;
 import org.eclipse.persistence.sessions.SessionEvent;
 import org.eclipse.persistence.sessions.SessionEventAdapter;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,31 +50,27 @@ import org.junit.runner.RunWith;
 @RunWith(EmfRunner.class)
 public class TestQueryProperties implements PUPropertiesProvider {
 
-    private static int setTimeout;
+    private static int statementTimeout;
 
-    private final static int realTimeout = 3099;
+    private final static int propertyTimeout = 3099;
 
     @Emf(name = "timeoutEMF", classes = { Employee.class }, createTables = DDLGen.DROP_CREATE, properties = {
-            @Property(name = PersistenceUnitProperties.QUERY_TIMEOUT, value = "" + TestQueryProperties.realTimeout) })
+            @Property(name = PersistenceUnitProperties.QUERY_TIMEOUT, value = "" + TestQueryProperties.propertyTimeout) })
     private EntityManagerFactory emfTimeout;
 
+    @Emf(name = "timeoutWithUnitSecondsEMF", classes = { Employee.class }, createTables = DDLGen.DROP_CREATE, properties = {
+            @Property(name = PersistenceUnitProperties.QUERY_TIMEOUT, value = "" + TestQueryProperties.propertyTimeout),
+            @Property(name = PersistenceUnitProperties.QUERY_TIMEOUT_UNIT, value = "SECONDS") })
+    private EntityManagerFactory emfTimeoutSeconds;
+
     @Emf(name = "timeoutWithUnitMintuesEMF", classes = { Employee.class }, createTables = DDLGen.DROP_CREATE, properties = {
-            @Property(name = PersistenceUnitProperties.QUERY_TIMEOUT, value = "" + TestQueryProperties.realTimeout),
+            @Property(name = PersistenceUnitProperties.QUERY_TIMEOUT, value = "" + TestQueryProperties.propertyTimeout),
             @Property(name = PersistenceUnitProperties.QUERY_TIMEOUT_UNIT, value = "MINUTES") })
     private EntityManagerFactory emfTimeoutMinutes;
 
-    @Emf(name = "timeoutWithUnitMillisecondsEMF", classes = { Employee.class }, createTables = DDLGen.DROP_CREATE, properties = {
-            @Property(name = PersistenceUnitProperties.QUERY_TIMEOUT, value = "" + TestQueryProperties.realTimeout),
-            @Property(name = PersistenceUnitProperties.QUERY_TIMEOUT_UNIT, value = "MILLISECONDS") })
-    private EntityManagerFactory emfTimeoutMilliseconds;
-
     /**
-     * Test that setting the property "PersistenceUnitProperties.QUERY_TIMEOUT_UNIT" sets the
-     * timeout accordingly on the executed java.sql.Statement.
-     *
-     * Assumes value will be converted to Seconds for JDBC.
-     *
-     * @throws Exception
+     * Test that setting the property: PersistenceUnitProperties.QUERY_TIMEOUT_UNIT to the default value
+     *  will see the expected value of seconds being set on the statement
      */
     @Test
     public void testTimeoutUnitDefault() throws Exception {
@@ -83,17 +79,22 @@ public class TestQueryProperties implements PUPropertiesProvider {
             em = emfTimeout.createEntityManager();
 
             em.getTransaction().begin();
-            Query q = em.createQuery("SELECT x FROM Employee x");
-            q.getResultList();
+            em.createQuery("SELECT x FROM Employee x").getResultList();
 
-            int queryTimeoutSeconds = TestQueryProperties.realTimeout;
+            //Convert the timeout set (MILLISECONDS) to what is expected by the JDBC layer (SECONDS)
+            double queryTimeoutSeconds = TestQueryProperties.propertyTimeout / 1000d;
+            //if there was a remainder, it should round up
+            if(queryTimeoutSeconds % 1 > 0) {
+                queryTimeoutSeconds += 1;
+            }
 
-            Assert.assertEquals(queryTimeoutSeconds, TestQueryProperties.setTimeout);
-
-            em.getTransaction().rollback();
+            Assert.assertEquals((int)queryTimeoutSeconds, TestQueryProperties.statementTimeout);
         } catch (Exception e) {
             Assert.fail(e.getLocalizedMessage());
         } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
             if (em != null) {
                 em.close();
             }
@@ -101,12 +102,37 @@ public class TestQueryProperties implements PUPropertiesProvider {
     }
 
     /**
-     * Test that setting the property "PersistenceUnitProperties.QUERY_TIMEOUT_UNIT" sets the
-     * timeout accordingly on the executed java.sql.Statement.
-     *
-     * Assumes value will be converted to Seconds for JDBC.
-     *
-     * @throws Exception
+     * Test that setting the property: PersistenceUnitProperties.QUERY_TIMEOUT_UNIT to "SECONDS" value
+     *  will see the expected value of seconds being set on the statement
+     */
+    @Test
+    public void testTimeoutUnitSeconds() throws Exception {
+        EntityManager em = null;
+        try {
+            em = emfTimeoutSeconds.createEntityManager();
+
+            em.getTransaction().begin();
+            em.createQuery("SELECT x FROM Employee x").getResultList();
+
+            //Convert the timeout set (SECONDS) to what is expected by the JDBC layer (SECONDS)
+            int queryTimeoutSeconds = TestQueryProperties.propertyTimeout;
+
+            Assert.assertEquals(queryTimeoutSeconds, TestQueryProperties.statementTimeout);
+        } catch (Exception e) {
+            Assert.fail(e.getLocalizedMessage());
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if (em != null) {
+                em.close();
+            }
+        }
+    }
+
+    /**
+     * Test that setting the property: PersistenceUnitProperties.QUERY_TIMEOUT_UNIT to "MINUTES" value
+     *  will see the expected value of seconds being set on the statement
      */
     @Test
     public void testTimeoutUnitMinutes() throws Exception {
@@ -115,53 +141,18 @@ public class TestQueryProperties implements PUPropertiesProvider {
             em = emfTimeoutMinutes.createEntityManager();
 
             em.getTransaction().begin();
-            Query q = em.createQuery("SELECT x FROM Employee x");
-            q.getResultList();
+            em.createQuery("SELECT x FROM Employee x").getResultList();
 
-            int queryTimeoutSeconds = TestQueryProperties.realTimeout * 60;
+            //Convert the timeout set (MINUTES) to what is expected by the JDBC layer (SECONDS)
+            int queryTimeoutSeconds = TestQueryProperties.propertyTimeout * 60;
 
-            Assert.assertEquals(queryTimeoutSeconds, TestQueryProperties.setTimeout);
-
-            em.getTransaction().rollback();
+            Assert.assertEquals(queryTimeoutSeconds, TestQueryProperties.statementTimeout);
         } catch (Exception e) {
             Assert.fail(e.getLocalizedMessage());
         } finally {
-            if (em != null) {
-                em.close();
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
             }
-        }
-    }
-
-    /**
-     * Test that setting the property "PersistenceUnitProperties.QUERY_TIMEOUT_UNIT" sets the
-     * timeout accordingly on the executed java.sql.Statement.
-     *
-     * Assumes value will be converted to Seconds for JDBC.
-     *
-     * @throws Exception
-     */
-    @Test
-    public void testTimeoutUnitMilliseconds() throws Exception {
-        EntityManager em = null;
-        try {
-            em = emfTimeoutMilliseconds.createEntityManager();
-
-            em.getTransaction().begin();
-            Query q = em.createQuery("SELECT x FROM Employee x");
-            q.getResultList();
-
-            double queryTimeoutSeconds = TestQueryProperties.realTimeout / 1000d;
-            //if there was a remainder, it should round up
-            if(queryTimeoutSeconds % 1 > 0){
-                queryTimeoutSeconds += 1;
-            }
-
-            Assert.assertEquals((int)queryTimeoutSeconds, TestQueryProperties.setTimeout);
-
-            em.getTransaction().rollback();
-        } catch (Exception e) {
-            Assert.fail(e.getLocalizedMessage());
-        } finally {
             if (em != null) {
                 em.close();
             }
@@ -234,9 +225,11 @@ public class TestQueryProperties implements PUPropertiesProvider {
         }
 
         public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            //Get the query timeout being set on the statement
+            //This value should be in seconds, since that is what the Statement expects
             if (method.getName().equals("setQueryTimeout") && proxy instanceof PreparedStatement) {
-                if (args.length > 0) {
-                    TestQueryProperties.setTimeout = (Integer) args[0];
+                if(args.length > 0) {
+                    TestQueryProperties.statementTimeout = (Integer) args[0];
                 }
             }
             return method.invoke(wrappedStatement, args);

--- a/jpa/eclipselink.jpa.test/resource/eclipselink-advanced-field-access-model/osgi/persistence.xml
+++ b/jpa/eclipselink.jpa.test/resource/eclipselink-advanced-field-access-model/osgi/persistence.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -41,10 +41,10 @@
         <class>org.eclipse.persistence.testing.models.jpa.fieldaccess.advanced.WorldRank</class>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="javax.persistence.lock.timeout" value="5"/>
+            <property name="javax.persistence.lock.timeout" value="5000"/>
             <!--This property is added to test 'querytimeout' property and test is
                 implemented in 'EntityManagerJUnitTestSuite.testQueryTimeOut()'-->
-            <property name="javax.persistence.query.timeout" value="100"/>
+            <property name="javax.persistence.query.timeout" value="100000"/>
             <property name="javax.persistence.jdbc.driver" value="TEST_DRIVER_CLASS"/>
             <property name="javax.persistence.jdbc.url" value="TEST_DATABASE_URL"/>
             <property name="javax.persistence.jdbc.user" value="TEST_DATABASE_USER"/>

--- a/jpa/eclipselink.jpa.test/resource/eclipselink-advanced-field-access-model/persistence.xml
+++ b/jpa/eclipselink.jpa.test/resource/eclipselink-advanced-field-access-model/persistence.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -18,10 +18,10 @@
         <mapping-file>META-INF/static-ref-orm.xml</mapping-file>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="javax.persistence.lock.timeout" value="5"/>
+            <property name="javax.persistence.lock.timeout" value="5000"/>
             <!--This property is added to test 'querytimeout' property and test is
                 implemented in 'EntityManagerJUnitTestSuite.testQueryTimeOut()'-->
-            <property name="javax.persistence.query.timeout" value="100"/>
+            <property name="javax.persistence.query.timeout" value="100000"/>
             <property name="javax.persistence.jdbc.driver" value="@driverClass@"/>
             <property name="javax.persistence.jdbc.url" value="@dbURL@"/>
             <property name="javax.persistence.jdbc.user" value="@dbUser@"/>

--- a/jpa/eclipselink.jpa.test/resource/eclipselink-advanced-field-access-model/server/persistence.xml
+++ b/jpa/eclipselink.jpa.test/resource/eclipselink-advanced-field-access-model/server/persistence.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -21,7 +21,7 @@
         <properties>
             <!--This property is added to test 'querytimeout' property and test is
                 implemented in 'EntityManagerJUnitTestSuite.testQueryTimeOut()'-->
-            <property name="javax.persistence.query.timeout" value="100"/>
+            <property name="javax.persistence.query.timeout" value="100000"/>
             <property name="eclipselink.target-server" value="@server-platform@"/>
             <property name="eclipselink.target-database" value="@database-platform@"/>
             <property name="eclipselink.weaving" value="@server-weaving@"/>

--- a/jpa/eclipselink.jpa.test/resource/eclipselink-advanced-field-access-model/spring/persistence.xml
+++ b/jpa/eclipselink.jpa.test/resource/eclipselink-advanced-field-access-model/spring/persistence.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -18,10 +18,10 @@
         <mapping-file>META-INF/static-ref-orm.xml</mapping-file>
         <!-- exclude-unlisted-classes>false</exclude-unlisted-classes-->
         <properties>
-            <property name="javax.persistence.lock.timeout" value="5"/>
+            <property name="javax.persistence.lock.timeout" value="5000"/>
             <!--This property is added to test 'querytimeout' property and test is
                 implemented in 'EntityManagerJUnitTestSuite.testQueryTimeOut()'-->
-            <property name="javax.persistence.query.timeout" value="100"/>
+            <property name="javax.persistence.query.timeout" value="100000"/>
             <!--property name="javax.persistence.jdbc.driver" value="TEST_DRIVER_CLASS"/>
             <property name="javax.persistence.jdbc.url" value="TEST_DATABASE_URL"/>
             <property name="javax.persistence.jdbc.user" value="TEST_DATABASE_USER"/>

--- a/jpa/eclipselink.jpa.test/resource/eclipselink-annotation-model/osgi/persistence.xml
+++ b/jpa/eclipselink.jpa.test/resource/eclipselink-annotation-model/osgi/persistence.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -78,7 +78,7 @@
             <property name="eclipselink.weaving.internal" value="false"/-->
             <property name="eclipselink.weaving" value="false"/>
             <property name="eclipselink.orm.validate.schema" value="true"/>
-            <property name="javax.persistence.lock.timeout" value="5"/>
+            <property name="javax.persistence.lock.timeout" value="5000"/>
             <property name="eclipselink.id-validation" value="NEGATIVE"/>
         </properties>
     </persistence-unit>

--- a/jpa/eclipselink.jpa.test/resource/eclipselink-annotation-model/persistence.xml
+++ b/jpa/eclipselink.jpa.test/resource/eclipselink-annotation-model/persistence.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -76,9 +76,9 @@
             <property name="eclipselink.weaving.eager" value="true"/>
             <property name="eclipselink.weaving.internal" value="false"/-->
             <property name="eclipselink.orm.validate.schema" value="true"/>
-            <property name="javax.persistence.lock.timeout" value="5"/>
+            <property name="javax.persistence.lock.timeout" value="5000"/>
             <property name="eclipselink.id-validation" value="NEGATIVE"/>
-            <property name="javax.persistence.query.timeout" value="20"/>
+            <property name="javax.persistence.query.timeout" value="20000"/>
             <property name="NAME" value="Montreal%"/>
             <!-- Since we don't exclude unlisted classes here, we will       -->
             <!-- eventually hit the multitenant entities which turn native   -->

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/advanced/Employee.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/advanced/Employee.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -194,7 +195,7 @@ import org.eclipse.persistence.sessions.Session;
     name="findAllEmployeesByIdAndFirstName",
     query="Select employee from Employee employee where employee.id = :id and employee.firstName = :firstName",
     hints={
-                @QueryHint(name=QueryHints.PESSIMISTIC_LOCK_TIMEOUT, value="15")
+                @QueryHint(name=QueryHints.PESSIMISTIC_LOCK_TIMEOUT, value="15000")
     }
 ),
 // BUG 259329 - Update named queries have a lock mode type defaulted to NONE need to

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/composite/advanced/member_2/Employee.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/composite/advanced/member_2/Employee.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -152,7 +153,7 @@ import static org.eclipse.persistence.annotations.OptimisticLockingType.VERSION_
     name="findAllEmployeesByIdAndFirstName",
     query="Select employee from Employee employee where employee.id = :id and employee.firstName = :firstName",
     hints={
-                @QueryHint(name=QueryHints.PESSIMISTIC_LOCK_TIMEOUT, value="15")
+                @QueryHint(name=QueryHints.PESSIMISTIC_LOCK_TIMEOUT, value="15000")
     }
 ),
 // BUG 259329 - Update named queries have a lock mode type defaulted to NONE need to

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/advanced/EntityManagerJUnitTestSuite.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/advanced/EntityManagerJUnitTestSuite.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 1998, 2018 IBM Corporation. All rights reserved.
+ * Copyright (c) 1998, 2019 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -2065,7 +2065,7 @@ public class EntityManagerJUnitTestSuite extends JUnitTestCase {
                     beginTransaction(em2);
 
                     HashMap<String, Object> properties = new HashMap<String, Object>();
-                    properties.put(QueryHints.PESSIMISTIC_LOCK_TIMEOUT, 5);
+                    properties.put(QueryHints.PESSIMISTIC_LOCK_TIMEOUT, 5000);
                     Employee employee2 = em2.find(Employee.class, employee.getId(), LockModeType.PESSIMISTIC_READ, properties);
                     employee2.setFirstName("Invalid Lock Employee");
                     commitTransaction(em2);
@@ -2118,7 +2118,7 @@ public class EntityManagerJUnitTestSuite extends JUnitTestCase {
                     beginTransaction(em2);
 
                     HashMap<String, Object> properties = new HashMap<String, Object>();
-                    properties.put(QueryHints.PESSIMISTIC_LOCK_TIMEOUT, 5);
+                    properties.put(QueryHints.PESSIMISTIC_LOCK_TIMEOUT, 5000);
                     Employee employee2 = em2.find(Employee.class, employee.getId(), LockModeType.PESSIMISTIC_WRITE, properties);
                     employee2.setFirstName("Invalid Lock Employee");
                     commitTransaction(em2);

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/advanced/PessimisticLockingExtendedScopeTestSuite.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/advanced/PessimisticLockingExtendedScopeTestSuite.java
@@ -1,6 +1,7 @@
 /*
- * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2010, 2018 SAP. All rights reserved.
+ * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019 SAP. All rights reserved.
+ * Copyright (c) 2019 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -379,7 +380,7 @@ import org.eclipse.persistence.testing.models.jpa.advanced.entities.EntyE;
         LockModeType lockMode = LockModeType.PESSIMISTIC_WRITE;
         Map<String, Object> properties = new HashMap();
         properties.put(QueryHints.PESSIMISTIC_LOCK_SCOPE, PessimisticLockScope.EXTENDED);
-        properties.put(QueryHints.PESSIMISTIC_LOCK_TIMEOUT, 10);
+        properties.put(QueryHints.PESSIMISTIC_LOCK_TIMEOUT, 10000);
 
         EntityManager em1 = createEntityManager();
         try {

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/composite/advanced/EntityManagerJUnitTestSuite.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/composite/advanced/EntityManagerJUnitTestSuite.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 1998, 2018 IBM Corporation. All rights reserved.
+ * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -2104,7 +2104,7 @@ public class EntityManagerJUnitTestSuite extends JUnitTestCase {
                     beginTransaction(em2);
 
                     HashMap<String, Object> properties = new HashMap<String, Object>();
-                    properties.put(QueryHints.PESSIMISTIC_LOCK_TIMEOUT, 5);
+                    properties.put(QueryHints.PESSIMISTIC_LOCK_TIMEOUT, 5000);
                     Employee employee2 = em2.find(Employee.class, employee.getId(), LockModeType.PESSIMISTIC_READ, properties);
                     employee2.setFirstName("Invalid Lock Employee");
                     commitTransaction(em2);
@@ -2158,7 +2158,7 @@ public class EntityManagerJUnitTestSuite extends JUnitTestCase {
                     beginTransaction(em2);
 
                     HashMap<String, Object> properties = new HashMap<String, Object>();
-                    properties.put(QueryHints.PESSIMISTIC_LOCK_TIMEOUT, 5);
+                    properties.put(QueryHints.PESSIMISTIC_LOCK_TIMEOUT, 5000);
                     Employee employee2 = em2.find(Employee.class, employee.getId(), LockModeType.PESSIMISTIC_WRITE, properties);
                     employee2.setFirstName("Invalid Lock Employee");
                     commitTransaction(em2);

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/fieldaccess/advanced/EntityManagerJUnitTestSuite.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/fieldaccess/advanced/EntityManagerJUnitTestSuite.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -2598,10 +2599,10 @@ public class EntityManagerJUnitTestSuite extends JUnitTestCase {
         ObjectLevelReadQuery olrQuery = (ObjectLevelReadQuery)((EJBQueryImpl)query).getDatabaseQuery();
 
         //testing for query timeout specified in persistence.xml
-        assertTrue("Timeout overriden or not set in persistence.xml",olrQuery.getQueryTimeout() == 100);
-        query.setHint(QueryHints.JDBC_TIMEOUT, 500);
+        assertTrue("Timeout overriden or not set in persistence.xml", olrQuery.getQueryTimeout() == 100000);
+        query.setHint(QueryHints.JDBC_TIMEOUT, 500000);
         olrQuery = (ObjectLevelReadQuery)((EJBQueryImpl)query).getDatabaseQuery();
-        assertTrue( olrQuery.getQueryTimeout() == 500);
+        assertTrue(olrQuery.getQueryTimeout() == 500000);
 
         closeEntityManager(em);
 

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/jpql/JUnitJPQLComplexTestSuite.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/jpql/JUnitJPQLComplexTestSuite.java
@@ -1,5 +1,7 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019 IBM Corporation. All rights reserved.
+ * 
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -4490,7 +4492,7 @@ public class JUnitJPQLComplexTestSuite extends JUnitTestCase
                             beginTransaction(em2);
                             Query query2 = em2.createQuery("select e from Employee e where e.id = :id");
                             query2.setParameter("id", bobId);
-                            query2.setHint(QueryHints.PESSIMISTIC_LOCK_TIMEOUT, 10);
+                            query2.setHint(QueryHints.PESSIMISTIC_LOCK_TIMEOUT, 10000);
                             Employee emp = (Employee) query2.getSingleResult(); // might wait for lock to be released
                             emp.setFirstName("Robert");
                             commitTransaction(em2); // might wait for lock to be released

--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/QueryHintsHandler.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/QueryHintsHandler.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -831,7 +832,7 @@ public class QueryHintsHandler {
             return query;
         }
     }
-    
+
     protected static class PessimisticLockTimeoutUnitHint extends Hint {
         PessimisticLockTimeoutUnitHint() {
             super(QueryHints.PESSIMISTIC_LOCK_TIMEOUT_UNIT, "");
@@ -1985,6 +1986,7 @@ public class QueryHintsHandler {
         @Override
         DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
             query.setQueryTimeout(QueryHintsHandler.parseIntegerHint(valueToApply, QueryHints.QUERY_TIMEOUT));
+            query.setIsPrepared(false);
             return query;
         }
     }


### PR DESCRIPTION
for #402

I was taking a look at the merged requests and I don't think it actually fixed the issue. The JPA spec clearly says that the value you provide to `javax.persistence.lock.timeout` & `javax.persistence.query.timeout` is in milliseconds, but #74 and https://bugs.eclipse.org/bugs/show_bug.cgi?id=456067 elected to just set the default as seconds. I had set the default to SECONDS in 456067 because I didnt want to change behavior, but I feel like this was not correct. The value should be provided in MILLISECONDS and this is what 533724 was opened to address as well.

Also, I quickly tested QUERY_TIMEOUT and it didn't seem to work (the timeout was always set as 0)! I noticed that this property didnt unprepare the query. After fixing that, QUERY_TIMEOUT started working as expected. I added a couple tests for that property.

Signed-off-by: Will Dazey <dazeydev.3@gmail.com>