### PR TITLE
[2.7] Bug 546312 - Add missing mapping for java.time classes to DatabasePlatform

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
@@ -1328,14 +1328,21 @@ public class DatabasePlatform extends DatasourcePlatform {
             return Types.TIMESTAMP;
         } else if (javaType == ClassConstants.UTILDATE ) {
             return Types.TIMESTAMP;
-        } else if (javaType == ClassConstants.TIME) {
+        } else if (javaType == ClassConstants.TIME ||
+            javaType == ClassConstants.TIME_LTIME) { //bug 546312
             return Types.TIME;
-        } else if (javaType == ClassConstants.SQLDATE) {
+        } else if (javaType == ClassConstants.SQLDATE ||
+            javaType == ClassConstants.TIME_LDATE) { //bug 546312
             return Types.DATE;
         } else if (javaType == ClassConstants.TIMESTAMP ||
-            javaType == ClassConstants.UTILDATE) { //bug 5237080, return TIMESTAMP for java.util.Date as well
+            javaType == ClassConstants.UTILDATE || //bug 5237080, return TIMESTAMP for java.util.Date as well
+            javaType == ClassConstants.TIME_LDATETIME) { //bug 546312
             return Types.TIMESTAMP;
-        } else if (javaType == ClassConstants.ABYTE) {
+        } else if(javaType == ClassConstants.TIME_OTIME) { //bug 546312
+            return Types.TIME_WITH_TIMEZONE;
+        } else if(javaType == ClassConstants.TIME_ODATETIME) { //bug 546312
+            return Types.TIMESTAMP_WITH_TIMEZONE;
+        }else if (javaType == ClassConstants.ABYTE) {
             return Types.LONGVARBINARY;
         } else if (javaType == ClassConstants.APBYTE) {
             return Types.LONGVARBINARY;

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/datetime/DateTime.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/datetime/DateTime.java
@@ -27,6 +27,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
+import java.time.ZoneOffset;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
@@ -46,13 +47,14 @@ import javax.persistence.TemporalType;
 @Entity
 @Table(name = "CMP3_DATE_TIME")
 public class DateTime implements Serializable {
+
     private Integer id;
     private java.sql.Date date;
     private LocalDate localDate;
     private LocalTime localTime;
     private LocalDateTime localDateTime;
-    private OffsetDateTime offsetDateTime;
     private OffsetTime offsetTime;
+    private OffsetDateTime offsetDateTime;
     private Time time;
     private Timestamp timestamp;
     private Date utilDate;
@@ -61,19 +63,19 @@ public class DateTime implements Serializable {
     private Map<Date, DateTime> uniSelfMap;
 
     public DateTime() {
-    }
+        LocalTime localTime = LocalTime.of(0, 0);
+        LocalDateTime localDateTime = LocalDateTime.ofEpochSecond(0, 0, ZoneOffset.UTC);
 
-    public DateTime(java.sql.Date date, LocalDateTime localDateTime, Time time, Timestamp timestamp, Date utilDate, Calendar calendar, LocalDate localDate, LocalTime localTime, OffsetTime offsetTime, OffsetDateTime offsetDateTime) {
-        this.date = date;
-        this.localDate = localDate;
+        this.date = new java.sql.Date(0);
+        this.localDate = LocalDate.ofEpochDay(0);
         this.localTime = localTime;
         this.localDateTime = localDateTime;
-        this.offsetTime = offsetTime;
-        this.offsetDateTime = offsetDateTime;
-        this.time = time;
-        this.timestamp = timestamp;
-        this.utilDate = utilDate;
-        this.calendar = calendar;
+        this.offsetTime = OffsetTime.of(localTime, ZoneOffset.UTC);
+        this.offsetDateTime = OffsetDateTime.of(localDateTime, ZoneOffset.UTC);
+        this.time = new Time(0);
+        this.timestamp = new Timestamp(0);
+        this.utilDate = new Date(0);
+        this.calendar = Calendar.getInstance();
 
         uniSelfMap = new HashMap<Date, DateTime>();
         uniSelfMap.put(new Date(), this);
@@ -192,5 +194,4 @@ public class DateTime implements Serializable {
     public void setUniSelfMap(Map<Date, DateTime> u) {
         uniSelfMap = u;
     }
-
 }

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/datetime/DateTime.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/datetime/DateTime.java
@@ -22,6 +22,11 @@ import static javax.persistence.GenerationType.TABLE;
 import java.io.Serializable;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
@@ -29,11 +34,9 @@ import java.util.Map;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
-import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
-import javax.persistence.MapKeyColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.persistence.TableGenerator;
@@ -41,10 +44,15 @@ import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 
 @Entity
-@Table(name="CMP3_DATE_TIME")
+@Table(name = "CMP3_DATE_TIME")
 public class DateTime implements Serializable {
     private Integer id;
     private java.sql.Date date;
+    private LocalDate localDate;
+    private LocalTime localTime;
+    private LocalDateTime localDateTime;
+    private OffsetDateTime offsetDateTime;
+    private OffsetTime offsetTime;
     private Time time;
     private Timestamp timestamp;
     private Date utilDate;
@@ -55,8 +63,13 @@ public class DateTime implements Serializable {
     public DateTime() {
     }
 
-    public DateTime(java.sql.Date date, Time time, Timestamp timestamp, Date utilDate, Calendar calendar) {
+    public DateTime(java.sql.Date date, LocalDateTime localDateTime, Time time, Timestamp timestamp, Date utilDate, Calendar calendar, LocalDate localDate, LocalTime localTime, OffsetTime offsetTime, OffsetDateTime offsetDateTime) {
         this.date = date;
+        this.localDate = localDate;
+        this.localTime = localTime;
+        this.localDateTime = localDateTime;
+        this.offsetTime = offsetTime;
+        this.offsetDateTime = offsetDateTime;
         this.time = time;
         this.timestamp = timestamp;
         this.utilDate = utilDate;
@@ -67,14 +80,9 @@ public class DateTime implements Serializable {
     }
 
     @Id
-    @GeneratedValue(strategy=TABLE, generator="DATETIME_TABLE_GENERATOR")
-    @TableGenerator(
-        name="DATETIME_TABLE_GENERATOR",
-        table="CMP3_DATETIME_SEQ",
-        pkColumnName="SEQ_NAME",
-        valueColumnName="SEQ_COUNT"
-    )
-    @Column(name="DT_ID")
+    @GeneratedValue(strategy = TABLE, generator = "DATETIME_TABLE_GENERATOR")
+    @TableGenerator(name = "DATETIME_TABLE_GENERATOR", table = "CMP3_DATETIME_SEQ", pkColumnName = "SEQ_NAME", valueColumnName = "SEQ_COUNT")
+    @Column(name = "DT_ID")
     public Integer getId() {
         return id;
     }
@@ -83,7 +91,7 @@ public class DateTime implements Serializable {
         this.id = id;
     }
 
-    @Column(name="SQL_DATE")
+    @Column(name = "SQL_DATE")
     public java.sql.Date getDate() {
         return date;
     }
@@ -92,7 +100,52 @@ public class DateTime implements Serializable {
         this.date = date;
     }
 
-    @Column(name="SQL_TIME")
+    @Column(name = "LOCAL_DATE")
+    public LocalDate getLocalDate() {
+        return localDate;
+    }
+
+    public void setLocalDate(LocalDate localDate) {
+        this.localDate = localDate;
+    }
+
+    @Column(name = "LOCAL_TIME")
+    public LocalTime getLocalTime() {
+        return localTime;
+    }
+
+    public void setLocalTime(LocalTime localTime) {
+        this.localTime = localTime;
+    }
+
+    @Column(name = "OFFSET_DATE_TIME")
+    public OffsetDateTime getOffsetDateTime() {
+        return offsetDateTime;
+    }
+
+    public void setOffsetDateTime(OffsetDateTime offsetDateTime) {
+        this.offsetDateTime = offsetDateTime;
+    }
+
+    @Column(name = "OFFSET_TIME")
+    public OffsetTime getOffsetTime() {
+        return offsetTime;
+    }
+
+    public void setOffsetTime(OffsetTime offsetTime) {
+        this.offsetTime = offsetTime;
+    }
+
+    @Column(name = "LOCAL_DATE_TIME")
+    public LocalDateTime getLocalDateTime() {
+        return localDateTime;
+    }
+
+    public void setLocalDateTime(LocalDateTime localDateTime) {
+        this.localDateTime = localDateTime;
+    }
+
+    @Column(name = "SQL_TIME")
     public Time getTime() {
         return time;
     }
@@ -101,7 +154,7 @@ public class DateTime implements Serializable {
         this.time = date;
     }
 
-    @Column(name="SQL_TS")
+    @Column(name = "SQL_TS")
     public Timestamp getTimestamp() {
         return timestamp;
     }
@@ -110,7 +163,7 @@ public class DateTime implements Serializable {
         this.timestamp = date;
     }
 
-    @Column(name="UTIL_DATE")
+    @Column(name = "UTIL_DATE")
     @Temporal(TemporalType.TIMESTAMP)
     public Date getUtilDate() {
         return utilDate;
@@ -120,7 +173,7 @@ public class DateTime implements Serializable {
         this.utilDate = date;
     }
 
-    @Column(name="CAL")
+    @Column(name = "CAL")
     // No @Temporal to test defaulting
     public Calendar getCalendar() {
         return calendar;
@@ -139,6 +192,5 @@ public class DateTime implements Serializable {
     public void setUniSelfMap(Map<Date, DateTime> u) {
         uniSelfMap = u;
     }
-
 
 }

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/datetime/DateTimePopulator.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/datetime/DateTimePopulator.java
@@ -16,9 +16,10 @@ package org.eclipse.persistence.testing.models.jpa.datetime;
 
 import java.lang.reflect.Method;
 import java.sql.Time;
-
 import java.sql.Timestamp;
-
+import java.time.OffsetTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -113,13 +114,18 @@ public class DateTimePopulator {
     @SuppressWarnings("deprecation")
     public DateTime buildAttributes(Calendar cal) {
         DateTime dateTime = new DateTime();
-        long time = cal.getTime().getTime();;
+        long time = cal.getTime().getTime();
 
         dateTime.setDate(new java.sql.Date(time));
         dateTime.setTime(new Time(cal.get(Calendar.HOUR_OF_DAY), cal.get(Calendar.MINUTE), cal.get(Calendar.SECOND)));
         dateTime.setTimestamp(new Timestamp(time));
         dateTime.setUtilDate(new Date(time));
         dateTime.setCalendar(cal);
+        dateTime.setLocalDate(cal.getTime().toInstant().atZone(ZoneId.systemDefault()).toLocalDate());
+        dateTime.setLocalTime(cal.getTime().toInstant().atZone(ZoneId.systemDefault()).toLocalTime());
+        dateTime.setLocalDateTime(dateTime.getLocalDate().atTime(dateTime.getLocalTime()));
+        dateTime.setOffsetTime(OffsetTime.of(dateTime.getLocalTime(), ZoneOffset.UTC));
+        dateTime.setOffsetDateTime(dateTime.getOffsetTime().atDate(dateTime.getLocalDate()));
 
         return dateTime;
     }

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/datetime/DateTimeTableCreator.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/datetime/DateTimeTableCreator.java
@@ -83,6 +83,56 @@ public class DateTimeTableCreator extends TogglingFastTableCreator {
         fieldPOSTALCODE.setShouldAllowNull(true);
         table.addField(fieldPOSTALCODE);
 
+        FieldDefinition fieldLocalDate = new FieldDefinition();
+        fieldLocalDate.setName("LOCAL_DATE");
+        fieldLocalDate.setTypeName("DATE");
+        fieldLocalDate.setSize(6);
+        fieldLocalDate.setIsPrimaryKey(false);
+        fieldLocalDate.setIsIdentity(false);
+        fieldLocalDate.setUnique(false);
+        fieldLocalDate.setShouldAllowNull(true);
+        table.addField(fieldLocalDate);
+
+        FieldDefinition fieldLocalTime = new FieldDefinition();
+        fieldLocalTime.setName("LOCAL_TIME");
+        fieldLocalTime.setTypeName("TIME");
+        fieldLocalTime.setSize(6);
+        fieldLocalTime.setIsPrimaryKey(false);
+        fieldLocalTime.setIsIdentity(false);
+        fieldLocalTime.setUnique(false);
+        fieldLocalTime.setShouldAllowNull(true);
+        table.addField(fieldLocalTime);
+
+        FieldDefinition fieldLocalDateTime = new FieldDefinition();
+        fieldLocalDateTime.setName("LOCAL_DATE_TIME");
+        fieldLocalDateTime.setTypeName("TIMESTAMP");
+        fieldLocalDateTime.setSize(6);
+        fieldLocalDateTime.setIsPrimaryKey(false);
+        fieldLocalDateTime.setIsIdentity(false);
+        fieldLocalDateTime.setUnique(false);
+        fieldLocalDateTime.setShouldAllowNull(true);
+        table.addField(fieldLocalDateTime);
+
+        FieldDefinition fieldOffsetTime = new FieldDefinition();
+        fieldOffsetTime.setName("OFFSET_TIME");
+        fieldOffsetTime.setTypeName("TIME");
+        fieldOffsetTime.setSize(6);
+        fieldOffsetTime.setIsPrimaryKey(false);
+        fieldOffsetTime.setIsIdentity(false);
+        fieldOffsetTime.setUnique(false);
+        fieldOffsetTime.setShouldAllowNull(true);
+        table.addField(fieldOffsetTime);
+
+        FieldDefinition fieldOffsetDateTime = new FieldDefinition();
+        fieldOffsetDateTime.setName("OFFSET_DATE_TIME");
+        fieldOffsetDateTime.setTypeName("TIMESTAMP");
+        fieldOffsetDateTime.setSize(6);
+        fieldOffsetDateTime.setIsPrimaryKey(false);
+        fieldOffsetDateTime.setIsIdentity(false);
+        fieldOffsetDateTime.setUnique(false);
+        fieldOffsetDateTime.setShouldAllowNull(true);
+        table.addField(fieldOffsetDateTime);
+
         FieldDefinition fieldCalToCal = new FieldDefinition();
         fieldCalToCal.setName("CAL");
         fieldCalToCal.setTypeName("TIMESTAMP");

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/datetime/NullBindingJUnitTestCase.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/datetime/NullBindingJUnitTestCase.java
@@ -17,12 +17,6 @@
 //       - 375101: Date and Calendar should not require @Temporal.
 package org.eclipse.persistence.testing.tests.jpa.datetime;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.OffsetDateTime;
-import java.time.OffsetTime;
-import java.time.ZoneOffset;
 import java.util.Date;
 import java.util.Map;
 
@@ -53,6 +47,7 @@ import junit.framework.TestSuite;
  * @see org.eclipse.persistence.testing.models.jpa.datetime.DateTimeTableCreator
  */
 public class NullBindingJUnitTestCase extends JUnitTestCase {
+
     private static int datetimeId;
 
     public NullBindingJUnitTestCase() {
@@ -103,9 +98,7 @@ public class NullBindingJUnitTestCase extends JUnitTestCase {
         DateTime dt;
 
         beginTransaction(em);
-        LocalTime localTime = LocalTime.of(0, 0);
-        LocalDateTime localDateTime = LocalDateTime.ofEpochSecond(0, 0, ZoneOffset.UTC);
-        dt = new DateTime(new java.sql.Date(0), localDateTime, new java.sql.Time(0), new java.sql.Timestamp(0), new java.util.Date(0), java.util.Calendar.getInstance(), LocalDate.ofEpochDay(0), localTime, OffsetTime.of(localTime, ZoneOffset.UTC), OffsetDateTime.of(localDateTime, ZoneOffset.UTC));
+        dt = new DateTime();
         em.persist(dt);
 
         datetimeId = dt.getId();

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/datetime/NullBindingJUnitTestCase.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/datetime/NullBindingJUnitTestCase.java
@@ -17,30 +17,37 @@
 //       - 375101: Date and Calendar should not require @Temporal.
 package org.eclipse.persistence.testing.tests.jpa.datetime;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
 import java.util.Date;
 import java.util.Map;
 
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
 
-import junit.framework.Test;
-import junit.framework.TestSuite;
-
 import org.eclipse.persistence.testing.framework.junit.JUnitTestCase;
 import org.eclipse.persistence.testing.models.jpa.datetime.DateTime;
 import org.eclipse.persistence.testing.models.jpa.datetime.DateTimeTableCreator;
 
+import junit.framework.Test;
+import junit.framework.TestSuite;
+
 /**
  * <p>
- * <b>Purpose</b>: Test binding of null values to temporal type fields in TopLink's JPA
- * implementation.
+ * <b>Purpose</b>: Test binding of null values to temporal type fields in
+ * TopLink's JPA implementation.
  * <p>
- * <b>Description</b>: This class creates a test suite and adds tests to the suite. The database
- * gets initialized prior to the test methods.
+ * <b>Description</b>: This class creates a test suite and adds tests to the
+ * suite. The database gets initialized prior to the test methods.
  * <p>
  * <b>Responsibilities</b>:
  * <ul>
- * <li>Run tests for binding of null values to temporal type fields in TopLink's JPA implementation.
+ * <li>Run tests for binding of null values to temporal type fields in TopLink's
+ * JPA implementation.
  * </ul>
  *
  * @see org.eclipse.persistence.testing.models.jpa.datetime.DateTimeTableCreator
@@ -61,6 +68,14 @@ public class NullBindingJUnitTestCase extends JUnitTestCase {
         suite.addTest(new NullBindingJUnitTestCase("testSetup"));
         suite.addTest(new NullBindingJUnitTestCase("testCreateDateTime"));
         suite.addTest(new NullBindingJUnitTestCase("testNullifySqlDate"));
+        suite.addTest(new NullBindingJUnitTestCase("testNullifyLocalDate"));
+        suite.addTest(new NullBindingJUnitTestCase("testNullifyLocalTime"));
+        suite.addTest(new NullBindingJUnitTestCase("testNullifyLocalDateTime"));
+        // following two types seem to have limited support on the different
+        // DBMSs:
+        // suite.addTest(new NullBindingJUnitTestCase("testNullifyOffsetTime"));
+        // suite.addTest(new
+        // NullBindingJUnitTestCase("testNullifyOffsetDateTime"));
         suite.addTest(new NullBindingJUnitTestCase("testNullifyTime"));
         suite.addTest(new NullBindingJUnitTestCase("testNullifyTimestamp"));
         suite.addTest(new NullBindingJUnitTestCase("testNullifyUtilDate"));
@@ -71,8 +86,8 @@ public class NullBindingJUnitTestCase extends JUnitTestCase {
     }
 
     /**
-     * The setup is done as a test, both to record its failure, and to allow execution in the
-     * server.
+     * The setup is done as a test, both to record its failure, and to allow
+     * execution in the server.
      */
     public void testSetup() {
         new DateTimeTableCreator().replaceTables(JUnitTestCase.getServerSession());
@@ -88,9 +103,9 @@ public class NullBindingJUnitTestCase extends JUnitTestCase {
         DateTime dt;
 
         beginTransaction(em);
-        dt =
-            new DateTime(new java.sql.Date(0), new java.sql.Time(0), new java.sql.Timestamp(0), new java.util.Date(0),
-                java.util.Calendar.getInstance());
+        LocalTime localTime = LocalTime.of(0, 0);
+        LocalDateTime localDateTime = LocalDateTime.ofEpochSecond(0, 0, ZoneOffset.UTC);
+        dt = new DateTime(new java.sql.Date(0), localDateTime, new java.sql.Time(0), new java.sql.Timestamp(0), new java.util.Date(0), java.util.Calendar.getInstance(), LocalDate.ofEpochDay(0), localTime, OffsetTime.of(localTime, ZoneOffset.UTC), OffsetDateTime.of(localDateTime, ZoneOffset.UTC));
         em.persist(dt);
 
         datetimeId = dt.getId();
@@ -113,6 +128,116 @@ public class NullBindingJUnitTestCase extends JUnitTestCase {
             q = em.createQuery("SELECT dt FROM DateTime dt WHERE dt.id = " + datetimeId);
             dt2 = (DateTime) q.getSingleResult();
             assertTrue("Error setting java.sql.Date field to null", dt2.getDate() == null);
+        } catch (RuntimeException e) {
+            if (isTransactionActive(em)) {
+                rollbackTransaction(em);
+            }
+            closeEntityManager(em);
+            throw e;
+        }
+    }
+
+    public void testNullifyLocalDate() {
+        EntityManager em = createEntityManager();
+        Query q;
+        DateTime dt, dt2;
+
+        try {
+            beginTransaction(em);
+            dt = em.find(DateTime.class, datetimeId);
+            dt.setLocalDate(null);
+            commitTransaction(em);
+            q = em.createQuery("SELECT dt FROM DateTime dt WHERE dt.id = " + datetimeId);
+            dt2 = (DateTime) q.getSingleResult();
+            assertTrue("Error setting java.time.LocalDateTime field to null", dt2.getLocalDate() == null);
+        } catch (RuntimeException e) {
+            if (isTransactionActive(em)) {
+                rollbackTransaction(em);
+            }
+            closeEntityManager(em);
+            throw e;
+        }
+    }
+
+    public void testNullifyLocalTime() {
+        EntityManager em = createEntityManager();
+        Query q;
+        DateTime dt, dt2;
+
+        try {
+            beginTransaction(em);
+            dt = em.find(DateTime.class, datetimeId);
+            dt.setLocalTime(null);
+            commitTransaction(em);
+            q = em.createQuery("SELECT dt FROM DateTime dt WHERE dt.id = " + datetimeId);
+            dt2 = (DateTime) q.getSingleResult();
+            assertTrue("Error setting java.time.LocalDateTime field to null", dt2.getLocalTime() == null);
+        } catch (RuntimeException e) {
+            if (isTransactionActive(em)) {
+                rollbackTransaction(em);
+            }
+            closeEntityManager(em);
+            throw e;
+        }
+    }
+
+    public void testNullifyLocalDateTime() {
+        EntityManager em = createEntityManager();
+        Query q;
+        DateTime dt, dt2;
+
+        try {
+            beginTransaction(em);
+            dt = em.find(DateTime.class, datetimeId);
+            dt.setLocalDateTime(null);
+            commitTransaction(em);
+            q = em.createQuery("SELECT dt FROM DateTime dt WHERE dt.id = " + datetimeId);
+            dt2 = (DateTime) q.getSingleResult();
+            assertTrue("Error setting java.time.LocalDateTime field to null", dt2.getLocalDateTime() == null);
+        } catch (RuntimeException e) {
+            if (isTransactionActive(em)) {
+                rollbackTransaction(em);
+            }
+            closeEntityManager(em);
+            throw e;
+        }
+    }
+
+    public void testNullifyOffsetTime() {
+        EntityManager em = createEntityManager();
+        Query q;
+        DateTime dt, dt2;
+
+        try {
+            beginTransaction(em);
+            dt = em.find(DateTime.class, datetimeId);
+            dt.setOffsetTime(null);
+            commitTransaction(em);
+            q = em.createQuery("SELECT dt FROM DateTime dt WHERE dt.id = " + datetimeId);
+            dt2 = (DateTime) q.getSingleResult();
+            assertTrue("Error setting java.time.LocalDateTime field to null", dt2.getOffsetTime() == null);
+        } catch (RuntimeException e) {
+            if (isTransactionActive(em)) {
+                rollbackTransaction(em);
+            }
+            closeEntityManager(em);
+            throw e;
+        }
+    }
+
+    public void testNullifyOffsetDateTime() {
+        EntityManager em = createEntityManager();
+        Query q;
+        DateTime dt, dt2;
+
+        try {
+            beginTransaction(em);
+            dt = em.find(DateTime.class, datetimeId);
+            dt.setOffsetDateTime(null);
+            commitTransaction(em);
+            q = em.createQuery("SELECT dt FROM DateTime dt WHERE dt.id = " + datetimeId);
+            dt2 = (DateTime) q.getSingleResult();
+            assertTrue("Error setting java.time.LocalDateTime field to null", dt2.getOffsetDateTime() == null);
         } catch (RuntimeException e) {
             if (isTransactionActive(em)) {
                 rollbackTransaction(em);


### PR DESCRIPTION
Backport of #415 for eclipselink 2.7