### PR TITLE
Bug 545779 - NullPointerException when MoxyJsonProvider reads a JSONArray of primitives. for example "[1]"

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/exceptions/JSONException.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/exceptions/JSONException.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.exceptions;
+
+import org.eclipse.persistence.exceptions.i18n.ExceptionMessageGenerator;
+
+/**
+ * <b>Purpose:</b>
+ * <ul><li>This class provides an implementation of EclipseLinkException specific to the EclipseLink JSON handling (marshall, unmarshall, Jersey provider)</li>
+ * </ul>
+ * @since Oracle EclipseLink 2.7.5
+ */
+public class JSONException extends EclipseLinkException {
+    // Error code range for this exception is 60001 - 61000.
+    public static final int ERROR_INVALID_DOCUMENT = 60001;
+
+    public JSONException(String theMessage) {
+        super(theMessage);
+    }
+
+    protected JSONException(String message, Exception internalException) {
+        super(message, internalException);
+    }
+
+    public static JSONException errorInvalidDocument(Exception internalEx) {
+        Object[] args = {  };
+        JSONException ex = new JSONException(ExceptionMessageGenerator.buildMessage(JSONException.class, ERROR_INVALID_DOCUMENT, args));
+        ex.setErrorCode(ERROR_INVALID_DOCUMENT);
+        ex.setInternalException(internalEx);
+        return ex;
+    }
+}

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/exceptions/i18n/JSONExceptionResource.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/exceptions/i18n/JSONExceptionResource.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.exceptions.i18n;
+
+import java.util.ListResourceBundle;
+
+/**
+ * INTERNAL:
+ * <b>Purpose:</b><p>English ResourceBundle for JSONException.</p>
+ */
+public class JSONExceptionResource extends ListResourceBundle {
+    static final Object[][] contents = {
+            {"60001", "Input JSON document is invalid or doesn't match target object graph."},
+    };
+
+    /**
+     * Return the lookup table.
+     */
+    protected Object[][] getContents() {
+        return contents;
+    }
+}

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/exceptions/i18n/JSONExceptionResource.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/exceptions/i18n/JSONExceptionResource.java
@@ -21,7 +21,7 @@ import java.util.ListResourceBundle;
  * <b>Purpose:</b><p>English ResourceBundle for JSONException.</p>
  */
 public class JSONExceptionResource extends ListResourceBundle {
-    static final Object[][] contents = {
+    public static final Object[][] contents = {
             {"60001", "Input JSON document is invalid or doesn't match target object graph."},
     };
 

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/rs/MOXyJsonProvider.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/rs/MOXyJsonProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -67,6 +67,7 @@ import javax.xml.bind.Unmarshaller;
 import javax.xml.namespace.QName;
 import javax.xml.transform.stream.StreamSource;
 
+import org.eclipse.persistence.exceptions.JSONException;
 import org.eclipse.persistence.internal.core.helper.CoreClassConstants;
 import org.eclipse.persistence.internal.helper.Helper;
 import org.eclipse.persistence.internal.oxm.Constants;
@@ -734,6 +735,8 @@ public class MOXyJsonProvider implements MessageBodyReader<Object>, MessageBodyW
             throw new WebApplicationException(unmarshalException, builder.build());
         } catch(JAXBException jaxbException) {
             throw new WebApplicationException(jaxbException);
+        } catch(NullPointerException nullPointerException) {
+            throw new WebApplicationException(JSONException.errorInvalidDocument(nullPointerException));
         }
     }
 


### PR DESCRIPTION
Bug 545779 - NullPointerException when MoxyJsonProvider reads a JSONArray of primitives. for example "[1]"

Fix for this bug. This exception handing initial implementation for JSON related errors. 

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>