### PR TITLE
WIP: Bug# 545940 - LIKE query must escape '[' and ']' characters

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/expressions/Expression.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/expressions/Expression.java
@@ -57,6 +57,7 @@ import org.eclipse.persistence.mappings.DatabaseMapping;
 import org.eclipse.persistence.queries.DatabaseQuery;
 import org.eclipse.persistence.queries.ReadQuery;
 import org.eclipse.persistence.queries.ReportQuery;
+import org.eclipse.persistence.queries.transform.LikePatternTransformation;
 
 /**
  * <p>
@@ -3864,6 +3865,23 @@ public abstract class Expression implements Serializable, Cloneable {
      * Print SQL
      */
     public abstract void printSQL(ExpressionSQLPrinter printer);
+
+    // TODO: Transformation setup should be better done in caller method as lambda
+    /**
+     * INTERNAL:
+     * Print SQL and apply transformation on value to be printed.
+     * Only {@code ConstantExpression} and {@code ParameterExpression} support this method with transformation instance.
+     * @param printer target SQL expression printer
+     * @param transform SQL parameters delayed transformation
+     * @param arg transformation method expression argument
+     */
+    public void printSQL(ExpressionSQLPrinter printer, LikePatternTransformation.Function transform, Expression arg) {
+        if (transform == null) {
+            printSQL(printer);
+        } else {
+            throw new UnsupportedOperationException("Print SQL with transformation is not supported for this expression");
+        }
+    }
 
     /**
      * INTERNAL:

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/expressions/ExpressionOperator.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/expressions/ExpressionOperator.java
@@ -34,7 +34,6 @@ import java.util.Vector;
 
 import org.eclipse.persistence.exceptions.QueryException;
 import org.eclipse.persistence.internal.expressions.ArgumentListFunctionExpression;
-import org.eclipse.persistence.internal.expressions.ConstantExpression;
 import org.eclipse.persistence.internal.expressions.ExpressionJavaPrinter;
 import org.eclipse.persistence.internal.expressions.ExpressionSQLPrinter;
 import org.eclipse.persistence.internal.expressions.FunctionExpression;
@@ -47,7 +46,6 @@ import org.eclipse.persistence.internal.helper.Helper;
 import org.eclipse.persistence.internal.helper.JavaPlatform;
 import org.eclipse.persistence.internal.security.PrivilegedAccessHelper;
 import org.eclipse.persistence.internal.security.PrivilegedNewInstanceFromClass;
-import org.eclipse.persistence.queries.transform.LikePatternTransformation;
 
 /**
  * <p>

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/expressions/ExpressionOperator.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/expressions/ExpressionOperator.java
@@ -2215,14 +2215,12 @@ public class ExpressionOperator implements Serializable {
                     // by passing lambda with what to initialize
                     pattern.printSQL(printer, printer.getPlatform()::escapeLikePattern, escape);
                 } else {
-                    string.printSQL(printer);
+                    pattern.printSQL(printer);
                 }
                 printDatabaseString(printer, dbStringIndex++);
                 if (escape != null) {
                     escape.printSQL(printer);
-                    if (dbStringIndex < getDatabaseStrings().length) {
-                        printer.printString(getDatabaseStrings()[dbStringIndex++]);
-                    }
+                    printDatabaseString(printer, dbStringIndex++);
                 }
                 // This is just for safety if there are more arguments than 3.
                 for (int i = 3; i < argumentIndices.length; i++) {

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
@@ -3571,4 +3571,29 @@ public class DatabasePlatform extends DatasourcePlatform {
         }
     }
 
+    // Only MS SQL and Sybase ASE are known to need pattern escaping.
+    // Only MS SQL platform was fixed.
+    /**
+     * Check whether JPQL LIKE expression pattern needs escaping.
+     * @return always returns false
+     */
+    public boolean shouldEscapeLikePattern() {
+        return false;
+    }
+
+    // Returns unmodified pattern string by default.
+    /**
+     * INTERNAL:
+     * JPQL LIKE expression pattern definition contains only two wild cards: '%' for any sequence of characters
+     * and '_' for any single character. Any other characters with special meaning must be escaped if specific
+     * database supports them.
+     * @param pattern source pattern to be escaped
+     * @param escapeChar character used to escape pattern, first character from provided {@code String} is used
+     * @return pattern with other characters with special meaning escaped. Default implementation does not recognize
+     *         any characters to be escaped so unmodified pattern {@code String} is returned.
+     */
+    public String escapeLikePattern(final String pattern, final String escapeChar) {
+        return pattern;
+    }
+
 }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatasourceCall.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatasourceCall.java
@@ -42,6 +42,8 @@ import org.eclipse.persistence.logging.SessionLog;
 import org.eclipse.persistence.mappings.structures.ObjectRelationalDatabaseField;
 import org.eclipse.persistence.queries.Call;
 import org.eclipse.persistence.queries.DatabaseQuery;
+import org.eclipse.persistence.queries.transform.ParameterTransformation;
+import org.eclipse.persistence.queries.transform.Transformations;
 
 /**
  * INTERNAL:
@@ -86,9 +88,14 @@ public abstract class DatasourceCall implements Call {
     protected static final int RETURN_CURSOR = 4;
     protected static final int EXECUTE_UPDATE = 5;
 
+    // Bug# 545940 - Delayed SQL parameters transformation container is part of the datasource invocation class.
+    /** Delayed datasource call parameters transformations. */
+    private final Transformations transformations;
+
     public DatasourceCall() {
         this.isPrepared = false;
         this.shouldProcessTokenInQuotes = true;
+        this.transformations = new Transformations();
     }
 
     /**
@@ -971,4 +978,23 @@ public abstract class DatasourceCall implements Call {
             parameterTypes = newParameterTypes;
         }
     }
+
+    /**
+     * INTERNAL:
+     * Add delayed SQL parameter transformation.
+     * @param transformation transformation to be added.
+     */
+    public void addTransformation(ParameterTransformation transformation) {
+        transformations.add(transformation);
+    }
+
+    /**
+     * INTERNAL:
+     * Return delayed SQL parameter transformations.
+     * @return delayed SQL parameter transformations
+     */
+    public Transformations getTransformations() {
+        return transformations;
+    }
+
 }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatasourceCall.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatasourceCall.java
@@ -90,7 +90,7 @@ public abstract class DatasourceCall implements Call {
 
     // Bug# 545940 - Delayed SQL parameters transformation container is part of the datasource invocation class.
     /** Delayed datasource call parameters transformations. */
-    private final Transformations transformations;
+    private transient final Transformations transformations;
 
     public DatasourceCall() {
         this.isPrepared = false;

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/expressions/ConstantExpression.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/expressions/ConstantExpression.java
@@ -195,7 +195,6 @@ public class ConstantExpression extends Expression {
         } else {
             if (arg.isConstantExpression()) {
                 String argValue = ((ConstantExpression)arg).getValue().toString();
-                Object sourceValue = localBase != null ? localBase.getFieldValue(value, getSession()) : value;
                 String valueToPrint = transform.transform((String)value, argValue);
                 printer.printPrimitive(valueToPrint);
             } else {

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/expressions/ConstantExpression.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/expressions/ConstantExpression.java
@@ -190,7 +190,7 @@ public class ConstantExpression extends Expression {
      */
     @Override
     public void printSQL(ExpressionSQLPrinter printer, LikePatternTransformation.Function transform, Expression arg) {
-        if (transform == null || value == null) {
+        if (transform == null || arg == null || value == null) {
             printSQL(printer);
         } else {
             if (arg.isConstantExpression()) {

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/expressions/FunctionExpression.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/expressions/FunctionExpression.java
@@ -570,8 +570,7 @@ public class FunctionExpression extends BaseExpression {
                 printer.getCall().setUsesBinding(false);
             }
         }
-        ExpressionOperator realOperator;
-        realOperator = getPlatformOperator(printer.getPlatform());
+        ExpressionOperator realOperator = getPlatformOperator(printer.getPlatform());
         realOperator.printCollection(this.children, printer);
     }
 

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/expressions/ParameterExpression.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/expressions/ParameterExpression.java
@@ -32,6 +32,7 @@ import org.eclipse.persistence.internal.sessions.AbstractRecord;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
 import org.eclipse.persistence.mappings.DatabaseMapping;
 import org.eclipse.persistence.queries.DatabaseQuery;
+import org.eclipse.persistence.queries.transform.LikePatternTransformation;
 
 /**
  * Used for parameterized expressions, such as expression defined in mapping queries.
@@ -153,6 +154,16 @@ public class ParameterExpression extends BaseExpression {
             }
         }
         return localBase.getBuilder();
+    }
+
+    /**
+     * INTERNAL:
+     * Get parameter expression name.
+     * @return name of this parameter expression
+     */
+    @Override
+    public String getName() {
+        return field != null ? field.getName() : super.getName();
     }
 
     public DatabaseField getField() {
@@ -369,6 +380,26 @@ public class ParameterExpression extends BaseExpression {
             if (getField() != null) {
                 printer.printParameter(this);
             }
+        }
+    }
+
+    // Bug# 545940 - Register delayed transformaion for JPQL LIKE expression
+    // TODO: Transformation setup should be better done in caller method as lambda
+    /**
+     * INTERNAL:
+     * Print SQL and apply transformation on value to be printed
+     * @param printer target SQL expression printer
+     * @param transform SQL parameters delayed transformation
+     * @param arg transformation method expression argument
+     */
+    @Override
+    public void printSQL(ExpressionSQLPrinter printer, LikePatternTransformation.Function transform, Expression arg) {
+        if (transform == null) {
+            printSQL(printer);
+        } else {
+            printer.printParameter(this);
+            printer.getCall().addTransformation(
+                    new LikePatternTransformation(this, arg, printer.getPlatform()::escapeLikePattern));
         }
     }
 

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/expressions/ParameterExpression.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/expressions/ParameterExpression.java
@@ -156,16 +156,6 @@ public class ParameterExpression extends BaseExpression {
         return localBase.getBuilder();
     }
 
-    /**
-     * INTERNAL:
-     * Get parameter expression name.
-     * @return name of this parameter expression
-     */
-    @Override
-    public String getName() {
-        return field != null ? field.getName() : super.getName();
-    }
-
     public DatabaseField getField() {
         return field;
     }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/expressions/ParameterExpression.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/expressions/ParameterExpression.java
@@ -384,7 +384,7 @@ public class ParameterExpression extends BaseExpression {
      */
     @Override
     public void printSQL(ExpressionSQLPrinter printer, LikePatternTransformation.Function transform, Expression arg) {
-        if (transform == null) {
+        if (transform == null || arg == null) {
             printSQL(printer);
         } else {
             printer.printParameter(this);

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/CallQueryMechanism.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/CallQueryMechanism.java
@@ -29,6 +29,7 @@ import org.eclipse.persistence.internal.expressions.*;
 import org.eclipse.persistence.descriptors.ClassDescriptor;
 import org.eclipse.persistence.exceptions.*;
 import org.eclipse.persistence.queries.*;
+import org.eclipse.persistence.queries.transform.Transformations;
 
 /**
  * <p><b>Purpose</b>:
@@ -453,4 +454,27 @@ public class CallQueryMechanism extends DatasourceCallQueryMechanism {
             }
         }
     }
+
+    // Bug# 545940 - Access to delayed SQL parameter transformations container stored in DatasourceCall
+
+    /**
+     * INTERNAL:
+     * Return delayed SQL parameter transformations.
+     * @return delayed SQL parameter transformations
+     */
+    @Override
+    public Transformations getTransformations() {
+        return call != null ? call.getTransformations() : null;
+    }
+
+    /**
+     * INTERNAL:
+     * Check whether delayed SQL parameter transformations are registered.
+     * @return whether at least one delayed SQL parameter transformation is registered
+     */
+    @Override
+    public boolean hasTransformations() {
+        return call != null ? !call.getTransformations().isEmpty() : false;
+    }
+
 }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/DatabaseQueryMechanism.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/DatabaseQueryMechanism.java
@@ -53,6 +53,7 @@ import org.eclipse.persistence.queries.ModifyQuery;
 import org.eclipse.persistence.queries.ObjectBuildingQuery;
 import org.eclipse.persistence.queries.ReadObjectQuery;
 import org.eclipse.persistence.queries.WriteObjectQuery;
+import org.eclipse.persistence.queries.transform.Transformations;
 import org.eclipse.persistence.sessions.DatabaseRecord;
 import org.eclipse.persistence.tools.profiler.QueryMonitor;
 
@@ -1127,4 +1128,26 @@ public abstract class DatabaseQueryMechanism implements Cloneable, Serializable 
     public void unprepare() {
 
     }
+
+    // Bug# 545940 - Access to delayed SQL parameter transformations container stored in DatasourceCall
+    // Abstract class contains no DatasourceCall instance so there is nothing to return until being overriden
+
+    /**
+     * INTERNAL:
+     * Return delayed SQL parameter transformations.
+     * @return delayed SQL parameter transformations
+     */
+    public Transformations getTransformations() {
+        return null;
+    }
+
+    /**
+     * INTERNAL:
+     * Check whether delayed SQL parameter transformations are registered.
+     * @return whether at least one delayed SQL parameter transformation is registered
+     */
+    public boolean hasTransformations() {
+        return false;
+    }
+
 }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/SQLServerPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/SQLServerPlatform.java
@@ -45,6 +45,11 @@ import org.eclipse.persistence.queries.*;
  * @since TOPLink/Java 1.0
  */
 public class SQLServerPlatform extends org.eclipse.persistence.platform.database.DatabasePlatform {
+
+    // Bug# 545940 - Transformation used to escape JPQL LIKE pattern
+    /** Default escape character for logical operator LIKE. */
+    public static final char DEFAULT_LIKE_ESCAPE_CHAR = '\\';
+
     /** Support for sequence objects and OFFSET FETCH NEXT added in SQL Server 2012 */
     private boolean isVersion11OrHigher;
     private boolean isConnectionDataInitialized;
@@ -815,9 +820,6 @@ public class SQLServerPlatform extends org.eclipse.persistence.platform.database
 
     // Bug# 545940 - Transformation used to escape JPQL LIKE pattern
 
-    /** Default escape character for logical operator LIKE. */
-    public static final char DEFAULT_LIKE_ESCAPE_CHAR = '\\';
-
     /** Pattern escaping state machine states. */
     private static enum EscState {
         REGULAR,
@@ -869,6 +871,8 @@ public class SQLServerPlatform extends org.eclipse.persistence.platform.database
                     sb.append(c);
                     state = EscState.REGULAR;
                     break;
+                default:
+                    throw new IllegalStateException("Unknown state value!");
             }
         }
         return sb.toString();

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/DatabaseQuery.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/DatabaseQuery.java
@@ -2055,9 +2055,8 @@ public abstract class DatabaseQuery implements Cloneable, Serializable {
      * Size of source lists and order of parameters must be the same in both lists.
      * @param row target AbstractRecord instance
      * @param argumentFields query parameters fields
-     * @param argumentValues query parameters values
      */
-    private void transformArguments(AbstractRecord row, List<DatabaseField> argumentFields, List argumentValues) {
+    private void transformArguments(AbstractRecord row, List<DatabaseField> argumentFields) {
         Transformations transformations = getQueryMechanism().getTransformations();
         int argumentsSize = argumentFields.size();
         for (int index = 0; index < argumentsSize; index++) {
@@ -2095,7 +2094,7 @@ public abstract class DatabaseQuery implements Cloneable, Serializable {
             transformations.setQuery(this);
             transformations.setParamValues(argumentFields, argumentValues);
             transformations.transformConstants();
-            transformArguments(row, argumentFields, argumentValues);
+            transformArguments(row, argumentFields);
         } else {
             copyArguments(row, argumentFields, argumentValues);
         }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/transform/LikePatternTransformation.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/transform/LikePatternTransformation.java
@@ -21,6 +21,7 @@ import org.eclipse.persistence.expressions.Expression;
 import org.eclipse.persistence.internal.databaseaccess.DatasourceCall;
 import org.eclipse.persistence.internal.expressions.ConstantExpression;
 import org.eclipse.persistence.internal.expressions.ParameterExpression;
+import org.eclipse.persistence.internal.helper.DatabaseField;
 import org.eclipse.persistence.internal.queries.DatasourceCallQueryMechanism;
 import org.eclipse.persistence.queries.DatabaseQuery;
 
@@ -102,9 +103,12 @@ public class LikePatternTransformation extends ParameterTransformation {
             escapeString = ((ConstantExpression)escape).getValue().toString();
         }
         if (escape.isParameterExpression()) {
-            Object escValue = paramValues.get(((ParameterExpression)escape).getName());
-            if (escValue != null) {
-                escapeString = escValue.toString();
+            DatabaseField field = ((ParameterExpression)escape).getField();
+            if (field != null) {
+                Object escValue = paramValues.get(field.getName());
+                if (escValue != null) {
+                    escapeString = escValue.toString();
+                }
             }
         }
         return escapeString;
@@ -166,7 +170,8 @@ public class LikePatternTransformation extends ParameterTransformation {
     @Override
     public String getParameterName() {
         if (isParameterExpression()) {
-            return pattern.getName();
+            DatabaseField field = ((ParameterExpression)pattern).getField();
+            return field != null ? field.getName() : null;
         } else {
             return null;
         }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/transform/LikePatternTransformation.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/transform/LikePatternTransformation.java
@@ -33,6 +33,19 @@ import org.eclipse.persistence.queries.DatabaseQuery;
  */
 public class LikePatternTransformation extends ParameterTransformation {
 
+    /** Escape character expression. Can be ConstantExpression or ParameterExpression. */
+    private final Expression escape;
+
+    /** Pattern expression. Can be ConstantExpression or ParameterExpression. */
+    private final Expression pattern;
+
+    /** Parameters list index of pattern value in DatasourceCall for ConstantExpression to allow modify it.
+     *  Value of {@code -1} means that this value is not defined. */
+    private final int patternIndex;
+
+    /** Pattern transformation function. */
+    private final Function transformation;
+
     /**
      * Lambda/functional interface for transformation method.
      */
@@ -51,19 +64,6 @@ public class LikePatternTransformation extends ParameterTransformation {
          */
         public String transform(final String pattern, final String escapeChar);
     }
-
-    /** Escape character expression. Can be ConstantExpression or ParameterExpression. */
-    private final Expression escape;
-
-    /** Pattern expression. Can be ConstantExpression or ParameterExpression. */
-    private final Expression pattern;
-
-    /** Parameters list index of pattern value in DatasourceCall for ConstantExpression to allow modify it.
-     *  Value of {@code -1} means that this value is not defined. */
-    private final int patternIndex;
-
-    /** Pattern transformation function. */
-    private final Function transformation;
 
     /**
      * Creates an instance of JPQL LIKE expression pattern parameter transformation.

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/transform/LikePatternTransformation.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/transform/LikePatternTransformation.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     04/16/2019-3.0 Tomas Kraus
+//       - 545940: Delayed parameter transformations
+package org.eclipse.persistence.queries.transform;
+
+import java.util.Map;
+
+import org.eclipse.persistence.expressions.Expression;
+import org.eclipse.persistence.internal.databaseaccess.DatasourceCall;
+import org.eclipse.persistence.internal.expressions.ConstantExpression;
+import org.eclipse.persistence.internal.expressions.ParameterExpression;
+import org.eclipse.persistence.internal.queries.DatasourceCallQueryMechanism;
+import org.eclipse.persistence.queries.DatabaseQuery;
+
+/**
+ * JPQL LIKE expression pattern parameter transformation.
+ * Calls transformation registered as functional interface on LIKE pattern argument using escape character provided
+ * as part of LIKE expression.
+ * Source of transformation implementation is database plaform.
+ */
+public class LikePatternTransformation extends ParameterTransformation {
+
+    /**
+     * Lambda/functional interface for transformation method.
+     */
+    public static interface Function {
+        /**
+         * JPQL LIKE expression pattern definition contains only two wild cards:
+         * '%' for any sequence of characters and '_' for any single character.
+         * Any other characters with special meaning must be escaped if specific
+         * database supports them.
+         *
+         * @param pattern source pattern to be escaped
+         * @param escapeChar character used to escape pattern, first character from provided {@code String} is used
+         * @return pattern with other characters with special meaning escaped.
+         *         Default implementation does not recognize any characters to
+         *         be escaped so unmodified pattern {@code String} is returned.
+         */
+        public String transform(final String pattern, final String escapeChar);
+    }
+
+    /** Escape character expression. Can be ConstantExpression or ParameterExpression. */
+    private final Expression escape;
+
+    /** Pattern expression. Can be ConstantExpression or ParameterExpression. */
+    private final Expression pattern;
+
+    /** Parameters list index of pattern value in DatasourceCall for ConstantExpression to allow modify it.
+     *  Value of {@code -1} means that this value is not defined. */
+    private final int patternIndex;
+
+    /** Pattern transformation function. */
+    private final Function transformation;
+
+    /**
+     * Creates an instance of JPQL LIKE expression pattern parameter transformation.
+     * Constructor with parameters list index in DatasourceCall is required for ConstantExpression.
+     * @param pattern source pattern expression
+     * @param patternIndex parameters list index of pattern value in DatasourceCall
+     * @param escape expression with escape character
+     * @param transformation transformation method from database platform
+     */
+    public LikePatternTransformation(Expression pattern, int patternIndex, Expression escape, Function transformation) {
+        this.pattern = pattern;
+        this.patternIndex = patternIndex;
+        this.escape = escape;
+        this.transformation = transformation;
+    }
+
+    /**
+     * Creates an instance of JPQL LIKE expression pattern parameter transformation.
+     * Constructor without parameters list index in DatasourceCall is required for ParameterExpression.
+     * Parameters list index of pattern value in DatasourceCall  is set to -1.
+     * @param pattern source pattern expression
+     * @param escape expression with escape character
+     * @param transformation transformation method from database platform
+     */
+    public LikePatternTransformation(Expression pattern, Expression escape, Function transformation) {
+        this(pattern, -1, escape, transformation);
+    }
+
+    /**
+     * Retrieve escape character from escape character expression and provided parameter values.
+     * @param paramValues query parameters values {@link Map}
+     * @return escape character from escape character expression or {@code null} if no such value exists
+     */
+    private String escapeString(Map<String, Object> paramValues) {
+        String escapeString = null;
+        if (escape.isConstantExpression()) {
+            escapeString = ((ConstantExpression)escape).getValue().toString();
+        }
+        if (escape.isParameterExpression()) {
+            Object escValue = paramValues.get(((ParameterExpression)escape).getName());
+            if (escValue != null) {
+                escapeString = escValue.toString();
+            }
+        }
+        return escapeString;
+    }
+
+    /**
+     * Transform parameter value from {@link org.eclipse.persistence.internal.expressions.ParameterExpression}.
+     * @param paramName name of query parameter to transform
+     * @param paramValues {@link Map} of parameter values
+     * @param query query containing parameters to transform
+     * @return transformed parameter value.
+     */
+    @Override
+    public Object transformParam(String paramName, Map<String, Object> paramValues, DatabaseQuery query) {
+        String escapeString = escapeString(paramValues);
+        return transformation.transform(paramValues.get(paramName).toString(), escapeString);
+    }
+
+    /**
+     * Transform constant values from {@link org.eclipse.persistence.internal.expressions.ConstantExpression}.
+     * Transformation will update constant values directlry in {@link org.eclipse.persistence.queries.SQLCall} instance
+     * @param paramValues {@link Map} of parameter values
+     * @param query query containing parameters to transform
+     */
+    @Override
+    public void transformConstant(Map<String, Object> paramValues, DatabaseQuery query) {
+        DatasourceCall call = ((DatasourceCallQueryMechanism) query.getQueryMechanism()).getCall();
+        String escapeString = escapeString(paramValues);
+        String value = ((ConstantExpression) pattern).getValue().toString();
+        String transformedvalue = transformation.transform(value, escapeString);
+        call.getParameters().set(patternIndex, transformedvalue);
+    }
+
+    /**
+     * Check whether pattern expression is ConstantExpression.
+     * @return value of {@code true} when pattern expression is an instance of ConstantExpression
+     *         or {@code false} otherwise.
+     */
+    @Override
+    public boolean isConstantExpression() {
+        return pattern.isConstantExpression();
+    }
+
+    /**
+     * Check whether pattern expression is ParameterExpression.
+     * @return value of {@code true} when pattern expression is an instance of ParameterExpression
+     *         or {@code false} otherwise.
+     */
+    @Override
+    public boolean isParameterExpression() {
+        return pattern.isParameterExpression();
+    }
+
+    /**
+     * Get name of parameter in ParameterExpression.
+     * @return name of parameter of parameter expression is an instance of ParameterExpression
+     *         or {@code null} otherwise.
+     */
+    @Override
+    public String getParameterName() {
+        if (isParameterExpression()) {
+            return pattern.getName();
+        } else {
+            return null;
+        }
+    }
+
+}

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/transform/ParameterTransformation.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/transform/ParameterTransformation.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     04/16/2019-3.0 Tomas Kraus
+//       - 545940: Delayed parameter transformations
+package org.eclipse.persistence.queries.transform;
+
+import java.util.Map;
+
+import org.eclipse.persistence.queries.DatabaseQuery;
+
+/**
+ * SQL parameters delayed transformation.
+ */
+public abstract class ParameterTransformation {
+
+    /**
+     * Transform parameter value from {@link org.eclipse.persistence.internal.expressions.ParameterExpression}.
+     * @param paramName name of query parameter to transform
+     * @param paramValues {@link Map} of parameter values
+     * @param query query containing parameters to transform
+     * @return transformed parameter value.
+     */
+    public abstract Object transformParam(String name, Map<String, Object> paramValues, DatabaseQuery query);
+
+    /**
+     * Transform constant values from {@link org.eclipse.persistence.internal.expressions.ConstantExpression}.
+     * Transformation will update constant values directlry in {@link org.eclipse.persistence.queries.SQLCall} instance
+     * @param paramValues {@link Map} of parameter values
+     * @param query query containing parameters to transform
+     */
+    public abstract void transformConstant(Map<String, Object> paramValues, DatabaseQuery query);
+
+    /**
+     * Check whether pattern expression is ConstantExpression.
+     * @return value of {@code true} when pattern expression is an instance of ConstantExpression
+     *         or {@code false} otherwise.
+     */
+    public abstract boolean isConstantExpression();
+
+    /**
+     * Check whether pattern expression is ParameterExpression.
+     * @return value of {@code true} when pattern expression is an instance of ParameterExpression
+     *         or {@code false} otherwise.
+     */
+    public abstract boolean isParameterExpression();
+
+    /**
+     * Get name of parameter in ParameterExpression.
+     * @return name of parameter of parameter expression is an instance of ParameterExpression
+     *         or {@code null} otherwise.
+     */
+    public abstract String getParameterName();
+
+
+}

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/transform/Transformations.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/transform/Transformations.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     04/16/2019-3.0 Tomas Kraus
+//       - 545940: Delayed parameter transformations
+package org.eclipse.persistence.queries.transform;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.persistence.internal.helper.DatabaseField;
+import org.eclipse.persistence.internal.queries.DatabaseQueryMechanism;
+import org.eclipse.persistence.queries.DatabaseQuery;
+
+/**
+ * SQL parameters delayed transformation container.
+ */
+public class Transformations {
+
+    /** List of registered transformations for constant expressions. */
+    private final List<ParameterTransformation> constant;
+
+    /** List of registered transformations for parameter expressions. */
+    private final Map<String, ParameterTransformation> parameter;
+
+    /** Query containing parameters to transform. Must be set before executing the transformations (for both constant
+     *  and parameter expressions). */
+    protected DatabaseQuery query;
+
+    /** Map of parameter values. Must be set before executing the transformations (for both constant
+     *  and parameter expressions). */
+    private Map<String, Object> paramValues;
+
+    /**
+     * Creates an instance of SQL parameters delayed transformation container.
+     */
+    public Transformations() {
+        constant = new LinkedList<>();
+        parameter = new HashMap<>();
+        paramValues = null;
+        query = null;
+    }
+
+    /**
+     * Set query containing parameters to transform.
+     * This setter must be called before executing any transformations.
+     * @param query query containing parameters to transform
+     */
+    public void setQuery(DatabaseQuery query) {
+        this.query = query;
+    }
+
+    /**
+     * Set parameter names and values.
+     * This setter must be called before executing any transformations.
+     * Size of source lists and order of parameters must be the same in both lists.
+     * @param paramFields list of parameter fields.
+     * @param paramValuesList list of parameter values.
+     */
+    public void setParamValues(List<DatabaseField> paramFields, List paramValuesList) {
+        int argumentsSize = paramFields.size();
+        paramValues = new HashMap<>(argumentsSize);
+        for (int index = 0; index < argumentsSize; index++) {
+            String paramName = (String)paramFields.get(index).getName();
+            paramValues.put(paramName, paramValuesList.get(index));
+        }
+    }
+
+    /**
+     * Checke whether at least one transformation is registered.
+     * @return value of {@code true} when at least one transformation is registered or {@code false} otherwise.
+     */
+    public boolean isEmpty() {
+        return constant.isEmpty() && parameter.isEmpty();
+    }
+
+    /**
+     * Adds a transformation into this container.
+     * @param transformation a transformation to be added
+     */
+    public void add(ParameterTransformation transformation) {
+        if (transformation.isConstantExpression()) {
+            constant.add(transformation);
+        } else {
+            parameter.put(transformation.getParameterName(), transformation);
+        }
+    }
+
+    /**
+     * Process all registered constant transformations.
+     * All processed transformations are removed from the transformations {@link List}.
+     */
+    public void transformConstants() {
+        DatabaseQueryMechanism queryMechanism = query.getQueryMechanism();
+        if (queryMechanism != null && (
+                queryMechanism.isCallQueryMechanism() || queryMechanism.isStatementQueryMechanism()
+                || queryMechanism.isJPQLCallQueryMechanism())) {
+            for (ParameterTransformation transformation : constant) {
+                transformation.transformConstant(paramValues, query);
+            }
+        }
+        // This helps garbage collector too.
+        constant.clear();
+    }
+
+    /**
+     * Process registered parameters transformation for specific parameter.
+     * Transformation is removed from transformations {@link Map}.
+     */
+    public Object transformParam(String paramName) {
+        ParameterTransformation transformation = parameter.remove(paramName);
+        if (transformation != null) {
+            return transformation.transformParam(paramName, paramValues, query);
+        }
+        return paramValues.get(paramName);
+    }
+
+}

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/advanced/EmployeePopulator.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/advanced/EmployeePopulator.java
@@ -528,6 +528,56 @@ public class EmployeePopulator {
         return employee;
     }
 
+    // Bug# 545940 - LIKE query must escape '[' and ']' characters to not allow using them as REGEX pattern.
+    //               This entity lastName contains string with REGEX pattern.
+    public Employee basicEmployeeExample16() {
+        Employee employee = createEmployee();
+
+        try {
+            employee.setFirstName("Betty");
+            employee.setLastName("Be[ea]dril");
+            employee.setFemale();
+            employee.setSalary(500001);
+            startCalendar.set(1970, 0, 1, 22, 0, 0);
+            endCalendar.set(1970, 0, 1, 5, 30, 0);
+            employee.setPeriod(employmentPeriodExample4());
+            employee.setAddress(addressExample2());
+            employee.setDepartment(departmentExample4());
+            employee.addPhoneNumber(phoneNumberExample5());
+            employee.addPhoneNumber(phoneNumberExample3());
+
+        } catch (Exception exception) {
+            throw new RuntimeException(exception.toString());
+        }
+
+        return employee;
+    }
+
+    // Bug# 545940 - LIKE query must escape '[' and ']' characters to not allow using them as REGEX pattern.
+    //               This entity lastName contains string matching REGEX pattern.
+    public Employee basicEmployeeExample17() {
+        Employee employee = createEmployee();
+
+        try {
+            employee.setFirstName("Betty");
+            employee.setLastName("Beedril");
+            employee.setFemale();
+            employee.setSalary(500001);
+            startCalendar.set(1970, 0, 1, 22, 0, 0);
+            endCalendar.set(1970, 0, 1, 5, 30, 0);
+            employee.setPeriod(employmentPeriodExample4());
+            employee.setAddress(addressExample2());
+            employee.setDepartment(departmentExample5());
+            employee.addPhoneNumber(phoneNumberExample5());
+            employee.addPhoneNumber(phoneNumberExample3());
+
+        } catch (Exception exception) {
+            throw new RuntimeException(exception.toString());
+        }
+
+        return employee;
+    }
+
     public EquipmentCode basicEquipmentCodeExampleA() {
         EquipmentCode equipmentCode = createEquipmentCode();
 
@@ -1052,6 +1102,18 @@ public class EmployeePopulator {
     public Department departmentExample3() {
         Department department = new Department();
         department.setName("Department 3");
+        return department;
+    }
+
+    public Department departmentExample4() {
+        Department department = new Department();
+        department.setName("Department 4");
+        return department;
+    }
+
+    public Department departmentExample5() {
+        Department department = new Department();
+        department.setName("Department 5");
         return department;
     }
 


### PR DESCRIPTION
Implemented for MS SQL platform.
Covers both constant and parameter expressions in JPQL query.