### PR TITLE
Bug 521424: Add MOXY to logger categories

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/logging/LogCategory.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/logging/LogCategory.java
@@ -37,6 +37,7 @@ import org.eclipse.persistence.config.PersistenceUnitProperties;
  * <tr><td>&nbsp;</td><td>METADATA</td>       <td>&nbsp;</td><td>= "metadata"</td></tr>
  * <tr><td>&nbsp;</td><td>METAMODEL</td>      <td>&nbsp;</td><td>= "metamodel"</td></tr>
  * <tr><td>&nbsp;</td><td>MONITORING</td>     <td>&nbsp;</td><td>= "monitoring"</td></tr>
+ * <tr><td>&nbsp;</td><td>MOXY</td>           <td>&nbsp;</td><td>= "moxy"</td></tr>
  * <tr><td>&nbsp;</td><td>PROPAGATION</td>    <td>&nbsp;</td><td>= "propagation"</td></tr>
  * <tr><td>&nbsp;</td><td>PROPERTIES</td>     <td>&nbsp;</td><td>= "properties"</td></tr>
  * <tr><td>&nbsp;</td><td>QUERY</td>          <td>&nbsp;</td><td>= "query"</td></tr>
@@ -61,15 +62,16 @@ public enum LogCategory {
     METAMODEL(  (byte)0x0A, SessionLog.METAMODEL),
     MISC(       (byte)0x0B, SessionLog.MISC),
     MONITORING( (byte)0x0C, SessionLog.MONITORING),
-    PROCESSOR(  (byte)0x0D, SessionLog.PROCESSOR),
-    PROPAGATION((byte)0x0E, SessionLog.PROPAGATION),
-    PROPERTIES( (byte)0x0F, SessionLog.PROPERTIES),
-    QUERY(      (byte)0x10, SessionLog.QUERY),
-    SEQUENCING( (byte)0x11, SessionLog.SEQUENCING),
-    SERVER(     (byte)0x12, SessionLog.SERVER),
-    SQL(        (byte)0x13, SessionLog.SQL),
-    TRANSACTION((byte)0x14, SessionLog.TRANSACTION),
-    WEAVER(     (byte)0x15, SessionLog.WEAVER);
+    MOXY(       (byte)0x0D, SessionLog.MOXY),
+    PROCESSOR(  (byte)0x0E, SessionLog.PROCESSOR),
+    PROPAGATION((byte)0x0F, SessionLog.PROPAGATION),
+    PROPERTIES( (byte)0x10, SessionLog.PROPERTIES),
+    QUERY(      (byte)0x11, SessionLog.QUERY),
+    SEQUENCING( (byte)0x12, SessionLog.SEQUENCING),
+    SERVER(     (byte)0x13, SessionLog.SERVER),
+    SQL(        (byte)0x14, SessionLog.SQL),
+    TRANSACTION((byte)0x15, SessionLog.TRANSACTION),
+    WEAVER(     (byte)0x16, SessionLog.WEAVER);
 
     /** Logging categories enumeration length. */
     public static final int length = LogCategory.values().length;


### PR DESCRIPTION
This would fix `IllegalArgumentException: Unknown logging category name.` on startup when `org.eclipse.persistence.logging.slf4j.SLF4JLogger` is selected as a logger.