### PR TITLE
Bug 501058 - Unmarshalling JSON with @XmlValue + @XmlAttribute(s) leaves value blank if value property is before attributes

### DIFF
--- a/foundation/org.eclipse.persistence.core/core.iml
+++ b/foundation/org.eclipse.persistence.core/core.iml
@@ -48,7 +48,6 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/../../plugins/org.glassfish.jakarta.json.jar!/" />
           <root url="jar://$MODULE_DIR$/../../plugins/jakarta.json.jar!/" />
         </CLASSES>
         <JAVADOC />
@@ -58,7 +57,7 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/../../plugins/com.sun.mail.jakarta.mail.jar!/" />
+          <root url="jar://$MODULE_DIR$/../../plugins/jakarta.mail.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES />

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/record/json/JsonStructureReader.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/record/json/JsonStructureReader.java
@@ -265,8 +265,17 @@ public class JsonStructureReader extends XMLReaderAdapter {
                 break;
             }
             case OBJECT: {
+                Entry<String, JsonValue> xmlValueEntry = null;
                 for (Entry<String, JsonValue> nextEntry : ((JsonObject) jsonValue).entrySet()) {
-                    parsePair(nextEntry.getKey(), nextEntry.getValue());
+                    if (textWrapper != null && textWrapper.equals(nextEntry.getKey())) {
+                        xmlValueEntry = nextEntry;
+                    } else {
+                        parsePair(nextEntry.getKey(), nextEntry.getValue());
+                    }
+                }
+                //Proceed JSON value mapped to @XmlValue property as a last
+                if (xmlValueEntry != null) {
+                    parsePair(xmlValueEntry.getKey(), xmlValueEntry.getValue());
                 }
                 break;
             }

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/json/xmlvalue/personUnmarshalValueFirst.json
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/json/xmlvalue/personUnmarshalValueFirst.json
@@ -1,0 +1,12 @@
+{"person":{
+   "address":{
+      "unmarshalWrapper":"someStreet someCity somePostalCode"
+    },
+   "firstName":"Sally",
+   "lastName":"Smith",
+    "phoneNumber":{
+      "unmarshalWrapper":"1234567",
+      "areaCode":"613"
+      }
+ }
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/JSONTestSuite.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/JSONTestSuite.java
@@ -47,6 +47,7 @@ import org.eclipse.persistence.testing.jaxb.json.unmapped.JsonUnmappedTestCases;
 import org.eclipse.persistence.testing.jaxb.json.wrapper.AllWrapperTestCases;
 import org.eclipse.persistence.testing.jaxb.json.xmlvalue.XMLValuePropDifferentTestCases;
 import org.eclipse.persistence.testing.jaxb.json.xmlvalue.XMLValuePropTestCases;
+import org.eclipse.persistence.testing.jaxb.json.xmlvalue.XMLValuePropValueFirstInJSONTestCases;
 import org.eclipse.persistence.testing.oxm.xmlconversionmanager.NumberTestCases;
 
 public class JSONTestSuite extends TestSuite {
@@ -78,6 +79,7 @@ public class JSONTestSuite extends TestSuite {
           suite.addTestSuite(IncludeRootTrueWithXMLRootElementTestCases.class);
           suite.addTestSuite(XMLValuePropTestCases.class);
           suite.addTestSuite(XMLValuePropDifferentTestCases.class);
+          suite.addTestSuite(XMLValuePropValueFirstInJSONTestCases.class);
           suite.addTestSuite(NumberTestCases.class);
           suite.addTestSuite(EscapeCharactersTestCases.class);
           suite.addTestSuite(UsAsciiTestCases.class);

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/xmlvalue/XMLValuePropValueFirstInJSONTestCases.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/json/xmlvalue/XMLValuePropValueFirstInJSONTestCases.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Radek Felcman - bug fix 501058 (version 2.7.5)
+package org.eclipse.persistence.testing.jaxb.json.xmlvalue;
+
+import org.eclipse.persistence.jaxb.MarshallerProperties;
+import org.eclipse.persistence.jaxb.UnmarshallerProperties;
+
+public class XMLValuePropValueFirstInJSONTestCases extends XMLValuePropTestCases {
+
+    private final static String JSON_RESOURCE = "org/eclipse/persistence/testing/jaxb/json/xmlvalue/personUnmarshalValueFirst.json";
+    private final static String JSON_WRITE_RESOURCE = "org/eclipse/persistence/testing/jaxb/json/xmlvalue/personMarshal.json";
+
+    public XMLValuePropValueFirstInJSONTestCases(String name) throws Exception {
+        super(name);
+        setClasses(new Class[]{Person.class});
+        setControlJSON(JSON_RESOURCE);
+        setWriteControlJSON(JSON_WRITE_RESOURCE);
+    }
+
+    public void setUp() throws Exception{
+        super.setUp();
+        jaxbMarshaller.setProperty(MarshallerProperties.JSON_VALUE_WRAPPER, "marshalWrapper");
+        jaxbUnmarshaller.setProperty(UnmarshallerProperties.JSON_VALUE_WRAPPER, "unmarshalWrapper");
+    }
+}


### PR DESCRIPTION
Bug 501058 - Unmarshalling JSON with @XmlValue + @XmlAttribute(s) leaves value blank if value property is before attributes

Bug Fix + unit test.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>