### PR TITLE
Fix for bug #463042

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/expressions/ExpressionOperator.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/expressions/ExpressionOperator.java
@@ -58,7 +58,7 @@ public class ExpressionOperator implements Serializable {
     static final long serialVersionUID = -7066100204792043980L;
     protected int selector;
     protected String name;
-    protected String[] databaseStrings;
+    private String[] databaseStrings;
     protected boolean isPrefix = false;
     protected boolean isRepeating = false;
     protected Class nodeClass;
@@ -757,15 +757,24 @@ public class ExpressionOperator implements Serializable {
         return true;
     }
 
-    public void copyTo(ExpressionOperator operator){
+    /**
+     * Partial deep-clone of the operator instance.
+     * <p>
+     * This is only used by <tt>ListExpressionOperator.copyTo()</tt>.
+     *
+     * @param operator
+     *            the operator to copy the current state to
+     */
+    protected void copyTo(ExpressionOperator operator){
+        // "name" is not copied.
         operator.selector = selector;
         operator.isPrefix = isPrefix;
         operator.isRepeating = isRepeating;
         operator.nodeClass = nodeClass;
         operator.type = type;
-        operator.databaseStrings = databaseStrings == null ? null : Helper.copyStringArray(databaseStrings);
-        operator.argumentIndices = argumentIndices == null ? null : Helper.copyIntArray(argumentIndices);
-        operator.javaStrings = javaStrings == null ? null : Helper.copyStringArray(javaStrings);
+        operator.databaseStrings = Helper.copyStringArray(databaseStrings);
+        operator.argumentIndices = Helper.copyIntArray(argumentIndices);
+        operator.javaStrings = Helper.copyStringArray(javaStrings);
         operator.isBindingSupported = isBindingSupported;
     }
 

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/expressions/ListExpressionOperator.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/expressions/ListExpressionOperator.java
@@ -129,26 +129,27 @@ public class ListExpressionOperator extends ExpressionOperator {
         // of a new object instance are:
         // - isComplete
         // - numberOfItems
-
-        // TODO patrick.haller@sap.com: is this calculation correct? Why is "numberOfItems" including #startStrings and
-        // #terminationStrings?
-        final int _numberOfItems = noOfItems - startStrings.length - terminationStrings.length;
-        assert _numberOfItems > 0;
-
-        final String[] databaseStrings = new String[startStrings.length + _numberOfItems * separators.length
-                + terminationStrings.length];
-        System.arraycopy(startStrings, 0, databaseStrings, 0, startStrings.length);
-
-        int pos = startStrings.length;
-        for (int j = 0; j < _numberOfItems; j++)
-        {
-            System.arraycopy(separators, 0, databaseStrings, pos, separators.length);
-            pos += separators.length;
+        final String[] databaseStrings = new String[noOfItems + 1];
+        int i = 0;
+        while (i < startStrings.length){
+            databaseStrings[i] = startStrings[i];
+            i++;
         }
-        System.arraycopy(terminationStrings, 0, databaseStrings, pos, terminationStrings.length);
+        while  (i < noOfItems - (terminationStrings.length - 1)){
+            for (int j=0;j<separators.length;j++){
+                databaseStrings[i] = separators[j];
+                i++;
+            }
+        }
+        while (i <= noOfItems){
+            for (int j=0;j<terminationStrings.length;j++){
+                databaseStrings[i] = terminationStrings[j];
+                    i++;
+            }
+        }
         return databaseStrings;
     }
-
+    
     public int getNumberOfItems(){
         return numberOfItems;
     }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/expressions/ListExpressionOperator.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/expressions/ListExpressionOperator.java
@@ -14,7 +14,7 @@
 //     tware - initial API and implementation from for JPA 2.0 criteria API
 package org.eclipse.persistence.expressions;
 
-import java.util.Vector;
+import java.util.List;
 
 import org.eclipse.persistence.internal.expressions.ArgumentListFunctionExpression;
 import org.eclipse.persistence.internal.helper.Helper;
@@ -200,10 +200,10 @@ public class ListExpressionOperator extends ExpressionOperator {
 
     /*
      * (non-Javadoc)
-     * @see org.eclipse.persistence.expressions.ExpressionOperator#printsAs(java.util.Vector)
+     * @see org.eclipse.persistence.expressions.ExpressionOperator#printsAs(java.util.List)
      */
     @Override
-    public void printsAs(Vector dbStrings)
+    public void printsAs(List<String> dbStrings)
     {
         // The parent class's side-effect modification of the externalized
         // databaseStrings array is unsupported.


### PR DESCRIPTION
by avoiding sharing the ListExpressionOperator
instance between threads. This is achieved by
cloning the operator instance in
ArgumentListFunctionExpression.postCopyIn().

Before, getDatabaseStrings() and parallel modifications to
numberOfItems were clashing.

https://bugs.eclipse.org/bugs/show_bug.cgi?id=463042

Change-Id: Ia2e29da74797494394d0323dcc5ded501d72b433
Signed-off-by: Patrick Haller <patrick.haller@sap.com>