### PR TITLE
[master] Bug 547023 - Add LOB Locator support to core Oracle platform (master)

### DIFF
--- a/foundation/org.eclipse.persistence.core/resource/org/eclipse/persistence/internal/helper/VendorNameToPlatformMapping.properties
+++ b/foundation/org.eclipse.persistence.core/resource/org/eclipse/persistence/internal/helper/VendorNameToPlatformMapping.properties
@@ -1,6 +1,6 @@
 #
-# Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
-# Copyright (c) 1998, 2018 IBM Corporation. All rights reserved.
+# Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1998, 2019 IBM Corporation. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at
@@ -21,6 +21,8 @@
 #       - 465063 : Updated platform regex to match productName returned from a DB2/I connection.
 #     05/22/2018 - Will Dazey
 #       - 532160 : Add support for non-extension OracleXPlatform classes
+#     05/06/2019 - Jody Grassel
+#       - 547023 : Add LOB Locator support for core Oracle platform.
 
 # Key-Value file containing mappings between DB product name, major version, product version and
 # database platform class name.
@@ -34,10 +36,12 @@
 # to platform class entries should be placed before less specific entries. Each
 # platform entry must be on its own line, an entry cannot span multiple lines.
 
+(?is)oracle.*18.*=org.eclipse.persistence.platform.database.oracle.Oracle18Platform
 (?is)oracle.*12.*=org.eclipse.persistence.platform.database.oracle.Oracle12Platform
 (?is)oracle.*11.*=org.eclipse.persistence.platform.database.oracle.Oracle11Platform
 (?is)oracle.*10.*=org.eclipse.persistence.platform.database.oracle.Oracle10Platform
 (?is)oracle.*9.*=org.eclipse.persistence.platform.database.oracle.Oracle9Platform
+(?is)core.oracle.*18.*=org.eclipse.persistence.platform.database.Oracle18Platform
 (?is)core.oracle.*12.*=org.eclipse.persistence.platform.database.Oracle12Platform
 (?is)core.oracle.*11.*=org.eclipse.persistence.platform.database.Oracle11Platform
 (?is)core.oracle.*10.*=org.eclipse.persistence.platform.database.Oracle10Platform

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/Oracle10Platform.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/Oracle10Platform.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018 IBM Corporation. All rights reserved.
+ * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -37,5 +37,17 @@ public class Oracle10Platform extends Oracle9Platform {
     protected String buildFirstRowsHint(int max){
         //bug 374136: override setting the FIRST_ROWS hint as this is not needed on Oracle10g
         return "";
+    }
+    
+    /**
+     * INTERNAL:
+     * Indicate whether app. server should unwrap connection
+     * to use lob locator.
+     * No need to unwrap connection because
+     * writeLob method doesn't use oracle proprietary classes.
+     */
+    @Override
+    public boolean isNativeConnectionRequiredForLobLocator() {
+        return false;
     }
 }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/Oracle18Platform.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/Oracle18Platform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -12,24 +12,14 @@
  */
 
 // Contributors:
-//     06/26/2018 - Will Dazey
-//       - 532160 : Add support for non-extension OracleXPlatform classes
+//     IBM - initial drop
 //     05/06/2019 - Jody Grassel
 //       - 547023 : Add LOB Locator support for core Oracle platform.
 
 package org.eclipse.persistence.platform.database;
 
-/**
- * <p><b>Purpose:</b>
- * Provides Oracle version specific behavior when 
- * org.eclipse.persistence.oracle bundle is not available.
- */
-public class Oracle11Platform extends Oracle10Platform {
-    public Oracle11Platform() {
+public class Oracle18Platform extends Oracle12Platform {
+    public Oracle18Platform() {
         super();
-        
-        // Locator is no longer required to write LOB values
-        usesLocatorForLOBWrite = false;
     }
 }
-

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/Oracle8Platform.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/Oracle8Platform.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018 IBM Corporation. All rights reserved.
+ * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,7 +14,25 @@
 // Contributors:
 //     06/26/2018 - Will Dazey
 //       - 532160 : Add support for non-extension OracleXPlatform classes
+//     05/06/2019 - Jody Grassel
+//       - 547023 : Add LOB Locator support for core Oracle platform.
+
 package org.eclipse.persistence.platform.database;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Hashtable;
+
+import org.eclipse.persistence.internal.databaseaccess.DatabaseCall;
+import org.eclipse.persistence.internal.databaseaccess.FieldTypeDefinition;
+import org.eclipse.persistence.internal.databaseaccess.Platform;
+import org.eclipse.persistence.internal.databaseaccess.SimpleAppendCallCustomParameter;
+import org.eclipse.persistence.internal.helper.ClassConstants;
+import org.eclipse.persistence.internal.helper.DatabaseField;
+import org.eclipse.persistence.internal.sessions.AbstractSession;
+import org.eclipse.persistence.logging.SessionLog;
+import org.eclipse.persistence.queries.Call;
 
 /**
  * <p><b>Purpose:</b>
@@ -22,4 +40,211 @@ package org.eclipse.persistence.platform.database;
  * org.eclipse.persistence.oracle bundle is not available.
  */
 public class Oracle8Platform extends OraclePlatform {
+    /**
+     * Locator is required for Oracle thin driver to write LOB value exceeds the
+     * limits
+     */
+    protected boolean usesLocatorForLOBWrite = true;
+
+    /** The LOB value limits when the Locator is required for the writing */
+    protected int lobValueLimits = 0;
+
+    /**
+     * INTERNAL:
+     */
+    @Override
+    protected Hashtable buildFieldTypes() {
+        Hashtable fieldTypeMapping = super.buildFieldTypes();
+
+        fieldTypeMapping.put(Byte[].class, new FieldTypeDefinition("BLOB", false));
+        fieldTypeMapping.put(Character[].class, new FieldTypeDefinition("CLOB", false));
+
+        return fieldTypeMapping;
+    }
+
+    /**
+     * INTERNAL: Allow for conversion from the Oracle type to the Java type.
+     */
+    @Override
+    public void copyInto(Platform platform) {
+        super.copyInto(platform);
+        if (!(platform instanceof Oracle8Platform)) {
+            return;
+        }
+        Oracle8Platform oracle8Platform = (Oracle8Platform) platform;
+        oracle8Platform.setShouldUseLocatorForLOBWrite(shouldUseLocatorForLOBWrite());
+        oracle8Platform.setLobValueLimits(getLobValueLimits());
+    }
+
+    /**
+     * INTERNAL Used by SQLCall.appendModify(..) If the field should be passed
+     * to customModifyInDatabaseCall, retun true, otherwise false. Methods
+     * shouldCustomModifyInDatabaseCall and customModifyInDatabaseCall should be
+     * kept in sync: shouldCustomModifyInDatabaseCall should return true if and
+     * only if the field is handled by customModifyInDatabaseCall.
+     */
+    @Override
+    public boolean shouldUseCustomModifyForCall(DatabaseField field) {
+        if (shouldUseLocatorForLOBWrite()) {
+            Class type = field.getType();
+            if (ClassConstants.BLOB.equals(type) || ClassConstants.CLOB.equals(type)) {
+                return true;
+            }
+        }
+        return super.shouldUseCustomModifyForCall(field);
+    }
+
+    /**
+     * INTERNAL: Return if the LOB value size is larger than the limit, i.e. 4k.
+     */
+    protected boolean lobValueExceedsLimit(Object value) {
+        if (value == null) {
+            return false;
+        }
+        int limit = getLobValueLimits();
+        if (value instanceof byte[]) {// blob
+            return ((byte[]) value).length >= limit;
+        } else if (value instanceof String) {// clob
+            return ((String) value).length() >= limit;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * INTERNAL: This method is used to unwrap the oracle connection wrapped by
+     * the application server. TopLink needs this unwrapped connection for
+     * certain Oracle Specific support. (ie TIMESTAMPTZ, LOB) This is added as a
+     * workaround for bug 4565190
+     */
+    @Override
+    public Connection getConnection(AbstractSession session, Connection connection) {
+        if (session.getServerPlatform() != null && (session.getLogin()).shouldUseExternalConnectionPooling()) {
+            // This is added as a workaround for bug 4460996
+            return session.getServerPlatform().unwrapConnection(connection);
+        }
+        return connection;
+    }
+
+    /**
+     * INTERNAL Used by SQLCall.translate(..) Typically there is no field
+     * translation (and this is default implementation). However on different
+     * platforms (Oracle) there are cases such that the values for binding and
+     * appending may be different (BLOB, CLOB). In these special cases the
+     * method returns a wrapper object which knows whether it should be bound or
+     * appended and knows how to do that.
+     */
+    @Override
+    public Object getCustomModifyValueForCall(Call call, Object value, DatabaseField field, boolean shouldBind) {
+        Class type = field.getType();
+        if (ClassConstants.BLOB.equals(type) || ClassConstants.CLOB.equals(type)) {
+            if (value == null) {
+                return null;
+            }
+            Object lobValue = convertToDatabaseType(value);
+            if (shouldUseLocatorForLOBWrite() & lobValueExceedsLimit(lobValue)) {
+                ((DatabaseCall) call).addContext(field, lobValue);
+                if (ClassConstants.BLOB.equals(type)) {
+                    if (shouldBind) {
+                        lobValue = new byte[1];
+                    } else {
+                        lobValue = new SimpleAppendCallCustomParameter("empty_blob()");
+                    }
+                } else {
+                    if (shouldBind) {
+                        lobValue = new String(" ");
+                    } else {
+                        lobValue = new SimpleAppendCallCustomParameter("empty_clob()");
+                    }
+                }
+            }
+            
+            return lobValue;
+        }
+        return super.getCustomModifyValueForCall(call, value, field, shouldBind);
+    }
+
+    
+    /**
+     * INTERNAL: Write LOB value - only on Oracle8 and up
+     */
+    @SuppressWarnings("deprecation")
+    @Override
+    public void writeLOB(DatabaseField field, Object value, ResultSet resultSet, AbstractSession session)
+            throws SQLException {
+        if (isBlob(field.getType())) {
+            // change for 338585 to use getName instead of getNameDelimited
+            java.sql.Blob blob = (java.sql.Blob) resultSet.getObject(field.getName());
+            blob.setBytes(1, (byte[]) value);
+            //impose the localization
+            session.log(SessionLog.FINEST, SessionLog.SQL, "write_BLOB", Long.valueOf(blob.length()), field.getName());
+        } else if (isClob(field.getType())) {
+            // change for 338585 to use getName instead of getNameDelimited
+            java.sql.Clob clob = (java.sql.Clob) resultSet.getObject(field.getName());
+            clob.setString(1, (String) value);
+            //impose the localization
+            session.log(SessionLog.FINEST, SessionLog.SQL, "write_CLOB", Long.valueOf(clob.length()), field.getName());
+        } else {
+            // do nothing for now, open to BFILE or NCLOB types
+        }
+    }
+
+    /**
+     * INTERNAL: Used in writeLOB method only to identify a BLOB
+     */
+    protected boolean isBlob(Class type) {
+        return ClassConstants.BLOB.equals(type);
+    }
+
+    /**
+     * INTERNAL: Used in writeLOB method only to identify a CLOB
+     */
+    protected boolean isClob(Class type) {
+        return ClassConstants.CLOB.equals(type);
+    }
+
+    /**
+     * INTERNAL: Indicates whether app. server should unwrap connection to use
+     * lob locator.
+     */
+    @Override
+    public boolean isNativeConnectionRequiredForLobLocator() {
+        return true;
+    }
+
+    /**
+     * PUBLIC: Set if the locator is required for the LOB write. The default is
+     * true. For Oracle thin driver, the locator is recommended for large size (
+     * >4k for Oracle8, >5.9K for Oracle9) BLOB/CLOB value write.
+     */
+    public void setShouldUseLocatorForLOBWrite(boolean usesLocatorForLOBWrite) {
+        this.usesLocatorForLOBWrite = usesLocatorForLOBWrite;
+    }
+
+    /**
+     * PUBLIC: Return if the locator is required for the LOB write. The default
+     * is true. For Oracle thin driver, the locator is recommended for large
+     * size ( >4k for Oracle8, >5.9K for Oracle9) BLOB/CLOB value write.
+     */
+    public boolean shouldUseLocatorForLOBWrite() {
+        return usesLocatorForLOBWrite;
+    }
+
+    /**
+     * PUBLIC: Return the BLOB/CLOB value limits on thin driver. The default
+     * value is 0. If usesLocatorForLOBWrite is true, locator will be used in
+     * case the lob's size is larger than lobValueLimit.
+     */
+    public int getLobValueLimits() {
+        return lobValueLimits;
+    }
+
+    /**
+     * PUBLIC: Set the BLOB/CLOB value limits on thin driver. The default value
+     * is 0. If usesLocatorForLOBWrite is true, locator will be used in case the
+     * lob's size is larger than lobValueLimit.
+     */
+    public void setLobValueLimits(int lobValueLimits) {
+        this.lobValueLimits = lobValueLimits;
+    }
 }

--- a/foundation/org.eclipse.persistence.oracle/src/org/eclipse/persistence/platform/database/oracle/Oracle18Platform.java
+++ b/foundation/org.eclipse.persistence.oracle/src/org/eclipse/persistence/platform/database/oracle/Oracle18Platform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -12,24 +12,14 @@
  */
 
 // Contributors:
-//     06/26/2018 - Will Dazey
-//       - 532160 : Add support for non-extension OracleXPlatform classes
+//     IBM - initial drop
 //     05/06/2019 - Jody Grassel
 //       - 547023 : Add LOB Locator support for core Oracle platform.
 
-package org.eclipse.persistence.platform.database;
+package org.eclipse.persistence.platform.database.oracle;
 
-/**
- * <p><b>Purpose:</b>
- * Provides Oracle version specific behavior when 
- * org.eclipse.persistence.oracle bundle is not available.
- */
-public class Oracle11Platform extends Oracle10Platform {
-    public Oracle11Platform() {
+public class Oracle18Platform extends Oracle12Platform {
+    public Oracle18Platform() {
         super();
-        
-        // Locator is no longer required to write LOB values
-        usesLocatorForLOBWrite = false;
     }
 }
-

--- a/jpa/eclipselink.jpa.test.jse/antbuild.xml
+++ b/jpa/eclipselink.jpa.test.jse/antbuild.xml
@@ -46,7 +46,16 @@
     <property name="javax.transaction" value="${jse.el.plugins.dir}/jakarta.transaction-api.jar"/>
     <property name="javax.validation" value="${jse.el.plugins.dir}/jakarta.validation-api.jar"/>
     <property name="javax.persistence" value="${jse.jpa.plugins.dir}/jakarta.persistence_2.2.2.jar"/>
+
+    <fileset id="jse.antlr.jar.path" dir="${jse.el.plugins.dir}" includes="*antlr_*.jar"/>
+    <pathconvert property="jse.antlr.jar" refid="jse.antlr.jar.path"/>
+    <fileset id="jse.asm.jar.path" dir="${jse.el.plugins.dir}" includes="*asm_*.jar"/>
+    <pathconvert property="jse.asm.jar" refid="jse.asm.jar.path"/>
+    <property name="jse.core.jar" value="${jse.el.plugins.dir}/org.eclipse.persistence.core_${version.string}.jar"/>
+    <property name="jse.jpa.jar" value="${jse.el.plugins.dir}/org.eclipse.persistence.jpa_${version.string}.jar"/>
+    <property name="jse.jpql.jar" value="${jse.el.plugins.dir}/org.eclipse.persistence.jpa.jpql_${version.string}.jar"/>
     <property name="jse.modelgen.jar" value="${jse.el.plugins.dir}/org.eclipse.persistence.jpa.modelgen_${version.string}.jar"/>
+    <property name="jse.dbws.jar" value="${jse.el.plugins.dir}/org.eclipse.persistence.dbws_${version.string}.jar"/>
 
     <!-- JVM used to run tests -->
     <property name="test.junit.jvm" value="${env.JAVA_HOME}"/>
@@ -67,11 +76,16 @@
     </path>
     <path id="run.jse.path">
         <pathelement path="${jse.classes.dir}" />
-        <pathelement path="${jse.eclipselink.jar}" />
+        <pathelement path="${javax.persistence}" />
+        <pathelement path="${jse.antlr.jar}" />
+        <pathelement path="${jse.asm.jar}" />
+        <pathelement path="${jse.core.jar}" />
+        <pathelement path="${jse.jpa.jar}" />
+        <pathelement path="${jse.jpql.jar}" />
         <pathelement path="${jse.modelgen.jar}" />
+        <pathelement path="${jse.dbws.jar}" />
         <pathelement path="${javax.transaction}" />
         <pathelement path="${javax.validation}" />
-        <pathelement path="${javax.persistence}" />
         <pathelement path="${junit.lib}" />
         <pathelement path="${jdbc.driver.jar}" />
     </path>

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/oraclefeatures/OracleLOBLocatorSessionCustomizer.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/oraclefeatures/OracleLOBLocatorSessionCustomizer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 IBM Corporation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     IBM - initial drop
+//     05/06/2019 - Jody Grassel
+//       - 547023 : Add LOB Locator support for core Oracle platform.
+
+package org.eclipse.persistence.jpa.test.oraclefeatures;
+
+import org.eclipse.persistence.config.SessionCustomizer;
+import org.eclipse.persistence.internal.databaseaccess.Platform;
+import org.eclipse.persistence.platform.database.Oracle8Platform;
+import org.eclipse.persistence.sessions.Session;
+import org.eclipse.persistence.sessions.SessionEvent;
+import org.eclipse.persistence.sessions.SessionEventAdapter;
+
+public class OracleLOBLocatorSessionCustomizer implements SessionCustomizer {
+
+    @Override
+    public void customize(Session session) throws Exception {
+        session.getEventManager().addListener(new OracleLobSessionEventAdapter());
+    }
+    
+    private class OracleLobSessionEventAdapter extends SessionEventAdapter {
+        /**
+         * PUBLIC:
+         * This Event is raised after the session logs in.
+         */
+        public void postLogin(SessionEvent event) {
+            Session session = event.getSession();
+            Platform dbPlatform = session.getDatasourcePlatform();
+            if (dbPlatform instanceof Oracle8Platform) {
+                ((Oracle8Platform) dbPlatform).setShouldUseLocatorForLOBWrite(true);
+            }
+        }
+    }
+
+}

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/oraclefeatures/TestOracleLOBLocatorFeature.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/oraclefeatures/TestOracleLOBLocatorFeature.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 IBM Corporation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     IBM - initial drop
+//     05/06/2019 - Jody Grassel
+//       - 547023 : Add LOB Locator support for core Oracle platform.
+
+package org.eclipse.persistence.jpa.test.oraclefeatures;
+
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+
+import org.eclipse.persistence.internal.jpa.EntityManagerFactoryImpl;
+import org.eclipse.persistence.jpa.test.framework.DDLGen;
+import org.eclipse.persistence.jpa.test.framework.Emf;
+import org.eclipse.persistence.jpa.test.framework.EmfRunner;
+import org.eclipse.persistence.jpa.test.framework.Property;
+import org.eclipse.persistence.jpa.test.oraclefeatures.model.OracleLobEntity;
+import org.eclipse.persistence.platform.database.DatabasePlatform;
+import org.eclipse.persistence.platform.database.OraclePlatform;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(EmfRunner.class)
+public class TestOracleLOBLocatorFeature {
+    private final static char[] alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghikjlmnopqrstuvwxyz".toCharArray();
+    private final static int alphaLen = alphabet.length;
+
+    @Emf(name = "emfWithSessionCustomizer",createTables = DDLGen.DROP_CREATE, classes = { OracleLobEntity.class }, properties = {
+            @Property(name = "eclipselink.session.customizer", value="org.eclipse.persistence.jpa.test.oraclefeatures.OracleLOBLocatorSessionCustomizer")
+//            @Property(name = "eclipselink.logging.level", value = "FINEST"),
+    })
+    private EntityManagerFactory emf;
+
+    @Emf(name = "emfNoSessionCustomizer", createTables = DDLGen.DROP_CREATE, classes = { OracleLobEntity.class })
+    private EntityManagerFactory emfNoSessionCustomizer;
+
+    
+    private SecureRandom sr = new SecureRandom();
+
+    @Test
+    public void testOracleLOBLocator() throws Exception {
+        if (!checkIsOracle()) {
+            // Skip if not testing against Oracle
+            return;
+        }
+
+        System.out.println("***** Begin testOracleLOBLocator");
+
+        EntityManager em = emf.createEntityManager();
+        try {
+            OracleLobEntity blobEntity = new OracleLobEntity();
+            blobEntity.setStrData("Some Data");
+
+            int datalen = 50000;
+            byte[] data = new byte[datalen];
+            sr.nextBytes(data);
+            blobEntity.setBlobData(data);
+
+            char[] cdata = new char[datalen];
+            for (int i = 0; i < datalen; i++) {
+                cdata[i] = alphabet[Math.abs((sr.nextInt() % alphaLen))];
+            }
+            blobEntity.setClobData(new String(cdata));
+
+            em.getTransaction().begin();
+            em.persist(blobEntity);
+            em.getTransaction().commit();
+
+            em.clear();
+
+            OracleLobEntity findEntity = em.find(OracleLobEntity.class, blobEntity.getId());
+            Assert.assertNotNull(findEntity);
+            Assert.assertEquals(blobEntity.getStrData(), findEntity.getStrData());
+            Assert.assertEquals(blobEntity.getBlobData(), findEntity.getBlobData());
+            Assert.assertEquals(blobEntity.getClobData(), findEntity.getClobData());
+        } finally {
+            if(em != null) {
+                if (em.getTransaction().isActive()) {
+                    em.getTransaction().rollback();
+                }
+                if(em.isOpen()) {
+                    em.close();
+                 }
+            }
+            System.out.println("***** End testOracleLOBLocator");
+        }
+    }
+
+    @Test
+    public void testOracleLOBLocatorWithEmptyClob() throws Exception {
+        if (!checkIsOracle()) {
+            // Skip if not testing against Oracle
+            return;
+        }
+
+        System.out.println("***** Begin testOracleLOBLocatorWithEmptyClob");
+
+        EntityManager em = emf.createEntityManager();
+        try {
+            OracleLobEntity blobEntity = new OracleLobEntity();
+            blobEntity.setStrData("Some Data");
+
+            int datalen = 50000;
+            byte[] data = new byte[datalen];
+            sr.nextBytes(data);
+            blobEntity.setBlobData(data);
+
+            blobEntity.setClobData("");
+
+            em.getTransaction().begin();
+            em.persist(blobEntity);
+            em.getTransaction().commit();
+
+            em.clear();
+
+            OracleLobEntity findEntity = em.find(OracleLobEntity.class, blobEntity.getId());
+            Assert.assertNotNull(findEntity);
+            Assert.assertEquals(blobEntity.getStrData(), findEntity.getStrData());
+            Assert.assertEquals(blobEntity.getBlobData(), findEntity.getBlobData());
+            Assert.assertEquals(blobEntity.getClobData(), findEntity.getClobData());
+        } finally {
+            if(em != null) {
+                if (em.getTransaction().isActive()) {
+                    em.getTransaction().rollback();
+                }
+                if(em.isOpen()) {
+                    em.close();
+                 }
+            }
+            System.out.println("***** End testOracleLOBLocatorWithEmptyClob");
+        }
+    }
+    
+    @Test
+    public void testOracleWithoutLOBLocatorWithEmptyClob() throws Exception {
+        // After Oracle 11, the lob locator is disabled by default (requiring a Session Customizer to reenable it)
+        // So the test should fail because Eclipselink will try store a null value instead of an empty_blob()/empty_clob()
+        // and violate the NOT NULL constraint.
+        Set<String> notAllowedPlatforms = new HashSet<String>();
+        notAllowedPlatforms.add("org.eclipse.persistence.platform.database.Oracle8Platform");
+        notAllowedPlatforms.add("org.eclipse.persistence.platform.database.Oracle9Platform");
+        notAllowedPlatforms.add("org.eclipse.persistence.platform.database.Oracle10Platform");
+        
+        
+        if (!checkIsOracle() || notAllowedPlatforms.contains(getPlatform(emfNoSessionCustomizer).getClass().getName())) {
+            // Skip if not testing against Oracle
+            return;
+        }
+
+        System.out.println("***** Begin testOracleWithoutLOBLocatorWithEmptyClob");
+
+        EntityManager em = emfNoSessionCustomizer.createEntityManager();
+        try {
+            OracleLobEntity blobEntity = new OracleLobEntity();
+            blobEntity.setStrData("Some Data");
+
+            int datalen = 50000;
+            byte[] data = new byte[datalen];
+            sr.nextBytes(data);
+            blobEntity.setBlobData(data);
+
+            blobEntity.setClobData("");
+            
+            try {
+                em.getTransaction().begin();
+                em.persist(blobEntity);
+                em.getTransaction().commit();
+            } catch (javax.persistence.RollbackException re) {
+                // Expected
+                Assert.assertThat(re, getExceptionChainMatcher(java.sql.SQLIntegrityConstraintViolationException.class));
+            }
+
+            
+        } finally {
+            if(em != null) {
+                if (em.getTransaction().isActive()) {
+                    em.getTransaction().rollback();
+                }
+                if(em.isOpen()) {
+                    em.close();
+                 }
+            }
+            System.out.println("***** End testOracleWithoutLOBLocatorWithEmptyClob");
+        }
+    }
+    
+
+    private boolean checkIsOracle() {
+        return (emf != null && getPlatform(emf) instanceof OraclePlatform);
+    }
+
+    private DatabasePlatform getPlatform(EntityManagerFactory emf) {
+        DatabasePlatform platform = ((EntityManagerFactoryImpl) emf).getServerSession().getPlatform();
+        return platform;
+    }
+    
+    @SuppressWarnings("rawtypes")
+    protected Matcher getExceptionChainMatcher(final Class t) {
+        return new BaseMatcher() {
+            final protected Class<?> expected = t;
+
+            @Override
+            public boolean matches(Object obj) {
+                if (obj == null) {
+                    return (expected == null);
+                }
+
+                if (!(obj instanceof Throwable)) {
+                    return false;
+                }
+
+                final ArrayList<Throwable> tList = new ArrayList<Throwable>();
+
+                Throwable t = (Throwable) obj;
+                while (t != null) {
+                    tList.add(t);
+                    if (expected.equals(t.getClass())) {
+                        return true;
+                    }
+
+                    if (expected.isAssignableFrom(t.getClass())) {
+                        return true;
+                    }
+
+                    t = t.getCause();
+                }
+
+                return false;
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText(expected.toString());
+            }
+
+        };
+    }
+
+}

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/oraclefeatures/model/OracleLobEntity.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/oraclefeatures/model/OracleLobEntity.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 IBM Corporation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     IBM - initial drop
+//     05/06/2019 - Jody Grassel
+//       - 547023 : Add LOB Locator support for core Oracle platform.
+
+package org.eclipse.persistence.jpa.test.oraclefeatures.model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+
+@Entity
+public class OracleLobEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Integer id;
+
+    private String strData;
+
+    @Lob
+    private byte[] blobData;
+
+    @Lob
+    @Column(columnDefinition = "CLOB NOT NULL")
+    private String clobData;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getStrData() {
+        return strData;
+    }
+
+    public void setStrData(String strData) {
+        this.strData = strData;
+    }
+
+    public byte[] getBlobData() {
+        return blobData;
+    }
+
+    public void setBlobData(byte[] blobData) {
+        this.blobData = blobData;
+    }
+
+    public String getClobData() {
+        return clobData;
+    }
+
+    public void setClobData(String clobData) {
+        this.clobData = clobData;
+    }
+
+    @Override
+    public String toString() {
+        return "OracleBlobEntity [id=" + id + ", strData=" + strData + "]";
+    }
+
+}


### PR DESCRIPTION
Porting the LOB Locator capabilities from the Oracle platform extensions project to the core Oracle platform (using reflection).  Preserving the original behavior where this is disabled in versions 11+.  In addition, adding a database platform for Oracle 18.

Signed-off-by: Joe Grassel <jgrassel@us.ibm.com>