### PR TITLE
[2.7] Fix erronous Javadoc update from bug 547023

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/Oracle8Platform.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/Oracle8Platform.java
@@ -215,7 +215,7 @@ public class Oracle8Platform extends OraclePlatform {
     /**
      * PUBLIC: Set if the locator is required for the LOB write. The default is
      * true. For Oracle thin driver, the locator is recommended for large size (
-     * >4k for Oracle8, >5.9K for Oracle9) BLOB/CLOB value write.
+     * &gt;4k for Oracle8, &gt;5.9K for Oracle9) BLOB/CLOB value write.
      */
     public void setShouldUseLocatorForLOBWrite(boolean usesLocatorForLOBWrite) {
         this.usesLocatorForLOBWrite = usesLocatorForLOBWrite;
@@ -224,7 +224,7 @@ public class Oracle8Platform extends OraclePlatform {
     /**
      * PUBLIC: Return if the locator is required for the LOB write. The default
      * is true. For Oracle thin driver, the locator is recommended for large
-     * size ( >4k for Oracle8, >5.9K for Oracle9) BLOB/CLOB value write.
+     * size ( &gt;4k for Oracle8, &gt;5.9K for Oracle9) BLOB/CLOB value write.
      */
     public boolean shouldUseLocatorForLOBWrite() {
         return usesLocatorForLOBWrite;


### PR DESCRIPTION
Signed-off-by: Joe Grassel <fyrewyld@gmail.com>

The bugfix for 547023 used '>' in javadoc in the new Oracle8 platform, which causes problems in javadoc generation. Pull request to fix this.