### PR TITLE
[2.6_WAS] Fix persistence unit properties javadoc

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/PersistenceUnitProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/PersistenceUnitProperties.java
@@ -1036,7 +1036,7 @@ public class PersistenceUnitProperties {
      * <li>"<code>true</code>" - bindings will use platform default
      * </ul>
      * 
-     * @see org.eclipse.persistence.config.PersistenceUnitProperties.JDBC_BIND_PARAMETERS
+     * @see #JDBC_BIND_PARAMETERS
     */
    public static final String JDBC_FORCE_BIND_PARAMETERS = "eclipselink.jdbc.force-bind-parameters";
 


### PR DESCRIPTION
While trying to get the nightly builds for the 2.6_WAS branch back to green, noticed the following Javadoc error (which isn't involved in any of my recent changes):

```
[javadoc] /jobs/genie.eclipselink/eclipselink-nightly-2.6_WAS/workspace/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/PersistenceUnitProperties.java:1039: error: reference not found
  [javadoc]      * @see org.eclipse.persistence.config.PersistenceUnitProperties.JDBC_BIND_PARAMETERS
  [javadoc]             ^
  [javadoc] 1 error
  [javadoc] 100 warnings
```

Updating the 2.6_WAS javadoc link to match what is in master