### PR TITLE
[Non Bug] MOXy logging improvement

### DIFF
--- a/foundation/org.eclipse.persistence.core/core.iml
+++ b/foundation/org.eclipse.persistence.core/core.iml
@@ -49,6 +49,7 @@
       <library>
         <CLASSES>
           <root url="jar://$MODULE_DIR$/../../plugins/org.glassfish.jakarta.json.jar!/" />
+          <root url="jar://$MODULE_DIR$/../../plugins/jakarta.json.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES />

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/localization/i18n/JAXBLocalizationResource.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/localization/i18n/JAXBLocalizationResource.java
@@ -42,13 +42,6 @@ public class JAXBLocalizationResource extends ListResourceBundle {
             {"malformed_url_error", "Error: Unexpected MalformedURLException"},
             {"io_exception_error", "Error: Unexpected IOException"},
             {"version", "Version: "},
-            {"start_marshalling", "Marshalling \"{0}\" into {1} started"},
-            {"start_unmarshalling", "Unmarshalling {0} into \"{1}\" started"},
-            {"read_from_moxy_json_provider", "MOXyJsonProvider.readFrom(...) is called."},
-            {"write_to_moxy_json_provider", "MOXyJsonProvider.writeTo(...) is called."},
-            {"set_marshaller_property", "Setting marshaller property (name/value): {0}/{1}"},
-            {"set_unmarshaller_property", "Setting unmarshaller property (name/value): {0}/{1}"},
-            {"set_jaxb_context_property", "Setting JAXBContext property (name/value): {0}/{1}"}
     };
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/localization/i18n/JAXBLocalizationResource.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/localization/i18n/JAXBLocalizationResource.java
@@ -21,32 +21,33 @@ import java.util.ListResourceBundle;
 
 public class JAXBLocalizationResource extends ListResourceBundle {
     static final Object[][] contents = {
-                                           { "start_orajaxb", "Invoking orajaxb" },
-                                           { "start_toplink", "Invoking TopLink Generation" },
-                                           { "read_customization", "Reading Customization File" },
-                                           { "generate_source", "Generating Implementation Classes" },
-                                           { "start_mw_project", "Creating Mapping Workbench Project" },
-                                           { "create_descriptors", "Creating Descriptors" },
-                                           { "create_mappings", "Adding mappings to descriptors" },
-                                           { "setup_inheritance", "Setting up inheritance" },
-                                           { "add_namespace_resolvers", "Adding namespace resolvers" },
-                                           { "generate_files", "Writing Deployment XML and Session Configuration" },
-                                           { "missing_src_dir", "Source Output Directory name is missing" },
-                                           { "missing_project_dir", "TopLink Workbench Project directory name is missing" },
-                                           { "missing_output_dir", "TopLink Output Directory name is missing" },
-                                           { "missing_target_package", "Target Package Name is missing" },
-                                           { "impl_package_missing", "Implementation Class Package Name is missing" },
-                                           { "missing_schema_file", "Input Schema file is missing" },
-                                           { "missing_customization", "Input customization file is missing" },
-                                           { "error", "Error: " },
-                                           { "malformed_url_error", "Error: Unexpected MalformedURLException" },
-                                           { "io_exception_error", "Error: Unexpected IOException" },
-                                           { "version", "Version: " },
+            {"start_orajaxb", "Invoking orajaxb"},
+            {"start_toplink", "Invoking TopLink Generation"},
+            {"read_customization", "Reading Customization File"},
+            {"generate_source", "Generating Implementation Classes"},
+            {"start_mw_project", "Creating Mapping Workbench Project"},
+            {"create_descriptors", "Creating Descriptors"},
+            {"create_mappings", "Adding mappings to descriptors"},
+            {"setup_inheritance", "Setting up inheritance"},
+            {"add_namespace_resolvers", "Adding namespace resolvers"},
+            {"generate_files", "Writing Deployment XML and Session Configuration"},
+            {"missing_src_dir", "Source Output Directory name is missing"},
+            {"missing_project_dir", "TopLink Workbench Project directory name is missing"},
+            {"missing_output_dir", "TopLink Output Directory name is missing"},
+            {"missing_target_package", "Target Package Name is missing"},
+            {"impl_package_missing", "Implementation Class Package Name is missing"},
+            {"missing_schema_file", "Input Schema file is missing"},
+            {"missing_customization", "Input customization file is missing"},
+            {"error", "Error: "},
+            {"malformed_url_error", "Error: Unexpected MalformedURLException"},
+            {"io_exception_error", "Error: Unexpected IOException"},
+            {"version", "Version: "},
+            {"start_marshalling", "Marshalling into {0} started"},
     };
 
     /**
-    * Return the lookup table.
-    */
+     * Return the lookup table.
+     */
     @Override
     protected Object[][] getContents() {
         return contents;

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/localization/i18n/JAXBLocalizationResource.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/localization/i18n/JAXBLocalizationResource.java
@@ -27,7 +27,7 @@ public class JAXBLocalizationResource extends ListResourceBundle {
             {"generate_source", "Generating Implementation Classes"},
             {"start_mw_project", "Creating Mapping Workbench Project"},
             {"create_descriptors", "Creating Descriptors"},
-            {"create_mappings", "Adding mappings to descriptors"},
+            {"create_mappings", "Adding mappings to descriptor {0}"},
             {"setup_inheritance", "Setting up inheritance"},
             {"add_namespace_resolvers", "Adding namespace resolvers"},
             {"generate_files", "Writing Deployment XML and Session Configuration"},
@@ -42,7 +42,13 @@ public class JAXBLocalizationResource extends ListResourceBundle {
             {"malformed_url_error", "Error: Unexpected MalformedURLException"},
             {"io_exception_error", "Error: Unexpected IOException"},
             {"version", "Version: "},
-            {"start_marshalling", "Marshalling into {0} started"},
+            {"start_marshalling", "Marshalling \"{0}\" into {1} started"},
+            {"start_unmarshalling", "Unmarshalling {0} into \"{1}\" started"},
+            {"read_from_moxy_json_provider", "MOXyJsonProvider.readFrom(...) is called."},
+            {"write_to_moxy_json_provider", "MOXyJsonProvider.writeTo(...) is called."},
+            {"set_marshaller_property", "Setting marshaller property (name/value): {0}/{1}"},
+            {"set_unmarshaller_property", "Setting unmarshaller property (name/value): {0}/{1}"},
+            {"set_jaxb_context_property", "Setting JAXBContext property (name/value): {0}/{1}"}
     };
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/localization/i18n/JAXBLocalizationResource.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/localization/i18n/JAXBLocalizationResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2018 IBM Corporation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/localization/i18n/TraceLocalizationResource.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/localization/i18n/TraceLocalizationResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2018 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -362,7 +362,14 @@ public class TraceLocalizationResource extends ListResourceBundle {
         { "jaxp_sec_disabled", "Xml Security disabled, no JAXP {0} external access configuration necessary." },
         { "jaxp_sec_explicit", "Detected explicitly JAXP configuration, no JAXP {0} external access configuration necessary." },
         { "jaxp_sec_prop_supported", "Property {0} is supported and has been successfully set by used JAXP implementation." },
-        { "jaxp_sec_prop_not_supported", "Property {0} is not supported by used JAXP implementation." }
+        { "jaxp_sec_prop_not_supported", "Property {0} is not supported by used JAXP implementation." },
+        { "moxy_start_marshalling", "Marshalling \"{0}\" into {1} started"},
+        { "moxy_start_unmarshalling", "Unmarshalling {0} into \"{1}\" by \"{2}\" started"},
+        { "moxy_read_from_moxy_json_provider", "MOXyJsonProvider.readFrom(...) is called."},
+        { "moxy_write_to_moxy_json_provider", "MOXyJsonProvider.writeTo(...) is called."},
+        { "moxy_set_marshaller_property", "Setting marshaller property (name/value): {0}/{1}"},
+        { "moxy_set_unmarshaller_property", "Setting unmarshaller property (name/value): {0}/{1}"},
+        { "moxy_set_jaxb_context_property", "Setting JAXBContext property (name/value): {0}/{1}"}
     };
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLMarshaller.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLMarshaller.java
@@ -605,7 +605,15 @@ public abstract class XMLMarshaller<
      * @param descriptor the XMLDescriptor for the object being marshalled
      */
     protected void marshal(Object object, MarshalRecord marshalRecord, ABSTRACT_SESSION session, DESCRIPTOR descriptor, boolean isXMLRoot) {
-        logMarshall(object);
+        SessionLog logger = AbstractSessionLog.getLog();
+
+        if (logger.shouldLog(SessionLog.FINE, SessionLog.MOXY)) {
+            logger.log(SessionLog.FINE, SessionLog.MOXY, "moxy_start_marshalling", new Object[] { (object!= null)?object.getClass().getName():"N/A", this.mediaType});
+        }
+        if (object != null && logPayload != null && this.isLogPayload()) {
+                AbstractSessionLog.getLog().log(SessionLog.FINEST, SessionLog.MOXY, object.toString(), new Object[0], false);
+        }
+
         if(null != schema) {
             marshalRecord = new ValidatingMarshalRecord(marshalRecord, this);
         }
@@ -1407,13 +1415,5 @@ public abstract class XMLMarshaller<
 
     public void setLogPayload(Boolean logPayload) {
         this.logPayload = logPayload;
-    }
-
-    private void logMarshall(Object object) {
-        String i18nmsg = JAXBLocalization.buildMessage("start_marshalling", new Object[] { (object!= null)?object.getClass().getName():"N/A", this.mediaType });
-        AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MOXY, i18nmsg, new Object[0], false);
-        if (object != null && logPayload != null && this.isLogPayload()) {
-            AbstractSessionLog.getLog().log(SessionLog.FINEST, SessionLog.MOXY, object.toString(), new Object[0], false);
-        }
     }
 }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLMarshaller.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLMarshaller.java
@@ -1410,10 +1410,10 @@ public abstract class XMLMarshaller<
     }
 
     private void logMarshall(Object object) {
-        String i18nmsg = JAXBLocalization.buildMessage("start_marshalling", new Object[] { this.mediaType });
+        String i18nmsg = JAXBLocalization.buildMessage("start_marshalling", new Object[] { (object!= null)?object.getClass().getName():"N/A", this.mediaType });
         AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MOXY, i18nmsg, new Object[0], false);
-        if (this.isLogPayload()) {
-            AbstractSessionLog.getLog().log(SessionLog.INFO, SessionLog.MOXY, object.toString(), new Object[0], false);
+        if (object != null && this.isLogPayload()) {
+            AbstractSessionLog.getLog().log(SessionLog.FINEST, SessionLog.MOXY, object.toString(), new Object[0], false);
         }
     }
 }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLMarshaller.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLMarshaller.java
@@ -40,6 +40,7 @@ import org.eclipse.persistence.exceptions.EclipseLinkException;
 import org.eclipse.persistence.exceptions.XMLMarshalException;
 import org.eclipse.persistence.internal.core.helper.CoreClassConstants;
 import org.eclipse.persistence.internal.core.sessions.CoreAbstractSession;
+import org.eclipse.persistence.internal.localization.JAXBLocalization;
 import org.eclipse.persistence.internal.oxm.mappings.Descriptor;
 import org.eclipse.persistence.internal.oxm.mappings.Field;
 import org.eclipse.persistence.internal.oxm.record.AbstractMarshalRecord;
@@ -604,9 +605,7 @@ public abstract class XMLMarshaller<
      * @param descriptor the XMLDescriptor for the object being marshalled
      */
     protected void marshal(Object object, MarshalRecord marshalRecord, ABSTRACT_SESSION session, DESCRIPTOR descriptor, boolean isXMLRoot) {
-        if (this.isLogPayload()) {
-            AbstractSessionLog.getLog().log(SessionLog.INFO, SessionLog.MOXY, object.toString(), new Object[0], false);
-        }
+        logMarshall(object);
         if(null != schema) {
             marshalRecord = new ValidatingMarshalRecord(marshalRecord, this);
         }
@@ -1408,5 +1407,13 @@ public abstract class XMLMarshaller<
 
     public void setLogPayload(boolean logPayload) {
         this.logPayload = logPayload;
+    }
+
+    private void logMarshall(Object object) {
+        String i18nmsg = JAXBLocalization.buildMessage("start_marshalling", new Object[] { this.mediaType });
+        AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MOXY, i18nmsg, new Object[0], false);
+        if (this.isLogPayload()) {
+            AbstractSessionLog.getLog().log(SessionLog.INFO, SessionLog.MOXY, object.toString(), new Object[0], false);
+        }
     }
 }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLMarshaller.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLMarshaller.java
@@ -148,7 +148,7 @@ public abstract class XMLMarshaller<
     private boolean wrapperAsCollectionName = false;
     private String xmlHeader;
     private Object marshalAttributeGroup;
-    private boolean logPayload = false;
+    private Boolean logPayload;
 
     public XMLMarshaller(CONTEXT context) {
         super(context);
@@ -1401,18 +1401,18 @@ public abstract class XMLMarshaller<
         return this.marshalAttributeGroup;
     }
 
-    public boolean isLogPayload() {
+    public Boolean isLogPayload() {
         return logPayload;
     }
 
-    public void setLogPayload(boolean logPayload) {
+    public void setLogPayload(Boolean logPayload) {
         this.logPayload = logPayload;
     }
 
     private void logMarshall(Object object) {
         String i18nmsg = JAXBLocalization.buildMessage("start_marshalling", new Object[] { (object!= null)?object.getClass().getName():"N/A", this.mediaType });
         AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MOXY, i18nmsg, new Object[0], false);
-        if (object != null && this.isLogPayload()) {
+        if (object != null && logPayload != null && this.isLogPayload()) {
             AbstractSessionLog.getLog().log(SessionLog.FINEST, SessionLog.MOXY, object.toString(), new Object[0], false);
         }
     }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLMarshaller.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLMarshaller.java
@@ -46,6 +46,8 @@ import org.eclipse.persistence.internal.oxm.record.AbstractMarshalRecord;
 import org.eclipse.persistence.internal.oxm.record.ExtendedResult;
 import org.eclipse.persistence.internal.oxm.record.namespaces.PrefixMapperNamespaceResolver;
 import org.eclipse.persistence.internal.security.PrivilegedAccessHelper;
+import org.eclipse.persistence.logging.AbstractSessionLog;
+import org.eclipse.persistence.logging.SessionLog;
 import org.eclipse.persistence.oxm.JSONWithPadding;
 import org.eclipse.persistence.oxm.attachment.XMLAttachmentMarshaller;
 import org.eclipse.persistence.oxm.record.ContentHandlerRecord;
@@ -145,6 +147,7 @@ public abstract class XMLMarshaller<
     private boolean wrapperAsCollectionName = false;
     private String xmlHeader;
     private Object marshalAttributeGroup;
+    private boolean logPayload = false;
 
     public XMLMarshaller(CONTEXT context) {
         super(context);
@@ -601,6 +604,9 @@ public abstract class XMLMarshaller<
      * @param descriptor the XMLDescriptor for the object being marshalled
      */
     protected void marshal(Object object, MarshalRecord marshalRecord, ABSTRACT_SESSION session, DESCRIPTOR descriptor, boolean isXMLRoot) {
+        if (this.isLogPayload()) {
+            AbstractSessionLog.getLog().log(SessionLog.INFO, SessionLog.MOXY, object.toString(), new Object[0], false);
+        }
         if(null != schema) {
             marshalRecord = new ValidatingMarshalRecord(marshalRecord, this);
         }
@@ -1396,4 +1402,11 @@ public abstract class XMLMarshaller<
         return this.marshalAttributeGroup;
     }
 
+    public boolean isLogPayload() {
+        return logPayload;
+    }
+
+    public void setLogPayload(boolean logPayload) {
+        this.logPayload = logPayload;
+    }
 }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLUnmarshaller.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLUnmarshaller.java
@@ -667,28 +667,39 @@ public class XMLUnmarshaller<
                 if(xmlStreamReader != null) {
                     InputSource inputSource = (InputSource) PrivilegedAccessHelper.invokeConstructor(xmlStreamReaderInputSourceConstructor, new Object[]{xmlStreamReader});
                     XMLReader xmlReader = (XMLReader) PrivilegedAccessHelper.invokeConstructor(xmlStreamReaderReaderConstructor, new Object[]{});
-                    return platformUnmarshaller.unmarshal(xmlReader, inputSource, clazz);
+                    Object result = platformUnmarshaller.unmarshal(xmlReader, inputSource, clazz);
+                    logPayload(result);
+                    return result;
                 } else {
                     Object xmlEventReader = PrivilegedAccessHelper.invokeMethod(staxSourceGetEventReaderMethod, source);
                     if(xmlEventReader != null) {
                         InputSource inputSource = (InputSource)PrivilegedAccessHelper.invokeConstructor(xmlEventReaderInputSourceConstructor, new Object[]{xmlEventReader});
                         XMLReader xmlReader = (XMLReader)PrivilegedAccessHelper.invokeConstructor(xmlEventReaderReaderConstructor, new Object[]{});
-                        return platformUnmarshaller.unmarshal(xmlReader, inputSource, clazz);
+                        Object result = platformUnmarshaller.unmarshal(xmlReader, inputSource, clazz);
+                        logPayload(result);
+                        return result;
                     }
                 }
             } catch(Exception e) {
                 throw XMLMarshalException.unmarshalException(e);
             }
         }
-        return platformUnmarshaller.unmarshal(source, clazz);
+        Object result = platformUnmarshaller.unmarshal(source, clazz);
+        logPayload(result);
+        return result;
+
     }
 
     public Object unmarshal(XMLReader xmlReader, InputSource inputSource) {
-        return this.platformUnmarshaller.unmarshal(xmlReader, inputSource);
+        Object result = this.platformUnmarshaller.unmarshal(xmlReader, inputSource);
+        logPayload(result);
+        return result;
     }
 
     public Object unmarshal(XMLReader xmlReader, InputSource inputSource, Class clazz) {
-        return this.platformUnmarshaller.unmarshal(xmlReader, inputSource, clazz);
+        Object result = this.platformUnmarshaller.unmarshal(xmlReader, inputSource, clazz);
+        logPayload(result);
+        return result;
     }
 
     @Override

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLUnmarshaller.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLUnmarshaller.java
@@ -1021,8 +1021,11 @@ public class XMLUnmarshaller<
     }
 
     private void logUnmarshall(Object object) {
-        String i18nmsg = JAXBLocalization.buildMessage("start_unmarshalling", new Object[] { this.mediaType, (object!= null)?object.getClass().getName():"N/A" });
-        AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MOXY, i18nmsg, new Object[0], false);
+        SessionLog logger = AbstractSessionLog.getLog();
+
+        if (logger.shouldLog(SessionLog.FINE, SessionLog.MOXY)) {
+            logger.log(SessionLog.FINE, SessionLog.MOXY, "moxy_start_unmarshalling", new Object[] { (object!= null)?object.getClass().getName():"N/A", this.mediaType, platformUnmarshaller.getClass().getName() });
+        }
         if (object != null && logPayload != null && this.isLogPayload()) {
             AbstractSessionLog.getLog().log(SessionLog.FINEST, SessionLog.MOXY, object.toString(), new Object[0], false);
         }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLUnmarshaller.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLUnmarshaller.java
@@ -37,6 +37,8 @@ import org.eclipse.persistence.internal.oxm.record.PlatformUnmarshaller;
 import org.eclipse.persistence.internal.oxm.record.UnmarshalRecord;
 import org.eclipse.persistence.internal.oxm.record.XMLPlatform;
 import org.eclipse.persistence.internal.security.PrivilegedAccessHelper;
+import org.eclipse.persistence.logging.AbstractSessionLog;
+import org.eclipse.persistence.logging.SessionLog;
 import org.eclipse.persistence.oxm.attachment.XMLAttachmentUnmarshaller;
 import org.eclipse.persistence.oxm.record.XMLRootRecord;
 import org.eclipse.persistence.platform.xml.XMLParser;
@@ -108,6 +110,7 @@ public class XMLUnmarshaller<
     private static Constructor xmlEventReaderInputSourceConstructor;
 
     private JsonTypeConfiguration jsonTypeConfiguration;
+    private boolean logPayload = false;
 
     /**
      * @since EclipseLink 2.4
@@ -360,7 +363,9 @@ public class XMLUnmarshaller<
         if (file == null) {
             throw XMLMarshalException.nullArgumentException();
         }
-        return platformUnmarshaller.unmarshal(file);
+        Object result = platformUnmarshaller.unmarshal(file);
+        logPayload(result);
+        return result;
     }
 
     /**
@@ -377,7 +382,9 @@ public class XMLUnmarshaller<
         if ((null == file) || (null == clazz)) {
             throw XMLMarshalException.nullArgumentException();
         }
-        return platformUnmarshaller.unmarshal(file, clazz);
+        Object result = platformUnmarshaller.unmarshal(file, clazz);
+        logPayload(result);
+        return result;
     }
 
     /**
@@ -394,7 +401,9 @@ public class XMLUnmarshaller<
         if (inputStream == null) {
             throw XMLMarshalException.nullArgumentException();
         }
-        return platformUnmarshaller.unmarshal(inputStream);
+        Object result = platformUnmarshaller.unmarshal(inputStream);
+        logPayload(result);
+        return result;
     }
 
     /**
@@ -411,7 +420,9 @@ public class XMLUnmarshaller<
         if ((null == inputStream) || (null == clazz)) {
             throw XMLMarshalException.nullArgumentException();
         }
-        return platformUnmarshaller.unmarshal(inputStream, clazz);
+        Object result = platformUnmarshaller.unmarshal(inputStream, clazz);
+        logPayload(result);
+        return result;
     }
 
     /**
@@ -428,7 +439,9 @@ public class XMLUnmarshaller<
         if (reader == null) {
             throw XMLMarshalException.nullArgumentException();
         }
-        return platformUnmarshaller.unmarshal(reader);
+        Object result = platformUnmarshaller.unmarshal(reader);
+        logPayload(result);
+        return result;
     }
 
     /**
@@ -445,7 +458,9 @@ public class XMLUnmarshaller<
         if ((null == reader) || (null == clazz)) {
             throw XMLMarshalException.nullArgumentException();
         }
-        return platformUnmarshaller.unmarshal(reader, clazz);
+        Object result = platformUnmarshaller.unmarshal(reader, clazz);
+        logPayload(result);
+        return result;
     }
 
     /**
@@ -462,7 +477,9 @@ public class XMLUnmarshaller<
         if (url == null) {
             throw XMLMarshalException.nullArgumentException();
         }
-        return platformUnmarshaller.unmarshal(url);
+        Object result = platformUnmarshaller.unmarshal(url);
+        logPayload(result);
+        return result;
     }
 
     /**
@@ -479,7 +496,9 @@ public class XMLUnmarshaller<
         if ((null == url) || (null == clazz)) {
             throw XMLMarshalException.nullArgumentException();
         }
-        return platformUnmarshaller.unmarshal(url, clazz);
+        Object result = platformUnmarshaller.unmarshal(url, clazz);
+        logPayload(result);
+        return result;
     }
 
     /**
@@ -496,7 +515,9 @@ public class XMLUnmarshaller<
         if (inputSource == null) {
             throw XMLMarshalException.nullArgumentException();
         }
-        return platformUnmarshaller.unmarshal(inputSource);
+        Object result = platformUnmarshaller.unmarshal(inputSource);
+        logPayload(result);
+        return result;
     }
 
     /**
@@ -513,7 +534,9 @@ public class XMLUnmarshaller<
         if ((null == inputSource) || (null == clazz)) {
             throw XMLMarshalException.nullArgumentException();
         }
-        return platformUnmarshaller.unmarshal(inputSource, clazz);
+        Object result = platformUnmarshaller.unmarshal(inputSource, clazz);
+        logPayload(result);
+        return result;
     }
 
     /**
@@ -530,7 +553,9 @@ public class XMLUnmarshaller<
             throw XMLMarshalException.nullArgumentException();
         }
         if ((node.getNodeType() == Node.DOCUMENT_NODE) || (node.getNodeType() == Node.ELEMENT_NODE) || (node.getNodeType() == Node.DOCUMENT_FRAGMENT_NODE)) {
-            return platformUnmarshaller.unmarshal(node);
+            Object result = platformUnmarshaller.unmarshal(node);
+            logPayload(result);
+            return result;
         } else {
             throw XMLMarshalException.unmarshalException();
         }
@@ -550,7 +575,9 @@ public class XMLUnmarshaller<
         if ((null == node) || (null == clazz)) {
             throw XMLMarshalException.nullArgumentException();
         }
-        return platformUnmarshaller.unmarshal(node, clazz);
+        Object result = platformUnmarshaller.unmarshal(node, clazz);
+        logPayload(result);
+        return result;
     }
 
     /**
@@ -573,13 +600,17 @@ public class XMLUnmarshaller<
                 if(xmlStreamReader != null) {
                     InputSource inputSource = (InputSource) PrivilegedAccessHelper.invokeConstructor(xmlStreamReaderInputSourceConstructor, new Object[]{xmlStreamReader});
                     XMLReader xmlReader = (XMLReader) PrivilegedAccessHelper.invokeConstructor(xmlStreamReaderReaderConstructor, new Object[0]);
-                    return platformUnmarshaller.unmarshal(xmlReader, inputSource);
+                    Object result = platformUnmarshaller.unmarshal(xmlReader, inputSource);
+                    logPayload(result);
+                    return result;
                 } else {
                     Object xmlEventReader = PrivilegedAccessHelper.invokeMethod(staxSourceGetEventReaderMethod, source);
                     if(xmlEventReader != null) {
                         InputSource inputSource = (InputSource)PrivilegedAccessHelper.invokeConstructor(xmlEventReaderInputSourceConstructor, new Object[]{xmlEventReader});
                         XMLReader xmlReader = (XMLReader)PrivilegedAccessHelper.invokeConstructor(xmlEventReaderReaderConstructor, new Object[]{});
-                        return platformUnmarshaller.unmarshal(xmlReader, inputSource);
+                        Object result = platformUnmarshaller.unmarshal(xmlReader, inputSource);
+                        logPayload(result);
+                        return result;
                     }
                 }
             } catch(Exception e) {
@@ -967,6 +998,20 @@ public class XMLUnmarshaller<
 
     public final void setDisableSecureProcessing(boolean disableSecureProcessing) {
         platformUnmarshaller.setDisableSecureProcessing(disableSecureProcessing);
+    }
+
+    public boolean isLogPayload() {
+        return logPayload;
+    }
+
+    public void setLogPayload(boolean logPayload) {
+        this.logPayload = logPayload;
+    }
+
+    private void logPayload(Object object) {
+        if (this.isLogPayload()) {
+            AbstractSessionLog.getLog().log(SessionLog.INFO, SessionLog.MOXY, object.toString(), new Object[0], false);
+        }
     }
 
 }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLUnmarshaller.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLUnmarshaller.java
@@ -111,7 +111,7 @@ public class XMLUnmarshaller<
     private static Constructor xmlEventReaderInputSourceConstructor;
 
     private JsonTypeConfiguration jsonTypeConfiguration;
-    private boolean logPayload = false;
+    private Boolean logPayload;
 
     /**
      * @since EclipseLink 2.4
@@ -1012,18 +1012,18 @@ public class XMLUnmarshaller<
         platformUnmarshaller.setDisableSecureProcessing(disableSecureProcessing);
     }
 
-    public boolean isLogPayload() {
+    public Boolean isLogPayload() {
         return logPayload;
     }
 
-    public void setLogPayload(boolean logPayload) {
+    public void setLogPayload(Boolean logPayload) {
         this.logPayload = logPayload;
     }
 
     private void logUnmarshall(Object object) {
         String i18nmsg = JAXBLocalization.buildMessage("start_unmarshalling", new Object[] { this.mediaType, (object!= null)?object.getClass().getName():"N/A" });
         AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MOXY, i18nmsg, new Object[0], false);
-        if (object != null && this.isLogPayload()) {
+        if (object != null && logPayload != null && this.isLogPayload()) {
             AbstractSessionLog.getLog().log(SessionLog.FINEST, SessionLog.MOXY, object.toString(), new Object[0], false);
         }
     }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLUnmarshaller.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLUnmarshaller.java
@@ -32,6 +32,7 @@ import org.eclipse.persistence.core.sessions.CoreSession;
 import org.eclipse.persistence.exceptions.EclipseLinkException;
 import org.eclipse.persistence.exceptions.XMLMarshalException;
 import org.eclipse.persistence.internal.core.sessions.CoreAbstractSession;
+import org.eclipse.persistence.internal.localization.JAXBLocalization;
 import org.eclipse.persistence.internal.oxm.mappings.Descriptor;
 import org.eclipse.persistence.internal.oxm.record.PlatformUnmarshaller;
 import org.eclipse.persistence.internal.oxm.record.UnmarshalRecord;
@@ -364,7 +365,7 @@ public class XMLUnmarshaller<
             throw XMLMarshalException.nullArgumentException();
         }
         Object result = platformUnmarshaller.unmarshal(file);
-        logPayload(result);
+        logUnmarshall(result);
         return result;
     }
 
@@ -383,7 +384,7 @@ public class XMLUnmarshaller<
             throw XMLMarshalException.nullArgumentException();
         }
         Object result = platformUnmarshaller.unmarshal(file, clazz);
-        logPayload(result);
+        logUnmarshall(result);
         return result;
     }
 
@@ -402,7 +403,7 @@ public class XMLUnmarshaller<
             throw XMLMarshalException.nullArgumentException();
         }
         Object result = platformUnmarshaller.unmarshal(inputStream);
-        logPayload(result);
+        logUnmarshall(result);
         return result;
     }
 
@@ -421,7 +422,7 @@ public class XMLUnmarshaller<
             throw XMLMarshalException.nullArgumentException();
         }
         Object result = platformUnmarshaller.unmarshal(inputStream, clazz);
-        logPayload(result);
+        logUnmarshall(result);
         return result;
     }
 
@@ -440,7 +441,7 @@ public class XMLUnmarshaller<
             throw XMLMarshalException.nullArgumentException();
         }
         Object result = platformUnmarshaller.unmarshal(reader);
-        logPayload(result);
+        logUnmarshall(result);
         return result;
     }
 
@@ -459,7 +460,7 @@ public class XMLUnmarshaller<
             throw XMLMarshalException.nullArgumentException();
         }
         Object result = platformUnmarshaller.unmarshal(reader, clazz);
-        logPayload(result);
+        logUnmarshall(result);
         return result;
     }
 
@@ -478,7 +479,7 @@ public class XMLUnmarshaller<
             throw XMLMarshalException.nullArgumentException();
         }
         Object result = platformUnmarshaller.unmarshal(url);
-        logPayload(result);
+        logUnmarshall(result);
         return result;
     }
 
@@ -497,7 +498,7 @@ public class XMLUnmarshaller<
             throw XMLMarshalException.nullArgumentException();
         }
         Object result = platformUnmarshaller.unmarshal(url, clazz);
-        logPayload(result);
+        logUnmarshall(result);
         return result;
     }
 
@@ -516,7 +517,7 @@ public class XMLUnmarshaller<
             throw XMLMarshalException.nullArgumentException();
         }
         Object result = platformUnmarshaller.unmarshal(inputSource);
-        logPayload(result);
+        logUnmarshall(result);
         return result;
     }
 
@@ -535,7 +536,7 @@ public class XMLUnmarshaller<
             throw XMLMarshalException.nullArgumentException();
         }
         Object result = platformUnmarshaller.unmarshal(inputSource, clazz);
-        logPayload(result);
+        logUnmarshall(result);
         return result;
     }
 
@@ -554,7 +555,7 @@ public class XMLUnmarshaller<
         }
         if ((node.getNodeType() == Node.DOCUMENT_NODE) || (node.getNodeType() == Node.ELEMENT_NODE) || (node.getNodeType() == Node.DOCUMENT_FRAGMENT_NODE)) {
             Object result = platformUnmarshaller.unmarshal(node);
-            logPayload(result);
+            logUnmarshall(result);
             return result;
         } else {
             throw XMLMarshalException.unmarshalException();
@@ -576,7 +577,7 @@ public class XMLUnmarshaller<
             throw XMLMarshalException.nullArgumentException();
         }
         Object result = platformUnmarshaller.unmarshal(node, clazz);
-        logPayload(result);
+        logUnmarshall(result);
         return result;
     }
 
@@ -601,7 +602,7 @@ public class XMLUnmarshaller<
                     InputSource inputSource = (InputSource) PrivilegedAccessHelper.invokeConstructor(xmlStreamReaderInputSourceConstructor, new Object[]{xmlStreamReader});
                     XMLReader xmlReader = (XMLReader) PrivilegedAccessHelper.invokeConstructor(xmlStreamReaderReaderConstructor, new Object[0]);
                     Object result = platformUnmarshaller.unmarshal(xmlReader, inputSource);
-                    logPayload(result);
+                    logUnmarshall(result);
                     return result;
                 } else {
                     Object xmlEventReader = PrivilegedAccessHelper.invokeMethod(staxSourceGetEventReaderMethod, source);
@@ -609,7 +610,7 @@ public class XMLUnmarshaller<
                         InputSource inputSource = (InputSource)PrivilegedAccessHelper.invokeConstructor(xmlEventReaderInputSourceConstructor, new Object[]{xmlEventReader});
                         XMLReader xmlReader = (XMLReader)PrivilegedAccessHelper.invokeConstructor(xmlEventReaderReaderConstructor, new Object[]{});
                         Object result = platformUnmarshaller.unmarshal(xmlReader, inputSource);
-                        logPayload(result);
+                        logUnmarshall(result);
                         return result;
                     }
                 }
@@ -668,7 +669,7 @@ public class XMLUnmarshaller<
                     InputSource inputSource = (InputSource) PrivilegedAccessHelper.invokeConstructor(xmlStreamReaderInputSourceConstructor, new Object[]{xmlStreamReader});
                     XMLReader xmlReader = (XMLReader) PrivilegedAccessHelper.invokeConstructor(xmlStreamReaderReaderConstructor, new Object[]{});
                     Object result = platformUnmarshaller.unmarshal(xmlReader, inputSource, clazz);
-                    logPayload(result);
+                    logUnmarshall(result);
                     return result;
                 } else {
                     Object xmlEventReader = PrivilegedAccessHelper.invokeMethod(staxSourceGetEventReaderMethod, source);
@@ -676,7 +677,7 @@ public class XMLUnmarshaller<
                         InputSource inputSource = (InputSource)PrivilegedAccessHelper.invokeConstructor(xmlEventReaderInputSourceConstructor, new Object[]{xmlEventReader});
                         XMLReader xmlReader = (XMLReader)PrivilegedAccessHelper.invokeConstructor(xmlEventReaderReaderConstructor, new Object[]{});
                         Object result = platformUnmarshaller.unmarshal(xmlReader, inputSource, clazz);
-                        logPayload(result);
+                        logUnmarshall(result);
                         return result;
                     }
                 }
@@ -685,20 +686,20 @@ public class XMLUnmarshaller<
             }
         }
         Object result = platformUnmarshaller.unmarshal(source, clazz);
-        logPayload(result);
+        logUnmarshall(result);
         return result;
 
     }
 
     public Object unmarshal(XMLReader xmlReader, InputSource inputSource) {
         Object result = this.platformUnmarshaller.unmarshal(xmlReader, inputSource);
-        logPayload(result);
+        logUnmarshall(result);
         return result;
     }
 
     public Object unmarshal(XMLReader xmlReader, InputSource inputSource, Class clazz) {
         Object result = this.platformUnmarshaller.unmarshal(xmlReader, inputSource, clazz);
-        logPayload(result);
+        logUnmarshall(result);
         return result;
     }
 
@@ -1019,9 +1020,11 @@ public class XMLUnmarshaller<
         this.logPayload = logPayload;
     }
 
-    private void logPayload(Object object) {
-        if (this.isLogPayload()) {
-            AbstractSessionLog.getLog().log(SessionLog.INFO, SessionLog.MOXY, object.toString(), new Object[0], false);
+    private void logUnmarshall(Object object) {
+        String i18nmsg = JAXBLocalization.buildMessage("start_unmarshalling", new Object[] { this.mediaType, (object!= null)?object.getClass().getName():"N/A" });
+        AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MOXY, i18nmsg, new Object[0], false);
+        if (object != null && this.isLogPayload()) {
+            AbstractSessionLog.getLog().log(SessionLog.FINEST, SessionLog.MOXY, object.toString(), new Object[0], false);
         }
     }
 

--- a/moxy/eclipselink.moxy.test/moxy.test.iml
+++ b/moxy/eclipselink.moxy.test/moxy.test.iml
@@ -80,7 +80,7 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/../../plugins/org.glassfish.jakarta.json.jar!/" />
+          <root url="jar://$MODULE_DIR$/../../plugins/jakarta.json.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES />

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBContext.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBContext.java
@@ -1606,6 +1606,8 @@ public class JAXBContext extends javax.xml.bind.JAXBContext {
                 setPropertyOnMarshaller(JAXBContextProperties.JSON_TYPE_COMPATIBILITY, marshaller);
                 setPropertyOnMarshaller(JAXBContextProperties.JSON_USE_XSD_TYPES_WITH_PREFIX, marshaller);
                 setPropertyOnMarshaller(JAXBContextProperties.JSON_TYPE_ATTRIBUTE_NAME, marshaller);
+                setPropertyOnMarshaller(JAXBContextProperties.MOXY_LOGGING_LEVEL, marshaller);
+                setPropertyOnMarshaller(JAXBContextProperties.MOXY_LOG_PAYLOAD, marshaller);
             }
 
             return marshaller;
@@ -1640,6 +1642,8 @@ public class JAXBContext extends javax.xml.bind.JAXBContext {
                 setPropertyOnUnmarshaller(JAXBContextProperties.JSON_TYPE_COMPATIBILITY, unmarshaller);
                 setPropertyOnUnmarshaller(JAXBContextProperties.JSON_USE_XSD_TYPES_WITH_PREFIX, unmarshaller);
                 setPropertyOnUnmarshaller(JAXBContextProperties.JSON_TYPE_ATTRIBUTE_NAME, unmarshaller);
+                setPropertyOnUnmarshaller(JAXBContextProperties.MOXY_LOGGING_LEVEL, unmarshaller);
+                setPropertyOnUnmarshaller(JAXBContextProperties.MOXY_LOG_PAYLOAD, unmarshaller);
             }
             return unmarshaller;
         }

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBContext.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBContext.java
@@ -803,7 +803,12 @@ public class JAXBContext extends javax.xml.bind.JAXBContext {
          * @param classLoader the classLoader to use.  If null then Thread.currentThread().getContextClassLoader() will be used.
          */
         public JAXBContextInput(Map properties, ClassLoader classLoader) {
-            logProperties(properties);
+            SessionLog logger = AbstractSessionLog.getLog();
+            if (properties != null && logger.shouldLog(SessionLog.FINE, SessionLog.MOXY)) {
+                for (Object key : properties.keySet()) {
+                    logger.log(SessionLog.FINE, SessionLog.MOXY, "moxy_set_jaxb_context_property", new Object[]{key.toString(), properties.get(key).toString()});
+                }
+            }
             this.properties = properties;
             if (null == classLoader) {
                 this.classLoader = Thread.currentThread().getContextClassLoader();
@@ -1691,14 +1696,4 @@ public class JAXBContext extends javax.xml.bind.JAXBContext {
         Object propertyValue = properties.get(JAXBContextProperties.BEAN_VALIDATION_FACETS);
         if (propertyValue != null) inputImpl.setFacets((Boolean) propertyValue);
     }
-
-    private static void logProperties(Map properties) {
-        if (properties != null) {
-            for (Object key: properties.keySet()) {
-                String i18nmsg = JAXBLocalization.buildMessage("set_jaxb_context_property", new Object[] {key.toString(), properties.get(key).toString()});
-                AbstractSessionLog.getLog().log(SessionLog.CONFIG, SessionLog.MOXY, i18nmsg, new Object[0], false);
-            }
-        }
-    }
-
 }

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBContext.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBContext.java
@@ -68,6 +68,7 @@ import org.eclipse.persistence.internal.jaxb.WrappedValue;
 import org.eclipse.persistence.internal.jaxb.json.schema.JsonSchemaGenerator;
 import org.eclipse.persistence.internal.jaxb.json.schema.model.JsonSchema;
 import org.eclipse.persistence.internal.jaxb.many.ManyValue;
+import org.eclipse.persistence.internal.localization.JAXBLocalization;
 import org.eclipse.persistence.internal.oxm.Constants;
 import org.eclipse.persistence.internal.oxm.Root;
 import org.eclipse.persistence.internal.oxm.XMLConversionManager;
@@ -90,6 +91,9 @@ import org.eclipse.persistence.jaxb.json.JsonSchemaOutputResolver;
 import org.eclipse.persistence.jaxb.xmlmodel.JavaType;
 import org.eclipse.persistence.jaxb.xmlmodel.XmlBindings;
 import org.eclipse.persistence.jaxb.xmlmodel.XmlBindings.JavaTypes;
+import org.eclipse.persistence.logging.AbstractSessionLog;
+import org.eclipse.persistence.logging.LogLevel;
+import org.eclipse.persistence.logging.SessionLog;
 import org.eclipse.persistence.mappings.DatabaseMapping;
 import org.eclipse.persistence.oxm.MediaType;
 import org.eclipse.persistence.oxm.NamespaceResolver;
@@ -160,6 +164,9 @@ public class JAXBContext extends javax.xml.bind.JAXBContext {
     static {
         PARSER_FEATURES.put("http://apache.org/xml/features/validation/schema/normalized-value", false);
         PARSER_FEATURES.put("http://apache.org/xml/features/validation/schema/element-default", false);
+        if (MOXySystemProperties.moxyLoggingLevel != null) {
+            AbstractSessionLog.getLog().setLevel(LogLevel.toValue(MOXySystemProperties.moxyLoggingLevel).getId(), SessionLog.MOXY);
+        }
     }
 
     private static final String RI_XML_ACCESSOR_FACTORY_SUPPORT = "com.sun.xml.bind.XmlAccessorFactory";
@@ -796,6 +803,7 @@ public class JAXBContext extends javax.xml.bind.JAXBContext {
          * @param classLoader the classLoader to use.  If null then Thread.currentThread().getContextClassLoader() will be used.
          */
         public JAXBContextInput(Map properties, ClassLoader classLoader) {
+            logProperties(properties);
             this.properties = properties;
             if (null == classLoader) {
                 this.classLoader = Thread.currentThread().getContextClassLoader();
@@ -1683,4 +1691,14 @@ public class JAXBContext extends javax.xml.bind.JAXBContext {
         Object propertyValue = properties.get(JAXBContextProperties.BEAN_VALIDATION_FACETS);
         if (propertyValue != null) inputImpl.setFacets((Boolean) propertyValue);
     }
+
+    private static void logProperties(Map properties) {
+        if (properties != null) {
+            for (Object key: properties.keySet()) {
+                String i18nmsg = JAXBLocalization.buildMessage("set_jaxb_context_property", new Object[] {key.toString(), properties.get(key).toString()});
+                AbstractSessionLog.getLog().log(SessionLog.CONFIG, SessionLog.MOXY, i18nmsg, new Object[0], false);
+            }
+        }
+    }
+
 }

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBContextProperties.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBContextProperties.java
@@ -405,7 +405,7 @@ public class JAXBContextProperties {
      * @see org.eclipse.persistence.jaxb.UnmarshallerProperties#MOXY_LOGGING_LEVEL
      * @see org.eclipse.persistence.logging.LogLevel
      */
-    public static final String MOXY_LOGGING_LEVEL = "eclipselink.moxy.logging.level";
+    public static final String MOXY_LOGGING_LEVEL = "eclipselink.logging.level.moxy";
 
     /**
      * Property for logging Entities content during marshalling/unmarshalling operation in MOXy.
@@ -415,12 +415,12 @@ public class JAXBContextProperties {
      * Use it carefully. It can produce high amount of data in the log files.
      *
      * Usage: set to {@link Boolean#TRUE} to enable payload logging, set to {@link Boolean#FALSE} to disable it.
-     * It can be set via system property with name "eclipselink.moxy.logging.payload" too.
+     * It can be set via system property with name "eclipselink.logging.payload.moxy" too.
      * By default it is disabled.
      *
      * @since 3.0
      * @see org.eclipse.persistence.jaxb.MarshallerProperties#MOXY_LOG_PAYLOAD
      * @see org.eclipse.persistence.jaxb.UnmarshallerProperties#MOXY_LOG_PAYLOAD
      */
-    public static final String MOXY_LOG_PAYLOAD = "eclipselink.moxy.logging.payload";
+    public static final String MOXY_LOG_PAYLOAD = "eclipselink.logging.payload.moxy";
 }

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBContextProperties.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBContextProperties.java
@@ -414,7 +414,7 @@ public class JAXBContextProperties {
      * Use it carefully. It can produce high amount of data in the log files.
      *
      * Usage: set to {@link Boolean#TRUE} to enable payload logging, set to {@link Boolean#FALSE} to disable it.
-     * It can be set via system property too. Setting via JAXBContext, marshaller, unmarshaller property has higher priority.
+     * It can be set via system property with name "eclipselink.moxy.logging.payload" too.
      * By default it is disabled.
      *
      * @since 3.0

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBContextProperties.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBContextProperties.java
@@ -392,5 +392,34 @@ public class JAXBContextProperties {
      */
     public static final String BEAN_VALIDATION_NO_OPTIMISATION = PersistenceUnitProperties.BEAN_VALIDATION_NO_OPTIMISATION;
 
+    /**
+     * Property for MOXy logging level.
+     *
+     * This is to make maintenance easier and to allow MOXy generate more diagnostic log messages.
+     *
+     * Allowed values are specified in {@link org.eclipse.persistence.logging.LogLevel}
+     * Default value is {@link org.eclipse.persistence.logging.LogLevel#INFO}
+     *
+     * @since 3.0
+     * @see org.eclipse.persistence.jaxb.MarshallerProperties#MOXY_LOGGING_LEVEL
+     * @see org.eclipse.persistence.jaxb.UnmarshallerProperties#MOXY_LOGGING_LEVEL
+     */
+    public static final String MOXY_LOGGING_LEVEL = "eclipselink.moxy.logging.level";
 
+    /**
+     * Property for logging Entities content during marshalling/unmarshalling operation in MOXy.
+     * It calls toString() method from entity.
+     *
+     * This is to make maintenance easier and to allow for debugging to check marshalled/unmarshalled content.
+     * Use it carefully. It can produce high amount of data in the log files.
+     *
+     * Usage: set to {@link Boolean#TRUE} to enable payload logging, set to {@link Boolean#FALSE} to disable it.
+     * It can be set via system property too. Setting via JAXBContext, marshaller, unmarshaller property has higher priority.
+     * By default it is disabled.
+     *
+     * @since 3.0
+     * @see org.eclipse.persistence.jaxb.MarshallerProperties#MOXY_LOG_PAYLOAD
+     * @see org.eclipse.persistence.jaxb.UnmarshallerProperties#MOXY_LOG_PAYLOAD
+     */
+    public static final String MOXY_LOG_PAYLOAD = "eclipselink.moxy.logging.payload";
 }

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBContextProperties.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBContextProperties.java
@@ -403,6 +403,7 @@ public class JAXBContextProperties {
      * @since 3.0
      * @see org.eclipse.persistence.jaxb.MarshallerProperties#MOXY_LOGGING_LEVEL
      * @see org.eclipse.persistence.jaxb.UnmarshallerProperties#MOXY_LOGGING_LEVEL
+     * @see org.eclipse.persistence.logging.LogLevel
      */
     public static final String MOXY_LOGGING_LEVEL = "eclipselink.moxy.logging.level";
 

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBMarshaller.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBMarshaller.java
@@ -59,6 +59,9 @@ import org.eclipse.persistence.internal.oxm.record.namespaces.MapNamespacePrefix
 import org.eclipse.persistence.internal.oxm.record.namespaces.NamespacePrefixMapperWrapper;
 import org.eclipse.persistence.jaxb.JAXBContext.RootLevelXmlAdapter;
 import org.eclipse.persistence.jaxb.attachment.AttachmentMarshallerAdapter;
+import org.eclipse.persistence.logging.AbstractSessionLog;
+import org.eclipse.persistence.logging.LogLevel;
+import org.eclipse.persistence.logging.SessionLog;
 import org.eclipse.persistence.oxm.CharacterEscapeHandler;
 import org.eclipse.persistence.oxm.JSONWithPadding;
 import org.eclipse.persistence.oxm.MediaType;
@@ -868,6 +871,9 @@ public class JAXBMarshaller implements javax.xml.bind.Marshaller {
                 if (MOXySystemProperties.moxyLogPayload != null) {
                     xmlMarshaller.setLogPayload(MOXySystemProperties.moxyLogPayload);
                 }
+                if (MOXySystemProperties.moxyLoggingLevel != null) {
+                    AbstractSessionLog.getLog().setLevel(LogLevel.toValue(MOXySystemProperties.moxyLoggingLevel).getId(), SessionLog.MOXY);
+                }
                 if (Constants.JAXB_FRAGMENT.equals(key)) {
                     if (value == null) {
                         throw new PropertyException(key, Constants.EMPTY_STRING);
@@ -919,6 +925,8 @@ public class JAXBMarshaller implements javax.xml.bind.Marshaller {
                     xmlMarshaller.setCharacterEscapeHandler((CharacterEscapeHandler) value);
                 } else if (MarshallerProperties.MOXY_LOG_PAYLOAD.equals(key)) {
                     xmlMarshaller.setLogPayload(((Boolean) value));
+                } else if (MarshallerProperties.MOXY_LOGGING_LEVEL.equals(key)) {
+                    AbstractSessionLog.getLog().setLevel(LogLevel.toValue((String) value).getId(), SessionLog.MOXY);
                 } else if (SUN_CHARACTER_ESCAPE_HANDLER.equals(key) || SUN_JSE_CHARACTER_ESCAPE_HANDLER.equals(key) || SUN_CHARACTER_ESCAPE_HANDLER_MARSHALLER.equals(key) || SUN_JSE_CHARACTER_ESCAPE_HANDLER_MARSHALLER.equals(key)) {
                     if (value == null) {
                         xmlMarshaller.setCharacterEscapeHandler(null);

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBMarshaller.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBMarshaller.java
@@ -347,6 +347,8 @@ public class JAXBMarshaller implements javax.xml.bind.Marshaller {
             return this.beanValidationGroups;
         } else if (MarshallerProperties.BEAN_VALIDATION_NO_OPTIMISATION.equals(key)) {
             return this.bvNoOptimisation;
+        } else if (MarshallerProperties.MOXY_LOG_PAYLOAD.equals(key)) {
+            return xmlMarshaller.isLogPayload();
         }
         throw new PropertyException(key);
     }
@@ -911,6 +913,8 @@ public class JAXBMarshaller implements javax.xml.bind.Marshaller {
                 xmlMarshaller.getJsonTypeConfiguration().setJsonTypeAttributeName((String)value);
             } else if (MarshallerProperties.CHARACTER_ESCAPE_HANDLER.equals(key)) {
                 xmlMarshaller.setCharacterEscapeHandler((CharacterEscapeHandler) value);
+            } else if (MarshallerProperties.MOXY_LOG_PAYLOAD.equals(key)) {
+                xmlMarshaller.setLogPayload(((Boolean) value) || MOXySystemProperties.moxyLogPayload);
             } else if (SUN_CHARACTER_ESCAPE_HANDLER.equals(key) || SUN_JSE_CHARACTER_ESCAPE_HANDLER.equals(key)  ||SUN_CHARACTER_ESCAPE_HANDLER_MARSHALLER.equals(key) || SUN_JSE_CHARACTER_ESCAPE_HANDLER_MARSHALLER.equals(key)) {
                 if (value == null) {
                     xmlMarshaller.setCharacterEscapeHandler(null);

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBMarshaller.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBMarshaller.java
@@ -864,137 +864,142 @@ public class JAXBMarshaller implements javax.xml.bind.Marshaller {
         try {
             if (key == null) {
                 throw new IllegalArgumentException();
-            } else if (Constants.JAXB_FRAGMENT.equals(key)) {
-                if(value == null){
-                     throw new PropertyException(key, Constants.EMPTY_STRING);
-                }
-                Boolean fragment = (Boolean) value;
-                xmlMarshaller.setFragment(fragment.booleanValue());
-            } else if (JAXB_FORMATTED_OUTPUT.equals(key)) {
-                if(value == null){
-                     throw new PropertyException(key, Constants.EMPTY_STRING);
-                 }
-                Boolean formattedOutput = (Boolean) value;
-                xmlMarshaller.setFormattedOutput(formattedOutput.booleanValue());
-            } else if (JAXB_ENCODING.equals(key)) {
-                xmlMarshaller.setEncoding((String) value);
-            } else if (JAXB_SCHEMA_LOCATION.equals(key)) {
-                xmlMarshaller.setSchemaLocation((String) value);
-            } else if (JAXB_NO_NAMESPACE_SCHEMA_LOCATION.equals(key)) {
-                xmlMarshaller.setNoNamespaceSchemaLocation((String) value);
-            } else if(MarshallerProperties.NAMESPACE_PREFIX_MAPPER.equals(key)) {
-                if(value == null){
-                    xmlMarshaller.setNamespacePrefixMapper(null);
-                }else if(value instanceof Map){
-                    NamespacePrefixMapper namespacePrefixMapper = new MapNamespacePrefixMapper((Map)value);
-                    xmlMarshaller.setNamespacePrefixMapper(namespacePrefixMapper);
-                }else{
-                    xmlMarshaller.setNamespacePrefixMapper((NamespacePrefixMapper)value);
-                }
-            } else if(SUN_NAMESPACE_PREFIX_MAPPER.equals(key) || SUN_JSE_NAMESPACE_PREFIX_MAPPER.equals(key)) {
-                if(value == null){
-                    xmlMarshaller.setNamespacePrefixMapper(null);
-                }else{
-                    xmlMarshaller.setNamespacePrefixMapper(new NamespacePrefixMapperWrapper(value));
-                }
-            } else if (MarshallerProperties.INDENT_STRING.equals(key) || SUN_INDENT_STRING.equals(key) || SUN_JSE_INDENT_STRING.equals(key)) {
-                xmlMarshaller.setIndentString((String) value);
-            } else if (MarshallerProperties.JSON_MARSHAL_EMPTY_COLLECTIONS.equals(key)){
-                xmlMarshaller.setMarshalEmptyCollections((Boolean) value);
-            } else if (MarshallerProperties.JSON_REDUCE_ANY_ARRAYS.equals(key)){
-                xmlMarshaller.setReduceAnyArrays((Boolean) value);
-            } else if (MarshallerProperties.JSON_WRAPPER_AS_ARRAY_NAME.equals(key)) {
-                xmlMarshaller.setWrapperAsCollectionName((Boolean) value);
-            } else if (MarshallerProperties.JSON_USE_XSD_TYPES_WITH_PREFIX.equals(key)) {
-                xmlMarshaller.getJsonTypeConfiguration().setUseXsdTypesWithPrefix((Boolean)value);
-            } else if (MarshallerProperties.JSON_TYPE_COMPATIBILITY.equals(key)) {
-                xmlMarshaller.getJsonTypeConfiguration().setJsonTypeCompatibility((Boolean)value);
-            } else if (MarshallerProperties.JSON_TYPE_ATTRIBUTE_NAME.equals(key)) {
-                xmlMarshaller.getJsonTypeConfiguration().setJsonTypeAttributeName((String)value);
-            } else if (MarshallerProperties.CHARACTER_ESCAPE_HANDLER.equals(key)) {
-                xmlMarshaller.setCharacterEscapeHandler((CharacterEscapeHandler) value);
-            } else if (MarshallerProperties.MOXY_LOG_PAYLOAD.equals(key)) {
-                xmlMarshaller.setLogPayload(((Boolean) value) || MOXySystemProperties.moxyLogPayload);
-            } else if (SUN_CHARACTER_ESCAPE_HANDLER.equals(key) || SUN_JSE_CHARACTER_ESCAPE_HANDLER.equals(key)  ||SUN_CHARACTER_ESCAPE_HANDLER_MARSHALLER.equals(key) || SUN_JSE_CHARACTER_ESCAPE_HANDLER_MARSHALLER.equals(key)) {
-                if (value == null) {
-                    xmlMarshaller.setCharacterEscapeHandler(null);
-                } else {
-                    xmlMarshaller.setCharacterEscapeHandler(new CharacterEscapeHandlerWrapper(value));
-                }
-            } else if (XML_DECLARATION.equals(key)) {
-                if(value == null){
-                     throw new PropertyException(key, Constants.EMPTY_STRING);
-                 }
-                Boolean fragment = !(Boolean) value;
-                xmlMarshaller.setFragment(fragment.booleanValue());
-            } else if (XML_HEADERS.equals(key)) {
-                xmlMarshaller.setXmlHeader((String) value);
-            } else if (OBJECT_IDENTITY_CYCLE_DETECTION.equals(key)) {
-                if(value == null){
-                     throw new PropertyException(key, Constants.EMPTY_STRING);
-                 }
-                xmlMarshaller.setEqualUsingIdenity(((Boolean) value).booleanValue());
-            } else if (MarshallerProperties.MEDIA_TYPE.equals(key)) {
-                MediaType mType = null;
-                if(value instanceof MediaType) {
-                    mType = (MediaType) value;
-                } else if(value instanceof String) {
-                    mType = MediaType.getMediaType((String)value);
-                }
-                if(mType == null){
-                    throw new PropertyException(key, Constants.EMPTY_STRING);
-                }
-                xmlMarshaller.setMediaType(mType);
-            } else if (MarshallerProperties.JSON_ATTRIBUTE_PREFIX.equals(key)) {
-                xmlMarshaller.setAttributePrefix((String)value);
-            } else if (MarshallerProperties.JSON_INCLUDE_ROOT.equals(key)) {
-         if(value == null){
-            throw new PropertyException(key, Constants.EMPTY_STRING);
-                 }
-                xmlMarshaller.setIncludeRoot((Boolean)value);
-            } else if(MarshallerProperties.JSON_VALUE_WRAPPER.equals(key)){
-                if(value == null || (((String)value).length() == 0)){
-                    throw new PropertyException(key, Constants.EMPTY_STRING);
-                }
-                xmlMarshaller.setValueWrapper((String)value);
-            } else if(MarshallerProperties.JSON_NAMESPACE_SEPARATOR.equals(key)){
-        if(value == null){
-            throw new PropertyException(key, Constants.EMPTY_STRING);
-                 }
-                xmlMarshaller.setNamespaceSeparator((Character)value);
-            } else if(MarshallerProperties.OBJECT_GRAPH.equals(key)) {
-                if(value == null) {
-                    xmlMarshaller.setMarshalAttributeGroup(null);
-                } else if(value instanceof ObjectGraphImpl) {
-                    xmlMarshaller.setMarshalAttributeGroup(((ObjectGraphImpl)value).getAttributeGroup());
-                } else if(value.getClass() == ClassConstants.STRING){
-                    xmlMarshaller.setMarshalAttributeGroup(value);
-                } else {
-                    throw org.eclipse.persistence.exceptions.JAXBException.invalidValueForObjectGraph(value);
-                }
-            } else if (MarshallerProperties.BEAN_VALIDATION_MODE.equals(key)) {
-                if(value == null){
-                    throw new PropertyException(key, Constants.EMPTY_STRING);
-                }
-                this.beanValidationMode = ((BeanValidationMode) value);
-            } else if (MarshallerProperties.BEAN_VALIDATION_FACTORY.equals(key)) {
-                //noinspection StatementWithEmptyBody
-                if(value == null) {
-                    // Allow null value for preferred validation factory.
-                }
-                this.prefValidatorFactory = value;
-            } else if (MarshallerProperties.BEAN_VALIDATION_GROUPS.equals(key)) {
-                if(value == null){
-                    throw new PropertyException(key, Constants.EMPTY_STRING);
-                }
-                this.beanValidationGroups = ((Class<?>[]) value);
-            } else if (MarshallerProperties.BEAN_VALIDATION_NO_OPTIMISATION.equals(key)) {
-                if(value == null){
-                    throw new PropertyException(key, Constants.EMPTY_STRING);
-                }
-                this.bvNoOptimisation = ((boolean) value);
             } else {
-                throw new PropertyException(key, value);
+                if (MOXySystemProperties.moxyLogPayload != null) {
+                    xmlMarshaller.setLogPayload(MOXySystemProperties.moxyLogPayload);
+                }
+                if (Constants.JAXB_FRAGMENT.equals(key)) {
+                    if (value == null) {
+                        throw new PropertyException(key, Constants.EMPTY_STRING);
+                    }
+                    Boolean fragment = (Boolean) value;
+                    xmlMarshaller.setFragment(fragment.booleanValue());
+                } else if (JAXB_FORMATTED_OUTPUT.equals(key)) {
+                    if (value == null) {
+                        throw new PropertyException(key, Constants.EMPTY_STRING);
+                    }
+                    Boolean formattedOutput = (Boolean) value;
+                    xmlMarshaller.setFormattedOutput(formattedOutput.booleanValue());
+                } else if (JAXB_ENCODING.equals(key)) {
+                    xmlMarshaller.setEncoding((String) value);
+                } else if (JAXB_SCHEMA_LOCATION.equals(key)) {
+                    xmlMarshaller.setSchemaLocation((String) value);
+                } else if (JAXB_NO_NAMESPACE_SCHEMA_LOCATION.equals(key)) {
+                    xmlMarshaller.setNoNamespaceSchemaLocation((String) value);
+                } else if (MarshallerProperties.NAMESPACE_PREFIX_MAPPER.equals(key)) {
+                    if (value == null) {
+                        xmlMarshaller.setNamespacePrefixMapper(null);
+                    } else if (value instanceof Map) {
+                        NamespacePrefixMapper namespacePrefixMapper = new MapNamespacePrefixMapper((Map) value);
+                        xmlMarshaller.setNamespacePrefixMapper(namespacePrefixMapper);
+                    } else {
+                        xmlMarshaller.setNamespacePrefixMapper((NamespacePrefixMapper) value);
+                    }
+                } else if (SUN_NAMESPACE_PREFIX_MAPPER.equals(key) || SUN_JSE_NAMESPACE_PREFIX_MAPPER.equals(key)) {
+                    if (value == null) {
+                        xmlMarshaller.setNamespacePrefixMapper(null);
+                    } else {
+                        xmlMarshaller.setNamespacePrefixMapper(new NamespacePrefixMapperWrapper(value));
+                    }
+                } else if (MarshallerProperties.INDENT_STRING.equals(key) || SUN_INDENT_STRING.equals(key) || SUN_JSE_INDENT_STRING.equals(key)) {
+                    xmlMarshaller.setIndentString((String) value);
+                } else if (MarshallerProperties.JSON_MARSHAL_EMPTY_COLLECTIONS.equals(key)) {
+                    xmlMarshaller.setMarshalEmptyCollections((Boolean) value);
+                } else if (MarshallerProperties.JSON_REDUCE_ANY_ARRAYS.equals(key)) {
+                    xmlMarshaller.setReduceAnyArrays((Boolean) value);
+                } else if (MarshallerProperties.JSON_WRAPPER_AS_ARRAY_NAME.equals(key)) {
+                    xmlMarshaller.setWrapperAsCollectionName((Boolean) value);
+                } else if (MarshallerProperties.JSON_USE_XSD_TYPES_WITH_PREFIX.equals(key)) {
+                    xmlMarshaller.getJsonTypeConfiguration().setUseXsdTypesWithPrefix((Boolean) value);
+                } else if (MarshallerProperties.JSON_TYPE_COMPATIBILITY.equals(key)) {
+                    xmlMarshaller.getJsonTypeConfiguration().setJsonTypeCompatibility((Boolean) value);
+                } else if (MarshallerProperties.JSON_TYPE_ATTRIBUTE_NAME.equals(key)) {
+                    xmlMarshaller.getJsonTypeConfiguration().setJsonTypeAttributeName((String) value);
+                } else if (MarshallerProperties.CHARACTER_ESCAPE_HANDLER.equals(key)) {
+                    xmlMarshaller.setCharacterEscapeHandler((CharacterEscapeHandler) value);
+                } else if (MarshallerProperties.MOXY_LOG_PAYLOAD.equals(key)) {
+                    xmlMarshaller.setLogPayload(((Boolean) value));
+                } else if (SUN_CHARACTER_ESCAPE_HANDLER.equals(key) || SUN_JSE_CHARACTER_ESCAPE_HANDLER.equals(key) || SUN_CHARACTER_ESCAPE_HANDLER_MARSHALLER.equals(key) || SUN_JSE_CHARACTER_ESCAPE_HANDLER_MARSHALLER.equals(key)) {
+                    if (value == null) {
+                        xmlMarshaller.setCharacterEscapeHandler(null);
+                    } else {
+                        xmlMarshaller.setCharacterEscapeHandler(new CharacterEscapeHandlerWrapper(value));
+                    }
+                } else if (XML_DECLARATION.equals(key)) {
+                    if (value == null) {
+                        throw new PropertyException(key, Constants.EMPTY_STRING);
+                    }
+                    Boolean fragment = !(Boolean) value;
+                    xmlMarshaller.setFragment(fragment.booleanValue());
+                } else if (XML_HEADERS.equals(key)) {
+                    xmlMarshaller.setXmlHeader((String) value);
+                } else if (OBJECT_IDENTITY_CYCLE_DETECTION.equals(key)) {
+                    if (value == null) {
+                        throw new PropertyException(key, Constants.EMPTY_STRING);
+                    }
+                    xmlMarshaller.setEqualUsingIdenity(((Boolean) value).booleanValue());
+                } else if (MarshallerProperties.MEDIA_TYPE.equals(key)) {
+                    MediaType mType = null;
+                    if (value instanceof MediaType) {
+                        mType = (MediaType) value;
+                    } else if (value instanceof String) {
+                        mType = MediaType.getMediaType((String) value);
+                    }
+                    if (mType == null) {
+                        throw new PropertyException(key, Constants.EMPTY_STRING);
+                    }
+                    xmlMarshaller.setMediaType(mType);
+                } else if (MarshallerProperties.JSON_ATTRIBUTE_PREFIX.equals(key)) {
+                    xmlMarshaller.setAttributePrefix((String) value);
+                } else if (MarshallerProperties.JSON_INCLUDE_ROOT.equals(key)) {
+                    if (value == null) {
+                        throw new PropertyException(key, Constants.EMPTY_STRING);
+                    }
+                    xmlMarshaller.setIncludeRoot((Boolean) value);
+                } else if (MarshallerProperties.JSON_VALUE_WRAPPER.equals(key)) {
+                    if (value == null || (((String) value).length() == 0)) {
+                        throw new PropertyException(key, Constants.EMPTY_STRING);
+                    }
+                    xmlMarshaller.setValueWrapper((String) value);
+                } else if (MarshallerProperties.JSON_NAMESPACE_SEPARATOR.equals(key)) {
+                    if (value == null) {
+                        throw new PropertyException(key, Constants.EMPTY_STRING);
+                    }
+                    xmlMarshaller.setNamespaceSeparator((Character) value);
+                } else if (MarshallerProperties.OBJECT_GRAPH.equals(key)) {
+                    if (value == null) {
+                        xmlMarshaller.setMarshalAttributeGroup(null);
+                    } else if (value instanceof ObjectGraphImpl) {
+                        xmlMarshaller.setMarshalAttributeGroup(((ObjectGraphImpl) value).getAttributeGroup());
+                    } else if (value.getClass() == ClassConstants.STRING) {
+                        xmlMarshaller.setMarshalAttributeGroup(value);
+                    } else {
+                        throw org.eclipse.persistence.exceptions.JAXBException.invalidValueForObjectGraph(value);
+                    }
+                } else if (MarshallerProperties.BEAN_VALIDATION_MODE.equals(key)) {
+                    if (value == null) {
+                        throw new PropertyException(key, Constants.EMPTY_STRING);
+                    }
+                    this.beanValidationMode = ((BeanValidationMode) value);
+                } else if (MarshallerProperties.BEAN_VALIDATION_FACTORY.equals(key)) {
+                    //noinspection StatementWithEmptyBody
+                    if (value == null) {
+                        // Allow null value for preferred validation factory.
+                    }
+                    this.prefValidatorFactory = value;
+                } else if (MarshallerProperties.BEAN_VALIDATION_GROUPS.equals(key)) {
+                    if (value == null) {
+                        throw new PropertyException(key, Constants.EMPTY_STRING);
+                    }
+                    this.beanValidationGroups = ((Class<?>[]) value);
+                } else if (MarshallerProperties.BEAN_VALIDATION_NO_OPTIMISATION.equals(key)) {
+                    if (value == null) {
+                        throw new PropertyException(key, Constants.EMPTY_STRING);
+                    }
+                    this.bvNoOptimisation = ((boolean) value);
+                } else {
+                    throw new PropertyException(key, value);
+                }
             }
         } catch (ClassCastException exception) {
             throw new PropertyException(key, exception);

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBMarshaller.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBMarshaller.java
@@ -869,7 +869,10 @@ public class JAXBMarshaller implements javax.xml.bind.Marshaller {
             if (key == null) {
                 throw new IllegalArgumentException();
             } else {
-                logProperty(key, value);
+                SessionLog logger = AbstractSessionLog.getLog();
+                if (logger.shouldLog(SessionLog.FINE, SessionLog.MOXY)) {
+                    logger.log(SessionLog.FINE, SessionLog.MOXY, "moxy_set_marshaller_property", new Object[] {key, value});
+                }
                 if (MOXySystemProperties.moxyLogPayload != null && xmlMarshaller.isLogPayload() == null) {
                     xmlMarshaller.setLogPayload(MOXySystemProperties.moxyLogPayload);
                 }
@@ -1050,10 +1053,4 @@ public class JAXBMarshaller implements javax.xml.bind.Marshaller {
         }
 
     }
-
-    private void logProperty(String key, Object value) {
-        String i18nmsg = JAXBLocalization.buildMessage("set_marshaller_property", new Object[] {key, value});
-        AbstractSessionLog.getLog().log(SessionLog.CONFIG, SessionLog.MOXY, i18nmsg, new Object[0], false);
-    }
-
 }

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBMarshaller.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBMarshaller.java
@@ -53,6 +53,7 @@ import org.eclipse.persistence.internal.helper.ClassConstants;
 import org.eclipse.persistence.internal.jaxb.ObjectGraphImpl;
 import org.eclipse.persistence.internal.jaxb.WrappedValue;
 import org.eclipse.persistence.internal.jaxb.many.ManyValue;
+import org.eclipse.persistence.internal.localization.JAXBLocalization;
 import org.eclipse.persistence.internal.oxm.Constants;
 import org.eclipse.persistence.internal.oxm.Root;
 import org.eclipse.persistence.internal.oxm.record.namespaces.MapNamespacePrefixMapper;
@@ -868,11 +869,9 @@ public class JAXBMarshaller implements javax.xml.bind.Marshaller {
             if (key == null) {
                 throw new IllegalArgumentException();
             } else {
+                logProperty(key, value);
                 if (MOXySystemProperties.moxyLogPayload != null) {
                     xmlMarshaller.setLogPayload(MOXySystemProperties.moxyLogPayload);
-                }
-                if (MOXySystemProperties.moxyLoggingLevel != null) {
-                    AbstractSessionLog.getLog().setLevel(LogLevel.toValue(MOXySystemProperties.moxyLoggingLevel).getId(), SessionLog.MOXY);
                 }
                 if (Constants.JAXB_FRAGMENT.equals(key)) {
                     if (value == null) {
@@ -1051,4 +1050,10 @@ public class JAXBMarshaller implements javax.xml.bind.Marshaller {
         }
 
     }
+
+    private void logProperty(String key, Object value) {
+        String i18nmsg = JAXBLocalization.buildMessage("set_marshaller_property", new Object[] {key, value});
+        AbstractSessionLog.getLog().log(SessionLog.CONFIG, SessionLog.MOXY, i18nmsg, new Object[0], false);
+    }
+
 }

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBMarshaller.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBMarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -870,7 +870,7 @@ public class JAXBMarshaller implements javax.xml.bind.Marshaller {
                 throw new IllegalArgumentException();
             } else {
                 logProperty(key, value);
-                if (MOXySystemProperties.moxyLogPayload != null) {
+                if (MOXySystemProperties.moxyLogPayload != null && xmlMarshaller.isLogPayload() == null) {
                     xmlMarshaller.setLogPayload(MOXySystemProperties.moxyLogPayload);
                 }
                 if (Constants.JAXB_FRAGMENT.equals(key)) {

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBUnmarshaller.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBUnmarshaller.java
@@ -54,6 +54,7 @@ import org.eclipse.persistence.internal.jaxb.IDResolverWrapper;
 import org.eclipse.persistence.internal.jaxb.ObjectGraphImpl;
 import org.eclipse.persistence.internal.jaxb.WrappedValue;
 import org.eclipse.persistence.internal.jaxb.many.ManyValue;
+import org.eclipse.persistence.internal.localization.JAXBLocalization;
 import org.eclipse.persistence.internal.oxm.Constants;
 import org.eclipse.persistence.internal.oxm.Root;
 import org.eclipse.persistence.internal.oxm.StrBuffer;
@@ -67,6 +68,8 @@ import org.eclipse.persistence.internal.oxm.record.XMLStreamReaderReader;
 import org.eclipse.persistence.internal.oxm.record.namespaces.PrefixMapperNamespaceResolver;
 import org.eclipse.persistence.jaxb.JAXBContext.RootLevelXmlAdapter;
 import org.eclipse.persistence.jaxb.attachment.AttachmentUnmarshallerAdapter;
+import org.eclipse.persistence.logging.AbstractSessionLog;
+import org.eclipse.persistence.logging.SessionLog;
 import org.eclipse.persistence.oxm.IDResolver;
 import org.eclipse.persistence.oxm.MediaType;
 import org.eclipse.persistence.oxm.NamespacePrefixMapper;
@@ -811,6 +814,7 @@ public class JAXBUnmarshaller implements Unmarshaller {
         if (key == null) {
             throw new IllegalArgumentException();
         }
+        logProperty(key, value);
         if (MOXySystemProperties.moxyLogPayload != null) {
             xmlUnmarshaller.setLogPayload(MOXySystemProperties.moxyLogPayload);
         }
@@ -1365,6 +1369,11 @@ public class JAXBUnmarshaller implements Unmarshaller {
             return jaxbElement;
         }
 
+    }
+
+    private void logProperty(String key, Object value) {
+        String i18nmsg = JAXBLocalization.buildMessage("set_unmarshaller_property", new Object[] {key, value});
+        AbstractSessionLog.getLog().log(SessionLog.CONFIG, SessionLog.MOXY, i18nmsg, new Object[0], false);
     }
 
 }

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBUnmarshaller.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBUnmarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -69,6 +69,7 @@ import org.eclipse.persistence.internal.oxm.record.namespaces.PrefixMapperNamesp
 import org.eclipse.persistence.jaxb.JAXBContext.RootLevelXmlAdapter;
 import org.eclipse.persistence.jaxb.attachment.AttachmentUnmarshallerAdapter;
 import org.eclipse.persistence.logging.AbstractSessionLog;
+import org.eclipse.persistence.logging.LogLevel;
 import org.eclipse.persistence.logging.SessionLog;
 import org.eclipse.persistence.oxm.IDResolver;
 import org.eclipse.persistence.oxm.MediaType;
@@ -815,7 +816,7 @@ public class JAXBUnmarshaller implements Unmarshaller {
             throw new IllegalArgumentException();
         }
         logProperty(key, value);
-        if (MOXySystemProperties.moxyLogPayload != null) {
+        if (MOXySystemProperties.moxyLogPayload != null && xmlUnmarshaller.isLogPayload() == null) {
             xmlUnmarshaller.setLogPayload(MOXySystemProperties.moxyLogPayload);
         }
         if (key.equals(UnmarshallerProperties.MEDIA_TYPE)) {
@@ -919,7 +920,9 @@ public class JAXBUnmarshaller implements Unmarshaller {
                     : (boolean) value;
             xmlUnmarshaller.setDisableSecureProcessing(disabled);
         } else if (UnmarshallerProperties.MOXY_LOG_PAYLOAD.equals(key)) {
-            xmlUnmarshaller.setLogPayload(((boolean) value) || MOXySystemProperties.moxyLogPayload);
+            xmlUnmarshaller.setLogPayload(((boolean) value));
+        } else if (MarshallerProperties.MOXY_LOGGING_LEVEL.equals(key)) {
+            AbstractSessionLog.getLog().setLevel(LogLevel.toValue((String) value).getId(), SessionLog.MOXY);
         } else {
             throw new PropertyException(key, value);
         }

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBUnmarshaller.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBUnmarshaller.java
@@ -815,7 +815,10 @@ public class JAXBUnmarshaller implements Unmarshaller {
         if (key == null) {
             throw new IllegalArgumentException();
         }
-        logProperty(key, value);
+        SessionLog logger = AbstractSessionLog.getLog();
+        if (logger.shouldLog(SessionLog.FINE, SessionLog.MOXY)) {
+            logger.log(SessionLog.FINE, SessionLog.MOXY, "moxy_set_unmarshaller_property", new Object[] {key, value});
+        }
         if (MOXySystemProperties.moxyLogPayload != null && xmlUnmarshaller.isLogPayload() == null) {
             xmlUnmarshaller.setLogPayload(MOXySystemProperties.moxyLogPayload);
         }
@@ -1371,12 +1374,5 @@ public class JAXBUnmarshaller implements Unmarshaller {
             }
             return jaxbElement;
         }
-
     }
-
-    private void logProperty(String key, Object value) {
-        String i18nmsg = JAXBLocalization.buildMessage("set_unmarshaller_property", new Object[] {key, value});
-        AbstractSessionLog.getLog().log(SessionLog.CONFIG, SessionLog.MOXY, i18nmsg, new Object[0], false);
-    }
-
 }

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBUnmarshaller.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBUnmarshaller.java
@@ -911,6 +911,8 @@ public class JAXBUnmarshaller implements Unmarshaller {
                     ? Boolean.parseBoolean((String) value)
                     : (boolean) value;
             xmlUnmarshaller.setDisableSecureProcessing(disabled);
+        } else if (UnmarshallerProperties.MOXY_LOG_PAYLOAD.equals(key)) {
+            xmlUnmarshaller.setLogPayload(((boolean) value) || MOXySystemProperties.moxyLogPayload);
         } else {
             throw new PropertyException(key, value);
         }
@@ -991,6 +993,8 @@ public class JAXBUnmarshaller implements Unmarshaller {
             return this.bvNoOptimisation;
         } else if (UnmarshallerProperties.DISABLE_SECURE_PROCESSING.equals(key)) {
             return xmlUnmarshaller.isSecureProcessingDisabled();
+        } else if (UnmarshallerProperties.MOXY_LOG_PAYLOAD.equals(key)) {
+            return xmlUnmarshaller.isLogPayload();
         }
         throw new PropertyException(key);
     }

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBUnmarshaller.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBUnmarshaller.java
@@ -811,6 +811,9 @@ public class JAXBUnmarshaller implements Unmarshaller {
         if (key == null) {
             throw new IllegalArgumentException();
         }
+        if (MOXySystemProperties.moxyLogPayload != null) {
+            xmlUnmarshaller.setLogPayload(MOXySystemProperties.moxyLogPayload);
+        }
         if (key.equals(UnmarshallerProperties.MEDIA_TYPE)) {
             MediaType mType = null;
             if(value instanceof MediaType) {

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/MOXySystemProperties.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/MOXySystemProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -60,6 +60,7 @@ public final class MOXySystemProperties {
      * @see org.eclipse.persistence.jaxb.JAXBContextProperties#MOXY_LOGGING_LEVEL
      * @see org.eclipse.persistence.jaxb.MarshallerProperties#MOXY_LOGGING_LEVEL
      * @see org.eclipse.persistence.jaxb.UnmarshallerProperties#MOXY_LOGGING_LEVEL
+     * @see org.eclipse.persistence.logging.LogLevel
      */
     public static final String MOXY_LOGGING_LEVEL = "eclipselink.moxy.logging.level";
 

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/MOXySystemProperties.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/MOXySystemProperties.java
@@ -71,7 +71,7 @@ public final class MOXySystemProperties {
      * Use it carefully. It can produce high amount of data in the log files.
      *
      * Usage: set to {@link Boolean#TRUE} to enable payload logging, set to {@link Boolean#FALSE} to disable it.
-     * It can be set via system property too. Setting via JAXBContext, marshaller, unmarshaller property has higher priority.
+     * It can be set via system property with name "eclipselink.moxy.logging.payload" too.
      * By default it is disabled.
      *
      * @since 3.0

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/MOXySystemProperties.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/MOXySystemProperties.java
@@ -62,7 +62,7 @@ public final class MOXySystemProperties {
      * @see org.eclipse.persistence.jaxb.UnmarshallerProperties#MOXY_LOGGING_LEVEL
      * @see org.eclipse.persistence.logging.LogLevel
      */
-    public static final String MOXY_LOGGING_LEVEL = "eclipselink.moxy.logging.level";
+    public static final String MOXY_LOGGING_LEVEL = "eclipselink.logging.level.moxy";
 
     /**
      * Property for logging Entities content during marshalling/unmarshalling operation in MOXy.
@@ -72,7 +72,7 @@ public final class MOXySystemProperties {
      * Use it carefully. It can produce high amount of data in the log files.
      *
      * Usage: set to {@link Boolean#TRUE} to enable payload logging, set to {@link Boolean#FALSE} to disable it.
-     * It can be set via system property with name "eclipselink.moxy.logging.payload" too.
+     * It can be set via system property with name "eclipselink.logging.payload.moxy" too.
      * By default it is disabled.
      *
      * @since 3.0
@@ -80,7 +80,7 @@ public final class MOXySystemProperties {
      * @see org.eclipse.persistence.jaxb.MarshallerProperties#MOXY_LOG_PAYLOAD
      * @see org.eclipse.persistence.jaxb.UnmarshallerProperties#MOXY_LOG_PAYLOAD
      */
-    public static final String MOXY_LOG_PAYLOAD = "eclipselink.moxy.logging.payload";
+    public static final String MOXY_LOG_PAYLOAD = "eclipselink.logging.payload.moxy";
 
 
     public static final Boolean xmlIdExtension = getBoolean(XML_ID_EXTENSION);

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/MOXySystemProperties.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/MOXySystemProperties.java
@@ -20,6 +20,7 @@ import java.security.PrivilegedExceptionAction;
 
 import org.eclipse.persistence.internal.oxm.OXMSystemProperties;
 import org.eclipse.persistence.internal.security.PrivilegedAccessHelper;
+import org.eclipse.persistence.logging.AbstractSessionLog;
 
 public final class MOXySystemProperties {
 
@@ -47,6 +48,39 @@ public final class MOXySystemProperties {
      */
     public static final String JSON_USE_XSD_TYPES_PREFIX = OXMSystemProperties.JSON_USE_XSD_TYPES_PREFIX;
 
+    /**
+     * Property for MOXy logging level.
+     *
+     * This is to make maintenance easier and to allow MOXy generate more diagnostic log messages.
+     *
+     * Allowed values are specified in {@link org.eclipse.persistence.logging.LogLevel}
+     * Default value is {@link org.eclipse.persistence.logging.LogLevel#INFO}
+     *
+     * @since 3.0
+     * @see org.eclipse.persistence.jaxb.JAXBContextProperties#MOXY_LOGGING_LEVEL
+     * @see org.eclipse.persistence.jaxb.MarshallerProperties#MOXY_LOGGING_LEVEL
+     * @see org.eclipse.persistence.jaxb.UnmarshallerProperties#MOXY_LOGGING_LEVEL
+     */
+    public static final String MOXY_LOGGING_LEVEL = "eclipselink.moxy.logging.level";
+
+    /**
+     * Property for logging Entities content during marshalling/unmarshalling operation in MOXy.
+     * It calls toString() method from entity.
+     *
+     * This is to make maintenance easier and to allow for debugging to check marshalled/unmarshalled content.
+     * Use it carefully. It can produce high amount of data in the log files.
+     *
+     * Usage: set to {@link Boolean#TRUE} to enable payload logging, set to {@link Boolean#FALSE} to disable it.
+     * It can be set via system property too. Setting via JAXBContext, marshaller, unmarshaller property has higher priority.
+     * By default it is disabled.
+     *
+     * @since 3.0
+     * @see org.eclipse.persistence.jaxb.JAXBContextProperties#MOXY_LOG_PAYLOAD
+     * @see org.eclipse.persistence.jaxb.MarshallerProperties#MOXY_LOG_PAYLOAD
+     * @see org.eclipse.persistence.jaxb.UnmarshallerProperties#MOXY_LOG_PAYLOAD
+     */
+    public static final String MOXY_LOG_PAYLOAD = "eclipselink.moxy.logging.payload";
+
 
     public static final Boolean xmlIdExtension = getBoolean(XML_ID_EXTENSION);
 
@@ -55,6 +89,10 @@ public final class MOXySystemProperties {
     public static final Boolean jsonTypeCompatibility = getBoolean(JSON_TYPE_COMPATIBILITY);
 
     public static final Boolean jsonUseXsdTypesPrefix = getBoolean(JSON_USE_XSD_TYPES_PREFIX);
+
+    public static final String moxyLoggingLevel = PrivilegedAccessHelper.getSystemProperty(MOXY_LOGGING_LEVEL, String.valueOf(AbstractSessionLog.getDefaultLoggingLevel()));
+
+    public static final Boolean moxyLogPayload = PrivilegedAccessHelper.getSystemPropertyBoolean(MOXY_LOG_PAYLOAD, false);
 
     /**
      * Returns value of system property.

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/MOXySystemProperties.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/MOXySystemProperties.java
@@ -90,7 +90,7 @@ public final class MOXySystemProperties {
 
     public static final Boolean jsonUseXsdTypesPrefix = getBoolean(JSON_USE_XSD_TYPES_PREFIX);
 
-    public static final String moxyLoggingLevel = PrivilegedAccessHelper.getSystemProperty(MOXY_LOGGING_LEVEL, String.valueOf(AbstractSessionLog.getDefaultLoggingLevel()));
+    public static final String moxyLoggingLevel = PrivilegedAccessHelper.getSystemProperty(MOXY_LOGGING_LEVEL, String.valueOf(AbstractSessionLog.INFO_LABEL));
 
     public static final Boolean moxyLogPayload = PrivilegedAccessHelper.getSystemPropertyBoolean(MOXY_LOG_PAYLOAD, false);
 

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/MarshallerProperties.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/MarshallerProperties.java
@@ -325,12 +325,12 @@ public class MarshallerProperties {
      * Use it carefully. It can produce high amount of data in the log files.
      *
      * Usage: set to {@link Boolean#TRUE} to enable payload logging, set to {@link Boolean#FALSE} to disable it.
-     * It can be set via system property too. Setting via JAXBContext, marshaller, unmarshaller property has higher priority.
+     * It can be set via system property with name "eclipselink.moxy.logging.payload" too.
      * By default it is disabled.
      *
      * @since 3.0
      * @see org.eclipse.persistence.jaxb.JAXBContextProperties#MOXY_LOG_PAYLOAD
      * @see org.eclipse.persistence.jaxb.UnmarshallerProperties#MOXY_LOG_PAYLOAD
      */
-    public static final String MOXY_LOG_PAYLOAD = "eclipselink.moxy.logging.payload";
+    public static final String MOXY_LOG_PAYLOAD = JAXBContextProperties.MOXY_LOG_PAYLOAD;
 }

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/MarshallerProperties.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/MarshallerProperties.java
@@ -316,7 +316,7 @@ public class MarshallerProperties {
      * @see org.eclipse.persistence.jaxb.UnmarshallerProperties#MOXY_LOGGING_LEVEL
      * @see org.eclipse.persistence.logging.LogLevel
      */
-    public static final String MOXY_LOGGING_LEVEL = "eclipselink.moxy.logging.level";
+    public static final String MOXY_LOGGING_LEVEL = "eclipselink.logging.level.moxy";
 
     /**
      * Property for logging Entities content during marshalling/unmarshalling operation in MOXy.
@@ -326,7 +326,7 @@ public class MarshallerProperties {
      * Use it carefully. It can produce high amount of data in the log files.
      *
      * Usage: set to {@link Boolean#TRUE} to enable payload logging, set to {@link Boolean#FALSE} to disable it.
-     * It can be set via system property with name "eclipselink.moxy.logging.payload" too.
+     * It can be set via system property with name "eclipselink.logging.payload.moxy" too.
      * By default it is disabled.
      *
      * @since 3.0

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/MarshallerProperties.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/MarshallerProperties.java
@@ -302,4 +302,35 @@ public class MarshallerProperties {
      * @see org.eclipse.persistence.jaxb.UnmarshallerProperties#BEAN_VALIDATION_NO_OPTIMISATION
      */
     public static final String BEAN_VALIDATION_NO_OPTIMISATION = JAXBContextProperties.BEAN_VALIDATION_NO_OPTIMISATION;
+
+    /**
+     * Property for MOXy logging level.
+     *
+     * This is to make maintenance easier and to allow MOXy generate more diagnostic log messages.
+     *
+     * Allowed values are specified in {@link org.eclipse.persistence.logging.LogLevel}
+     * Default value is {@link org.eclipse.persistence.logging.LogLevel#INFO}
+     *
+     * @since 3.0
+     * @see org.eclipse.persistence.jaxb.JAXBContextProperties#MOXY_LOGGING_LEVEL
+     * @see org.eclipse.persistence.jaxb.UnmarshallerProperties#MOXY_LOGGING_LEVEL
+     */
+    public static final String MOXY_LOGGING_LEVEL = "eclipselink.moxy.logging.level";
+
+    /**
+     * Property for logging Entities content during marshalling/unmarshalling operation in MOXy.
+     * It calls toString() method from entity.
+     *
+     * This is to make maintenance easier and to allow for debugging to check marshalled/unmarshalled content.
+     * Use it carefully. It can produce high amount of data in the log files.
+     *
+     * Usage: set to {@link Boolean#TRUE} to enable payload logging, set to {@link Boolean#FALSE} to disable it.
+     * It can be set via system property too. Setting via JAXBContext, marshaller, unmarshaller property has higher priority.
+     * By default it is disabled.
+     *
+     * @since 3.0
+     * @see org.eclipse.persistence.jaxb.JAXBContextProperties#MOXY_LOG_PAYLOAD
+     * @see org.eclipse.persistence.jaxb.UnmarshallerProperties#MOXY_LOG_PAYLOAD
+     */
+    public static final String MOXY_LOG_PAYLOAD = "eclipselink.moxy.logging.payload";
 }

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/MarshallerProperties.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/MarshallerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -314,6 +314,7 @@ public class MarshallerProperties {
      * @since 3.0
      * @see org.eclipse.persistence.jaxb.JAXBContextProperties#MOXY_LOGGING_LEVEL
      * @see org.eclipse.persistence.jaxb.UnmarshallerProperties#MOXY_LOGGING_LEVEL
+     * @see org.eclipse.persistence.logging.LogLevel
      */
     public static final String MOXY_LOGGING_LEVEL = "eclipselink.moxy.logging.level";
 

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/UnmarshallerProperties.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/UnmarshallerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -334,6 +334,7 @@ public class UnmarshallerProperties {
      * @since 3.0
      * @see org.eclipse.persistence.jaxb.JAXBContextProperties#MOXY_LOGGING_LEVEL
      * @see org.eclipse.persistence.jaxb.MarshallerProperties#MOXY_LOGGING_LEVEL
+     * @see org.eclipse.persistence.logging.LogLevel
      */
     public static final String MOXY_LOGGING_LEVEL = "eclipselink.moxy.logging.level";
 

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/UnmarshallerProperties.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/UnmarshallerProperties.java
@@ -323,4 +323,34 @@ public class UnmarshallerProperties {
 
     public static final String DISABLE_SECURE_PROCESSING = OXMSystemProperties.DISABLE_SECURE_PROCESSING;
 
+    /**
+     * Property for MOXy logging level.
+     *
+     * This is to make maintenance easier and to allow MOXy generate more diagnostic log messages.
+     *
+     * Allowed values are specified in {@link org.eclipse.persistence.logging.LogLevel}
+     * Default value is {@link org.eclipse.persistence.logging.LogLevel#INFO}
+     *
+     * @since 3.0
+     * @see org.eclipse.persistence.jaxb.JAXBContextProperties#MOXY_LOGGING_LEVEL
+     * @see org.eclipse.persistence.jaxb.MarshallerProperties#MOXY_LOGGING_LEVEL
+     */
+    public static final String MOXY_LOGGING_LEVEL = "eclipselink.moxy.logging.level";
+
+    /**
+     * Property for logging Entities content during marshalling/unmarshalling operation in MOXy.
+     * It calls toString() method from entity.
+     *
+     * This is to make maintenance easier and to allow for debugging to check marshalled/unmarshalled content.
+     * Use it carefully. It can produce high amount of data in the log files.
+     *
+     * Usage: set to {@link Boolean#TRUE} to enable payload logging, set to {@link Boolean#FALSE} to disable it.
+     * It can be set via system property too. Setting via JAXBContext, marshaller, unmarshaller property has higher priority.
+     * By default it is disabled.
+     *
+     * @since 3.0
+     * @see org.eclipse.persistence.jaxb.JAXBContextProperties#MOXY_LOG_PAYLOAD
+     * @see org.eclipse.persistence.jaxb.MarshallerProperties#MOXY_LOG_PAYLOAD
+     */
+    public static final String MOXY_LOG_PAYLOAD = "eclipselink.moxy.logging.payload";
 }

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/UnmarshallerProperties.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/UnmarshallerProperties.java
@@ -336,7 +336,7 @@ public class UnmarshallerProperties {
      * @see org.eclipse.persistence.jaxb.MarshallerProperties#MOXY_LOGGING_LEVEL
      * @see org.eclipse.persistence.logging.LogLevel
      */
-    public static final String MOXY_LOGGING_LEVEL = "eclipselink.moxy.logging.level";
+    public static final String MOXY_LOGGING_LEVEL = "eclipselink.logging.level.moxy";
 
     /**
      * Property for logging Entities content during marshalling/unmarshalling operation in MOXy.
@@ -346,12 +346,12 @@ public class UnmarshallerProperties {
      * Use it carefully. It can produce high amount of data in the log files.
      *
      * Usage: set to {@link Boolean#TRUE} to enable payload logging, set to {@link Boolean#FALSE} to disable it.
-     * It can be set via system property with name "eclipselink.moxy.logging.payload" too.
+     * It can be set via system property with name "eclipselink.logging.payload.moxy" too.
      * By default it is disabled.
      *
      * @since 3.0
      * @see org.eclipse.persistence.jaxb.JAXBContextProperties#MOXY_LOG_PAYLOAD
      * @see org.eclipse.persistence.jaxb.MarshallerProperties#MOXY_LOG_PAYLOAD
      */
-    public static final String MOXY_LOG_PAYLOAD = "eclipselink.moxy.logging.payload";
+    public static final String MOXY_LOG_PAYLOAD = "eclipselink.logging.payload.moxy";
 }

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/UnmarshallerProperties.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/UnmarshallerProperties.java
@@ -345,7 +345,7 @@ public class UnmarshallerProperties {
      * Use it carefully. It can produce high amount of data in the log files.
      *
      * Usage: set to {@link Boolean#TRUE} to enable payload logging, set to {@link Boolean#FALSE} to disable it.
-     * It can be set via system property too. Setting via JAXBContext, marshaller, unmarshaller property has higher priority.
+     * It can be set via system property with name "eclipselink.moxy.logging.payload" too.
      * By default it is disabled.
      *
      * @since 3.0

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/compiler/MappingsGenerator.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/compiler/MappingsGenerator.java
@@ -78,6 +78,7 @@ import org.eclipse.persistence.internal.libraries.asm.ClassWriter;
 import org.eclipse.persistence.internal.libraries.asm.MethodVisitor;
 import org.eclipse.persistence.internal.libraries.asm.Opcodes;
 import org.eclipse.persistence.internal.libraries.asm.Type;
+import org.eclipse.persistence.internal.localization.JAXBLocalization;
 import org.eclipse.persistence.internal.oxm.Constants;
 import org.eclipse.persistence.internal.oxm.NamespaceResolver;
 import org.eclipse.persistence.internal.oxm.XMLConversionManager;
@@ -123,6 +124,8 @@ import org.eclipse.persistence.jaxb.xmlmodel.XmlNullPolicy;
 import org.eclipse.persistence.jaxb.xmlmodel.XmlTransformation;
 import org.eclipse.persistence.jaxb.xmlmodel.XmlTransformation.XmlReadTransformer;
 import org.eclipse.persistence.jaxb.xmlmodel.XmlTransformation.XmlWriteTransformer;
+import org.eclipse.persistence.logging.AbstractSessionLog;
+import org.eclipse.persistence.logging.SessionLog;
 import org.eclipse.persistence.mappings.DatabaseMapping;
 import org.eclipse.persistence.mappings.converters.Converter;
 import org.eclipse.persistence.oxm.XMLConstants;
@@ -2522,6 +2525,9 @@ public class MappingsGenerator {
                 }
             }
             info.postInitialize();
+            if (descriptor != null) {
+                logMappingGeneration(descriptor);
+            }
         }
     }
 
@@ -3529,5 +3535,16 @@ public class MappingsGenerator {
 
     private NamespaceResolver getNamespaceResolverForDescriptor(NamespaceInfo info) {
         return info.getNamespaceResolverForDescriptor(globalNamespaceResolver, isDefaultNamespaceAllowed);
+    }
+
+    private void logMappingGeneration(Descriptor xmlDescriptor) {
+        String i18nmsg = JAXBLocalization.buildMessage("create_mappings", new Object[] { xmlDescriptor.getJavaClassName() });
+        AbstractSessionLog.getLog().log(SessionLog.FINEST, SessionLog.MOXY, i18nmsg, new Object[0], false);
+        Iterator mappingIterator = xmlDescriptor.getMappings().iterator();
+        Mapping xmlMapping;
+        while (mappingIterator.hasNext()) {
+            xmlMapping = (Mapping) mappingIterator.next();
+            AbstractSessionLog.getLog().log(SessionLog.FINEST, SessionLog.MOXY, xmlMapping.toString(), new Object[0], false);
+        }
     }
 }

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/compiler/MappingsGenerator.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/compiler/MappingsGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/rs/MOXyJsonProvider.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/rs/MOXyJsonProvider.java
@@ -69,6 +69,7 @@ import javax.xml.transform.stream.StreamSource;
 
 import org.eclipse.persistence.internal.core.helper.CoreClassConstants;
 import org.eclipse.persistence.internal.helper.Helper;
+import org.eclipse.persistence.internal.localization.JAXBLocalization;
 import org.eclipse.persistence.internal.oxm.Constants;
 import org.eclipse.persistence.internal.queries.CollectionContainerPolicy;
 import org.eclipse.persistence.internal.queries.ContainerPolicy;
@@ -657,6 +658,7 @@ public class MOXyJsonProvider implements MessageBodyReader<Object>, MessageBodyW
 
             Set<Class<?>> domainClasses = getDomainClasses(genericType);
             JAXBContext jaxbContext = getJAXBContext(domainClasses, annotations, mediaType, httpHeaders);
+            logAction("read_from_moxy_json_provider");
             Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
             unmarshaller.setProperty(UnmarshallerProperties.MEDIA_TYPE, MediaType.APPLICATION_JSON);
             unmarshaller.setProperty(UnmarshallerProperties.JSON_ATTRIBUTE_PREFIX, attributePrefix);
@@ -943,6 +945,7 @@ public class MOXyJsonProvider implements MessageBodyReader<Object>, MessageBodyW
 
             Set<Class<?>> domainClasses = getDomainClasses(genericType);
             JAXBContext jaxbContext = getJAXBContext(domainClasses, annotations, mediaType, httpHeaders);
+            logAction("write_to_moxy_json_provider");
             Marshaller marshaller = jaxbContext.createMarshaller();
             marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, formattedOutput);
             marshaller.setProperty(MarshallerProperties.MEDIA_TYPE, MediaType.APPLICATION_JSON);
@@ -977,6 +980,11 @@ public class MOXyJsonProvider implements MessageBodyReader<Object>, MessageBodyW
         } catch(JAXBException jaxbException) {
             throw new WebApplicationException(jaxbException);
         }
+    }
+
+    private void logAction(String key) {
+        String i18nmsg = JAXBLocalization.buildMessage(key, new Object[0]);
+        AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MOXY, i18nmsg, new Object[0], false);
     }
 
 }

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/rs/MOXyJsonProvider.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/rs/MOXyJsonProvider.java
@@ -658,7 +658,11 @@ public class MOXyJsonProvider implements MessageBodyReader<Object>, MessageBodyW
 
             Set<Class<?>> domainClasses = getDomainClasses(genericType);
             JAXBContext jaxbContext = getJAXBContext(domainClasses, annotations, mediaType, httpHeaders);
-            logAction("read_from_moxy_json_provider");
+            SessionLog logger = AbstractSessionLog.getLog();
+
+            if (logger.shouldLog(SessionLog.FINE, SessionLog.MOXY)) {
+                logger.log(SessionLog.FINE, SessionLog.MOXY, "moxy_read_from_moxy_json_provider", new Object[0]);
+            }
             Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
             unmarshaller.setProperty(UnmarshallerProperties.MEDIA_TYPE, MediaType.APPLICATION_JSON);
             unmarshaller.setProperty(UnmarshallerProperties.JSON_ATTRIBUTE_PREFIX, attributePrefix);
@@ -945,7 +949,11 @@ public class MOXyJsonProvider implements MessageBodyReader<Object>, MessageBodyW
 
             Set<Class<?>> domainClasses = getDomainClasses(genericType);
             JAXBContext jaxbContext = getJAXBContext(domainClasses, annotations, mediaType, httpHeaders);
-            logAction("write_to_moxy_json_provider");
+            SessionLog logger = AbstractSessionLog.getLog();
+
+            if (logger.shouldLog(SessionLog.FINE, SessionLog.MOXY)) {
+                logger.log(SessionLog.FINE, SessionLog.MOXY, "moxy_write_to_moxy_json_provider", new Object[0]);
+            }
             Marshaller marshaller = jaxbContext.createMarshaller();
             marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, formattedOutput);
             marshaller.setProperty(MarshallerProperties.MEDIA_TYPE, MediaType.APPLICATION_JSON);
@@ -981,10 +989,4 @@ public class MOXyJsonProvider implements MessageBodyReader<Object>, MessageBodyW
             throw new WebApplicationException(jaxbException);
         }
     }
-
-    private void logAction(String key) {
-        String i18nmsg = JAXBLocalization.buildMessage(key, new Object[0]);
-        AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MOXY, i18nmsg, new Object[0], false);
-    }
-
 }

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/rs/MOXyJsonProvider.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/rs/MOXyJsonProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at


### PR DESCRIPTION
This is MOXy improvement of logging system.
After this path MOXy can log info about different events related with marshalling/unmarshalling like:
* Set JAXBContext/marshaller/unmarshaller properties (name/value)
* Start marshalling/unmarshalling
* Mappings generation
* List of mappings
* Payload log (content of entities - output depends on `toString()` implementation in POJO)

Logging could be controlled by system properties like
`... -Declipselink.moxy.logging.payload=true -Declipselink.moxy.logging.level=FINE`

or JAXBContext/marshaller/unmarshaller properties like

`props.put(JAXBContextProperties.MOXY_LOG_PAYLOAD, true);`
`props.put(JAXBContextProperties.MOXY_LOGGING_LEVEL, "FINE");`

Payload log messages are produced only when:
`eclipselink.moxy.logging.payload=true && eclipselink.moxy.logging.level=FINEST`
