### PR TITLE
[Non bug] JPA JSE test fix

### DIFF
--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQueryCase.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQueryCase.java
@@ -16,236 +16,290 @@ package org.eclipse.persistence.jpa.test.query;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
 import java.util.List;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.TypedQuery;
+
 import org.eclipse.persistence.jpa.test.framework.DDLGen;
 import org.eclipse.persistence.jpa.test.framework.Emf;
 import org.eclipse.persistence.jpa.test.framework.EmfRunner;
 import org.eclipse.persistence.jpa.test.framework.Property;
 import org.eclipse.persistence.jpa.test.query.model.Dto01;
 import org.eclipse.persistence.jpa.test.query.model.EntityTbl01;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(EmfRunner.class)
 public class TestQueryCase {
-    @Emf(createTables = DDLGen.DROP_CREATE, classes = { EntityTbl01.class }, 
-            properties = { @Property(name="eclipselink.logging.level", value="FINE") })
+    @Emf(createTables = DDLGen.DROP_CREATE, classes = {EntityTbl01.class},
+            properties = {@Property(name = "eclipselink.logging.level", value = "FINE")})
     private EntityManagerFactory emf;
 
     private static boolean POPULATED = false;
 
     @Test
     public void testQueryCase1() {
-        if (emf == null)
-            return;
+        EntityManager em = null;
+        try {
+            if (emf == null)
+                return;
 
-        if(!POPULATED) 
-            populate();
+            if (!POPULATED)
+                populate();
 
-        EntityManager em = emf.createEntityManager();
+            em = emf.createEntityManager();
 
-        em.getTransaction().begin();
+            em.getTransaction().begin();
 
-        TypedQuery<EntityTbl01> query = em.createQuery(""
-                + "SELECT t FROM EntityTbl01 t "
+            TypedQuery<EntityTbl01> query = em.createQuery(""
+                    + "SELECT t FROM EntityTbl01 t "
                     + "WHERE t.itemString1 = ( "
-                        + "CASE t.itemInteger1 "
-                            + "WHEN 1000 THEN '047010' "
-                            + "WHEN 100 THEN '023010' "
-                            + "ELSE '033020' "
-                        + "END )", EntityTbl01.class);
+                    + "CASE t.itemInteger1 "
+                    + "WHEN 1000 THEN '047010' "
+                    + "WHEN 100 THEN '023010' "
+                    + "ELSE '033020' "
+                    + "END )", EntityTbl01.class);
 
-        List<EntityTbl01> dto01 = query.getResultList();
-        assertNotNull(dto01);
-        assertEquals(0, dto01.size());
+            List<EntityTbl01> dto01 = query.getResultList();
+            assertNotNull(dto01);
+            assertEquals(0, dto01.size());
 
-        query = em.createQuery(""
-                + "SELECT t FROM EntityTbl01 t "
+            query = em.createQuery(""
+                    + "SELECT t FROM EntityTbl01 t "
                     + "WHERE t.itemString1 = ( "
-                        + "CASE t.itemInteger1 "
-                            + "WHEN 1 THEN 'A' "
-                            + "WHEN 100 THEN 'B' "
-                            + "ELSE 'C' "
-                        + "END )", EntityTbl01.class);
-        dto01 = query.getResultList();
-        assertNotNull(dto01);
-        assertEquals(1, dto01.size());
+                    + "CASE t.itemInteger1 "
+                    + "WHEN 1 THEN 'A' "
+                    + "WHEN 100 THEN 'B' "
+                    + "ELSE 'C' "
+                    + "END )", EntityTbl01.class);
+            dto01 = query.getResultList();
+            assertNotNull(dto01);
+            assertEquals(1, dto01.size());
 
-        assertEquals("A", dto01.get(0).getItemString1());
-        assertEquals("B", dto01.get(0).getItemString2());
-        assertEquals("C", dto01.get(0).getItemString3());
-        assertEquals("D", dto01.get(0).getItemString4());
-        assertEquals(new Integer(1), dto01.get(0).getItemInteger1());
-
-        em.getTransaction().rollback();
+            assertEquals("A", dto01.get(0).getItemString1());
+            assertEquals("B", dto01.get(0).getItemString2());
+            assertEquals("C", dto01.get(0).getItemString3());
+            assertEquals("D", dto01.get(0).getItemString4());
+            assertEquals(new Integer(1), dto01.get(0).getItemInteger1());
+        } catch (Exception e) {
+            fail(e.getLocalizedMessage());
+        } finally {
+            if (em != null) {
+                if (em.getTransaction().isActive()) {
+                    em.getTransaction().rollback();
+                }
+                em.close();
+            }
+        }
     }
 
     @Test
     public void testQueryCase2() {
-        if (emf == null)
-            return;
+        EntityManager em = null;
+        try {
+            if (emf == null)
+                return;
 
-        if(!POPULATED) 
-            populate();
+            if (!POPULATED)
+                populate();
 
-        EntityManager em = emf.createEntityManager();
+            em = emf.createEntityManager();
 
-        em.getTransaction().begin();
+            em.getTransaction().begin();
 
-        TypedQuery<EntityTbl01> query = em.createQuery(""
-                + "SELECT t FROM EntityTbl01 t "
+            TypedQuery<EntityTbl01> query = em.createQuery(""
+                    + "SELECT t FROM EntityTbl01 t "
                     + "WHERE t.itemString1 = ( "
-                        + "CASE "
-                            + "WHEN t.itemInteger1 = 1000 THEN '047010' "
-                            + "WHEN t.itemInteger1 = 100 THEN '023010' "
-                            + "ELSE '033020' "
-                        + "END )", EntityTbl01.class);
-
-        List<EntityTbl01> dto01 = query.getResultList();
-        assertNotNull(dto01);
-        assertEquals(0, dto01.size());
-
-        query = em.createQuery(""
-                + "SELECT t FROM EntityTbl01 t "
-                + "WHERE t.itemString1 = ( "
                     + "CASE "
-                        + "WHEN t.itemInteger1 = 1 THEN 'A' "
-                        + "WHEN t.itemInteger1 = 100 THEN 'B' "
-                        + "ELSE 'C' "
+                    + "WHEN t.itemInteger1 = 1000 THEN '047010' "
+                    + "WHEN t.itemInteger1 = 100 THEN '023010' "
+                    + "ELSE '033020' "
                     + "END )", EntityTbl01.class);
 
-        dto01 = query.getResultList();
-        assertNotNull(dto01);
-        assertEquals(1, dto01.size());
+            List<EntityTbl01> dto01 = query.getResultList();
+            assertNotNull(dto01);
+            assertEquals(0, dto01.size());
 
-        assertEquals("A", dto01.get(0).getItemString1());
-        assertEquals("B", dto01.get(0).getItemString2());
-        assertEquals("C", dto01.get(0).getItemString3());
-        assertEquals("D", dto01.get(0).getItemString4());
-        assertEquals(new Integer(1), dto01.get(0).getItemInteger1());
-
-        query = em.createQuery(""
-                + "SELECT t FROM EntityTbl01 t "
-                + "WHERE t.itemString1 = ( "
+            query = em.createQuery(""
+                    + "SELECT t FROM EntityTbl01 t "
+                    + "WHERE t.itemString1 = ( "
                     + "CASE "
-                        + "WHEN t.itemInteger1 = 1 AND t.KeyString = 'Key01' THEN 'A' "
-                        + "WHEN t.itemInteger1 = 100 THEN 'B' "
-                        + "ELSE 'C' "
+                    + "WHEN t.itemInteger1 = 1 THEN 'A' "
+                    + "WHEN t.itemInteger1 = 100 THEN 'B' "
+                    + "ELSE 'C' "
                     + "END )", EntityTbl01.class);
 
-        em.getTransaction().rollback();
+            dto01 = query.getResultList();
+            assertNotNull(dto01);
+            assertEquals(1, dto01.size());
+
+            assertEquals("A", dto01.get(0).getItemString1());
+            assertEquals("B", dto01.get(0).getItemString2());
+            assertEquals("C", dto01.get(0).getItemString3());
+            assertEquals("D", dto01.get(0).getItemString4());
+            assertEquals(new Integer(1), dto01.get(0).getItemInteger1());
+
+            query = em.createQuery(""
+                    + "SELECT t FROM EntityTbl01 t "
+                    + "WHERE t.itemString1 = ( "
+                    + "CASE "
+                    + "WHEN t.itemInteger1 = 1 AND t.KeyString = 'Key01' THEN 'A' "
+                    + "WHEN t.itemInteger1 = 100 THEN 'B' "
+                    + "ELSE 'C' "
+                    + "END )", EntityTbl01.class);
+        } catch (Exception e) {
+            fail(e.getLocalizedMessage());
+        } finally {
+            if (em != null) {
+                if (em.getTransaction().isActive()) {
+                    em.getTransaction().rollback();
+                }
+                em.close();
+            }
+        }
     }
 
     @Test
     public void testQueryCase3() {
-        if (emf == null)
-            return;
+        EntityManager em = null;
+        try {
+            if (emf == null)
+                return;
 
-        if(!POPULATED) 
-            populate();
+            if (!POPULATED)
+                populate();
 
-        EntityManager em = emf.createEntityManager();
+            em = emf.createEntityManager();
 
-        em.getTransaction().begin();
+            em.getTransaction().begin();
 
-        TypedQuery<Dto01> query = em.createQuery(""
-                + "SELECT new org.eclipse.persistence.jpa.test.query.model.Dto01("
+            TypedQuery<Dto01> query = em.createQuery(""
+                    + "SELECT new org.eclipse.persistence.jpa.test.query.model.Dto01("
                     + "t.itemString1, "               // String
                     + "CASE t.itemString2 "           // String
-                        + "WHEN 'J' THEN 'Japan' "
-                        + "ELSE 'Other' "
+                    + "WHEN 'J' THEN 'Japan' "
+                    + "ELSE 'Other' "
                     + "END  "
                     + ", "
-                      + "SUM("      // Returns Long (4.8.5)
-                          + "CASE "
-                              + "WHEN t.itemString3 = 'C' "
-                              + "THEN 1 ELSE 0 "
-                          + "END" 
-                      +") "
-                    + ", "
-                      + "SUM("      // Returns Long (4.8.5)
-                          + "CASE "
-                              + "WHEN t.itemString4 = 'D' "
-                              + "THEN 1 ELSE 0 "
-                          + "END" 
-                      + ") " 
+                    + "SUM("      // Returns Long (4.8.5)
+                    + "CASE "
+                    + "WHEN t.itemString3 = 'C' "
+                    + "THEN 1 ELSE 0 "
+                    + "END"
                     + ") "
-                + "FROM EntityTbl01 t "
-                + "GROUP BY t.itemString1, t.itemString2", Dto01.class);
+                    + ", "
+                    + "SUM("      // Returns Long (4.8.5)
+                    + "CASE "
+                    + "WHEN t.itemString4 = 'D' "
+                    + "THEN 1 ELSE 0 "
+                    + "END"
+                    + ") "
+                    + ") "
+                    + "FROM EntityTbl01 t "
+                    + "GROUP BY t.itemString1, t.itemString2", Dto01.class);
 
-        List<Dto01> dto01 = query.getResultList();
-        assertNotNull(dto01);
-        assertEquals(1, dto01.size());
-        assertEquals("A", dto01.get(0).getStr1());
-        assertEquals("Other", dto01.get(0).getStr2());
-        assertNull(dto01.get(0).getStr3());
-        assertNull(dto01.get(0).getStr4());
-        assertEquals(new Integer(2), dto01.get(0).getInteger1());
-        assertEquals(new Integer(2), dto01.get(0).getInteger2());
-
-        em.getTransaction().rollback();
+            List<Dto01> dto01 = query.getResultList();
+            assertNotNull(dto01);
+            assertEquals(1, dto01.size());
+            assertEquals("A", dto01.get(0).getStr1());
+            assertEquals("Other", dto01.get(0).getStr2());
+            assertNull(dto01.get(0).getStr3());
+            assertNull(dto01.get(0).getStr4());
+            assertEquals(new Integer(2), dto01.get(0).getInteger1());
+            assertEquals(new Integer(2), dto01.get(0).getInteger2());
+        } catch (Exception e) {
+            fail(e.getLocalizedMessage());
+        } finally {
+            if (em != null) {
+                if (em.getTransaction().isActive()) {
+                    em.getTransaction().rollback();
+                }
+                em.close();
+            }
+        }
     }
 
     @Test
     public void testQueryCase4() {
-        if (emf == null)
-            return;
+        EntityManager em = null;
+        try {
+            if (emf == null)
+                return;
 
-        if(!POPULATED) 
-            populate();
+            if (!POPULATED)
+                populate();
 
-        EntityManager em = emf.createEntityManager();
+            em = emf.createEntityManager();
 
-        em.getTransaction().begin();
+            em.getTransaction().begin();
 
-        TypedQuery<Integer> query = em.createQuery(""
-                + "SELECT ("
-                   + "CASE t.itemString2 "
-                   + "WHEN 'A' THEN 42 "
-                   + "WHEN 'B' THEN 100 "
-                   + "ELSE 0 "
-                   + "END "
-                + ") "
-                + "FROM EntityTbl01 t", Integer.class);
+            TypedQuery<Integer> query = em.createQuery(""
+                    + "SELECT ("
+                    + "CASE t.itemString2 "
+                    + "WHEN 'A' THEN 42 "
+                    + "WHEN 'B' THEN 100 "
+                    + "ELSE 0 "
+                    + "END "
+                    + ") "
+                    + "FROM EntityTbl01 t", Integer.class);
 
-        List<Integer> intList = query.getResultList();
-        assertNotNull(intList);
-        assertEquals(2, intList.size());
-        assertEquals(new Integer(100), intList.get(0));
-        assertEquals(new Integer(100), intList.get(1));
-
-        em.getTransaction().rollback();
+            List<Integer> intList = query.getResultList();
+            assertNotNull(intList);
+            assertEquals(2, intList.size());
+            assertEquals(new Integer(100), intList.get(0));
+            assertEquals(new Integer(100), intList.get(1));
+        } catch (Exception e) {
+            fail(e.getLocalizedMessage());
+        } finally {
+            if (em != null) {
+                if (em.getTransaction().isActive()) {
+                    em.getTransaction().rollback();
+                }
+                em.close();
+            }
+        }
     }
 
     private void populate() {
-        EntityManager em = emf.createEntityManager();
+        EntityManager em = null;
+        try {
+            em = emf.createEntityManager();
 
-        em.getTransaction().begin();
+            em.getTransaction().begin();
 
-        EntityTbl01 tbl1 = new EntityTbl01();
-        tbl1.setKeyString("Key01");
-        tbl1.setItemString1("A");
-        tbl1.setItemString2("B");
-        tbl1.setItemString3("C");
-        tbl1.setItemString4("D");
-        tbl1.setItemInteger1(1);
-        em.persist(tbl1);
+            EntityTbl01 tbl1 = new EntityTbl01();
+            tbl1.setKeyString("Key01");
+            tbl1.setItemString1("A");
+            tbl1.setItemString2("B");
+            tbl1.setItemString3("C");
+            tbl1.setItemString4("D");
+            tbl1.setItemInteger1(1);
+            em.persist(tbl1);
 
-        EntityTbl01 tbl2 = new EntityTbl01();
-        tbl2.setKeyString("Key02");
-        tbl2.setItemString1("A");
-        tbl2.setItemString2("B");
-        tbl2.setItemString3("C");
-        tbl2.setItemString4("D");
-        tbl2.setItemInteger1(2);
-        em.persist(tbl2);
+            EntityTbl01 tbl2 = new EntityTbl01();
+            tbl2.setKeyString("Key02");
+            tbl2.setItemString1("A");
+            tbl2.setItemString2("B");
+            tbl2.setItemString3("C");
+            tbl2.setItemString4("D");
+            tbl2.setItemInteger1(2);
+            em.persist(tbl2);
+            em.getTransaction().commit();
 
-        em.getTransaction().commit();
-
-        em.close();
+        } catch (Exception e) {
+            fail(e.getLocalizedMessage());
+        } finally {
+            if (em != null) {
+                if (em.getTransaction().isActive()) {
+                    em.getTransaction().rollback();
+                }
+                em.close();
+            }
+        }
 
         POPULATED = true;
     }

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQueryCase.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQueryCase.java
@@ -30,7 +30,9 @@ import org.eclipse.persistence.jpa.test.framework.EmfRunner;
 import org.eclipse.persistence.jpa.test.framework.Property;
 import org.eclipse.persistence.jpa.test.query.model.Dto01;
 import org.eclipse.persistence.jpa.test.query.model.EntityTbl01;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -39,230 +41,143 @@ public class TestQueryCase {
     @Emf(createTables = DDLGen.DROP_CREATE, classes = {EntityTbl01.class},
             properties = {@Property(name = "eclipselink.logging.level", value = "FINE")})
     private EntityManagerFactory emf;
+    private EntityManager em;
 
     private static boolean POPULATED = false;
 
     @Test
     public void testQueryCase1() {
-        EntityManager em = null;
-        try {
-            if (emf == null)
-                return;
+        TypedQuery<EntityTbl01> query = em.createQuery(""
+                + "SELECT t FROM EntityTbl01 t "
+                + "WHERE t.itemString1 = ( "
+                + "CASE t.itemInteger1 "
+                + "WHEN 1000 THEN '047010' "
+                + "WHEN 100 THEN '023010' "
+                + "ELSE '033020' "
+                + "END )", EntityTbl01.class);
 
-            if (!POPULATED)
-                populate();
+        List<EntityTbl01> dto01 = query.getResultList();
+        assertNotNull(dto01);
+        assertEquals(0, dto01.size());
 
-            em = emf.createEntityManager();
+        query = em.createQuery(""
+                + "SELECT t FROM EntityTbl01 t "
+                + "WHERE t.itemString1 = ( "
+                + "CASE t.itemInteger1 "
+                + "WHEN 1 THEN 'A' "
+                + "WHEN 100 THEN 'B' "
+                + "ELSE 'C' "
+                + "END )", EntityTbl01.class);
+        dto01 = query.getResultList();
+        assertNotNull(dto01);
+        assertEquals(1, dto01.size());
 
-            em.getTransaction().begin();
-
-            TypedQuery<EntityTbl01> query = em.createQuery(""
-                    + "SELECT t FROM EntityTbl01 t "
-                    + "WHERE t.itemString1 = ( "
-                    + "CASE t.itemInteger1 "
-                    + "WHEN 1000 THEN '047010' "
-                    + "WHEN 100 THEN '023010' "
-                    + "ELSE '033020' "
-                    + "END )", EntityTbl01.class);
-
-            List<EntityTbl01> dto01 = query.getResultList();
-            assertNotNull(dto01);
-            assertEquals(0, dto01.size());
-
-            query = em.createQuery(""
-                    + "SELECT t FROM EntityTbl01 t "
-                    + "WHERE t.itemString1 = ( "
-                    + "CASE t.itemInteger1 "
-                    + "WHEN 1 THEN 'A' "
-                    + "WHEN 100 THEN 'B' "
-                    + "ELSE 'C' "
-                    + "END )", EntityTbl01.class);
-            dto01 = query.getResultList();
-            assertNotNull(dto01);
-            assertEquals(1, dto01.size());
-
-            assertEquals("A", dto01.get(0).getItemString1());
-            assertEquals("B", dto01.get(0).getItemString2());
-            assertEquals("C", dto01.get(0).getItemString3());
-            assertEquals("D", dto01.get(0).getItemString4());
-            assertEquals(new Integer(1), dto01.get(0).getItemInteger1());
-        } catch (Exception e) {
-            fail(e.getLocalizedMessage());
-        } finally {
-            if (em != null) {
-                if (em.getTransaction().isActive()) {
-                    em.getTransaction().rollback();
-                }
-                em.close();
-            }
-        }
+        assertEquals("A", dto01.get(0).getItemString1());
+        assertEquals("B", dto01.get(0).getItemString2());
+        assertEquals("C", dto01.get(0).getItemString3());
+        assertEquals("D", dto01.get(0).getItemString4());
+        assertEquals(new Integer(1), dto01.get(0).getItemInteger1());
     }
 
     @Test
     public void testQueryCase2() {
-        EntityManager em = null;
-        try {
-            if (emf == null)
-                return;
+        TypedQuery<EntityTbl01> query = em.createQuery(""
+                + "SELECT t FROM EntityTbl01 t "
+                + "WHERE t.itemString1 = ( "
+                + "CASE "
+                + "WHEN t.itemInteger1 = 1000 THEN '047010' "
+                + "WHEN t.itemInteger1 = 100 THEN '023010' "
+                + "ELSE '033020' "
+                + "END )", EntityTbl01.class);
 
-            if (!POPULATED)
-                populate();
+        List<EntityTbl01> dto01 = query.getResultList();
+        assertNotNull(dto01);
+        assertEquals(0, dto01.size());
 
-            em = emf.createEntityManager();
+        query = em.createQuery(""
+                + "SELECT t FROM EntityTbl01 t "
+                + "WHERE t.itemString1 = ( "
+                + "CASE "
+                + "WHEN t.itemInteger1 = 1 THEN 'A' "
+                + "WHEN t.itemInteger1 = 100 THEN 'B' "
+                + "ELSE 'C' "
+                + "END )", EntityTbl01.class);
 
-            em.getTransaction().begin();
+        dto01 = query.getResultList();
+        assertNotNull(dto01);
+        assertEquals(1, dto01.size());
 
-            TypedQuery<EntityTbl01> query = em.createQuery(""
-                    + "SELECT t FROM EntityTbl01 t "
-                    + "WHERE t.itemString1 = ( "
-                    + "CASE "
-                    + "WHEN t.itemInteger1 = 1000 THEN '047010' "
-                    + "WHEN t.itemInteger1 = 100 THEN '023010' "
-                    + "ELSE '033020' "
-                    + "END )", EntityTbl01.class);
+        assertEquals("A", dto01.get(0).getItemString1());
+        assertEquals("B", dto01.get(0).getItemString2());
+        assertEquals("C", dto01.get(0).getItemString3());
+        assertEquals("D", dto01.get(0).getItemString4());
+        assertEquals(new Integer(1), dto01.get(0).getItemInteger1());
 
-            List<EntityTbl01> dto01 = query.getResultList();
-            assertNotNull(dto01);
-            assertEquals(0, dto01.size());
-
-            query = em.createQuery(""
-                    + "SELECT t FROM EntityTbl01 t "
-                    + "WHERE t.itemString1 = ( "
-                    + "CASE "
-                    + "WHEN t.itemInteger1 = 1 THEN 'A' "
-                    + "WHEN t.itemInteger1 = 100 THEN 'B' "
-                    + "ELSE 'C' "
-                    + "END )", EntityTbl01.class);
-
-            dto01 = query.getResultList();
-            assertNotNull(dto01);
-            assertEquals(1, dto01.size());
-
-            assertEquals("A", dto01.get(0).getItemString1());
-            assertEquals("B", dto01.get(0).getItemString2());
-            assertEquals("C", dto01.get(0).getItemString3());
-            assertEquals("D", dto01.get(0).getItemString4());
-            assertEquals(new Integer(1), dto01.get(0).getItemInteger1());
-
-            query = em.createQuery(""
-                    + "SELECT t FROM EntityTbl01 t "
-                    + "WHERE t.itemString1 = ( "
-                    + "CASE "
-                    + "WHEN t.itemInteger1 = 1 AND t.KeyString = 'Key01' THEN 'A' "
-                    + "WHEN t.itemInteger1 = 100 THEN 'B' "
-                    + "ELSE 'C' "
-                    + "END )", EntityTbl01.class);
-        } catch (Exception e) {
-            fail(e.getLocalizedMessage());
-        } finally {
-            if (em != null) {
-                if (em.getTransaction().isActive()) {
-                    em.getTransaction().rollback();
-                }
-                em.close();
-            }
-        }
+        query = em.createQuery(""
+                + "SELECT t FROM EntityTbl01 t "
+                + "WHERE t.itemString1 = ( "
+                + "CASE "
+                + "WHEN t.itemInteger1 = 1 AND t.KeyString = 'Key01' THEN 'A' "
+                + "WHEN t.itemInteger1 = 100 THEN 'B' "
+                + "ELSE 'C' "
+                + "END )", EntityTbl01.class);
     }
 
     @Test
     public void testQueryCase3() {
-        EntityManager em = null;
-        try {
-            if (emf == null)
-                return;
+        TypedQuery<Dto01> query = em.createQuery(""
+                + "SELECT new org.eclipse.persistence.jpa.test.query.model.Dto01("
+                + "t.itemString1, "               // String
+                + "CASE t.itemString2 "           // String
+                + "WHEN 'J' THEN 'Japan' "
+                + "ELSE 'Other' "
+                + "END  "
+                + ", "
+                + "SUM("      // Returns Long (4.8.5)
+                + "CASE "
+                + "WHEN t.itemString3 = 'C' "
+                + "THEN 1 ELSE 0 "
+                + "END"
+                + ") "
+                + ", "
+                + "SUM("      // Returns Long (4.8.5)
+                + "CASE "
+                + "WHEN t.itemString4 = 'D' "
+                + "THEN 1 ELSE 0 "
+                + "END"
+                + ") "
+                + ") "
+                + "FROM EntityTbl01 t "
+                + "GROUP BY t.itemString1, t.itemString2", Dto01.class);
 
-            if (!POPULATED)
-                populate();
-
-            em = emf.createEntityManager();
-
-            em.getTransaction().begin();
-
-            TypedQuery<Dto01> query = em.createQuery(""
-                    + "SELECT new org.eclipse.persistence.jpa.test.query.model.Dto01("
-                    + "t.itemString1, "               // String
-                    + "CASE t.itemString2 "           // String
-                    + "WHEN 'J' THEN 'Japan' "
-                    + "ELSE 'Other' "
-                    + "END  "
-                    + ", "
-                    + "SUM("      // Returns Long (4.8.5)
-                    + "CASE "
-                    + "WHEN t.itemString3 = 'C' "
-                    + "THEN 1 ELSE 0 "
-                    + "END"
-                    + ") "
-                    + ", "
-                    + "SUM("      // Returns Long (4.8.5)
-                    + "CASE "
-                    + "WHEN t.itemString4 = 'D' "
-                    + "THEN 1 ELSE 0 "
-                    + "END"
-                    + ") "
-                    + ") "
-                    + "FROM EntityTbl01 t "
-                    + "GROUP BY t.itemString1, t.itemString2", Dto01.class);
-
-            List<Dto01> dto01 = query.getResultList();
-            assertNotNull(dto01);
-            assertEquals(1, dto01.size());
-            assertEquals("A", dto01.get(0).getStr1());
-            assertEquals("Other", dto01.get(0).getStr2());
-            assertNull(dto01.get(0).getStr3());
-            assertNull(dto01.get(0).getStr4());
-            assertEquals(new Integer(2), dto01.get(0).getInteger1());
-            assertEquals(new Integer(2), dto01.get(0).getInteger2());
-        } catch (Exception e) {
-            fail(e.getLocalizedMessage());
-        } finally {
-            if (em != null) {
-                if (em.getTransaction().isActive()) {
-                    em.getTransaction().rollback();
-                }
-                em.close();
-            }
-        }
+        List<Dto01> dto01 = query.getResultList();
+        assertNotNull(dto01);
+        assertEquals(1, dto01.size());
+        assertEquals("A", dto01.get(0).getStr1());
+        assertEquals("Other", dto01.get(0).getStr2());
+        assertNull(dto01.get(0).getStr3());
+        assertNull(dto01.get(0).getStr4());
+        assertEquals(new Integer(2), dto01.get(0).getInteger1());
+        assertEquals(new Integer(2), dto01.get(0).getInteger2());
     }
 
     @Test
     public void testQueryCase4() {
-        EntityManager em = null;
-        try {
-            if (emf == null)
-                return;
+        TypedQuery<Integer> query = em.createQuery(""
+                + "SELECT ("
+                + "CASE t.itemString2 "
+                + "WHEN 'A' THEN 42 "
+                + "WHEN 'B' THEN 100 "
+                + "ELSE 0 "
+                + "END "
+                + ") "
+                + "FROM EntityTbl01 t", Integer.class);
 
-            if (!POPULATED)
-                populate();
-
-            em = emf.createEntityManager();
-
-            em.getTransaction().begin();
-
-            TypedQuery<Integer> query = em.createQuery(""
-                    + "SELECT ("
-                    + "CASE t.itemString2 "
-                    + "WHEN 'A' THEN 42 "
-                    + "WHEN 'B' THEN 100 "
-                    + "ELSE 0 "
-                    + "END "
-                    + ") "
-                    + "FROM EntityTbl01 t", Integer.class);
-
-            List<Integer> intList = query.getResultList();
-            assertNotNull(intList);
-            assertEquals(2, intList.size());
-            assertEquals(new Integer(100), intList.get(0));
-            assertEquals(new Integer(100), intList.get(1));
-        } catch (Exception e) {
-            fail(e.getLocalizedMessage());
-        } finally {
-            if (em != null) {
-                if (em.getTransaction().isActive()) {
-                    em.getTransaction().rollback();
-                }
-                em.close();
-            }
-        }
+        List<Integer> intList = query.getResultList();
+        assertNotNull(intList);
+        assertEquals(2, intList.size());
+        assertEquals(new Integer(100), intList.get(0));
+        assertEquals(new Integer(100), intList.get(1));
     }
 
     private void populate() {
@@ -304,4 +219,25 @@ public class TestQueryCase {
 
         POPULATED = true;
     }
+
+    @Before
+    public void setUp() throws Exception {
+        if (emf == null)
+            return;
+        if (!POPULATED)
+            populate();
+        em = emf.createEntityManager();
+        em.getTransaction().begin();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (em.getTransaction().isActive()) {
+            em.getTransaction().rollback();
+        }
+        if (em.isOpen()) {
+            em.close();
+        }
+    }
+
 }

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQueryCase.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQueryCase.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018 IBM Corporation, Oracle, and/or affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQueryHints.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQueryHints.java
@@ -60,7 +60,7 @@ public class TestQueryHints implements PUPropertiesProvider {
 
     private final static int propertyTimeout = 3099;
 
-    @Emf(name = "defaultEMF", classes = { Employee.class }, createTables = DDLGen.DROP_CREATE)
+    @Emf(name = "defaultEMF", classes = { Employee.class })
     private EntityManagerFactory emf;
 
     /**

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQueryHints.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQueryHints.java
@@ -89,10 +89,10 @@ public class TestQueryHints implements PUPropertiesProvider {
         } catch (Exception e) {
             Assert.fail(e.getLocalizedMessage());
         } finally {
-            if (em.getTransaction().isActive()) {
-                em.getTransaction().rollback();
-            }
             if (em != null) {
+                if (em.getTransaction().isActive()) {
+                    em.getTransaction().rollback();
+                }
                 em.close();
             }
         }
@@ -116,10 +116,10 @@ public class TestQueryHints implements PUPropertiesProvider {
         } catch (Exception e) {
             Assert.fail(e.getLocalizedMessage());
         } finally {
-            if (em.getTransaction().isActive()) {
-                em.getTransaction().rollback();
-            }
             if (em != null) {
+                if (em.getTransaction().isActive()) {
+                    em.getTransaction().rollback();
+                }
                 em.close();
             }
         }
@@ -147,10 +147,10 @@ public class TestQueryHints implements PUPropertiesProvider {
         } catch (Exception e) {
             Assert.fail(e.getLocalizedMessage());
         } finally {
-            if (em.getTransaction().isActive()) {
-                em.getTransaction().rollback();
-            }
             if (em != null) {
+                if (em.getTransaction().isActive()) {
+                    em.getTransaction().rollback();
+                }
                 em.close();
             }
         }
@@ -170,10 +170,10 @@ public class TestQueryHints implements PUPropertiesProvider {
         } catch (Exception e) {
             Assert.fail(e.getLocalizedMessage());
         } finally {
-            if (em.getTransaction().isActive()) {
-                em.getTransaction().rollback();
-            }
             if (em != null) {
+                if (em.getTransaction().isActive()) {
+                    em.getTransaction().rollback();
+                }
                 em.close();
             }
         }
@@ -201,10 +201,10 @@ public class TestQueryHints implements PUPropertiesProvider {
         } catch (Exception e) {
             Assert.fail(e.getLocalizedMessage());
         } finally {
-            if (em.getTransaction().isActive()) {
-                em.getTransaction().rollback();
-            }
             if (em != null) {
+                if (em.getTransaction().isActive()) {
+                    em.getTransaction().rollback();
+                }
                 em.close();
             }
         }
@@ -224,10 +224,10 @@ public class TestQueryHints implements PUPropertiesProvider {
         } catch (Exception e) {
             Assert.fail(e.getLocalizedMessage());
         } finally {
-            if (em.getTransaction().isActive()) {
-                em.getTransaction().rollback();
-            }
             if (em != null) {
+                if (em.getTransaction().isActive()) {
+                    em.getTransaction().rollback();
+                }
                 em.close();
             }
         }

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQueryHints.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQueryHints.java
@@ -60,12 +60,12 @@ public class TestQueryHints implements PUPropertiesProvider {
 
     private final static int propertyTimeout = 3099;
 
-    @Emf(name = "defaultEMF", classes = { Employee.class })
+    @Emf(name = "defaultEMF", classes = {Employee.class}, createTables = DDLGen.DROP_CREATE)
     private EntityManagerFactory emf;
 
     /**
      * Test that setting the Query Hint: QueryHints.JDBC_TIMEOUT to the default value
-     *  will see the expected value of seconds being set on the statement
+     * will see the expected value of seconds being set on the statement
      */
     @Test
     public void testJDBCQueryTimeout() throws Exception {
@@ -75,17 +75,17 @@ public class TestQueryHints implements PUPropertiesProvider {
 
             em.getTransaction().begin();
             em.createQuery("SELECT x FROM Employee x")
-                .setHint(QueryHints.QUERY_TIMEOUT, TestQueryHints.propertyTimeout)
-                .getResultList();
+                    .setHint(QueryHints.QUERY_TIMEOUT, TestQueryHints.propertyTimeout)
+                    .getResultList();
 
             //Convert the timeout set (MILLISECONDS) to what is expected by the JDBC layer (SECONDS)
             double queryTimeoutSeconds = TestQueryHints.propertyTimeout / 1000d;
             //if there was a remainder, it should round up
-            if(queryTimeoutSeconds % 1 > 0) {
+            if (queryTimeoutSeconds % 1 > 0) {
                 queryTimeoutSeconds += 1;
             }
 
-            Assert.assertEquals((int)queryTimeoutSeconds, TestQueryHints.statementTimeout);
+            Assert.assertEquals((int) queryTimeoutSeconds, TestQueryHints.statementTimeout);
         } catch (Exception e) {
             Assert.fail(e.getLocalizedMessage());
         } finally {
@@ -102,17 +102,17 @@ public class TestQueryHints implements PUPropertiesProvider {
 
             em.getTransaction().begin();
             em.createQuery("SELECT x FROM Employee x")
-                .setHint(QueryHints.JDBC_TIMEOUT, TestQueryHints.propertyTimeout)
-                .getResultList();
+                    .setHint(QueryHints.JDBC_TIMEOUT, TestQueryHints.propertyTimeout)
+                    .getResultList();
 
             //Convert the timeout set (MILLISECONDS) to what is expected by the JDBC layer (SECONDS)
             double queryTimeoutSeconds = TestQueryHints.propertyTimeout / 1000d;
             //if there was a remainder, it should round up
-            if(queryTimeoutSeconds % 1 > 0) {
+            if (queryTimeoutSeconds % 1 > 0) {
                 queryTimeoutSeconds += 1;
             }
 
-            Assert.assertEquals((int)queryTimeoutSeconds, TestQueryHints.statementTimeout);
+            Assert.assertEquals((int) queryTimeoutSeconds, TestQueryHints.statementTimeout);
         } catch (Exception e) {
             Assert.fail(e.getLocalizedMessage());
         } finally {
@@ -127,7 +127,7 @@ public class TestQueryHints implements PUPropertiesProvider {
 
     /**
      * Test that setting the Query Hint: QueryHints.JDBC_TIMEOUT_UNIT to the "SECONDS" value
-     *  will see the expected value of seconds being set on the statement
+     * will see the expected value of seconds being set on the statement
      */
     @Test
     public void testQueryTimeoutUnitSeconds() throws Exception {
@@ -137,8 +137,8 @@ public class TestQueryHints implements PUPropertiesProvider {
 
             em.getTransaction().begin();
             em.createQuery("SELECT x FROM Employee x")
-                .setHint(QueryHints.QUERY_TIMEOUT, TestQueryHints.propertyTimeout)
-                .setHint(QueryHints.QUERY_TIMEOUT_UNIT, TimeUnit.SECONDS.toString()).getResultList();
+                    .setHint(QueryHints.QUERY_TIMEOUT, TestQueryHints.propertyTimeout)
+                    .setHint(QueryHints.QUERY_TIMEOUT_UNIT, TimeUnit.SECONDS.toString()).getResultList();
 
             //Convert the timeout set (SECONDS) to what is expected by the JDBC layer (SECONDS)
             int queryTimeoutSecondsDouble = TestQueryHints.propertyTimeout;
@@ -160,8 +160,8 @@ public class TestQueryHints implements PUPropertiesProvider {
 
             em.getTransaction().begin();
             em.createQuery("SELECT x FROM Employee x")
-                .setHint(QueryHints.JDBC_TIMEOUT, TestQueryHints.propertyTimeout)
-                .setHint(QueryHints.QUERY_TIMEOUT_UNIT, TimeUnit.SECONDS.toString()).getResultList();
+                    .setHint(QueryHints.JDBC_TIMEOUT, TestQueryHints.propertyTimeout)
+                    .setHint(QueryHints.QUERY_TIMEOUT_UNIT, TimeUnit.SECONDS.toString()).getResultList();
 
             //Convert the timeout set (SECONDS) to what is expected by the JDBC layer (SECONDS)
             int queryTimeoutSecondsDouble = TestQueryHints.propertyTimeout;
@@ -181,7 +181,7 @@ public class TestQueryHints implements PUPropertiesProvider {
 
     /**
      * Test that setting the Query Hint: QueryHints.JDBC_TIMEOUT_UNIT to the "MINUTES" value
-     *  will see the expected value of seconds being set on the statement
+     * will see the expected value of seconds being set on the statement
      */
     @Test
     public void testQueryTimeoutUnitMinutes() throws Exception {
@@ -191,8 +191,8 @@ public class TestQueryHints implements PUPropertiesProvider {
 
             em.getTransaction().begin();
             em.createQuery("SELECT x FROM Employee x")
-                .setHint(QueryHints.QUERY_TIMEOUT, TestQueryHints.propertyTimeout)
-                .setHint(QueryHints.QUERY_TIMEOUT_UNIT, TimeUnit.MINUTES.toString()).getResultList();
+                    .setHint(QueryHints.QUERY_TIMEOUT, TestQueryHints.propertyTimeout)
+                    .setHint(QueryHints.QUERY_TIMEOUT_UNIT, TimeUnit.MINUTES.toString()).getResultList();
 
             //Convert the timeout set (MINUTES) to what is expected by the JDBC layer (SECONDS)
             int queryTimeoutSeconds = TestQueryHints.propertyTimeout * 60;
@@ -214,8 +214,8 @@ public class TestQueryHints implements PUPropertiesProvider {
 
             em.getTransaction().begin();
             em.createQuery("SELECT x FROM Employee x")
-                .setHint(QueryHints.JDBC_TIMEOUT, TestQueryHints.propertyTimeout)
-                .setHint(QueryHints.QUERY_TIMEOUT_UNIT, TimeUnit.MINUTES.toString()).getResultList();
+                    .setHint(QueryHints.JDBC_TIMEOUT, TestQueryHints.propertyTimeout)
+                    .setHint(QueryHints.QUERY_TIMEOUT_UNIT, TimeUnit.MINUTES.toString()).getResultList();
 
             //Convert the timeout set (MINUTES) to what is expected by the JDBC layer (SECONDS)
             int queryTimeoutSeconds = TestQueryHints.propertyTimeout * 60;
@@ -313,7 +313,7 @@ public class TestQueryHints implements PUPropertiesProvider {
         }
 
         public static Connector createStatementProxy(Connector toWrap) {
-            return (Connector) Proxy.newProxyInstance(Connector.class.getClassLoader(), new Class[] { Connector.class }, new ConnectorInvocationHandler(toWrap));
+            return (Connector) Proxy.newProxyInstance(Connector.class.getClassLoader(), new Class[]{Connector.class}, new ConnectorInvocationHandler(toWrap));
         }
     }
 
@@ -332,7 +332,7 @@ public class TestQueryHints implements PUPropertiesProvider {
         }
 
         public static Connection createStatementProxy(Connection toWrap) {
-            return (Connection) Proxy.newProxyInstance(Connection.class.getClassLoader(), new Class[] { Connection.class }, new ConnectionInvocationHandler(toWrap));
+            return (Connection) Proxy.newProxyInstance(Connection.class.getClassLoader(), new Class[]{Connection.class}, new ConnectionInvocationHandler(toWrap));
         }
     }
 
@@ -347,15 +347,15 @@ public class TestQueryHints implements PUPropertiesProvider {
             //Get the query timeout being set on the statement
             //This value should be in seconds, since that is what the Statement expects
             if (method.getName().equals("setQueryTimeout") && proxy instanceof PreparedStatement) {
-                if(args.length > 0) {
-                    TestQueryHints.statementTimeout = (Integer)args[0];
+                if (args.length > 0) {
+                    TestQueryHints.statementTimeout = (Integer) args[0];
                 }
             }
             return method.invoke(wrappedStatement, args);
         }
 
         public static PreparedStatement createStatementProxy(PreparedStatement toWrap) {
-            return (PreparedStatement) Proxy.newProxyInstance(PreparedStatement.class.getClassLoader(), new Class[] { PreparedStatement.class }, new PreparedStatementInvocationHandler(toWrap));
+            return (PreparedStatement) Proxy.newProxyInstance(PreparedStatement.class.getClassLoader(), new Class[]{PreparedStatement.class}, new PreparedStatementInvocationHandler(toWrap));
         }
     }
 }

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQueryProperties.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQueryProperties.java
@@ -92,10 +92,10 @@ public class TestQueryProperties implements PUPropertiesProvider {
         } catch (Exception e) {
             Assert.fail(e.getLocalizedMessage());
         } finally {
-            if (em.getTransaction().isActive()) {
-                em.getTransaction().rollback();
-            }
             if (em != null) {
+                if (em.getTransaction().isActive()) {
+                    em.getTransaction().rollback();
+                }
                 em.close();
             }
         }
@@ -121,10 +121,10 @@ public class TestQueryProperties implements PUPropertiesProvider {
         } catch (Exception e) {
             Assert.fail(e.getLocalizedMessage());
         } finally {
-            if (em.getTransaction().isActive()) {
-                em.getTransaction().rollback();
-            }
             if (em != null) {
+                if (em.getTransaction().isActive()) {
+                    em.getTransaction().rollback();
+                }
                 em.close();
             }
         }
@@ -150,10 +150,10 @@ public class TestQueryProperties implements PUPropertiesProvider {
         } catch (Exception e) {
             Assert.fail(e.getLocalizedMessage());
         } finally {
-            if (em.getTransaction().isActive()) {
-                em.getTransaction().rollback();
-            }
             if (em != null) {
+                if (em.getTransaction().isActive()) {
+                    em.getTransaction().rollback();
+                }
                 em.close();
             }
         }

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQueryProperties.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQueryProperties.java
@@ -54,16 +54,16 @@ public class TestQueryProperties implements PUPropertiesProvider {
 
     private final static int propertyTimeout = 3099;
 
-    @Emf(name = "timeoutEMF", classes = { Employee.class }, createTables = DDLGen.DROP_CREATE, properties = {
+    @Emf(name = "timeoutEMF", classes = { Employee.class }, properties = {
             @Property(name = PersistenceUnitProperties.QUERY_TIMEOUT, value = "" + TestQueryProperties.propertyTimeout) })
     private EntityManagerFactory emfTimeout;
 
-    @Emf(name = "timeoutWithUnitSecondsEMF", classes = { Employee.class }, createTables = DDLGen.DROP_CREATE, properties = {
+    @Emf(name = "timeoutWithUnitSecondsEMF", classes = { Employee.class }, properties = {
             @Property(name = PersistenceUnitProperties.QUERY_TIMEOUT, value = "" + TestQueryProperties.propertyTimeout),
             @Property(name = PersistenceUnitProperties.QUERY_TIMEOUT_UNIT, value = "SECONDS") })
     private EntityManagerFactory emfTimeoutSeconds;
 
-    @Emf(name = "timeoutWithUnitMintuesEMF", classes = { Employee.class }, createTables = DDLGen.DROP_CREATE, properties = {
+    @Emf(name = "timeoutWithUnitMintuesEMF", classes = { Employee.class }, properties = {
             @Property(name = PersistenceUnitProperties.QUERY_TIMEOUT, value = "" + TestQueryProperties.propertyTimeout),
             @Property(name = PersistenceUnitProperties.QUERY_TIMEOUT_UNIT, value = "MINUTES") })
     private EntityManagerFactory emfTimeoutMinutes;


### PR DESCRIPTION
This is fix for JPA JSE tests. Some tests can throw _NPE_ during `em.close(); em.getTransaction().rollback();` calls.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>