### PR TITLE
Bug 547328 - JPA NamedStoredProcedure call getOutputParameterValue class cast exception

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
@@ -1295,7 +1295,7 @@ public class DatabasePlatform extends DatasourcePlatform {
         } else if (javaType == ClassConstants.INTEGER) {
             return Types.INTEGER;
         } else if (javaType == ClassConstants.LONG) {
-            return Types.INTEGER;
+            return Types.BIGINT;
         } else if (javaType == ClassConstants.NUMBER) {
             return Types.DECIMAL;
         } else if (javaType == ClassConstants.SHORT ) {

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/advanced/AdvancedJPAJunitTest.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/advanced/AdvancedJPAJunitTest.java
@@ -367,8 +367,8 @@ public class AdvancedJPAJunitTest extends JUnitTestCase {
         try {
             query = em.createNamedQuery("StoredFunction_In");
             query.setParameter("P_IN", 1);
-            int result = (Integer)query.getSingleResult();
-            if (result != 1000) {
+            long result = (Long)query.getSingleResult();
+            if (result != 1000L) {
                 fail("Incorrect result returned:" + result);
             }
         } finally {
@@ -1974,7 +1974,7 @@ public class AdvancedJPAJunitTest extends JUnitTestCase {
             Object[] objectdata = (Object[])aQuery.getSingleResult();
 
             assertTrue("Address data not found or returned using stored procedure", ((objectdata!=null)&& (objectdata.length==2)) );
-            assertTrue("Address Id data returned doesn't match persisted address", (address1.getID() == ((Integer)objectdata[0]).intValue()) );
+            assertTrue("Address Id data returned doesn't match persisted address", (address1.getID() == ((Long)objectdata[0]).longValue()) );
             assertTrue("Address Street data returned doesn't match persisted address", ( address1.getStreet().equals(objectdata[1] )) );
         } catch (RuntimeException e) {
             if (isTransactionActive(em)){

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/advanced/AdvancedJPAJunitTest.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/advanced/AdvancedJPAJunitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2018 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/fieldaccess/advanced/AdvancedJPAJunitTest.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/fieldaccess/advanced/AdvancedJPAJunitTest.java
@@ -761,7 +761,7 @@ public class AdvancedJPAJunitTest extends JUnitTestCase {
             Object[] objectdata = (Object[])aQuery.getSingleResult();
 
             assertTrue("Address data not found or returned using stored procedure", ((objectdata!=null) && (objectdata.length==2)) );
-            assertTrue("Address Id data returned doesn't match persisted address", (address1.getId() == ((Integer)objectdata[0]).intValue()));
+            assertTrue("Address Id data returned doesn't match persisted address", (address1.getId() == ((Long)objectdata[0]).longValue()));
             assertTrue("Address Street data returned doesn't match persisted address", ( address1.getStreet().equals(objectdata[1] )) );
         } catch (RuntimeException e) {
             if (isTransactionActive(em)){

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/fieldaccess/advanced/AdvancedJPAJunitTest.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/fieldaccess/advanced/AdvancedJPAJunitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at


### PR DESCRIPTION
Bug 547328 - JPA NamedStoredProcedure call getOutputParameterValue class cast exception

This is fix for a SQL BIGINT <-> java.lang.Long (long) mapping during stored procedures/functions call. 
This is fix for unit tests too.
Before this fix SQL BIGINT was mapped to java.lang.Integer (int).
This fix has affection to stored procedures out parameters and stored function return based on BIGINT data type.
JDBC Specification (4.3, 3.0) recommends map JDBC Type: BIGINT <-> Java Type: long

Scope of BIGINT in most DBs is same a Java long see:
https://docs.oracle.com/javase/specs/jls/se11/html/jls-4.html#jls-4.2.1
https://dev.mysql.com/doc/refman/8.0/en/integer-types.html
https://docs.microsoft.com/en-us/sql/t-sql/data-types/int-bigint-smallint-and-tinyint-transact-sql?view=sql-server-2017
https://www.ibm.com/support/knowledgecenter/SSEPEK_10.0.0/sqlref/src/tpc/db2z_biginteger.html

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>