### PR TITLE
[master] Bug 391279: Fix usecase with existing FK mapping

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/mappings/DirectToFieldMapping.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/mappings/DirectToFieldMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -61,6 +61,6 @@ public class DirectToFieldMapping extends AbstractDirectMapping implements Relat
 
     @Override
     protected void writeValueIntoRow(AbstractRecord row, DatabaseField field, Object fieldValue) {
-        row.add(getField(), fieldValue);
+        row.put(getField(), fieldValue);
     }
 }

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/mapping/TestUnidirectionalOneToMany.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/mapping/TestUnidirectionalOneToMany.java
@@ -27,10 +27,16 @@ import org.eclipse.persistence.jpa.test.framework.EmfRunner;
 import org.eclipse.persistence.jpa.test.framework.Property;
 import org.eclipse.persistence.jpa.test.mapping.model.CommentA;
 import org.eclipse.persistence.jpa.test.mapping.model.CommentB;
+import org.eclipse.persistence.jpa.test.mapping.model.CommentC;
+import org.eclipse.persistence.jpa.test.mapping.model.CommentD;
 import org.eclipse.persistence.jpa.test.mapping.model.ComplexIdA;
 import org.eclipse.persistence.jpa.test.mapping.model.ComplexIdB;
+import org.eclipse.persistence.jpa.test.mapping.model.ComplexIdC;
+import org.eclipse.persistence.jpa.test.mapping.model.ComplexIdD;
 import org.eclipse.persistence.jpa.test.mapping.model.PostA;
 import org.eclipse.persistence.jpa.test.mapping.model.PostB;
+import org.eclipse.persistence.jpa.test.mapping.model.PostC;
+import org.eclipse.persistence.jpa.test.mapping.model.PostD;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -46,7 +52,9 @@ import org.junit.runner.RunWith;
 @RunWith(EmfRunner.class)
 public class TestUnidirectionalOneToMany {
     @Emf(createTables = DDLGen.DROP_CREATE,
-            classes = { CommentA.class, CommentB.class, ComplexIdA.class, ComplexIdB.class, PostA.class, PostB.class },
+            classes = { CommentA.class, CommentB.class, CommentC.class, CommentD.class, 
+                    ComplexIdA.class, ComplexIdB.class, ComplexIdC.class, ComplexIdD.class,
+                    PostA.class, PostB.class, PostC.class, PostD.class },
             properties = {
                 @Property(name = "eclipselink.cache.shared.default", value = "false"),
                 @Property(name = "eclipselink.logging.parameters", value = "true"),
@@ -172,6 +180,124 @@ public class TestUnidirectionalOneToMany {
             post.getComments().add(new CommentB("d"));
             post.getComments().add(new CommentB("e"));
             post.getComments().add(new CommentB("f"));
+
+            em.persist(post);
+
+            em.getTransaction().commit();
+        } finally {
+            if(em != null) {
+                if (em.getTransaction().isActive()) {
+                    em.getTransaction().rollback();
+                }
+                if(em.isOpen()) {
+                    em.close();
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testInsertComplexCOneToManyUni() {
+        EntityManager em = null;
+        try {
+            em = emf.createEntityManager();
+
+            em.getTransaction().begin();
+
+            PostC post = new PostC(5L);
+            post.setComments(new ArrayList<CommentC>());
+            post.getComments().add(new CommentC(new ComplexIdC(5L, "Type1"), "a"));
+            post.getComments().add(new CommentC(new ComplexIdC(5L, "Type2"), "b"));
+            post.getComments().add(new CommentC(new ComplexIdC(5L, "Type3"), "c"));
+
+            em.persist(post);
+
+            em.getTransaction().commit();
+        } finally {
+            if(em != null) {
+                if (em.getTransaction().isActive()) {
+                    em.getTransaction().rollback();
+                }
+                if(em.isOpen()) {
+                    em.close();
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testUpdateComplexCOneToManyUni() {
+        EntityManager em = null;
+        try {
+            em = emf.createEntityManager();
+
+            em.getTransaction().begin();
+
+            PostC post = new PostC(6L);
+            em.persist(post);
+            em.flush();
+
+            post.setComments(new ArrayList<CommentC>());
+            post.getComments().add(new CommentC(new ComplexIdC(6L, "Type4"), "d"));
+            post.getComments().add(new CommentC(new ComplexIdC(6L, "Type5"), "3"));
+            post.getComments().add(new CommentC(new ComplexIdC(6L, "Type6"), "f"));
+
+            em.persist(post);
+
+            em.getTransaction().commit();
+        } finally {
+            if(em != null) {
+                if (em.getTransaction().isActive()) {
+                    em.getTransaction().rollback();
+                }
+                if(em.isOpen()) {
+                    em.close();
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testInsertComplexDOneToManyUni() {
+        EntityManager em = null;
+        try {
+            em = emf.createEntityManager();
+
+            em.getTransaction().begin();
+
+            PostD post = new PostD(new ComplexIdD(20, 21));
+            post.setComments(new ArrayList<CommentD>());
+            post.getComments().add(new CommentD(new ComplexIdD(20, 21), "a"));
+
+            em.persist(post);
+
+            em.getTransaction().commit();
+        } finally {
+            if(em != null) {
+                if (em.getTransaction().isActive()) {
+                    em.getTransaction().rollback();
+                }
+                if(em.isOpen()) {
+                    em.close();
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testUpdateComplexDOneToManyUni() {
+        EntityManager em = null;
+        try {
+            em = emf.createEntityManager();
+
+            em.getTransaction().begin();
+
+            PostD post = new PostD(new ComplexIdD(22, 23));
+            em.persist(post);
+            em.flush();
+
+            post.setComments(new ArrayList<CommentD>());
+            post.getComments().add(new CommentD(new ComplexIdD(22, 23), "d"));
 
             em.persist(post);
 

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/mapping/model/CommentC.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/mapping/model/CommentC.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     06/19/2019 - Will Dazey
+//       - 391279: Add support for Unidirectional OneToMany mappings with non-nullable values
+package org.eclipse.persistence.jpa.test.mapping.model;
+
+import javax.persistence.Column;
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+
+@Entity
+public class CommentC {
+
+    @EmbeddedId
+    private ComplexIdC id;
+
+    @Column(nullable=false)
+    private String content;
+
+    public CommentC() { }
+
+    public CommentC(ComplexIdC id, String content) {
+        this.id = id;
+        this.content = content;
+    }
+
+    public ComplexIdC getId() {
+        return id;
+    }
+
+    public void setId(ComplexIdC id) {
+        this.id = id;
+    }
+
+    public void setContent(String s) {
+        content = s;
+    }
+
+    public String getContent() {
+        return content;
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/mapping/model/CommentD.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/mapping/model/CommentD.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     06/19/2019 - Will Dazey
+//       - 391279: Add support for Unidirectional OneToMany mappings with non-nullable values
+package org.eclipse.persistence.jpa.test.mapping.model;
+
+import javax.persistence.Column;
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+
+@Entity
+public class CommentD {
+
+    @EmbeddedId
+    private ComplexIdD id;
+
+    @Column(nullable=false)
+    private String content;
+
+    public CommentD() {
+    }
+
+    public CommentD(ComplexIdD id, String content) {
+        this.id = id;
+        this.content = content;
+    }
+
+    public void setContent(String s) {
+        content = s;
+    }
+
+    public String getContent() {
+        return content;
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/mapping/model/ComplexIdC.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/mapping/model/ComplexIdC.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     06/19/2019 - Will Dazey
+//       - 391279: Add support for Unidirectional OneToMany mappings with non-nullable values
+package org.eclipse.persistence.jpa.test.mapping.model;
+
+import java.io.Serializable;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+@Embeddable
+public class ComplexIdC implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    @Column(name = "COMPLEXID_C_A", nullable = false)
+    private long idA;
+
+    private String type;
+
+    public ComplexIdC() {
+        this.idA = 0;
+    }
+
+    public ComplexIdC(long aId, String type) {
+        this.idA = aId;
+        this.type = type;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + (int) (idA ^ (idA >>> 32));
+        result = prime * result + ((type == null) ? 0 : type.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        ComplexIdC other = (ComplexIdC) obj;
+        if (idA != other.idA)
+            return false;
+        if (type == null) {
+            if (other.type != null)
+                return false;
+        } else if (!type.equals(other.type))
+            return false;
+        return true;
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/mapping/model/ComplexIdD.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/mapping/model/ComplexIdD.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     06/19/2019 - Will Dazey
+//       - 391279: Add support for Unidirectional OneToMany mappings with non-nullable values
+package org.eclipse.persistence.jpa.test.mapping.model;
+
+import java.io.Serializable;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+@Embeddable
+public class ComplexIdD implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    @Column(name = "COMPLEXID_D_A", nullable = false)
+    private long idA;
+
+    @Column(name = "COMPLEXID_D_B", nullable = false)
+    private long idB;
+
+    public ComplexIdD() {
+        this.idA = 0;
+        this.idB = 0;
+    }
+
+    public ComplexIdD(long aId, long bId) {
+        this.idA = aId;
+        this.idB = bId;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + (int) (idA ^ (idA >>> 32));
+        result = prime * result + (int) (idB ^ (idB >>> 32));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        ComplexIdD other = (ComplexIdD) obj;
+        if (idA != other.idA)
+            return false;
+        if (idB != other.idB)
+            return false;
+        return true;
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/mapping/model/PostC.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/mapping/model/PostC.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     06/19/2019 - Will Dazey
+//       - 391279: Add support for Unidirectional OneToMany mappings with non-nullable values
+package org.eclipse.persistence.jpa.test.mapping.model;
+
+import java.util.List;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToMany;
+
+@Entity
+public class PostC {
+
+    @Id @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "COMPLEXID_C_A", referencedColumnName = "id", nullable = false)
+    private List<CommentC> comments;
+
+    public PostC() { }
+
+    public PostC(Long id) {
+        this.id = id;
+    }
+
+    public List<CommentC> getComments() {
+        return comments;
+    }
+
+    public void setComments(List<CommentC> comments) {
+        this.comments = comments;
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/mapping/model/PostD.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/mapping/model/PostD.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     06/19/2019 - Will Dazey
+//       - 391279: Add support for Unidirectional OneToMany mappings with non-nullable values
+package org.eclipse.persistence.jpa.test.mapping.model;
+
+import java.util.List;
+
+import javax.persistence.CascadeType;
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinColumns;
+import javax.persistence.OneToMany;
+
+@Entity
+public class PostD {
+
+    @EmbeddedId
+    private ComplexIdD id;
+
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumns({ 
+        @JoinColumn(name = "COMPLEXID_D_A", referencedColumnName = "COMPLEXID_D_A", nullable = false), 
+        @JoinColumn(name = "COMPLEXID_D_B", referencedColumnName = "COMPLEXID_D_B", nullable = false)
+    })
+    private List<CommentD> comments;
+
+    public PostD() { }
+
+    public PostD(ComplexIdD id) {
+        this.id = id;
+    }
+
+    public List<CommentD> getComments() {
+        return comments;
+    }
+
+    public void setComments(List<CommentD> comments) {
+        this.comments = comments;
+    }
+}


### PR DESCRIPTION
for #233 

The original 391279 did not account for the usecase of an existing foreign key mapping on the owning side and instead expected the FK would be added by the @JoinColumn. This results in an exception similar to this:
```
Execute query InsertObjectQuery(model.CommentC@378deffb)
INSERT INTO COMMENTC (COMPLEXID_C_A, CONTENT, COMPLEXID_C_A, TYPE) VALUES (?, ?, ?, ?)
Internal Exception: java.sql.SQLSyntaxErrorException: Column name 'COMPLEXID_C_A' appears more than once times in the column list of an INSERT statement. 
```

The issue is due to the use of `ObjectBuilder.buildRow(AbstractRecord databaseRow, Object object, AbstractSession session, WriteType writeType)` in `OneToManyMapping`. This method calls `DatabaseMapping.writeFromObjectIntoRow(Object object, AbstractRecord row, AbstractSession session, WriteType writeType)`, which adds to the given row, causing duplicates. 

Signed-off-by: Will Dazey <dazeydev.3@gmail.com>