### PR TITLE
Bug 546533 - QueryKeyExpression.printSQL writes no value

### DIFF
--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/jpql/JPQLSimpleTestSuite.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/jpql/JPQLSimpleTestSuite.java
@@ -30,7 +30,8 @@ public class JPQLSimpleTestSuite extends TestSuite {
         addTest(new SimpleBetweenAndTest());
         addTest(new SimpleBetweenTest());
         addTest(new SimpleConcatTest());
-        addTest(new SimpleConcatTestWithConstants1());
+        addTest(new SimpleConcatTestWithConstantsLiteralSecond());
+        addTest(new SimpleConcatTestWithConstantsLiteralFirst());
         addTest(new SimpleDoubleOrTest());
         addTest(new SimpleEqualsBracketsTest());
         addTest(new SimpleEqualsTest());

--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/jpql/SimpleConcatTestWithConstantsLiteralFirst.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/jpql/SimpleConcatTestWithConstantsLiteralFirst.java
@@ -14,13 +14,15 @@
 //     Oracle - initial API and implementation from Oracle TopLink
 package org.eclipse.persistence.testing.tests.jpql;
 
-import java.util.*;
-import org.eclipse.persistence.queries.*;
-import org.eclipse.persistence.expressions.*;
-import org.eclipse.persistence.testing.models.employee.domain.*;
+import org.eclipse.persistence.expressions.Expression;
+import org.eclipse.persistence.expressions.ExpressionBuilder;
+import org.eclipse.persistence.queries.ReadAllQuery;
+import org.eclipse.persistence.testing.models.employee.domain.Employee;
+
+import java.util.Vector;
 
 //This tests CONCAT with the second parameter being a constant String
-public class SimpleConcatTestWithConstants1 extends org.eclipse.persistence.testing.tests.jpql.JPQLTestCase {
+public class SimpleConcatTestWithConstantsLiteralFirst extends JPQLTestCase {
     public void setup() {
         Employee emp = (Employee)getSomeEmployees().firstElement();
 
@@ -31,7 +33,7 @@ public class SimpleConcatTestWithConstants1 extends org.eclipse.persistence.test
         partOne = emp.getFirstName();
 
         ExpressionBuilder builder = new ExpressionBuilder();
-        Expression whereClause = builder.get("firstName").concat("Smith").like(partOne + "Smith");
+        Expression whereClause = builder.literal("\"Smith\"").concat(builder.get("firstName")).like("Smith" + partOne);
 
         ReadAllQuery raq = new ReadAllQuery();
         raq.setReferenceClass(Employee.class);
@@ -40,8 +42,8 @@ public class SimpleConcatTestWithConstants1 extends org.eclipse.persistence.test
         Vector employees = (Vector)getSession().executeQuery(raq);
 
         ejbqlString = "SELECT OBJECT(emp) FROM Employee emp WHERE ";
-        ejbqlString = ejbqlString + "CONCAT(emp.firstName,\"Smith\") LIKE ";
-        ejbqlString = ejbqlString + "\"" + partOne + "Smith\"";
+        ejbqlString = ejbqlString + "CONCAT(\"Smith\",emp.firstName) LIKE ";
+        ejbqlString = ejbqlString + "\"Smith"+ partOne + "\"";
 
         setEjbqlString(ejbqlString);
         setOriginalOject(employees);

--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/jpql/SimpleConcatTestWithConstantsLiteralSecond.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/jpql/SimpleConcatTestWithConstantsLiteralSecond.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation from Oracle TopLink
+package org.eclipse.persistence.testing.tests.jpql;
+
+import java.util.*;
+import org.eclipse.persistence.queries.*;
+import org.eclipse.persistence.expressions.*;
+import org.eclipse.persistence.testing.models.employee.domain.*;
+
+//This tests CONCAT with the second parameter being a constant String
+public class SimpleConcatTestWithConstantsLiteralSecond extends org.eclipse.persistence.testing.tests.jpql.JPQLTestCase {
+    public void setup() {
+        Employee emp = (Employee)getSomeEmployees().firstElement();
+
+        String partOne;
+        String partTwo;
+        String ejbqlString;
+
+        partOne = emp.getFirstName();
+
+        ExpressionBuilder builder = new ExpressionBuilder();
+        Expression whereClause = builder.get("firstName").concat("Smith").like(partOne + "Smith");
+
+        ReadAllQuery raq = new ReadAllQuery();
+        raq.setReferenceClass(Employee.class);
+        raq.setSelectionCriteria(whereClause);
+
+        Vector employees = (Vector)getSession().executeQuery(raq);
+
+        ejbqlString = "SELECT OBJECT(emp) FROM Employee emp WHERE ";
+        ejbqlString = ejbqlString + "CONCAT(emp.firstName,\"Smith\") LIKE ";
+        ejbqlString = ejbqlString + "\"" + partOne + "Smith\"";
+
+        setEjbqlString(ejbqlString);
+        setOriginalOject(employees);
+        super.setup();
+    }
+}

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/ExpressionQueryMechanism.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/ExpressionQueryMechanism.java
@@ -2137,6 +2137,11 @@ public class ExpressionQueryMechanism extends StatementQueryMechanism {
                             return;
                         }
                     }
+                    // In some cases when expression starts with literal session is not set.
+                    // Like ....CONCAT('abcd', column)....
+                    if (baseExpression != null && (baseExpression instanceof ExpressionBuilder) && baseExpression.getSession() == null) {
+                        ((ExpressionBuilder) baseExpression).setSession(getSession());
+                    }
                     DatabaseField field = dataExpression.getField();
                     if(field != null) {
                         if(!field.getTable().equals((DatabaseTable)getResult())) {

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/criteria/JUnitCriteriaSimpleTestSuiteBase.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/criteria/JUnitCriteriaSimpleTestSuiteBase.java
@@ -643,10 +643,10 @@ public abstract class JUnitCriteriaSimpleTestSuiteBase<T> extends JUnitTestCase 
             CriteriaBuilder qb = em.getCriteriaBuilder();
             CriteriaQuery<Employee> cq = qb.createQuery(Employee.class);
             Root<Employee> root = wrapper.from(cq, Employee.class);
-            cq.where( qb.like(qb.concat(qb.literal("Smith"), wrapper.get(root, Employee_firstName) ), partOne+"Smith") );
+            cq.where( qb.like(qb.concat("Smith", wrapper.get(root, Employee_firstName) ), "Smith" + partOne) );
             List result = em.createQuery(cq).getResultList();
 
-            assertTrue("Concat test with constraints failed", comparer.compareObjects(result, expectedResult));
+            assertTrue("Concat test with constraints failed" , comparer.compareObjects(result, expectedResult));
         } finally {
             rollbackTransaction(em);
             closeEntityManager(em);

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/criteria/JUnitCriteriaSimpleTestSuiteBase.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/criteria/JUnitCriteriaSimpleTestSuiteBase.java
@@ -164,7 +164,8 @@ public abstract class JUnitCriteriaSimpleTestSuiteBase<T> extends JUnitTestCase 
             suite.addTest(constructor.newInstance("simpleBetweenTest"));
             suite.addTest(constructor.newInstance("simpleConcatTest"));
             suite.addTest(constructor.newInstance("simpleConcatTestWithParameters"));
-            suite.addTest(constructor.newInstance("simpleConcatTestWithConstants1"));
+            suite.addTest(constructor.newInstance("simpleConcatTestWithConstantsLiteralSecond"));
+            suite.addTest(constructor.newInstance("simpleConcatTestWithConstantsLiteralFirst"));
             suite.addTest(constructor.newInstance("simpleCountTest"));
             suite.addTest(constructor.newInstance("simpleThreeArgConcatTest"));
             suite.addTest(constructor.newInstance("simpleDistinctTest"));
@@ -582,9 +583,9 @@ public abstract class JUnitCriteriaSimpleTestSuiteBase<T> extends JUnitTestCase 
     }
 
 
-    //Test case for concat function with constants in EJBQL
+    //Test case for concat function with constants in EJBQL (string literal as second argument of concat(...) function
 
-    public void simpleConcatTestWithConstants1() {
+    public void simpleConcatTestWithConstantsLiteralSecond() {
         EntityManager em = createEntityManager();
         beginTransaction(em);
         try {
@@ -608,6 +609,41 @@ public abstract class JUnitCriteriaSimpleTestSuiteBase<T> extends JUnitTestCase 
             CriteriaQuery<Employee> cq = qb.createQuery(Employee.class);
             Root<Employee> root = wrapper.from(cq, Employee.class);
             cq.where( qb.like(qb.concat(wrapper.get(root, Employee_firstName), qb.literal("Smith") ), partOne+"Smith") );
+            List result = em.createQuery(cq).getResultList();
+
+            assertTrue("Concat test with constraints failed", comparer.compareObjects(result, expectedResult));
+        } finally {
+            rollbackTransaction(em);
+            closeEntityManager(em);
+        }
+    }
+
+    //Test case for concat function with constants in EJBQL (string literal as first argument of concat(...) function
+
+    public void simpleConcatTestWithConstantsLiteralFirst() {
+        EntityManager em = createEntityManager();
+        beginTransaction(em);
+        try {
+            Employee emp = (Employee)(getServerSession().readAllObjects(Employee.class).firstElement());
+
+            String partOne = emp.getFirstName();
+
+            ExpressionBuilder builder = new ExpressionBuilder();
+            Expression whereClause = builder.literal("\"Smith\"").concat(builder.get("firstName")).like("Smith" + partOne);
+
+            ReadAllQuery raq = new ReadAllQuery();
+            raq.setReferenceClass(Employee.class);
+            raq.setSelectionCriteria(whereClause);
+
+            Vector expectedResult = (Vector)getServerSession().executeQuery(raq);
+
+            clearCache();
+
+            //"SELECT OBJECT(emp) FROM Employee emp WHERE CONCAT(\"Smith\", emp.firstName) LIKE \"" + "Smith\"" + partOne
+            CriteriaBuilder qb = em.getCriteriaBuilder();
+            CriteriaQuery<Employee> cq = qb.createQuery(Employee.class);
+            Root<Employee> root = wrapper.from(cq, Employee.class);
+            cq.where( qb.like(qb.concat(qb.literal("Smith"), wrapper.get(root, Employee_firstName) ), partOne+"Smith") );
             List result = em.createQuery(cq).getResultList();
 
             assertTrue("Concat test with constraints failed", comparer.compareObjects(result, expectedResult));

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/jpql/JUnitJPQLSimpleTestSuite.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/jpql/JUnitJPQLSimpleTestSuite.java
@@ -585,7 +585,7 @@ public class JUnitJPQLSimpleTestSuite extends JUnitTestCase {
 
         ejbqlString = "SELECT OBJECT(emp) FROM Employee emp WHERE ";
         ejbqlString = ejbqlString + "CONCAT(\"Smith\",emp.firstName) LIKE ";
-        ejbqlString = ejbqlString + "\"Smith\""+ partOne + "\"";
+        ejbqlString = ejbqlString + "\"Smith"+ partOne + "\"";
 
         List result = em.createQuery(ejbqlString).getResultList();
 

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/jpql/JUnitJPQLSimpleTestSuite.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/jpql/JUnitJPQLSimpleTestSuite.java
@@ -105,7 +105,8 @@ public class JUnitJPQLSimpleTestSuite extends JUnitTestCase {
         suite.addTest(new JUnitJPQLSimpleTestSuite("simpleBetweenTest"));
         suite.addTest(new JUnitJPQLSimpleTestSuite("simpleConcatTest"));
         suite.addTest(new JUnitJPQLSimpleTestSuite("simpleConcatTestWithParameters"));
-        suite.addTest(new JUnitJPQLSimpleTestSuite("simpleConcatTestWithConstants1"));
+        suite.addTest(new JUnitJPQLSimpleTestSuite("simpleConcatTestWithConstantsLiteralSecond"));
+        suite.addTest(new JUnitJPQLSimpleTestSuite("simpleConcatTestWithConstantsLiteralFirst"));
         suite.addTest(new JUnitJPQLSimpleTestSuite("simpleThreeArgConcatTest"));
         suite.addTest(new JUnitJPQLSimpleTestSuite("simpleDistinctTest"));
         suite.addTest(new JUnitJPQLSimpleTestSuite("simpleDistinctNullTest"));
@@ -531,7 +532,7 @@ public class JUnitJPQLSimpleTestSuite extends JUnitTestCase {
 
     //Test case for concat function with constants in EJBQL
 
-    public void simpleConcatTestWithConstants1() {
+    public void simpleConcatTestWithConstantsLiteralSecond() {
         EntityManager em = createEntityManager();
 
         Employee emp = (Employee)(getServerSession().readAllObjects(Employee.class).firstElement());
@@ -555,6 +556,36 @@ public class JUnitJPQLSimpleTestSuite extends JUnitTestCase {
         ejbqlString = "SELECT OBJECT(emp) FROM Employee emp WHERE ";
         ejbqlString = ejbqlString + "CONCAT(emp.firstName,\"Smith\") LIKE ";
         ejbqlString = ejbqlString + "\"" + partOne + "Smith\"";
+
+        List result = em.createQuery(ejbqlString).getResultList();
+
+        Assert.assertTrue("Concat test with constraints failed", comparer.compareObjects(result, expectedResult));
+    }
+
+    public void simpleConcatTestWithConstantsLiteralFirst() {
+        EntityManager em = createEntityManager();
+
+        Employee emp = (Employee)(getServerSession().readAllObjects(Employee.class).firstElement());
+
+        String partOne;
+        String ejbqlString;
+
+        partOne = emp.getFirstName();
+
+        ExpressionBuilder builder = new ExpressionBuilder();
+        Expression whereClause = builder.literal("\"Smith\"").concat(builder.get("firstName")).like("Smith" + partOne);
+
+        ReadAllQuery raq = new ReadAllQuery();
+        raq.setReferenceClass(Employee.class);
+        raq.setSelectionCriteria(whereClause);
+
+        Vector expectedResult = (Vector)getServerSession().executeQuery(raq);
+
+        clearCache();
+
+        ejbqlString = "SELECT OBJECT(emp) FROM Employee emp WHERE ";
+        ejbqlString = ejbqlString + "CONCAT(\"Smith\",emp.firstName) LIKE ";
+        ejbqlString = ejbqlString + "\"Smith\""+ partOne + "\"";
 
         List result = em.createQuery(ejbqlString).getResultList();
 


### PR DESCRIPTION
Bug 546533 - QueryKeyExpression.printSQL writes no value

See: https://bugs.eclipse.org/bugs/show_bug.cgi?id=546533

Bug fix + unit tests

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>