### PR TITLE
[Non Bug] Travis JDK switch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,8 @@ env:
     - TEST_TARGET=build-distribution
 
 jdk:
-  - oraclejdk8
-  - oraclejdk11
+  - openjdk8
+  - openjdk11
 
 cache:
   directories:


### PR DESCRIPTION
Due license troubles JDK switch from OracleJDK to OpenJDK.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>