### PR TITLE
[2.6_WAS] Bug 547173 - EntityManager.unwrap(Connection.class) returns null

### DIFF
--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/basic/TestEntityManagerInterface.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/basic/TestEntityManagerInterface.java
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation. All rights reserved.
+ * This program and the accompanying materials are made available under the 
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0 
+ * which accompanies this distribution. 
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at 
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     05/10/2019-2.6_WAS Jody Grassel
+ *       - 547173: EntityManager.unwrap(Connection.class) returns null
+ ******************************************************************************/
+package org.eclipse.persistence.jpa.test.basic;
+
+import java.sql.Connection;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+
+import org.eclipse.persistence.jpa.test.framework.Emf;
+import org.eclipse.persistence.jpa.test.framework.EmfRunner;
+import org.eclipse.persistence.jpa.test.framework.Property;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(EmfRunner.class)
+public class TestEntityManagerInterface {
+    @Emf
+    private EntityManagerFactory emf;
+    
+    @Emf(name = "WithExclusiveConnection", properties = {@Property(name = "eclipselink.jdbc.exclusive-connection.mode", value = "Always")})
+    private EntityManagerFactory emfWithExclusiveConnection;
+    
+    @Test
+    public void testPreserveBehaviorWithNoTransaction() throws Exception {
+        EntityManager em = emf.createEntityManager();
+        try {
+            Connection conn = em.unwrap(Connection.class);
+            Assert.assertNull(conn); // No transaction, so expecting null
+        } finally {
+            if (em != null) {
+                em.close();
+            }
+        }
+    }
+    
+    @Test
+    public void testPreserveBehaviorWithTransaction() throws Exception {
+        EntityManager em = emf.createEntityManager();
+        try {
+            em.getTransaction().begin();
+            Connection conn = em.unwrap(Connection.class);
+            Assert.assertNotNull(conn); // Transaction active, so expecting a connection
+        } finally {
+            if (em != null) {
+                em.getTransaction().rollback();
+                em.close();
+            }
+        }
+    }
+    
+    @Test
+    public void testPreserveBehaviorAfterTransaction() throws Exception {
+        EntityManager em = emf.createEntityManager();
+        try {
+            em.getTransaction().begin();
+            Connection conn = em.unwrap(Connection.class);
+            Assert.assertNotNull(conn); // Transaction active, so expecting a connection
+            em.getTransaction().rollback();
+            
+            conn = em.unwrap(Connection.class);
+            Assert.assertNull(conn); // No transaction, so expecting null
+        } finally {
+            if (em != null) {
+                if (em.getTransaction().isActive())
+                    em.getTransaction().rollback();
+                em.close();
+            }
+        }
+    }
+    
+    @Test
+    public void testPreserveBehaviorWithTransactionWithExclusiveConnection() throws Exception {
+        EntityManager em = emfWithExclusiveConnection.createEntityManager();
+        try {
+            em.getTransaction().begin();
+            Connection conn = em.unwrap(Connection.class);
+            Assert.assertNotNull(conn); // Transaction active, so expecting a connection
+        } finally {
+            if (em != null) {
+                em.getTransaction().rollback();
+                em.close();
+            }
+        }
+    }
+    
+    @Test
+    public void testUnwrapWithExclusiveConnectionAfterTransaction() throws Exception {
+        EntityManager em = emfWithExclusiveConnection.createEntityManager();
+        try {
+            em.getTransaction().begin();
+            Connection conn = em.unwrap(Connection.class);
+            Assert.assertNotNull(conn);
+            
+            em.getTransaction().rollback();
+            
+            Connection conn2 = em.unwrap(Connection.class);
+            Assert.assertNotNull(conn2); // Expecting a connection to still be returned
+            Assert.assertSame(conn, conn2); // Expecting the same Connection
+        } finally {
+            if (em != null) {
+                if (em.getTransaction().isActive()) {
+                    em.getTransaction().rollback();
+                }
+                em.close();
+            }
+        }
+    }
+}

--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/EntityManagerImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/EntityManagerImpl.java
@@ -35,6 +35,8 @@
  *       - 393867: Named queries do not work when using EM level Table Per Tenant Multitenancy.
  *     02/27/2017-2.6_WAS Jody Grassel
  *       - 512255: Eclipselink JPA/Auditing capablity in EE Environment fails with JNDI name parameter type
+ *     05/10/2019-2.6_WAS Jody Grassel
+ *       - 547173: EntityManager.unwrap(Connection.class) returns null
  ******************************************************************************/
 package org.eclipse.persistence.internal.jpa;
 
@@ -2779,13 +2781,33 @@ public class EntityManagerImpl implements org.eclipse.persistence.jpa.JpaEntityM
             } else if (cls.equals(SessionBroker.class)) {            
                 return (T) this.getSessionBroker();
             } else if (cls.equals(java.sql.Connection.class)) {
-                UnitOfWorkImpl unitOfWork = (UnitOfWorkImpl) this.getUnitOfWork();
-                if(unitOfWork.isInTransaction() || unitOfWork.getParent().isExclusiveIsolatedClientSession()) {
-                    return (T) unitOfWork.getAccessor().getConnection();
+                final UnitOfWorkImpl unitOfWork = (UnitOfWorkImpl) this.getUnitOfWork();
+                final Accessor accessor = unitOfWork.getAccessor();
+                if (unitOfWork.getParent().isExclusiveIsolatedClientSession()) {
+                    // If the ExclusiveIsolatedClientSession hasn't serviced a query prior to the unwrap, 
+                    // there will be no available Connection.
+                    java.sql.Connection conn = accessor.getConnection();
+                    if (conn == null) {
+                        final boolean uowInTran = unitOfWork.isInTransaction();
+                        final boolean activeTran = checkForTransaction(false) != null;
+                        if (uowInTran || activeTran) {
+                            if (activeTran) {
+                                unitOfWork.beginEarlyTransaction();
+                            }
+                            accessor.incrementCallCount(unitOfWork.getParent());
+                            accessor.decrementCallCount();
+                            conn = accessor.getConnection();
+                        }
+                        // if not in a tx, still return null
+                    }
+                    
+                    return (T) conn;
+                } else if (unitOfWork.isInTransaction()) {
+                    return (T) accessor.getConnection();
                 }
+                
                 if (checkForTransaction(false) != null) { 
                     unitOfWork.beginEarlyTransaction();
-                    Accessor accessor = unitOfWork.getAccessor();
                     // Ensure external connection is acquired.
                     accessor.incrementCallCount(unitOfWork.getParent());
                     accessor.decrementCallCount();


### PR DESCRIPTION
Bug 547173 - EntityManager.unwrap(Connection.class) returns null

Fixes https://bugs.eclipse.org/bugs/show_bug.cgi?id=547173 for 2.6_WAS branch