### PR TITLE
Enable Foreign Key Constraints for HANAPlatform

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/HANAPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/HANAPlatform.java
@@ -459,7 +459,7 @@ public final class HANAPlatform extends DatabasePlatform {
 
     @Override
     public boolean supportsForeignKeyConstraints() {
-        return false;
+        return true;
     }
 
     /**


### PR DESCRIPTION
When using HANAPlatform as target database, we noticed that foreign key constraints are not created on HANA DB. This has been discussed here as well:
https://answers.sap.com/questions/601226/jpa-works-to-create-database-tables-locally-but-no.html

As times of missing FK support on HANA are over, you might consider merge my pull request, to support FK creation?

