### PR TITLE
#482 - fix for CacheId comparision with BINARY arrays

### DIFF
--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/junit/identitymaps/CacheIdTest.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/junit/identitymaps/CacheIdTest.java
@@ -1,0 +1,208 @@
+package org.eclipse.persistence.testing.tests.junit.identitymaps;
+
+import static org.junit.Assert.*;
+
+import org.eclipse.persistence.internal.identitymaps.CacheId;
+import org.junit.Test;
+
+public class CacheIdTest {
+
+	@Test
+	public void compareToForByteArrays() {
+		equal("many primaryKeys - equal",
+			newCacheId(new byte[] {1, 2}, new byte[] {2, 3}),
+			newCacheId(new byte[] {1, 2}, new byte[] {2, 3}));
+		equal("one primaryKey - equal",
+			newCacheId(new byte[] {1, 2}),
+			newCacheId(new byte[] {1, 2}));
+
+		smaller("one primaryKey - smaller on first element",
+			newCacheId(new byte[] {1, 2}), newCacheId(new byte[] {2, 3}));
+		greater("one primaryKey - greater on first element",
+			newCacheId(new byte[] {2, 3}), newCacheId(new byte[] {1, 3}));
+		smaller("one primaryKey - smaller on last element",
+			newCacheId(new byte[] {2, 1, 2}), newCacheId(new byte[] {2, 1, 3}));
+		greater("one primaryKey - greater  on last element",
+			newCacheId(new byte[] {0, 0, 3}), newCacheId(new byte[] {0, 0, 2}));
+
+		smaller("many primaryKey - smaller",
+			newCacheId(new byte[] {1, 2}, new byte[] {2, 2}), newCacheId(new byte[] {1, 2}, new byte[] {2, 3}));
+		greater("many primaryKey - greater",
+			newCacheId(new byte[] {2, 3}, new byte[] {1, 4}), newCacheId(new byte[] {2, 3}, new byte[] {1, 3}));
+
+		greater("one primaryKey - smaller by different size",
+			newCacheId(new byte[] {1, 2}), newCacheId(new byte[] {1}));
+		smaller("one primaryKey - greater by different size",
+			newCacheId(new byte[] {2}), newCacheId(new byte[] {2, 1}));
+	}
+
+	@Test
+	public void compareToForCharArrays() {
+		equal("many primaryKeys - equal",
+			newCacheId(new char[] {'a', 'b'}, new char[] {'b', 'c'}),
+			newCacheId(new char[] {'a', 'b'}, new char[] {'b', 'c'}));
+		equal("one primaryKey - equal",
+			newCacheId(new char[] {'a', 'b'}),
+			newCacheId(new char[] {'a', 'b'}));
+
+		smaller("one primaryKey - smaller on first element",
+			newCacheId(new char[] {'a', 'b'}), newCacheId(new char[] {'b', 'c'}));
+		greater("one primaryKey - greater on first element",
+			newCacheId(new char[] {'b', 'c'}), newCacheId(new char[] {'a', 'c'}));
+		smaller("one primaryKey - smaller on last element",
+			newCacheId(new char[] {'b', 'a', 'b'}), newCacheId(new char[] {'b', 'a', 'c'}));
+		greater("one primaryKey - greater  on last element",
+			newCacheId(new char[] {'0', '0', 'c'}), newCacheId(new char[] {'0', '0', 'b'}));
+
+		smaller("many primaryKey - smaller",
+			newCacheId(new char[] {'a', 'b'}, new char[] {'b', 'b'}), newCacheId(new char[] {'a', 'b'}, new char[] {'b', 'c'}));
+		greater("many primaryKey - greater",
+			newCacheId(new char[] {'b', 'c'}, new char[] {'a', 'd'}), newCacheId(new char[] {'b', 'c'}, new char[] {'a', 'c'}));
+
+		greater("one primaryKey - smaller by different size",
+			newCacheId(new char[] {'a', 'b'}), newCacheId(new char[] {'a'}));
+		smaller("one primaryKey - greater by different size",
+			newCacheId(new char[] {'b'}), newCacheId(new char[] {'b', 'a'}));
+	}
+
+	@Test
+	public void compareToForStringArrays() {
+		equal("many primaryKeys - equal",
+			newCacheId(new Object[] {"a", "b"}, new Object[] {"b", "c"}),
+			newCacheId(new Object[] {"a", "b"}, new Object[] {"b", "c"}));
+		equal("one primaryKey - equal",
+			newCacheId(new Object[] {"a", "b"}),
+			newCacheId(new Object[] {"a", "b"}));
+
+		smaller("one primaryKey - smaller on first element",
+			newCacheId(new Object[] {"a", "b"}), newCacheId(new Object[] {"b", "c"}));
+		greater("one primaryKey - greater on first element",
+			newCacheId(new Object[] {"b", "c"}), newCacheId(new Object[] {"a", "c"}));
+		smaller("one primaryKey - smaller on last element",
+			newCacheId(new Object[] {"b", "a", "b"}), newCacheId(new Object[] {"b", "a", "c"}));
+		greater("one primaryKey - greater  on last element",
+			newCacheId(new Object[] {"0", "0", "c"}), newCacheId(new Object[] {"0", "0", "b"}));
+
+		smaller("many primaryKey - smaller",
+			newCacheId(new Object[] {"a", "b"}, new Object[] {"b", "b"}), newCacheId(new Object[] {"a", "b"}, new Object[] {"b", "c"}));
+		greater("many primaryKey - greater",
+			newCacheId(new Object[] {"b", "c"}, new Object[] {"a", "d"}), newCacheId(new Object[] {"b", "c"}, new Object[] {"a", "c"}));
+
+		greater("one primaryKey - smaller by different size",
+			newCacheId(new Object[] {"a", "b"}), newCacheId(new Object[] {"a"}));
+		smaller("one primaryKey - greater by different size",
+			newCacheId(new Object[] {"b"}), newCacheId(new Object[] {"b", "a"}));
+	}
+
+	@Test
+	public void compareToForString() {
+		equal("many primaryKeys - equal",
+			newCacheId("a", "b"), newCacheId("a", "b"));
+		equal("one primaryKey - equal",
+			newCacheId("ab"), newCacheId("ab"));
+
+		smaller("one primaryKey - smaller",
+			newCacheId("ab"), newCacheId("bc"));
+		greater("one primaryKey - greater",
+			newCacheId("bc"), newCacheId("ac"));
+
+		smaller("many primaryKey - smaller",
+			newCacheId("ab", "bb"), newCacheId("ab", "bc"));
+		greater("many primaryKey - greater",
+			newCacheId("bc", "ad"), newCacheId("bc", "ac"));
+
+		greater("one primaryKey - smaller by different size",
+			newCacheId("ab"), newCacheId("a"));
+		smaller("one primaryKey - greater by different size",
+			newCacheId("b"), newCacheId("ba"));
+	}
+
+	@Test
+	public void compareToForNulls() {
+		equal("many primaryKeys - equal",
+			newCacheId("a", null), newCacheId("a", null));
+		equal("one primaryKey - equal",
+			newCacheId((Object)null), newCacheId((Object)null));
+
+		equal("null on first element - equal",
+			newCacheId(null, "a"), newCacheId(null, "a"));
+		greater("null on first element - greater",
+			newCacheId(null, "b"), newCacheId(null, "a"));
+
+		smaller("one primaryKey - smaller",
+			newCacheId((Object)null), newCacheId("any"));
+		greater("one primaryKey - greater",
+			newCacheId("any"), newCacheId((Object)null));
+
+		smaller("many primaryKey - smaller",
+			newCacheId("ab", (Object)null), newCacheId("ab", "any"));
+		greater("many primaryKey - greater",
+			newCacheId("bc", "any"), newCacheId("bc", (Object)null));
+	}
+
+	@Test
+	public void compareToForDifferentSize() {
+		smaller("smaller number of primary keys",
+			newCacheId("a"), newCacheId("a", "b"));
+		greater("greater number of primary keys",
+			newCacheId("a", "b"), newCacheId("a"));
+	}
+
+	@Test
+	public void compareToForNotComparable() {
+		equal("NotComparable on both sides - equal",
+			newCacheId(new NotComparable(1)), newCacheId(new NotComparable(1)));
+		greater("NotComparable on both sides - greater based on hashcode",
+			newCacheId(new NotComparable(2)), newCacheId(new NotComparable(1)));
+		smaller("NotComparable on both sides - smaller based on hashcode",
+			newCacheId(new NotComparable(1)), newCacheId(new NotComparable(2)));
+
+		smaller("not comparable on left side - result based on hashcode",
+			newCacheId(new NotComparable(1)), newCacheId("a"));
+		greater("not comparable on right side - result based on hashcode",
+			newCacheId("b"), newCacheId(new NotComparable(1)));
+	}
+
+	private CacheId newCacheId(Object... objects) {
+		return new CacheId(objects);
+	}
+
+	private void equal(String description, CacheId id1, CacheId id2) {
+		assertEquals(description, 0, id1.compareTo(id2));
+		assertEquals(description + " (equals consistency)", id1, id2);
+	}
+
+	private void smaller(String description, CacheId id1, CacheId id2) {
+		assertEquals(description, -1, id1.compareTo(id2));
+		assertNotEquals(description + " (equals consistency)", id1, id2);
+	}
+	private void greater(String description, CacheId id1, CacheId id2) {
+		assertEquals(description, 1, id1.compareTo(id2));
+		assertNotEquals(description + " (equals consistency)", id1, id2);
+	}
+
+	private static class NotComparable {
+		private int code;
+
+		private NotComparable(int code) {
+			this.code = code;
+		}
+
+		@Override
+		public int hashCode() {
+			return code;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj) {
+				return true;
+			}
+			if (obj == null || getClass() != obj.getClass()) {
+				return false;
+			}
+			NotComparable other = (NotComparable) obj;
+			return code == other.code;
+		}
+	}
+}

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/CacheId.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/CacheId.java
@@ -27,6 +27,7 @@ import org.eclipse.persistence.internal.helper.*;
  */
 public class CacheId implements Serializable, Comparable<CacheId> {
     public static final CacheId EMPTY = new CacheId(new Object[0]);
+    private static final CacheIdComparator COMPARATOR = new CacheIdComparator();
 
     /** The primary key values. */
     protected Object[] primaryKey;
@@ -203,43 +204,8 @@ public class CacheId implements Serializable, Comparable<CacheId> {
      * Determine if the receiver is greater or less than the key.
      */
     @Override
-    public int compareTo(CacheId id) {
-        if (this == id) {
-            return 0;
-        }
-        // PERF: Using direct variable access.
-        int size = this.primaryKey.length;
-        Object[] otherKey = id.primaryKey;
-        if (size == otherKey.length) {
-            for (int index = 0; index < size; index++) {
-                Object value = this.primaryKey[index];
-                Object otherValue = otherKey[index];
-                if (value == null) {
-                    if (otherValue != null) {
-                        return -1;
-                    } else {
-                        continue;
-                    }
-                } else if (otherValue == null) {
-                    return 1;
-                }
-                try {
-                    int compareTo = ((Comparable)value).compareTo(otherValue);
-                    if (compareTo != 0) {
-                        return compareTo;
-                    }
-                } catch (Exception exception) {
-                    return 0;
-                }
-            }
-            return 0;
-        } else {
-            if (size > otherKey.length) {
-                return 1;
-            } else {
-                return -1;
-            }
-        }
+    public int compareTo(CacheId otherId) {
+        return COMPARATOR.compare(this, otherId);
     }
 
     public boolean hasArray() {

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/CacheIdComparator.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/CacheIdComparator.java
@@ -1,0 +1,101 @@
+package org.eclipse.persistence.internal.identitymaps;
+
+import java.util.Comparator;
+
+import org.eclipse.persistence.internal.helper.*;
+
+/**
+ * Comparator for CacheIds with array comparison support
+ */
+class CacheIdComparator implements Comparator<CacheId> {
+
+    @Override
+    public int compare(CacheId id1, CacheId id2) {
+        if (id1 == id2) {
+            return 0;
+        }
+
+        return compareObjectArrays(id1.primaryKey, id2.primaryKey);
+    }
+
+    private int compareObjectArrays(Object[] array1, Object[] array2) {
+        if (array1.length == array2.length) {
+            for (int index = 0; index < array1.length; index++) {
+                Object value1 = array1[index];
+                Object value2 = array2[index];
+                if (value1 == null) {
+                    if (value2 != null) {
+                        return -1;
+                    } else {
+                        continue;
+                    }
+                } else if (value2 == null) {
+                    return 1;
+                }
+
+                Class value1Class = value1.getClass();
+                if (value1Class.isArray()) {
+                    Class value2Class = value2.getClass();
+                    if (value1Class == ClassConstants.APBYTE && value2Class == ClassConstants.APBYTE) {
+                        int result = compareByteArrays((byte[])value1, (byte[])value2);
+                        if (result != 0) {
+                            return result;
+                        }
+                    } else if (value1Class == ClassConstants.APCHAR && value2Class == ClassConstants.APCHAR) {
+                        int result = compareCharArrays((char[])value1, (char[])value2);
+                        if (result != 0) {
+                            return result;
+                        }
+                    } else {
+                        int result = compareObjectArrays((Object[])value1, (Object[])value2);
+                        if (result != 0) {
+                            return result;
+                        }
+                    }
+                } else {
+                    try {
+                        int compareTo = ((Comparable)value1).compareTo(value2);
+                        if (compareTo != 0) {
+                            return compareTo;
+                        }
+                    } catch (Exception exception) {
+                        int result = value1.hashCode() - value2.hashCode();
+                        if (result != 0) {
+                            return result > 0 ? 1 : -1;
+                        }
+                    }
+                }
+            }
+            return 0;
+        } else {
+            return array1.length > array2.length ? 1 : -1;
+        }
+
+    }
+
+    private int compareCharArrays(char[] array1, char[] array2) {
+        if (array1.length == array2.length) {
+            for (int index = 0; index < array1.length; index++) {
+                if (array1[index] != array2[index]) {
+                    return array1[index] > array2[index] ? 1 : -1;
+                }
+            }
+            return 0;
+        } else {
+            return array1.length > array2.length ? 1 : -1;
+        }
+    }
+
+    private int compareByteArrays(byte[] array1, byte[] array2) {
+        if (array1.length == array2.length) {
+            for (int index = 0; index < array1.length; index++) {
+                if (array1[index] != array2[index]) {
+                    return array1[index] > array2[index] ? 1 : -1;
+                }
+            }
+            return 0;
+        } else {
+            return array1.length > array2.length ? 1 : -1;
+        }
+    }
+}


### PR DESCRIPTION
Hi

I would like to post a fix for bug #482. The fix is basically an implementation of `CacheId.compareTo()` which supports char, byte or Object arrays in primary keys. The implementation was moved to `CacheIdComparator` for better encapsulation. 

Besides array support, I've changed current implementation for objects which don't implement `Comparable`. Current approach returns `0` when an exception is thrown during comparison. This create inconsistency with `equals()` method. For example: `new Object().compareTo(new Object())` returns `0`,
but new `Object().equals(new Object())` returns `false`. I've switch to compareTo based on hashCodes
which should give equals() consistency and stable results.

Signed-off-by: Michal Stochmialek <mst@avaleo.net>
