### PR TITLE
[2.7] Bug#531910 Add support for JGroups ver. 4.x in session coordination

### DIFF
--- a/antbuild.properties
+++ b/antbuild.properties
@@ -14,7 +14,7 @@
 
 # The directory that holds the oracle-specific jar files.
 # You can either put the jars in this directory, or specify your own directory.
-junit.lib= /home/Makis/.m2/repository/junit/junit/4.12/junit-4.12.jar
+junit.lib=../extension.lib.external/junit.jar
 tools.lib=${env.JAVA_HOME}/lib/tools.jar
 
 jacocoant.lib=../extension.lib.external/jacocoant.jar

--- a/antbuild.properties
+++ b/antbuild.properties
@@ -14,7 +14,7 @@
 
 # The directory that holds the oracle-specific jar files.
 # You can either put the jars in this directory, or specify your own directory.
-junit.lib=../extension.lib.external/junit.jar
+junit.lib= /home/Makis/.m2/repository/junit/junit/4.12/junit-4.12.jar
 tools.lib=${env.JAVA_HOME}/lib/tools.jar
 
 jacocoant.lib=../extension.lib.external/jacocoant.jar

--- a/buildsystem/compdeps/pom.xml
+++ b/buildsystem/compdeps/pom.xml
@@ -91,7 +91,7 @@
         <org.slf4j.version>1.7.25</org.slf4j.version>
         <wsdl4j.version>1.6.2</wsdl4j.version>
         <!-- CQ #7143 (Workswith) JGroups 3.2.8+ -->
-        <org.jgroups.version>3.6.17.Final</org.jgroups.version>
+        <org.jgroups.version>[3.6.17.Final,4.1.0.Final]</org.jgroups.version>
     </properties>
 
     <build>

--- a/buildsystem/compdeps/pom.xml
+++ b/buildsystem/compdeps/pom.xml
@@ -91,7 +91,7 @@
         <org.slf4j.version>1.7.25</org.slf4j.version>
         <wsdl4j.version>1.6.2</wsdl4j.version>
         <!-- CQ #7143 (Workswith) JGroups 3.2.8+ -->
-        <org.jgroups.version>[4.1.0.Final]</org.jgroups.version>
+        <org.jgroups.version>4.1.0.Final</org.jgroups.version>
     </properties>
 
     <build>

--- a/buildsystem/compdeps/pom.xml
+++ b/buildsystem/compdeps/pom.xml
@@ -91,7 +91,7 @@
         <org.slf4j.version>1.7.25</org.slf4j.version>
         <wsdl4j.version>1.6.2</wsdl4j.version>
         <!-- CQ #7143 (Workswith) JGroups 3.2.8+ -->
-        <org.jgroups.version>[3.6.17.Final,4.1.0.Final]</org.jgroups.version>
+        <org.jgroups.version>[4.1.0.Final]</org.jgroups.version>
     </properties>
 
     <build>

--- a/foundation/org.eclipse.persistence.extension/pom.xml
+++ b/foundation/org.eclipse.persistence.extension/pom.xml
@@ -35,14 +35,4 @@
         <release.version>2.7.5</release.version>
         <testId>eclipselink.${componentId}.test</testId>
     </properties>
-
-    <dependencies>
-      <dependency>
-        <groupId>org.jgroups</groupId>
-        <artifactId>jgroups</artifactId>
-        <version>3.2.8.Final</version>
-        <scope>compile</scope>
-      </dependency>
-    </dependencies>
-
 </project>

--- a/foundation/org.eclipse.persistence.extension/src/org/eclipse/persistence/internal/sessions/coordination/jgroups/JGroupsRemoteConnection.java
+++ b/foundation/org.eclipse.persistence.extension/src/org/eclipse/persistence/internal/sessions/coordination/jgroups/JGroupsRemoteConnection.java
@@ -93,9 +93,9 @@ public class JGroupsRemoteConnection extends BroadcastRemoteConnection {
     protected Object executeCommandInternal(Object command) throws Exception {
         Message message = null;
         if (command instanceof byte[]) {
-            message = new Message(null, null, (byte[])command);
+            message = new Message(null, (byte[])command);
         } else {
-            message = new Message(null, null, command);
+            message = new Message(null, command);
         }
 
         Object[] debugInfo = null;

--- a/uploadToNexus.xml
+++ b/uploadToNexus.xml
@@ -294,7 +294,7 @@
         <property name="dep.resource"      value="${dep.grp}jakarta.resource${dep.art}jakarta.resource-api${dep.ver}1.7.2${dep.type}jar${dep.scope}compile${dep.opt}false${dep.foot}"/>
         <property name="dep.servlet"       value="${dep.grp}jakarta.servlet${dep.art}jakarta.servlet-api${dep.ver}4.0.2${dep.type}jar${dep.scope}compile${dep.opt}false${dep.foot}"/>
         <property name="dep.wsdl"          value="${dep.grp}wsdl4j${dep.art}wsdl4j${dep.ver}1.6.3${dep.type}jar${dep.scope}compile${dep.opt}false${dep.foot}"/>
-        <property name="dep.jgroups"       value="${dep.grp}org.jgroups${dep.art}jgroups${dep.ver}4.1.0.Final${dep.type}jar${dep.scope}compile${dep.opt}false${dep.foot}"/>
+        <property name="dep.jgroups"       value="${dep.grp}org.jgroups${dep.art}jgroups${dep.ver}4.1.0.Final${dep.type}jar${dep.scope}compile${dep.opt}true${dep.foot}"/>
         <!-- These are EclipseLink maintained public API bundles so are published under the EclipseLink GroupID, but with their own version info -->
         <property name="dep.persistence"   value="${dep.grp}org.eclipse.persistence${dep.art}${jpaapi.prefix}${dep.ver}${jpaapi.mvn.version}${dep.type}jar${dep.scope}compile${dep.opt}false${dep.foot}"/>
         <property name="dep.sdoapi"        value="${dep.grp}org.eclipse.persistence${dep.art}${sdoapi.prefix}${dep.ver}${sdoapi.mvn.version}${dep.type}jar${dep.scope}compile${dep.opt}false${dep.foot}"/>

--- a/uploadToNexus.xml
+++ b/uploadToNexus.xml
@@ -184,7 +184,7 @@
         <property name="oracleddl.name"       value="EclipseLink OracleDDL Parser"/>
         <property name="oraclebndl.prefix"    value="org.eclipse.persistence.oracle"/>
         <property name="oraclebndl.criteria"  value="[1.0.0,9.0.0)"/>
-        <property name="oraclebndl.name"       value="EclipseLink Oracle Extensions"/>
+        <property name="oraclebndl.name"      value="EclipseLink Oracle Extensions"/>
         <property name="oraclenosql.prefix"   value="org.eclipse.persistence.oracle.nosql"/>
         <property name="oraclenosql.criteria" value="[1.0.0,9.0.0)"/>
         <property name="oraclenosql.name"     value="EclipseLink Oracle NoSQL database Extensions"/>
@@ -294,6 +294,7 @@
         <property name="dep.resource"      value="${dep.grp}jakarta.resource${dep.art}jakarta.resource-api${dep.ver}1.7.2${dep.type}jar${dep.scope}compile${dep.opt}false${dep.foot}"/>
         <property name="dep.servlet"       value="${dep.grp}jakarta.servlet${dep.art}jakarta.servlet-api${dep.ver}4.0.2${dep.type}jar${dep.scope}compile${dep.opt}false${dep.foot}"/>
         <property name="dep.wsdl"          value="${dep.grp}wsdl4j${dep.art}wsdl4j${dep.ver}1.6.3${dep.type}jar${dep.scope}compile${dep.opt}false${dep.foot}"/>
+        <property name="dep.jgroups"       value="${dep.grp}org.jgroups${dep.art}jgroups${dep.ver}4.1.0.Final${dep.type}jar${dep.scope}compile${dep.opt}false${dep.foot}"/>
         <!-- These are EclipseLink maintained public API bundles so are published under the EclipseLink GroupID, but with their own version info -->
         <property name="dep.persistence"   value="${dep.grp}org.eclipse.persistence${dep.art}${jpaapi.prefix}${dep.ver}${jpaapi.mvn.version}${dep.type}jar${dep.scope}compile${dep.opt}false${dep.foot}"/>
         <property name="dep.sdoapi"        value="${dep.grp}org.eclipse.persistence${dep.art}${sdoapi.prefix}${dep.ver}${sdoapi.mvn.version}${dep.type}jar${dep.scope}compile${dep.opt}false${dep.foot}"/>
@@ -330,7 +331,7 @@
         <property name="builder.dependencies"     value="${deps.head}${dep.core}${dep.dbws}${dep.moxy}${dep.jpa}${dep.nosql}${dep.oracle}${dep.servlet}${dep.wsdl}${dep.oracleddl}${deps.foot}"/>
         <property name="moxy.dependencies"        value="${deps.head}${dep.core}${deps.foot}"/>
         <property name="sdo.dependencies"         value="${deps.head}${dep.sdoapi}${dep.moxy}${dep.core}${deps.foot}"/>
-        <property name="extension.dependencies"   value="${deps.head}${dep.core}${deps.foot}"/>
+        <property name="extension.dependencies"   value="${deps.head}${dep.core}${dep.jgroups}${deps.foot}"/>
     </target>
 
     <!-- Nexus typicaly is configured to disallow uploads of already published versions (non-snapshot)   -->


### PR DESCRIPTION
Add support for JGroups ver. 4.x in session coordination mechanism.
That will allow to use newest `KUBE_PING` protocols and resolve some issues with Openshift 4 based replication (see https://github.com/eclipse/che/issues/13607 for example)

Original issue: https://bugs.eclipse.org/bugs/show_bug.cgi?id=531910