### PR TITLE
Travis switch to Open JDK and Ubuntu Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ services:
 env:
   global:
     - ANT_HOME=$HOME/apache-ant-1.10.5
-    - M2_HOME=/usr/local/maven-3.5.2
+    - M2_HOME=/usr/local/maven-3.6.0
   matrix:
     - TEST_TARGET=test-core
     - TEST_TARGET=test-jpa22

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,8 @@ env:
     - TEST_TARGET=build-distribution
 
 jdk:
-  - oraclejdk8
-  - oraclejdk11
+  - openjdk8
+  - openjdk11
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,6 @@ branches:
 
 addons:
   apt:
-    sources:
-      - mysql-5.7
     packages:
       - libmysql-java
       - mysql-server
@@ -44,7 +42,7 @@ env:
     - TEST_TARGET=build-distribution
 
 jdk:
-  - oraclejdk8
+  - openjdk8
   - openjdk11
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@
 
 language: java
 sudo: required
+dist: xenial
 
 branches:
   except:
@@ -20,11 +21,14 @@ branches:
 addons:
   apt:
     sources:
-      - mysql-5.7-trusty
+      - mysql-5.7
     packages:
       - libmysql-java
       - mysql-server
       - mysql-client
+
+services:
+  - mysql
 
 env:
   global:
@@ -40,7 +44,7 @@ env:
     - TEST_TARGET=build-distribution
 
 jdk:
-  - openjdk8
+  - oraclejdk8
   - openjdk11
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,8 +84,6 @@ before_script:
   - echo 'wildfly.config=standalone-full.xml' >> $HOME/build.properties
 
 script:
-  - ls /usr/lib/jvm/java-1.8.0-openjdk-amd64
-  - cat /usr/lib/jvm/java-1.8.0-openjdk-amd64/release
   - cat $HOME/build.properties
   - $ANT_HOME/bin/ant -f antbuild.xml build -Dfail.on.error=true
   - echo 'RUNNING TESTS, BE PATIENT...'

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,8 @@ before_script:
   - echo 'wildfly.config=standalone-full.xml' >> $HOME/build.properties
 
 script:
+  - ls /usr/lib/jvm/java-1.8.0-openjdk-amd64
+  - cat /usr/lib/jvm/java-1.8.0-openjdk-amd64/release
   - cat $HOME/build.properties
   - $ANT_HOME/bin/ant -f antbuild.xml build -Dfail.on.error=true
   - echo 'RUNNING TESTS, BE PATIENT...'

--- a/dbws/eclipselink.dbws.test.oracle/antbuild.xml
+++ b/dbws/eclipselink.dbws.test.oracle/antbuild.xml
@@ -107,6 +107,9 @@
         <!-- JVM used to run tests -->
         <property name="test.junit.jvm" value="${env.JAVA_HOME}"/>
         <property name="test.junit.jvm.exec" value="${test.junit.jvm}/bin/java"/>
+        <condition property="test.junit.jdk.JAVA_VERSION" value='"1.8.0"'>
+            <not><available file="${test.junit.jvm}/release"/></not>
+        </condition>
         <property prefix="test.junit.jdk" file="${test.junit.jvm}/release"/>
 
         <condition property="use.modules" value="true" else="false">

--- a/dbws/eclipselink.dbws.test.oracle/antbuild.xml
+++ b/dbws/eclipselink.dbws.test.oracle/antbuild.xml
@@ -107,6 +107,7 @@
         <!-- JVM used to run tests -->
         <property name="test.junit.jvm" value="${env.JAVA_HOME}"/>
         <property name="test.junit.jvm.exec" value="${test.junit.jvm}/bin/java"/>
+        <!-- Handle missing $JAVA_HOME/release file (Travis OpenJDK 8) -->
         <condition property="test.junit.jdk.JAVA_VERSION" value='"1.8.0"'>
             <not><available file="${test.junit.jvm}/release"/></not>
         </condition>

--- a/dbws/eclipselink.dbws.test/antbuild.xml
+++ b/dbws/eclipselink.dbws.test/antbuild.xml
@@ -98,6 +98,7 @@
         <!-- JVM used to run tests -->
         <property name="test.junit.jvm" value="${env.JAVA_HOME}"/>
         <property name="test.junit.jvm.exec" value="${test.junit.jvm}/bin/java"/>
+        <!-- Handle missing $JAVA_HOME/release file (Travis OpenJDK 8) -->
         <condition property="test.junit.jdk.JAVA_VERSION" value='"1.8.0"'>
             <not><available file="${test.junit.jvm}/release"/></not>
         </condition>

--- a/dbws/eclipselink.dbws.test/antbuild.xml
+++ b/dbws/eclipselink.dbws.test/antbuild.xml
@@ -98,6 +98,9 @@
         <!-- JVM used to run tests -->
         <property name="test.junit.jvm" value="${env.JAVA_HOME}"/>
         <property name="test.junit.jvm.exec" value="${test.junit.jvm}/bin/java"/>
+        <condition property="test.junit.jdk.JAVA_VERSION" value='"1.8.0"'>
+            <not><available file="${test.junit.jvm}/release"/></not>
+        </condition>
         <property prefix="test.junit.jdk" file="${test.junit.jvm}/release"/>
 
         <condition property="use.modules" value="true" else="false">

--- a/foundation/eclipselink.core.test/antbuild.xml
+++ b/foundation/eclipselink.core.test/antbuild.xml
@@ -115,7 +115,7 @@
         <property name="test.junit.jvm" value="${env.JAVA_HOME}"/>
         <property name="test.junit.jvm.exec" value="${test.junit.jvm}/bin/java"/>
 
-        <condition property="test.junit.jdk.JAVA_VERSION" value="1.8.0">
+        <condition property="test.junit.jdk.JAVA_VERSION" value='"1.8.0"'>
             <not><available file="${test.junit.jvm}/release"/></not>
         </condition>
         <property prefix="test.junit.jdk" file="${test.junit.jvm}/release"/>
@@ -124,6 +124,7 @@
         <condition property="use.modules" value="true" else="false">
             <not><matches pattern='"[1-8]\..*"' string="${test.junit.jdk.JAVA_VERSION}"/></not>
         </condition>
+        <echo message="use.modules              ='${use.modules}'"/>
 
         <!-- versioning -->
         <!-- These variables  are set in autobuild.xml. A manual build gets defaults -->

--- a/foundation/eclipselink.core.test/antbuild.xml
+++ b/foundation/eclipselink.core.test/antbuild.xml
@@ -114,6 +114,7 @@
         <!-- JVM used to run tests -->
         <property name="test.junit.jvm" value="${env.JAVA_HOME}"/>
         <property name="test.junit.jvm.exec" value="${test.junit.jvm}/bin/java"/>
+        <!-- Handle missing $JAVA_HOME/release file (Travis OpenJDK 8) -->
         <condition property="test.junit.jdk.JAVA_VERSION" value='"1.8.0"'>
             <not><available file="${test.junit.jvm}/release"/></not>
         </condition>

--- a/foundation/eclipselink.core.test/antbuild.xml
+++ b/foundation/eclipselink.core.test/antbuild.xml
@@ -114,17 +114,14 @@
         <!-- JVM used to run tests -->
         <property name="test.junit.jvm" value="${env.JAVA_HOME}"/>
         <property name="test.junit.jvm.exec" value="${test.junit.jvm}/bin/java"/>
-
         <condition property="test.junit.jdk.JAVA_VERSION" value='"1.8.0"'>
             <not><available file="${test.junit.jvm}/release"/></not>
         </condition>
         <property prefix="test.junit.jdk" file="${test.junit.jvm}/release"/>
-        <echo message="test.junit.jdk.JAVA_VERSION              ='${test.junit.jdk.JAVA_VERSION}'"/>
 
         <condition property="use.modules" value="true" else="false">
             <not><matches pattern='"[1-8]\..*"' string="${test.junit.jdk.JAVA_VERSION}"/></not>
         </condition>
-        <echo message="use.modules              ='${use.modules}'"/>
 
         <!-- versioning -->
         <!-- These variables  are set in autobuild.xml. A manual build gets defaults -->

--- a/foundation/eclipselink.core.test/antbuild.xml
+++ b/foundation/eclipselink.core.test/antbuild.xml
@@ -115,11 +115,11 @@
         <property name="test.junit.jvm" value="${env.JAVA_HOME}"/>
         <property name="test.junit.jvm.exec" value="${test.junit.jvm}/bin/java"/>
 
-        <condition property="test.junit.jdk" value='JAVA_VERSION="1.8.0"'>
+        <condition property="test.junit.jdk.JAVA_VERSION" value="1.8.0">
             <not><available file="${test.junit.jvm}/release"/></not>
         </condition>
         <property prefix="test.junit.jdk" file="${test.junit.jvm}/release"/>
-        <echo message="test.junit.jdk              ='${test.junit.jdk}'"/>
+        <echo message="test.junit.jdk.JAVA_VERSION              ='${test.junit.jdk.JAVA_VERSION}'"/>
 
         <condition property="use.modules" value="true" else="false">
             <not><matches pattern='"[1-8]\..*"' string="${test.junit.jdk.JAVA_VERSION}"/></not>

--- a/foundation/eclipselink.core.test/antbuild.xml
+++ b/foundation/eclipselink.core.test/antbuild.xml
@@ -114,7 +114,12 @@
         <!-- JVM used to run tests -->
         <property name="test.junit.jvm" value="${env.JAVA_HOME}"/>
         <property name="test.junit.jvm.exec" value="${test.junit.jvm}/bin/java"/>
+
+        <condition property="test.junit.jdk" value='JAVA_VERSION="1.8.0"'>
+            <not><available file="${test.junit.jvm}/release"/></not>
+        </condition>
         <property prefix="test.junit.jdk" file="${test.junit.jvm}/release"/>
+        <echo message="test.junit.jdk              ='${test.junit.jdk}'"/>
 
         <condition property="use.modules" value="true" else="false">
             <not><matches pattern='"[1-8]\..*"' string="${test.junit.jdk.JAVA_VERSION}"/></not>

--- a/foundation/eclipselink.extension.corba.test/antbuild.xml
+++ b/foundation/eclipselink.extension.corba.test/antbuild.xml
@@ -88,7 +88,6 @@
         </condition>
         <echo message="${custom.tst.properties.message}"/>
         <property file="${user.home}/test.properties"/>
-        <!-- Handle missing $JAVA_HOME/release file (Travis OpenJDK 8) -->
         <condition property="custom.local.properties.message" value="Loading ${basedir}/local.build.properties..."
                    else="Notice: custom properties file '${basedir}/local.build.properties' not found to load.">
             <available file="${basedir}/local.build.properties"/>
@@ -102,6 +101,7 @@
         <!-- JVM used to run tests -->
         <property name="test.junit.jvm" value="${env.JAVA_HOME}"/>
         <property name="test.junit.jvm.exec" value="${test.junit.jvm}/bin/java"/>
+        <!-- Handle missing $JAVA_HOME/release file (Travis OpenJDK 8) -->
         <condition property="test.junit.jdk.JAVA_VERSION" value='"1.8.0"'>
             <not><available file="${test.junit.jvm}/release"/></not>
         </condition>

--- a/foundation/eclipselink.extension.corba.test/antbuild.xml
+++ b/foundation/eclipselink.extension.corba.test/antbuild.xml
@@ -88,6 +88,7 @@
         </condition>
         <echo message="${custom.tst.properties.message}"/>
         <property file="${user.home}/test.properties"/>
+        <!-- Handle missing $JAVA_HOME/release file (Travis OpenJDK 8) -->
         <condition property="custom.local.properties.message" value="Loading ${basedir}/local.build.properties..."
                    else="Notice: custom properties file '${basedir}/local.build.properties' not found to load.">
             <available file="${basedir}/local.build.properties"/>

--- a/foundation/eclipselink.extension.corba.test/antbuild.xml
+++ b/foundation/eclipselink.extension.corba.test/antbuild.xml
@@ -101,6 +101,9 @@
         <!-- JVM used to run tests -->
         <property name="test.junit.jvm" value="${env.JAVA_HOME}"/>
         <property name="test.junit.jvm.exec" value="${test.junit.jvm}/bin/java"/>
+        <condition property="test.junit.jdk.JAVA_VERSION" value='"1.8.0"'>
+            <not><available file="${test.junit.jvm}/release"/></not>
+        </condition>
         <property prefix="test.junit.jdk" file="${test.junit.jvm}/release"/>
 
         <condition property="use.modules" value="true" else="false">

--- a/foundation/eclipselink.extension.oracle.spatial.test/antbuild.xml
+++ b/foundation/eclipselink.extension.oracle.spatial.test/antbuild.xml
@@ -107,6 +107,9 @@
         <!-- JVM used to run tests -->
         <property name="test.junit.jvm" value="${env.JAVA_HOME}"/>
         <property name="test.junit.jvm.exec" value="${test.junit.jvm}/bin/java"/>
+        <condition property="test.junit.jdk.JAVA_VERSION" value='"1.8.0"'>
+            <not><available file="${test.junit.jvm}/release"/></not>
+        </condition>
         <property prefix="test.junit.jdk" file="${test.junit.jvm}/release"/>
 
         <condition property="use.modules" value="true" else="false">

--- a/foundation/eclipselink.extension.oracle.spatial.test/antbuild.xml
+++ b/foundation/eclipselink.extension.oracle.spatial.test/antbuild.xml
@@ -107,6 +107,7 @@
         <!-- JVM used to run tests -->
         <property name="test.junit.jvm" value="${env.JAVA_HOME}"/>
         <property name="test.junit.jvm.exec" value="${test.junit.jvm}/bin/java"/>
+        <!-- Handle missing $JAVA_HOME/release file (Travis OpenJDK 8) -->
         <condition property="test.junit.jdk.JAVA_VERSION" value='"1.8.0"'>
             <not><available file="${test.junit.jvm}/release"/></not>
         </condition>

--- a/foundation/eclipselink.extension.oracle.test/antbuild.xml
+++ b/foundation/eclipselink.extension.oracle.test/antbuild.xml
@@ -107,6 +107,9 @@
         <!-- JVM used to run tests -->
         <property name="test.junit.jvm" value="${env.JAVA_HOME}"/>
         <property name="test.junit.jvm.exec" value="${test.junit.jvm}/bin/java"/>
+        <condition property="test.junit.jdk.JAVA_VERSION" value='"1.8.0"'>
+            <not><available file="${test.junit.jvm}/release"/></not>
+        </condition>
         <property prefix="test.junit.jdk" file="${test.junit.jvm}/release"/>
 
         <condition property="use.modules" value="true" else="false">

--- a/foundation/eclipselink.extension.oracle.test/antbuild.xml
+++ b/foundation/eclipselink.extension.oracle.test/antbuild.xml
@@ -107,6 +107,7 @@
         <!-- JVM used to run tests -->
         <property name="test.junit.jvm" value="${env.JAVA_HOME}"/>
         <property name="test.junit.jvm.exec" value="${test.junit.jvm}/bin/java"/>
+        <!-- Handle missing $JAVA_HOME/release file (Travis OpenJDK 8) -->
         <condition property="test.junit.jdk.JAVA_VERSION" value='"1.8.0"'>
             <not><available file="${test.junit.jvm}/release"/></not>
         </condition>

--- a/jpa/eclipselink.jpa.test/antbuild.xml
+++ b/jpa/eclipselink.jpa.test/antbuild.xml
@@ -108,6 +108,7 @@
         <!-- JVM used to run tests -->
         <property name="test.junit.jvm" value="${env.JAVA_HOME}"/>
         <property name="test.junit.jvm.exec" value="${test.junit.jvm}/bin/java"/>
+        <!-- Handle missing $JAVA_HOME/release file (Travis OpenJDK 8) -->
         <condition property="test.junit.jdk.JAVA_VERSION" value='"1.8.0"'>
             <not><available file="${test.junit.jvm}/release"/></not>
         </condition>

--- a/jpa/eclipselink.jpa.test/antbuild.xml
+++ b/jpa/eclipselink.jpa.test/antbuild.xml
@@ -108,6 +108,9 @@
         <!-- JVM used to run tests -->
         <property name="test.junit.jvm" value="${env.JAVA_HOME}"/>
         <property name="test.junit.jvm.exec" value="${test.junit.jvm}/bin/java"/>
+        <condition property="test.junit.jdk.JAVA_VERSION" value='"1.8.0"'>
+            <not><available file="${test.junit.jvm}/release"/></not>
+        </condition>
         <property prefix="test.junit.jdk" file="${test.junit.jvm}/release"/>
 
         <condition property="use.modules" value="true" else="false">

--- a/moxy/eclipselink.moxy.test/antbuild.xml
+++ b/moxy/eclipselink.moxy.test/antbuild.xml
@@ -112,6 +112,9 @@
     <!-- JVM used to run tests -->
     <property name="test.junit.jvm" value="${env.JAVA_HOME}"/>
     <property name="test.junit.jvm.exec" value="${test.junit.jvm}/bin/java"/>
+    <condition property="test.junit.jdk.JAVA_VERSION" value='"1.8.0"'>
+        <not><available file="${test.junit.jvm}/release"/></not>
+    </condition>
     <property prefix="test.junit.jdk" file="${test.junit.jvm}/release"/>
 
     <!-- JVM specific settings -->

--- a/moxy/eclipselink.moxy.test/antbuild.xml
+++ b/moxy/eclipselink.moxy.test/antbuild.xml
@@ -112,6 +112,7 @@
     <!-- JVM used to run tests -->
     <property name="test.junit.jvm" value="${env.JAVA_HOME}"/>
     <property name="test.junit.jvm.exec" value="${test.junit.jvm}/bin/java"/>
+    <!-- Handle missing $JAVA_HOME/release file (Travis OpenJDK 8) -->
     <condition property="test.junit.jdk.JAVA_VERSION" value='"1.8.0"'>
         <not><available file="${test.junit.jvm}/release"/></not>
     </condition>


### PR DESCRIPTION
This is another version of Travis-CI build script.
It reflects following changes in Travis CI environment:
1. Switch to Ubuntu Xenial (see **dist** _.travis.yml_)
2. Different MySQL server startup process (see **services** part in _.travis.yml_)
3. Switch to Open JDK 8, 11 from Oracle JDK due license changes (see **jdk** part in _.travis.yml_)

There is some fix in _antbuild.xml_ files for Open JDK 8. Open JDK 8 installation in Travis (Ubuntu-Xenial) doesn't contains _$JAVA_HOME/release_ file used by Ant build files to detect Java/JDK version. So build process applied incorrect javac release parameter => error message "[javac] javac: invalid target release: 9". In case of missing _$JAVA_HOME/release_ file "1.8.0" value is applied to `test.junit.jdk.JAVA_VERSION` Ant property.