### PR TITLE
[Non Bug] Travis JDK switch (Oracle JDK -> Open JDK) 2.7 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@
 
 language: java
 sudo: required
+dist: xenial
 
 branches:
   except:
@@ -19,17 +20,18 @@ branches:
 
 addons:
   apt:
-    sources:
-      - mysql-5.7-trusty
     packages:
       - libmysql-java
       - mysql-server
       - mysql-client
 
+services:
+  - mysql
+
 env:
   global:
     - ANT_HOME=$HOME/apache-ant-1.10.5
-    - M2_HOME=/usr/local/maven-3.5.2
+    - M2_HOME=/usr/local/maven-3.6.0
   matrix:
     - TEST_TARGET=test-core
     - TEST_TARGET=test-jpa22
@@ -39,7 +41,7 @@ env:
     - TEST_TARGET=build-distribution
 
 jdk:
-  - oraclejdk8
+  - openjdk8
   - openjdk10
 
 cache:

--- a/foundation/eclipselink.core.test/antbuild.xml
+++ b/foundation/eclipselink.core.test/antbuild.xml
@@ -114,6 +114,10 @@
         <!-- JVM used to run tests -->
         <property name="test.junit.jvm" value="${env.JAVA_HOME}"/>
         <property name="test.junit.jvm.exec" value="${test.junit.jvm}/bin/java"/>
+        <!-- Handle missing $JAVA_HOME/release file (Travis OpenJDK 8) -->
+        <condition property="test.junit.jdk.JAVA_VERSION" value='"1.8.0"'>
+            <not><available file="${test.junit.jvm}/release"/></not>
+        </condition>
         <property prefix="test.junit.jdk" file="${test.junit.jvm}/release"/>
 
         <condition property="use.modules" value="true" else="false">

--- a/moxy/eclipselink.moxy.test/antbuild.xml
+++ b/moxy/eclipselink.moxy.test/antbuild.xml
@@ -112,6 +112,10 @@
     <!-- JVM used to run tests -->
     <property name="test.junit.jvm" value="${env.JAVA_HOME}"/>
     <property name="test.junit.jvm.exec" value="${test.junit.jvm}/bin/java"/>
+    <!-- Handle missing $JAVA_HOME/release file (Travis OpenJDK 8) -->
+    <condition property="test.junit.jdk.JAVA_VERSION" value='"1.8.0"'>
+        <not><available file="${test.junit.jvm}/release"/></not>
+    </condition>
     <property prefix="test.junit.jdk" file="${test.junit.jvm}/release"/>
 
     <!-- JVM specific settings -->


### PR DESCRIPTION
Travis switch to Open JDK and Ubuntu Xenial.
Due license troubles JDK switch from OracleJDK to OpenJDK.
There is some fix in antbuild.xml files for Open JDK 8. Open JDK 8 installation in Travis (Ubuntu-Xenial) doesn't contains $JAVA_HOME/release file used by Ant build files to detect Java/JDK version.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>