### PR TITLE
[2.6_WAS][testBug] move table qualifier test to a better place

### DIFF
--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/sequence/TestTableQualifier.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/sequence/TestTableQualifier.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation. All rights reserved.
+ * This program and the accompanying materials are made available under the 
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0 
+ * which accompanies this distribution. 
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at 
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     dminsky,lukas - initial implementation
+ *  ******************************************************************************/
+package org.eclipse.persistence.jpa.test.sequence;
+
+import javax.persistence.EntityManagerFactory;
+
+import org.eclipse.persistence.descriptors.ClassDescriptor;
+import org.eclipse.persistence.internal.helper.DatabaseTable;
+import org.eclipse.persistence.jpa.test.framework.DDLGen;
+import org.eclipse.persistence.jpa.test.framework.Emf;
+import org.eclipse.persistence.jpa.test.framework.EmfRunner;
+import org.eclipse.persistence.jpa.test.sequence.model.EntityWithSchema;
+import org.eclipse.persistence.sequencing.TableSequence;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(EmfRunner.class)
+public class TestTableQualifier {
+
+    @Emf(name="tableQualifiers", createTables = DDLGen.NONE, classes = { EntityWithSchema.class })
+    private EntityManagerFactory emf;
+
+    /*
+     * Test for Bug 445466
+     * When a table qualifier is configured on an Entity/TableSequence combination,
+     * the SQL is not printed correctly. Programmatically test that an Entity's TableSequence
+     * has the expected table name & qualifier information configured.
+     */
+    @Test
+    public void testTableQualifierOnSequencingTableAndEntity() {
+        // Access serverSession directly, do not create an EM as the Entity 'EntityWithSchema'
+        // has a hard-coded schema for programmatic testing only
+        ClassDescriptor descriptor = ((org.eclipse.persistence.jpa.JpaEntityManager)emf.createEntityManager()).getServerSession().getDescriptor(EntityWithSchema.class);
+        TableSequence tableSequence = (TableSequence) descriptor.getSequence();
+        DatabaseTable table = tableSequence.getTable();
+
+        String tableName = table.getName(); // returns fully qualified table name, by design
+        String tableQualifier = table.getTableQualifier();
+
+        String tsQualifier = tableSequence.getQualifier();
+        String tsTableName = tableSequence.getTableName();
+        String tsQualifiedTableName = tableSequence.getQualifiedTableName();
+
+        Assert.assertNotNull("Table name should be non-null", tableName);
+        Assert.assertTrue("Table name should not be empty", tableName.length() > 0);
+        Assert.assertNotNull("Table qualifier should be non-null", tableQualifier);
+        Assert.assertTrue("Table qualifier should not be empty", tableQualifier.length() > 0);
+
+        Assert.assertEquals("Table Sequence : table name (with qualifier) should be equal", (tableQualifier + "." + tableName), tsTableName);
+        Assert.assertEquals("Table Sequence : table qualifier should be equal", tableQualifier, tsQualifier);
+        Assert.assertEquals("Table Sequence : qualified table name should be equal", (tableQualifier + "." + tableName), tsQualifiedTableName);
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/sequence/model/EntityWithSchema.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/sequence/model/EntityWithSchema.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2014 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 IBM Corporation. All rights reserved.
  * This program and the accompanying materials are made available under the 
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0 
  * which accompanies this distribution. 
@@ -8,9 +8,9 @@
  * http://www.eclipse.org/org/documents/edl-v10.php.
  *
  * Contributors:
- *     dminsky - initial implementation
- ******************************************************************************/  
-package org.eclipse.persistence.testing.models.jpa.advanced.entities;
+ *     dminsky,lukas - initial implementation
+ *  ******************************************************************************/
+package org.eclipse.persistence.jpa.test.sequence.model;
 
 import java.io.Serializable;
 import javax.persistence.*;
@@ -18,10 +18,12 @@ import javax.persistence.*;
 @Entity
 @Table(name="ENTITY_WITH_SCHEMA", schema=EntityWithSchema.CUSTOM_SCHEMA_NAME)
 public class EntityWithSchema implements Serializable {
-    
+
+    private static final long serialVersionUID = 1L;
+
     public static final String CUSTOM_SCHEMA_NAME = "CUSTOM_SCHEMA";
     public static final String CUSTOM_SEQUENCE_NAME = "CUSTOM_SEQUENCE";
-    
+
     // Table Sequence with a schema
     @Id
     @TableGenerator(
@@ -35,7 +37,7 @@ public class EntityWithSchema implements Serializable {
     @GeneratedValue(strategy=GenerationType.TABLE, generator="CustomSequenceGenerator")
     private Long id;
     private String name;
-    
+
     public EntityWithSchema() {
         super();
     }

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/advanced/AdvancedJunitTest.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/advanced/AdvancedJunitTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2014 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the 
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0 
  * which accompanies this distribution. 
@@ -46,7 +46,6 @@ import org.eclipse.persistence.testing.models.jpa.advanced.VegetablePK;
 import org.eclipse.persistence.testing.models.jpa.advanced.WorldRank;
 import org.eclipse.persistence.testing.models.jpa.advanced.PartnerLink;
 import org.eclipse.persistence.testing.models.jpa.advanced.LargeProject;
-import org.eclipse.persistence.testing.models.jpa.advanced.entities.EntityWithSchema;
 import org.eclipse.persistence.testing.models.jpa.advanced.entities.SimpleEntity;
 import org.eclipse.persistence.testing.models.jpa.advanced.entities.SimpleNature;
 import org.eclipse.persistence.testing.models.jpa.advanced.entities.SimpleLanguage;
@@ -75,7 +74,6 @@ public class AdvancedJunitTest extends JUnitTestCase {
         suite.addTest(new AdvancedJunitTest("testElementCollectionClear"));
         suite.addTest(new AdvancedJunitTest("testElementCollectionEntityMapKeyRemove"));
         suite.addTest(new AdvancedJunitTest("testSwitchBatchDuringSessionEvent"));
-        suite.addTest(new AdvancedJunitTest("testTableQualifierOnSequencingTableAndEntity"));
         
         return suite;
     }
@@ -529,35 +527,5 @@ public class AdvancedJunitTest extends JUnitTestCase {
             clearCache();
             closeEntityManager(em);
         }
-    }
-    
-    /*
-     * Test for Bug 445466
-     * When a table qualifier is configured on an Entity/TableSequence combination, 
-     * the SQL is not printed correctly. Programmatically test that an Entity's TableSequence 
-     * has the expected table name & qualifier information configured. 
-     */
-    public void testTableQualifierOnSequencingTableAndEntity() {
-        // Access serverSession directly, do not create an EM as the Entity 'EntityWithSchema' 
-        // has a hard-coded schema for programmatic testing only
-        ClassDescriptor descriptor = getServerSession(getPersistenceUnitName()).getDescriptor(EntityWithSchema.class);
-        TableSequence tableSequence = (TableSequence) descriptor.getSequence();
-        DatabaseTable table = tableSequence.getTable();
-        
-        String tableName = table.getName(); // returns fully qualified table name, by design
-        String tableQualifier = table.getTableQualifier();
-        
-        String tsQualifier = tableSequence.getQualifier();
-        String tsTableName = tableSequence.getTableName();
-        String tsQualifiedTableName = tableSequence.getQualifiedTableName();
-        
-        assertNotNull("Table name should be non-null", tableName);
-        assertTrue("Table name should not be empty", tableName.length() > 0);
-        assertNotNull("Table qualifier should be non-null", tableQualifier);
-        assertTrue("Table qualifier should not be empty", tableQualifier.length() > 0);
-        
-        assertEquals("Table Sequence : table name (with qualifier) should be equal", (tableQualifier + "." + tableName), tsTableName);
-        assertEquals("Table Sequence : table qualifier should be equal", tableQualifier, tsQualifier);
-        assertEquals("Table Sequence : qualified table name should be equal", (tableQualifier + "." + tableName), tsQualifiedTableName);
     }
 }


### PR DESCRIPTION
Running "test-lrg21" on 2.6_WAS results in the following failure:
```
    [junit] Internal Exception: java.sql.SQLSyntaxErrorException: ORA-01918: user 'CUSTOM_SCHEMA' does not exist
    [junit] 
    [junit] Error Code: 1918
    [junit] Call: CREATE TABLE CUSTOM_SCHEMA.CUSTOM_SEQUENCE (SEQ_NAME VARCHAR2(50) NOT NULL, SEQ_VALUE NUMBER(38) NULL, PRIMARY KEY (SEQ_NAME))
    [junit] Query: DataModifyQuery(sql="CREATE TABLE CUSTOM_SCHEMA.CUSTOM_SEQUENCE (SEQ_NAME VARCHAR2(50) NOT NULL, SEQ_VALUE NUMBER(38) NULL, PRIMARY KEY (SEQ_NAME))")
```

This issue doesnt occur on 2.7 branch due to this commit: https://github.com/eclipse-ee4j/eclipselink/commit/ec9aac7f48f3b9b9e0b42be459b80464f6ed9f32

So, this is a port of that test bug fix to the 2.6_WAS branch. 

Signed-off-by: Will Dazey <dazeydev.3@gmail.com>