### PR TITLE
JPA WDF Tests fix

### DIFF
--- a/jpa/eclipselink.jpa.wdf.test/src/org/eclipse/persistence/testing/tests/wdf/jpa1/entitymanager/TestClear.java
+++ b/jpa/eclipselink.jpa.wdf.test/src/org/eclipse/persistence/testing/tests/wdf/jpa1/entitymanager/TestClear.java
@@ -30,8 +30,8 @@ public class TestClear extends JPA1Base {
         JPAEnvironment env = getEnvironment();
         EntityManager em = env.getEntityManager();
         try {
-            Department dep1 = new Department(1, "one");
-            Department dep2 = new Department(2, "two");
+            Department dep1 = new Department(1111, "one");
+            Department dep2 = new Department(2222, "two");
             env.beginTransaction(em);
             em.persist(dep1);
             env.commitTransactionAndClear(em);


### PR DESCRIPTION
This prevents collision with other tests executed against same DB table.
There was collision at the DB row level.
Entities with same id "...new Department(1..." was used in multiple tests above same DB table.
This error happened at new ci-staging.eclipse.org build server.
For example there: https://ci-staging.eclipse.org/eclipselink/view/New%20Jobs/job/eclipselink-nightly-master/4/console

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>