### PR TITLE
Jenkins jobs for Ant build

### DIFF
--- a/autobuild.xml
+++ b/autobuild.xml
@@ -151,6 +151,16 @@
         <property name="git.hash" value="NA"/>
     </target>
 
+    <target name="check-maven" description="Verify the Maven tool is installed and configured">
+        <condition property="M2_HOME" value="${env.M2_HOME}"
+                   else="/opt/java/maven">
+            <isset property="env.M2_HOME"/>
+        </condition>
+        <echo message="Maven install (M2_HOME) set to: '${M2_HOME}'"/>
+        <available file="${M2_HOME}/bin/mvn" property="use.maven"/>
+        <fail message="Maven 3 not found. Build won't run if Maven 3 not installed and M2_HOME properly set!." unless="use.maven"/>
+    </target>
+
     <target name="pre-init" depends="get-git-hash">
         <tstamp>
             <format property="build.date" pattern="yyyyMMdd"/>
@@ -533,7 +543,7 @@
     </target -->
 
     <!--  =====     Milestone Init     =====  -->
-    <target name="promote-init" depends="publish-init"> <!-- In order to promote need the settings from Publish-init too -->
+    <target name="promote-init" depends="publish-init,check-maven"> <!-- In order to promote need the settings from Publish-init too -->
         <!-- git.hash and build.time should already be set to the git hash and build date of the -->
         <!-- build being promoted - however, build.time is undefined (it is currently unused)                   -->
         <fail unless="git.hash"        message="git.hash doesn't exist and it should before we reach this point!"/>

--- a/etc/jenkins/antbuild.xml
+++ b/etc/jenkins/antbuild.xml
@@ -1,0 +1,376 @@
+<!--
+
+    Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0,
+    or the Eclipse Distribution License v. 1.0 which is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+
+    SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+-->
+
+<project name="misc" default="assemble-repos" basedir=".">
+    <target name="assemble-repos" depends="validate-ready-to-start, init, clear-p2-loc, populate-p2-site, publish-p2-child, regen-composite-site"/>
+    <target name="regen-existing" depends="validate-ready-to-start, init, publish-p2-child, regen-composite-site"/>
+
+    <target name="validate-ready-to-start">
+        <fail message="Missing '-Dtype='. Should be set to 'n' for 'nightly', 'm' for 'milestone' or 'r' for 'release'." unless="type"/>
+        <fail message="Missing '-Dversion='. Should be set to the build version (1.1.3, 2.0.2, etc)." unless="version"/>
+        <fail message="Missing '-Ddate='. Should be set to the build date (20100429, 20100504, etc)." unless="date"/>
+        <fail message="Missing '-Dhash='. Should be set to the hash from the git repo (65a0fd5, fe7adf4, etc)." unless="hash"/>
+        <!-- make sure milestone tag is set if an 'm' build -->
+        <condition property="milestone.ok">
+            <or>
+                <and>
+                   <equals arg1="${type}" arg2="m"/>
+                   <isset property="mtag"/>
+                </and>
+                <not>
+                   <equals arg1="${type}" arg2="m"/>
+                </not>
+            </or>
+        </condition>
+        <fail message="Missing '-Dmtag='. Should be set to the Milestone tag (M1, M2, ..., RC1, etc), when type is set to 'm'" unless="milestone.ok"/>
+        <!-- setup static properties, and validate build type -->
+        <property name="do.composite"           value="true"/>
+        <property name="build.root.dir"         value="/opt/public/rt/eclipselink"/>
+        <property name="eclipselink.releng.dir" value="${build.root.dir}/eclipselink.releng"/>
+        <property name="blddeps.dir"            value="/shared/rt/eclipselink/bld_deps/master"/>
+        <property name="p2.SDK.install.dir"     value="${blddeps.dir}/eclipse"/>
+        <property name="download.base.dir"      value="/home/data/httpd/download.eclipse.org/rt/eclipselink"/>
+        <property name="install.base.dir"       value="/home/data/httpd/download.eclipse.org/rt/eclipselink/nightly"/>
+        <property name="archived.download.base.dir" value="??/rt/eclipselink"/>
+        <condition property="type.ok">
+            <or>
+               <equals arg1="${type}" arg2="n"/>
+               <equals arg1="${type}" arg2="m"/>
+               <equals arg1="${type}" arg2="r"/>
+            </or>
+        </condition>
+        <fail message="Invalid '-Dtype='. Should be set to 'n' for 'nightly', 'm' for 'milestone' or 'r' for 'release'." unless="type.ok"/>
+        <!-- setup type dependent properties -->
+        <condition property="build.type"       value="nightly">
+            <equals arg1="${type}" arg2="n"/>
+        </condition>
+        <condition property="build.type"           value="milestone"
+                                                    else="release">
+            <equals arg1="${type}" arg2="m"/>
+        </condition>
+        <condition property="p2.composite.root.dir" value="/home/data/httpd/download.eclipse.org/rt/eclipselink/updates"
+                                                     else="/home/data/httpd/download.eclipse.org/rt/eclipselink/${build.type}-updates">
+            <equals arg1="${type}" arg2="r"/>
+        </condition>
+        <!-- setup version dependent properties -->
+        <property name="release.version"           value="${version}"/>
+        <!-- setup revision dependent properties -->
+        <property name="release.version"           value="${version}"/>
+        <property name="version.qualifier"          value="v${date}-${hash}"/>
+        <property name="version.string"             value="${release.version}.${version.qualifier}"/>
+        <property name="bundle.install.zip"         value="eclipselink-plugins-${version.string}.zip"/>
+        <property name="nosql.install.zip"          value="eclipselink-plugins-nosql-${version.string}.zip"/>
+        <property name="p2.archive.presigned.zip"   value="eclipselink-P2-${version.string}.zip"/>
+        <property name="p2.archive.signed.zip"      value="eclipselink-P2signed-${version.string}.zip"/>
+        <condition property="p2.repos.dir"          value="${p2.composite.root.dir}/${version.string}_${mtag}"
+                                                     else="${p2.composite.root.dir}/${version.string}">
+            <equals arg1="${type}" arg2="m"/>
+        </condition>
+        <!-- validate build version -->
+        <condition property="installer.dir"        value="${install.base.dir}/${version}">
+            <available file="${install.base.dir}/${version}" type="dir"/>
+        </condition>
+        <condition property="installer.dir"        value="${download.base.dir}/${build.type}s/${version}">
+            <available file="${download.base.dir}/${build.type}s/${version}" type="dir"/>
+        </condition>
+        <condition property="installer.dir"        value="${archived.download.base.dir}/${build.type}s/${version}">
+            <available file="${archived.download.base.dir}/${build.type}/${version}" type="dir"/>
+        </condition>
+        <fail message="Invalid '-Dversion='. Cannot find '${install.base.dir}/${version}' or '${download.base.dir}/${build.type}s/${version}' or '${archived.download.base.dir}/${build.type}/${version}' dir." unless="installer.dir"/>
+        <!-- validate mtag -->
+        <!--  condition property="mtag.ok">
+            <or>
+                <available file="${installer.dir}/${mtag}" type="dir"/>
+                <not>
+                   <equals arg1="${type}" arg2="m"/>
+                </not>
+            </or>
+        </condition>
+        <fail message="Invalid '-Dmtag='. Cannot find '${installer.dir}/${mtag}' dir." unless="mtag.ok"/ -->
+        <!-- validate build date and hash (qualifier) -->
+        <condition property="bundle.install.file"   value="${installer.dir}/${bundle.install.zip}">
+            <available file="${installer.dir}/${bundle.install.zip}"/>
+        </condition>
+        <condition property="bundle.install.file"   value="${installer.dir}/${mtag}/${bundle.install.zip}">
+            <available file="${installer.dir}/${mtag}/${bundle.install.zip}"/>
+        </condition>
+        <condition property="bundle.install.file"   value="${installer.dir}/${date}/${bundle.install.zip}">
+            <available file="${installer.dir}/${date}/${bundle.install.zip}"/>
+        </condition>
+        <fail message="Invalid '-Ddate=' or '-Dhash'. Cannot find '${bundle.install.zip}'." unless="bundle.install.file"/>
+        <!-- same for nosql -->
+        <condition property="nosql.install.file"   value="${installer.dir}/${nosql.install.zip}">
+            <available file="${installer.dir}/${nosql.install.zip}"/>
+        </condition>
+        <condition property="nosql.install.file"   value="${installer.dir}/${mtag}/${nosql.install.zip}">
+            <available file="${installer.dir}/${mtag}/${nosql.install.zip}"/>
+        </condition>
+        <condition property="nosql.install.file"   value="${installer.dir}/${date}/${nosql.install.zip}">
+            <available file="${installer.dir}/${date}/${nosql.install.zip}"/>
+        </condition>
+        <condition property="nosql.missing">
+            <and>
+                <not> <equals arg1="${version}" arg2="2.3.4"/> </not>
+                <not> <isset property="nosql.install.file"/> </not>
+            </and>
+        </condition>
+
+        <fail message="Invalid '-Ddate=' or '-Dhash'. Cannot find '${nosql.install.zip}'." if="nosql.missing"/>
+        <!-- assumes will be doing full p2 setup therefore probably from nightly loc -->
+        <condition property="p2.archive.zip"        value="${installer.dir}/${date}/${p2.archive.presigned.zip}"
+                                                     else="${installer.dir}/${date}/${p2.archive.signed.zip}">
+            <equals arg1="${build.type}" arg2="nightly"/>
+        </condition>
+    </target>
+
+    <target name="init" depends="validate-ready-to-start">
+        <property name="category.qualifier"       value="${version.string}"/>
+        <!-- Tool definitions -->
+        <property name="p2.SDK.plugin.dir"        value="${p2.SDK.install.dir}/plugins"/>
+        <property name="p2.publisher.jar"         value="org.eclipse.equinox.p2.publisher_*.jar"/>
+        <property name="p2.launcher.jar"          value="org.eclipse.equinox.launcher_*.jar"/>
+        <property name="p2.artifact.jar"          value="org.eclipse.equinox.artifact.repository_*.jar"/>
+        <property name="regen.composite.script"   value="${eclipselink.releng.dir}/buildCompositeP2.sh"/>
+        <!-- Input definitions -->
+        <property name="p2.mirror.dir"            value="${mirror}"/>
+        <property name="p2.feature.dir"           value="${p2.repos.dir}/features"/>
+        <property name="p2.bundle.dir"            value="${p2.repos.dir}/plugins"/>
+        <!-- Output definitions -->
+        <property name="p2.repos.url"             value="file:/${p2.repos.dir}"/> <!-- DO NOT Override this one -->
+        <property name="p2.mirror.url"            value="file:/${p2.mirror.dir}"/> <!-- DO NOT Override this one -->
+        <property name="p2.release.repos.name"    value="EclipseLink Repository"/>
+        <property name="p2.milestone.repos.name"  value="EclipseLink Milestone Repository"/>
+        <property name="p2.nightly.repos.name"    value="EclipseLink Nightly Build Repository"/>
+        <property name="p2.release.repos.url"     value="http://download.eclipse.org/rt/eclipselink/updates"/>
+        <property name="p2.milestone.repos.url"   value="http://download.eclipse.org/rt/eclipselink/incremental-updates/milestone"/>
+        <property name="p2.nightly.repos.url"     value="http://download.eclipse.org/rt/eclipselink/incremental-updates/nightly"/>
+        <condition property="p2.repos.name"       value="&quot;${p2.nightly.repos.name}&quot;">
+            <equals arg1="${type}" arg2="n"/>
+        </condition>
+        <condition property="p2.repos.name"       value="&quot;${p2.milestone.repos.name}&quot;"
+                                                  else="&quot;${p2.release.repos.name}&quot;">
+            <equals arg1="${type}" arg2="m"/>
+        </condition>
+
+        <echo message="ant.project.name       ='${ant.project.name}'"/>
+        <echo message="java.home              ='${java.home}'"/>
+        <echo message=" ---"/>
+        <echo message="release.version        ='${release.version}'"/>
+        <echo message="version.qualifier      ='${version.qualifier}'"/>
+        <echo message="version.string         ='${version.string}'"/>
+        <echo message="category.qualifier     ='${category.qualifier}'"/>
+        <echo message=" ---"/>
+        <echo message="bundle.install.file    ='${bundle.install.file}'"/>
+        <echo message="nosql.install.file     ='${nosql.install.file}'"/>
+        <echo message="p2.archive.zip         ='${p2.archive.zip}'"/>
+        <echo message=" ---"/>
+        <echo message="p2.SDK.install.dir     ='${p2.SDK.install.dir}'"/>
+        <echo message="p2.publisher.jar       ='${p2.publisher.jar}'"/>
+        <echo message="p2.launcher.jar        ='${p2.launcher.jar}'"/>
+        <echo message="regen.composite.script ='${regen.composite.script}'"/>
+        <echo message=" ---"/>
+        <echo message="p2.repos.dir           ='${p2.repos.dir}'"/>
+        <echo message="p2.repos.url           ='${p2.repos.url}'"/>
+        <echo message="p2.feature.dir         ='${p2.feature.dir}'"/>
+        <echo message="p2.bundle.dir          ='${p2.bundle.dir}'"/>
+        <echo message="build.root.dir         ='${build.root.dir}'"/>
+        <echo message="p2.composite.root.dir  ='${p2.composite.root.dir}'"/>
+        <echo message="p2.repos.name          ='${p2.repos.name}'"/>
+        <echo message="-----"/>
+        <echo message="source URL (p2.repos.url)       ='${p2.repos.url}'"/>
+        <echo message="destination dir (p2.mirror.dir) ='${p2.mirror.dir}'"/>
+        <echo message="destination URL (p2.mirror.url) ='${p2.mirror.url}'"/>
+        <echo message="destination name(p2.mirror.name)='${p2.mirror.name}'"/>
+        <echo message="-----"/>
+
+        <!-- Test for needed resources -->
+        <available file="${bundle.install.file}"    property="bundle.installer.exist"/>
+        <available file="${nosql.install.file}"     property="nosql.installer.exist"/>
+        <available file="${p2.SDK.plugin.dir}"      property="sdk.install.exist"/>
+        <available file="${regen.composite.script}" property="regen.script.exist"/>
+
+        <!-- Make sure necessary resources exist -->
+        <fail message="Error: '${p2.SDK.plugin.dir}' not found!" unless="sdk.install.exist"/>
+    </target>
+
+    <target name="test-ready-to-go">
+        <!-- This condition meaningless if p2.archive.zip already set -->
+        <condition property="p2.archive.zip" value="${p2.archive.presigned.zip}" else="foobar.error">
+            <available file="${p2.archive.presigned.zip}"/>
+        </condition>
+        <available file="${p2.archive.zip}" property="signing.archive.exist"/>
+        <condition property="ready-to-go">
+            <and>
+                <isset property="signing.archive.exist"/>
+                <isset property="bundle.installer.exist"/>
+                <not> <isset property="nosql.missing"/> </not>
+            </and>
+        </condition>
+    </target>
+
+    <target name="not-ready-to-go" unless="ready-to-go" depends="test-ready-to-go">
+        <fail message="Bundle Installer (${bundle.install.file}) or NoSQL Installer (${nosql.install.file}) or p2 archive (${p2.archive.zip})not found! Skipping P2 repos generation."/>
+    </target>
+
+    <target name="clear-p2-loc" if="ready-to-go" depends="not-ready-to-go">
+        <!-- Clean existing repos if it exists (should only be true of a release redo, or the latest milestone or nightly) -->
+        <delete dir="${p2.repos.dir}" failonerror="false"/>
+        <echo message="Test without cleaning repos first."/>
+    </target>
+
+    <target name="populate-p2-site" if="ready-to-go" depends="init">
+        <mkdir dir="${p2.bundle.dir}"/>
+        <mkdir dir="${p2.feature.dir}"/>
+        <!-- populate update site with feature and bundle jars -->
+        <unzip dest="${p2.bundle.dir}" src="${bundle.install.file}">
+            <patternset>
+                <include name="**/*.jar"/>
+            </patternset>
+        </unzip>
+        <unzip dest="${p2.bundle.dir}" src="${nosql.install.file}">
+            <patternset>
+                <include name="**/*.jar"/>
+            </patternset>
+        </unzip>
+        <!-- Remove jars we are not including in features at this time (needs to be separate because exclude in unzip does not seem to work) -->
+        <delete>
+            <fileset
+                dir="${p2.bundle.dir}"
+                includes="
+                          *jms*.jar,
+                          com.sun*.jar,
+                          eclipselink*.jar,
+                          *ejb*.jar,
+                          javax.persistence*_1.*.jar,
+                          *preview*.jar,
+                          *javax.resource*.jar,
+                          *javax.transaction*.jar,
+                          javax.xml.bind.source*.jar,
+                          *modelgen*.jar,
+                          *soap*.jar,
+                          *xml.ws*.jar,
+                          *jpars*.jar"
+            />
+        </delete>
+        <unzip dest="${p2.feature.dir}" src="${p2.archive.zip}">
+            <patternset>
+                <include name="features/*.jar"/>
+            </patternset>
+            <mapper type="flatten"/>
+        </unzip>
+    </target>
+
+    <target name="publish-p2-child" if="do.composite">
+        <echo message="java.home        ='${java.home}'"/>
+        <echo message="p2.SDK.plugin.dir='${p2.SDK.plugin.dir}'"/>
+        <echo message="p2.launcher.jar  ='${p2.launcher.jar}'"/>
+        <echo message="p2.publisher.jar ='${p2.publisher.jar}'"/>
+        <echo message="-----"/>
+        <echo message="p2.repos.dir     ='${p2.repos.dir}'"/>
+        <echo message="p2.repos.url     ='${p2.repos.url}'"/>
+        <!-- Metadata generator apparently doesn't rebuild the artifact and content xml files if they already exist -->
+        <mkdir dir="${p2.repos.dir}"/>
+        <delete  failonerror="false">
+            <fileset dir="${p2.repos.dir}" includes="artifact*.*, content*.*"/>
+        </delete>
+        <java classname="org.eclipse.equinox.launcher.Main" fork="true" timeout="10800000" taskname="p2"
+            jvm="${java.home}/bin/java" failonerror="false" maxmemory="256m">
+            <classpath>
+                <fileset dir="${p2.SDK.plugin.dir}"
+                    includes="${p2.launcher.jar},
+                              ${p2.publisher.jar}"/>
+                <pathelement location="${p2.SDK.plugin.dir}" />
+            </classpath>
+            <arg line=" -application org.eclipse.equinox.p2.publisher.FeaturesAndBundlesPublisher" />
+            <arg line=" -metadataRepository ${p2.repos.url}" />
+            <arg line=" -artifactRepository ${p2.repos.url}" />
+            <arg line=" -source ${p2.repos.dir}" />
+            <arg line=" -compress -publishArtifacts -configs all" />
+        </java>
+    </target>
+
+    <target name="no-script-warning" unless="regen.script.exist" depends="init">
+        <echo message="Warning: Composite won't be generated."/>
+        <echo message="         '${regen.composite.script}' not found!"/>
+    </target>
+
+    <target name="regen-composite-site" if="regen.script.exist" depends="no-script-warning">
+        <chmod file="${regen.composite.script}" perm="ug+x"/>
+        <!-- Regenerate Composite Repos metadata -->
+        <echo message="regen.composite.script='${regen.composite.script}'"/>
+        <echo message="p2.composite.root.dir ='${p2.composite.root.dir}'"/>
+        <echo message="p2.repos.name         ='${p2.repos.name}'"/>
+        <exec executable="/bin/sh" failonerror="false" logError="true" >
+            <arg value="${regen.composite.script}"/>
+            <arg value="${p2.composite.root.dir}"/>
+            <arg value="${p2.repos.name}"/>
+        </exec>
+    </target>
+
+    <target name="test-mirror-ready-to-go">
+        <condition property="mirror-ready-to-go">
+            <and>
+                <isset property="p2.mirror.dir"/>
+                <isset property="p2.mirror.name"/>
+            </and>
+        </condition>
+    </target>
+
+    <target name="mirror-p2-repos" if="mirror-ready-to-go" depends="init, test-mirror-ready-to-go">
+        <property name="p2.mirror.name" value="EclipseLink build ${version.string} Repository"/>
+        <echo message="java.home        ='${java.home}'"/>
+        <echo message="p2.SDK.plugin.dir='${p2.SDK.plugin.dir}'"/>
+        <echo message="p2.launcher.jar  ='${p2.launcher.jar}'"/>
+        <echo message="p2.publisher.jar ='${p2.publisher.jar}'"/>
+        <echo message="-----"/>
+        <echo message="source URL (p2.repos.url)       ='${p2.repos.url}'"/>
+        <echo message="destination dir (p2.mirror.dir) ='${p2.mirror.dir}'"/>
+        <echo message="destination URL (p2.mirror.url) ='${p2.mirror.url}'"/>
+        <echo message="destination name(p2.mirror.name)='${p2.mirror.name}'"/>
+        <echo message="-----"/>
+        <!-- Metadata generator apparently doesn't rebuild the artifact and content xml files if they already exist -->
+        <mkdir dir="${p2.mirror.dir}"/>
+        <delete  failonerror="false">
+            <fileset dir="${p2.mirror.dir}" includes="artifact*.*, content*.*"/>
+        </delete>
+        <java classname="org.eclipse.equinox.launcher.Main" fork="true" timeout="10800000" taskname="p2.M.mirror"
+            jvm="${java.home}/bin/java" failonerror="false" maxmemory="256m">
+            <classpath>
+                <fileset dir="${p2.SDK.plugin.dir}"
+                    includes="${p2.launcher.jar},
+                              ${p2.artifact.jar}"/>
+                <pathelement location="${p2.SDK.plugin.dir}" />
+            </classpath>
+            <arg line=" -application org.eclipse.equinox.p2.metadata.repository.mirrorApplication" />
+            <arg line=" -source ${p2.repos.url}" />
+            <arg line=" -destination ${p2.mirror.url}" />
+            <arg line=" -destinationName '${p2.mirror.name}'" />
+        </java>
+        <java classname="org.eclipse.equinox.launcher.Main" fork="true" timeout="10800000" taskname="p2.A.mirror"
+            jvm="${java.home}/bin/java" failonerror="false" maxmemory="256m">
+            <classpath>
+                <fileset dir="${p2.SDK.plugin.dir}"
+                    includes="${p2.launcher.jar},
+                              ${p2.artifact.jar}"/>
+                <pathelement location="${p2.SDK.plugin.dir}" />
+            </classpath>
+            <arg line=" -application org.eclipse.equinox.p2.artifact.repository.mirrorApplication" />
+            <arg line=" -source ${p2.repos.url}" />
+            <arg line=" -destination ${p2.mirror.url}" />
+            <arg line=" -destinationName '${p2.mirror.name}'" />
+            <arg line=" -verbose -raw" />
+        </java>
+    </target>
+
+</project>

--- a/etc/jenkins/antbuild.xml
+++ b/etc/jenkins/antbuild.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at

--- a/etc/jenkins/build.groovy
+++ b/etc/jenkins/build.groovy
@@ -1,0 +1,142 @@
+// Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Distribution License v. 1.0, which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+// Job input parameters (passed from Properties Content field from Jenkins job):
+//  GIT_REPOSITORY_URL          - Git repository location (URL)
+//  GIT_BRANCH                  - Git branch
+//  SSH_CREDENTIALS_ID          - SSH credentials is used to access Git repository at the GitHub
+//  BUILD_RESULTS_TARGET_DIR    - Location in the projects-storage.eclipse.org server for nightly builds (jar files)
+//  TEST_RESULTS_TARGET_DIR     - Location in the projects-storage.eclipse.org server for nightly builds (test results)
+//  TEST_DB_URL                 - Test database URL
+//  TEST_DB_USERNAME            - Test database username
+//  TEST_DB_PASSWORD            - Test databse password
+//  CONTINUOUS_BUILD            - false - full nightly build with LRG and server tests and nightly build publish
+//                                true - continuous build with SRG tests without publishing nightly build results
+
+
+pipeline {
+    agent {
+        kubernetes {
+            label 'el-master-agent-pod'
+            yaml """
+apiVersion: v1
+kind: Pod
+spec:
+
+  volumes:
+  - name: tools
+    persistentVolumeClaim:
+      claimName: tools-claim-jiro-eclipselink
+  - name: volume-known-hosts
+    configMap:
+      name: known-hosts      
+  - name: settings-xml
+    secret:
+      secretName: m2-secret-dir
+      items:
+      - key: settings.xml
+        path: settings.xml
+  - name: toolchains-xml
+    configMap:
+      name: m2-dir
+      items:
+      - key: toolchains.xml
+        path: toolchains.xml
+  - name: settings-security-xml
+    secret:
+      secretName: m2-secret-dir
+      items:
+      - key: settings-security.xml
+        path: settings-security.xml
+  - name: m2-repo
+    emptyDir: {}
+    
+  containers:
+
+  - name: el-build
+    resources:
+      limits:
+        memory: "6Gi"
+        cpu: "4"
+      requests:
+        memory: "6Gi"
+        cpu: "4"
+    image: tkraus/el-build:1.1.5
+    volumeMounts:
+    - name: tools
+      mountPath: /opt/tools
+    - name: volume-known-hosts
+      mountPath: /home/jenkins/.ssh      
+    - name: settings-xml
+      mountPath: /home/jenkins/.m2/settings.xml
+      subPath: settings.xml
+      readOnly: true
+    - name: toolchains-xml
+      mountPath: /home/jenkins/.m2/toolchains.xml
+      subPath: toolchains.xml
+      readOnly: true
+    - name: settings-security-xml
+      mountPath: /home/jenkins/.m2/settings-security.xml
+      subPath: settings-security.xml
+      readOnly: true
+    - name: m2-repo
+      mountPath: /home/jenkins/.m2/repository
+    tty: true
+    command:
+    - cat
+"""
+        }
+    }
+    stages {
+        // Initialize build environment
+        stage('Init') {
+            steps {
+                container('el-build') {
+                    git branch: '${GIT_BRANCH}', url: '${GIT_REPOSITORY_URL}'
+                    sshagent(['SSH_CREDENTIALS_ID']) {
+                        sh """
+                            etc/jenkins/init.sh
+                            """
+                    }
+                    withCredentials([file(credentialsId: 'secret-subkeys.asc', variable: 'KEYRING')]) {
+                        sh label: '', script: '''
+                            gpg --batch --import "${KEYRING}"
+                            for fpr in $(gpg --list-keys --with-colons  | awk -F: \'/fpr:/ {print $10}\' | sort -u);
+                            do
+                                echo -e "5\\ny\\n" |  gpg --batch --command-fd 0 --expert --edit-key $fpr trust;
+                            done'''
+                    }
+                }
+            }
+        }
+        // Build
+        stage('Build') {
+            steps {
+                container('el-build') {
+                    sshagent(['SSH_CREDENTIALS_ID']) {
+                        sh """
+                            etc/jenkins/build.sh
+                        """
+                    }
+                }
+            }
+        }
+        // Publish to nightly
+        stage('Publish to nightly') {
+            steps {
+                container('el-build') {
+                    sshagent(['projects-storage.eclipse.org-bot-ssh']) {
+                        sh """
+                            etc/jenkins/publish_nightly.sh
+                            """
+                    }
+                }
+            }
+        }
+    }
+}

--- a/etc/jenkins/build.groovy
+++ b/etc/jenkins/build.groovy
@@ -158,7 +158,7 @@ spec:
         // Proceed test results - rest of test results without JPQL
         stage('Proceed test results - target dir') {
             steps {
-                junit '/home/jenkins/test.reports/target/TESTS-TestSuites.xml'
+                junit allowEmptyResults: true, testResults: '/home/jenkins/test.reports/target/TESTS-TestSuites.xml'
             }
         }
         // Publish to nightly

--- a/etc/jenkins/build.groovy
+++ b/etc/jenkins/build.groovy
@@ -133,10 +133,13 @@ spec:
                 container('el-build') {
                     sshagent(['SSH_CREDENTIALS_ID']) {
                         sh """
+                            #Move JPA.JPQL test report into another location to collect it in this pipeline stage only
                             if [ -f "jpa/org.eclipse.persistence.jpa.jpql.test/reports/TESTS-TestSuites.xml" ]; then
                                 mkdir -p ${HOME}/test.reports/jpa.jpql
                                 mv jpa/org.eclipse.persistence.jpa.jpql.test/reports/TESTS-TestSuites.xml ${HOME}/test.reports/jpa.jpql
                             fi
+                            #Move aggregated test report into another location. It duplicated with modules test reports.
+                            mv target/reports/TESTS-TestSuites.xml ${HOME}/test.reports/                            
                         """
                     }
                 }

--- a/etc/jenkins/build.groovy
+++ b/etc/jenkins/build.groovy
@@ -138,7 +138,7 @@ spec:
                         """
                     }
                 }
-                junit '/home/jenkins/test.reports/jpa.jpql/TESTS-TestSuites.xml'
+                junit allowEmptyResults: true, testResults: '/home/jenkins/test.reports/jpa.jpql/TESTS-TestSuites.xml'
             }
         }
         // Proceed test results - rest of test results without JPQL

--- a/etc/jenkins/build.groovy
+++ b/etc/jenkins/build.groovy
@@ -126,8 +126,23 @@ spec:
                 }
             }
         }
-        // Proceed test results
-        stage('Proceed test results') {
+        //Test results process is divided there into two steps due bug "java.nio.channels.ClosedChannelException" in Eclipse.org cloud environment
+        // Proceed test results - JPQL only
+        stage('Proceed test results - JPA.JPQL') {
+            steps {
+                container('el-build') {
+                    sshagent(['SSH_CREDENTIALS_ID']) {
+                        sh """
+                            mkdir -p ${HOME}/test.reports/jpa.jpql
+                            mv jpa/org.eclipse.persistence.jpa.jpql.test/reports/TESTS-TestSuites.xml ${HOME}/test.reports/jpa.jpql
+                        """
+                    }
+                }
+                junit '${HOME}/test.reports/jpa.jpql/TESTS-TestSuites.xml'
+            }
+        }
+        // Proceed test results - rest of test results without JPQL
+        stage('Proceed test results - without JPA.JPQL') {
             steps {
                 junit '**/reports/**/TESTS-TestSuites.xml'
             }

--- a/etc/jenkins/build.groovy
+++ b/etc/jenkins/build.groovy
@@ -129,7 +129,7 @@ spec:
         // Proceed test results
         stage('Proceed test results') {
             steps {
-                junit 'reports/**/TESTS-TestSuites.xml'
+                junit '**/reports/**/TESTS-TestSuites.xml'
             }
         }
         // Publish to nightly

--- a/etc/jenkins/build.groovy
+++ b/etc/jenkins/build.groovy
@@ -133,8 +133,10 @@ spec:
                 container('el-build') {
                     sshagent(['SSH_CREDENTIALS_ID']) {
                         sh """
-                            mkdir -p ${HOME}/test.reports/jpa.jpql
-                            mv jpa/org.eclipse.persistence.jpa.jpql.test/reports/TESTS-TestSuites.xml ${HOME}/test.reports/jpa.jpql
+                            if [ -f "jpa/org.eclipse.persistence.jpa.jpql.test/reports/TESTS-TestSuites.xml" ]; then
+                                mkdir -p ${HOME}/test.reports/jpa.jpql
+                                mv jpa/org.eclipse.persistence.jpa.jpql.test/reports/TESTS-TestSuites.xml ${HOME}/test.reports/jpa.jpql
+                            fi
                         """
                     }
                 }

--- a/etc/jenkins/build.groovy
+++ b/etc/jenkins/build.groovy
@@ -66,7 +66,7 @@ spec:
       requests:
         memory: "6Gi"
         cpu: "4"
-    image: tkraus/el-build:1.1.7
+    image: tkraus/el-build:1.1.8
     volumeMounts:
     - name: tools
       mountPath: /opt/tools

--- a/etc/jenkins/build.groovy
+++ b/etc/jenkins/build.groovy
@@ -140,8 +140,8 @@ spec:
                             fi
                             #Move aggregated test report into another location. It duplicated with modules test reports.
                             if [ -f "target/reports/TESTS-TestSuites.xml" ]; then
-                                mkdir -p ${HOME}/test.reports
-                                mv target/reports/TESTS-TestSuites.xml ${HOME}/test.reports/
+                                mkdir -p ${HOME}/test.reports/target
+                                mv target/reports/TESTS-TestSuites.xml ${HOME}/test.reports/target
                             fi                            
                         """
                     }
@@ -153,6 +153,12 @@ spec:
         stage('Proceed test results - without JPA.JPQL') {
             steps {
                 junit '**/reports/**/TESTS-TestSuites.xml'
+            }
+        }
+        // Proceed test results - rest of test results without JPQL
+        stage('Proceed test results - target dir') {
+            steps {
+                junit '/home/jenkins/test.reports/target/TESTS-TestSuites.xml'
             }
         }
         // Publish to nightly

--- a/etc/jenkins/build.groovy
+++ b/etc/jenkins/build.groovy
@@ -66,7 +66,7 @@ spec:
       requests:
         memory: "6Gi"
         cpu: "4"
-    image: tkraus/el-build:1.1.5
+    image: tkraus/el-build:1.1.7
     volumeMounts:
     - name: tools
       mountPath: /opt/tools

--- a/etc/jenkins/build.groovy
+++ b/etc/jenkins/build.groovy
@@ -138,7 +138,7 @@ spec:
                         """
                     }
                 }
-                junit '${HOME}/test.reports/jpa.jpql/TESTS-TestSuites.xml'
+                junit '/home/jenkins/test.reports/jpa.jpql/TESTS-TestSuites.xml'
             }
         }
         // Proceed test results - rest of test results without JPQL

--- a/etc/jenkins/build.groovy
+++ b/etc/jenkins/build.groovy
@@ -126,6 +126,12 @@ spec:
                 }
             }
         }
+        // Proceed test results
+        stage('Proceed test results') {
+            steps {
+                junit 'reports/**/TESTS-TestSuites.xml'
+            }
+        }
         // Publish to nightly
         stage('Publish to nightly') {
             steps {

--- a/etc/jenkins/build.groovy
+++ b/etc/jenkins/build.groovy
@@ -139,7 +139,10 @@ spec:
                                 mv jpa/org.eclipse.persistence.jpa.jpql.test/reports/TESTS-TestSuites.xml ${HOME}/test.reports/jpa.jpql
                             fi
                             #Move aggregated test report into another location. It duplicated with modules test reports.
-                            mv target/reports/TESTS-TestSuites.xml ${HOME}/test.reports/                            
+                            if [ -f "target/reports/TESTS-TestSuites.xml" ]; then
+                                mkdir -p ${HOME}/test.reports
+                                mv target/reports/TESTS-TestSuites.xml ${HOME}/test.reports/
+                            fi                            
                         """
                     }
                 }

--- a/etc/jenkins/build.sh
+++ b/etc/jenkins/build.sh
@@ -22,9 +22,8 @@ else
     ANT_TARGET=build-nightly
 fi
 
-export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.222.b10-0.fc30.x86_64/
 export ANT_OPTS=-Xmx4G
 set -o pipefail
-ant -f autobuild.xml ${ANT_TARGET} -DJAVA_HOME=${JAVA_HOME} -DM2_HOME=/opt/java/maven -Djdbc.driver.jar=${HOME}/extension.lib.external/mysql-connector-java-5.1.48.jar -Ddb.url=${TEST_DB_URL} -Ddb.user=${TEST_DB_USERNAME} -Ddb.pwd=${TEST_DB_PASSWORD} -Dextensions.depend.dir=${HOME}/extension.lib.external -Djunit.lib=${HOME}/extension.lib.external/junit-4.12.jar:${HOME}/extension.lib.external/hamcrest-core-1.3.jar:${HOME}/extension.lib.external/jmockit-1.35.jar -Dhudson.workspace=${WORKSPACE} -Dtest.logging.level=INFO -Dfail.on.error=true
+ant -f autobuild.xml ${ANT_TARGET} -Denv.JAVA_HOME=${JAVA_HOME} -DM2_HOME=/opt/java/maven -Djdbc.driver.jar=${HOME}/extension.lib.external/mysql-connector-java-5.1.48.jar -Ddb.url=${TEST_DB_URL} -Ddb.user=${TEST_DB_USERNAME} -Ddb.pwd=${TEST_DB_PASSWORD} -Dextensions.depend.dir=${HOME}/extension.lib.external -Djunit.lib=${HOME}/extension.lib.external/junit-4.12.jar:${HOME}/extension.lib.external/hamcrest-core-1.3.jar:${HOME}/extension.lib.external/jmockit-1.35.jar -Dhudson.workspace=${WORKSPACE} -Dtest.logging.level=INFO -Dfail.on.error=true
 
 /opt/bin/mysql-stop.sh

--- a/etc/jenkins/build.sh
+++ b/etc/jenkins/build.sh
@@ -22,8 +22,9 @@ else
     ANT_TARGET=build-nightly
 fi
 
+export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.222.b10-0.fc30.x86_64/
 export ANT_OPTS=-Xmx4G
 set -o pipefail
-ant -f autobuild.xml $ANT_TARGET -DM2_HOME=/opt/java/maven -Djdbc.driver.jar=$HOME/extension.lib.external/mysql-connector-java-5.1.48.jar -Ddb.url=$TEST_DB_URL -Ddb.user=$TEST_DB_USERNAME -Ddb.pwd=$TEST_DB_PASSWORD -Dextensions.depend.dir=$HOME/extension.lib.external -Djunit.lib=$HOME/extension.lib.external/junit-4.12.jar:$HOME/extension.lib.external/hamcrest-core-1.3.jar:$HOME/extension.lib.external/jmockit-1.35.jar -Dhudson.workspace=$WORKSPACE -Dtest.logging.level=INFO -Dfail.on.error=true
+ant -f autobuild.xml ${ANT_TARGET} -DJAVA_HOME=${JAVA_HOME} -DM2_HOME=/opt/java/maven -Djdbc.driver.jar=${HOME}/extension.lib.external/mysql-connector-java-5.1.48.jar -Ddb.url=${TEST_DB_URL} -Ddb.user=${TEST_DB_USERNAME} -Ddb.pwd=${TEST_DB_PASSWORD} -Dextensions.depend.dir=${HOME}/extension.lib.external -Djunit.lib=${HOME}/extension.lib.external/junit-4.12.jar:${HOME}/extension.lib.external/hamcrest-core-1.3.jar:${HOME}/extension.lib.external/jmockit-1.35.jar -Dhudson.workspace=${WORKSPACE} -Dtest.logging.level=INFO -Dfail.on.error=true
 
 /opt/bin/mysql-stop.sh

--- a/etc/jenkins/build.sh
+++ b/etc/jenkins/build.sh
@@ -1,0 +1,29 @@
+#!/bin/bash -e
+#
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Distribution License v. 1.0, which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+#
+# Arguments:
+#  N/A
+
+echo '-[ EclipseLink Build ]-----------------------------------------------------------'
+. /etc/profile
+/opt/bin/mysql-start.sh
+
+if [ ${CONTINUOUS_BUILD} = "true" ]; then
+    ANT_TARGET=build-continuous
+else
+    ANT_TARGET=build-nightly
+fi
+
+export ANT_OPTS=-Xmx4G
+set -o pipefail
+ant -f autobuild.xml $ANT_TARGET -DM2_HOME=/opt/java/maven -Djdbc.driver.jar=$HOME/extension.lib.external/mysql-connector-java-5.1.48.jar -Ddb.url=$TEST_DB_URL -Ddb.user=$TEST_DB_USERNAME -Ddb.pwd=$TEST_DB_PASSWORD -Dextensions.depend.dir=$HOME/extension.lib.external -Djunit.lib=$HOME/extension.lib.external/junit-4.12.jar:$HOME/extension.lib.external/hamcrest-core-1.3.jar:$HOME/extension.lib.external/jmockit-1.35.jar -Dhudson.workspace=$WORKSPACE -Dtest.logging.level=INFO -Dfail.on.error=true
+
+/opt/bin/mysql-stop.sh

--- a/etc/jenkins/build.sh
+++ b/etc/jenkins/build.sh
@@ -24,6 +24,6 @@ fi
 
 export ANT_OPTS=-Xmx4G
 set -o pipefail
-ant -f autobuild.xml ${ANT_TARGET} -Denv.JAVA_HOME=${JAVA_HOME} -DM2_HOME=/opt/java/maven -Djdbc.driver.jar=${HOME}/extension.lib.external/mysql-connector-java-5.1.48.jar -Ddb.url=${TEST_DB_URL} -Ddb.user=${TEST_DB_USERNAME} -Ddb.pwd=${TEST_DB_PASSWORD} -Dextensions.depend.dir=${HOME}/extension.lib.external -Djunit.lib=${HOME}/extension.lib.external/junit-4.12.jar:${HOME}/extension.lib.external/hamcrest-core-1.3.jar:${HOME}/extension.lib.external/jmockit-1.35.jar -Dhudson.workspace=${WORKSPACE} -Dtest.logging.level=INFO -Dfail.on.error=true
+ant -f autobuild.xml ${ANT_TARGET} -Denv.JAVA_HOME=${JAVA_HOME} -DM2_HOME=${HOME}/extension.lib.external/apache-maven-3.6.0 -Djdbc.driver.jar=${HOME}/extension.lib.external/mysql-connector-java-5.1.48.jar -Ddb.url=${TEST_DB_URL} -Ddb.user=${TEST_DB_USERNAME} -Ddb.pwd=${TEST_DB_PASSWORD} -Dextensions.depend.dir=${HOME}/extension.lib.external -Djunit.lib=${HOME}/extension.lib.external/junit-4.12.jar:${HOME}/extension.lib.external/hamcrest-core-1.3.jar:${HOME}/extension.lib.external/jmockit-1.35.jar -Dhudson.workspace=${WORKSPACE} -Dtest.logging.level=INFO -Dfail.on.error=true
 
 /opt/bin/mysql-stop.sh

--- a/etc/jenkins/init.sh
+++ b/etc/jenkins/init.sh
@@ -1,0 +1,50 @@
+#!/bin/bash -e
+#
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Distribution License v. 1.0, which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+#
+# Arguments:
+#  N/A
+
+echo '-[ EclipseLink Init ]-----------------------------------------------------------'
+
+mkdir -p $HOME/extension.lib.external/mavenant
+
+#DOWNLOAD SOME DEPENDENCIES
+wget -nc http://repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar -O $HOME/extension.lib.external/junit-4.12.jar
+wget -nc http://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar -O $HOME/extension.lib.external/hamcrest-core-1.3.jar
+wget -nc http://repo1.maven.org/maven2/org/jmockit/jmockit/1.35/jmockit-1.35.jar -O $HOME/extension.lib.external/jmockit-1.35.jar
+wget -nc http://repo1.maven.org/maven2/org/hibernate/validator/hibernate-validator/6.0.7.Final/hibernate-validator-6.0.7.Final.jar -O $HOME/extension.lib.external/hibernate-validator-6.0.7.Final.jar
+wget -nc http://repo1.maven.org/maven2/org/jboss/logging/jboss-logging/3.3.0.Final/jboss-logging-3.3.0.Final.jar -O $HOME/extension.lib.external/jboss-logging-3.3.0.Final.jar
+wget -nc http://repo1.maven.org/maven2/org/glassfish/javax.el/3.0.1-b08/javax.el-3.0.1-b08.jar -O $HOME/extension.lib.external/javax.el-3.0.1-b08.jar
+wget -nc http://repo1.maven.org/maven2/com/fasterxml/classmate/1.3.1/classmate-1.3.1.jar -O $HOME/extension.lib.external/classmate-1.3.1.jar
+wget -nc http://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.48/mysql-connector-java-5.1.48.jar -O $HOME/extension.lib.external/mysql-connector-java-5.1.48.jar
+wget -nc https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.tar.gz -O $HOME/extension.lib.external/apache-ant-1.10.5-bin.tar.gz
+wget -nc http://archive.apache.org/dist/maven/ant-tasks/2.1.3/binaries/maven-ant-tasks-2.1.3.jar -O $HOME/extension.lib.external/mavenant/maven-ant-tasks-2.1.3.jar
+wget -nc http://download.jboss.org/wildfly/15.0.1.Final/wildfly-15.0.1.Final.tar.gz -O $HOME/extension.lib.external/wildfly-15.0.1.Final.tar.gz
+wget -nc https://download.eclipse.org/eclipse/downloads/drops4/R-4.10-201812060815/eclipse-SDK-4.10-linux-gtk-x86_64.tar.gz -O $HOME/extension.lib.external/eclipse-SDK-4.10-linux-gtk-x86_64.tar.gz
+
+#UNPACK SOME  DEPENDENCIES
+tar -x -z -C $HOME/extension.lib.external -f $HOME/extension.lib.external/wildfly-15.0.1.Final.tar.gz
+tar -x -z -C $HOME/extension.lib.external -f $HOME/extension.lib.external/eclipse-SDK-4.10-linux-gtk-x86_64.tar.gz
+
+#PREPARE build.properties FILE
+echo "extensions.depend.dir=$HOME/extension.lib.external" >> $HOME/build.properties
+echo "junit.lib=$HOME/extension.lib.external/junit-4.12.jar:$HOME/extension.lib.external/hamcrest-core-1.3.jar" >> $HOME/build.properties
+echo 'jdbc.driver.jar=$HOME/extension.lib.external/mysql-connector-java-5.1.48.jar' >> $HOME/build.properties
+echo 'db.driver=com.mysql.jdbc.Driver' >> $HOME/build.properties
+echo "db.url=$TEST_DB_URL" >> $HOME/build.properties
+echo "db.user=$TEST_DB_USERNAME" >> $HOME/build.properties
+echo "db.pwd=$TEST_DB_PASSWORD" >> $HOME/build.properties
+echo 'db.platform=org.eclipse.persistence.platform.database.MySQLPlatform' >> $HOME/build.properties
+echo 'eclipse.install.dir=$HOME/extension.lib.external/eclipse' >> $HOME/build.properties
+echo 'server.name=wildfly' >> $HOME/build.properties
+echo "wildfly.home=$HOME/extension.lib.external/wildfly-15.0.1.Final" >> $HOME/build.properties
+echo 'wildfly.config=standalone-full.xml' >> $HOME/build.properties
+echo hudson.workspace=$WORKSPACE

--- a/etc/jenkins/init.sh
+++ b/etc/jenkins/init.sh
@@ -29,10 +29,12 @@ wget -nc https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.7-bin.tar.
 wget -nc http://archive.apache.org/dist/maven/ant-tasks/2.1.3/binaries/maven-ant-tasks-2.1.3.jar -O $HOME/extension.lib.external/mavenant/maven-ant-tasks-2.1.3.jar
 wget -nc http://download.jboss.org/wildfly/15.0.1.Final/wildfly-15.0.1.Final.tar.gz -O $HOME/extension.lib.external/wildfly-15.0.1.Final.tar.gz
 wget -nc https://download.eclipse.org/eclipse/downloads/drops4/R-4.10-201812060815/eclipse-SDK-4.10-linux-gtk-x86_64.tar.gz -O $HOME/extension.lib.external/eclipse-SDK-4.10-linux-gtk-x86_64.tar.gz
+wget -nc https://archive.apache.org/dist/maven/maven-3/3.6.0/binaries/apache-maven-3.6.0-bin.tar.gz -O $HOME/extension.lib.external/apache-maven-3.6.0-bin.tar.gz
 
 #UNPACK SOME  DEPENDENCIES
 tar -x -z -C $HOME/extension.lib.external -f $HOME/extension.lib.external/wildfly-15.0.1.Final.tar.gz
 tar -x -z -C $HOME/extension.lib.external -f $HOME/extension.lib.external/eclipse-SDK-4.10-linux-gtk-x86_64.tar.gz
+tar -x -z -C $HOME/extension.lib.external -f $HOME/extension.lib.external/apache-maven-3.6.0-bin.tar.gz
 
 #PREPARE build.properties FILE
 echo "extensions.depend.dir=$HOME/extension.lib.external" >> $HOME/build.properties

--- a/etc/jenkins/init.sh
+++ b/etc/jenkins/init.sh
@@ -25,7 +25,7 @@ wget -nc http://repo1.maven.org/maven2/org/jboss/logging/jboss-logging/3.3.0.Fin
 wget -nc http://repo1.maven.org/maven2/org/glassfish/javax.el/3.0.1-b08/javax.el-3.0.1-b08.jar -O $HOME/extension.lib.external/javax.el-3.0.1-b08.jar
 wget -nc http://repo1.maven.org/maven2/com/fasterxml/classmate/1.3.1/classmate-1.3.1.jar -O $HOME/extension.lib.external/classmate-1.3.1.jar
 wget -nc http://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.48/mysql-connector-java-5.1.48.jar -O $HOME/extension.lib.external/mysql-connector-java-5.1.48.jar
-wget -nc https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.tar.gz -O $HOME/extension.lib.external/apache-ant-1.10.5-bin.tar.gz
+wget -nc https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.7-bin.tar.gz -O $HOME/extension.lib.external/apache-ant-1.10.7-bin.tar.gz
 wget -nc http://archive.apache.org/dist/maven/ant-tasks/2.1.3/binaries/maven-ant-tasks-2.1.3.jar -O $HOME/extension.lib.external/mavenant/maven-ant-tasks-2.1.3.jar
 wget -nc http://download.jboss.org/wildfly/15.0.1.Final/wildfly-15.0.1.Final.tar.gz -O $HOME/extension.lib.external/wildfly-15.0.1.Final.tar.gz
 wget -nc https://download.eclipse.org/eclipse/downloads/drops4/R-4.10-201812060815/eclipse-SDK-4.10-linux-gtk-x86_64.tar.gz -O $HOME/extension.lib.external/eclipse-SDK-4.10-linux-gtk-x86_64.tar.gz

--- a/etc/jenkins/noSign.sh
+++ b/etc/jenkins/noSign.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#****************************************************************************************
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+# which accompanies this distribution.
+#
+# The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+# and the Eclipse Distribution License is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+# Contributors:
+#  - Radek Felcman - 26 August 2019 - Initial implementation
+#****************************************************************************************
+
+#----------------------------------------------------------------------------------------
+#    This script is there to handle/copy jar files to similar directory like sign.sh script.
+#    It's called by promote.sh script if jar signing is not enabled by parameter (default state).
+#----------------------------------------------------------------------------------------
+
+
+PRESIGNED_ZIP=$1
+SIGNED_OUTPUT=$3
+
+rm -rf presign_jars signed_jars $SIGNED_OUTPUT
+
+#extracting presigned zip
+unzip -q $PRESIGNED_ZIP -d presign_jars
+find presign_jars -type d |sed 's/presign_jars/signed_jars/g' |xargs mkdir -p
+
+#not signing the jars just copy them to the output directory
+for j in `find presign_jars -type f -name "*.jar"`
+do
+    echo "copying $j ..."
+    signed_jar=`echo $j |sed 's/presign_jars/signed_jars/g'`
+    cp ${j} ${signed_jar}
+done
+
+mkdir -p $SIGNED_OUTPUT
+cd signed_jars
+zip -q -r ../${SIGNED_OUTPUT}/${PRESIGNED_ZIP} *

--- a/etc/jenkins/pom.xml
+++ b/etc/jenkins/pom.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0,
+    or the Eclipse Distribution License v. 1.0 which is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+
+    SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+-->
+
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <url>http://www.eclipse.org/eclipselink/</url>
+    <name>EclipseLink Maven POM example</name>
+    <groupId>org.eclipse.persistence</groupId>
+    <artifactId>eclipselinkMavenTest</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <eclipselink.version>2.5.0</eclipselink.version>
+    </properties>
+
+    <!-- As of the 2.5.0 release, EclipseLink artifacts are available on Maven Central
+         so the following repository section shouldn't be required unless testing for
+         specific Milestone or SNAPSHOT builds
+    -->
+    <!-- repositories>
+        <repository>
+             <id>SonatypeOSS EclipseLink Repo</id>
+             <url>https://oss.sonatype.org/content/groups/staging</url>
+        </repository>
+    </repositories -->
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.5</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- NOTE: Below is simply a list of most of our published artifacts.
+             An actual project would only need a fraction of them depending
+             upon what functionality is required. In fact, "eclipselink"
+             contains the functionality of most of the other artifacts listed.
+
+             Also three artifacts, javax.persistence, org.eclipse.persistence.asm,
+             and org.eclipse.persistence.antlr aren't listed at all because they
+             are defined as transitive dependencies of the JPA OSGI bundle.
+        -->
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>eclipselink</artifactId>
+            <version>${eclipselink.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.core</artifactId>
+            <version>${eclipselink.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.jpa</artifactId>
+            <version>${eclipselink.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.jpa.modelgen.processor</artifactId>
+            <version>${eclipselink.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.moxy</artifactId>
+            <version>${eclipselink.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.sdo</artifactId>
+            <version>${eclipselink.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.oracle</artifactId>
+            <version>${eclipselink.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.oracle.nosql</artifactId>
+            <version>${eclipselink.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.jpars</artifactId>
+            <version>${eclipselink.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.dbws</artifactId>
+            <version>${eclipselink.version}</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <defaultGoal>verify</defaultGoal>
+    </build>
+
+</project>

--- a/etc/jenkins/promote.groovy
+++ b/etc/jenkins/promote.groovy
@@ -65,7 +65,7 @@ spec:
       requests:
         memory: "2Gi"
         cpu: "1"
-    image: tkraus/el-build:1.1.5
+    image: tkraus/el-build:1.1.7
     volumeMounts:
     - name: tools
       mountPath: /opt/tools

--- a/etc/jenkins/promote.groovy
+++ b/etc/jenkins/promote.groovy
@@ -1,0 +1,147 @@
+// Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Distribution License v. 1.0, which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+// Job input parameters:
+//  RELEASE                - Release switch
+//  MAJOR_VERSION          - EclipseLink major version like 2.6 , 2.7 , 3.0
+//  VERSION                - EclipseLink version. Must match with first part of NIGHTLY_BUILD_ID parameter like 2.7.5
+//  NIGHTLY_BUILD_ID       - Nightly build ID in following form <version>-<classifier>-<git commit short id> .
+//                           For example -  2.7.5.v20190614-4681d7f571
+//                           Check directory with nightly builds.
+//  RELEASE_CANDIDATE_ID   - Typical values are: RC1, RC2....
+//  SIGN                   - Sing content of promoted jar files true - sign false - don't sign.
+//  DEBUG                  - Show debug messages.
+
+
+pipeline {
+    agent {
+        kubernetes {
+            label 'el-master-agent-pod'
+            yaml """
+apiVersion: v1
+kind: Pod
+spec:
+
+  volumes:
+  - name: tools
+    persistentVolumeClaim:
+      claimName: tools-claim-jiro-eclipselink
+  - name: volume-known-hosts
+    configMap:
+      name: known-hosts      
+  - name: settings-xml
+    secret:
+      secretName: m2-secret-dir
+      items:
+      - key: settings.xml
+        path: settings.xml
+  - name: toolchains-xml
+    configMap:
+      name: m2-dir
+      items:
+      - key: toolchains.xml
+        path: toolchains.xml
+  - name: settings-security-xml
+    secret:
+      secretName: m2-secret-dir
+      items:
+      - key: settings-security.xml
+        path: settings-security.xml
+  - name: m2-repo
+    emptyDir: {}
+    
+  containers:
+
+  - name: el-build
+    resources:
+      limits:
+        memory: "2Gi"
+        cpu: "1"
+      requests:
+        memory: "2Gi"
+        cpu: "1"
+    image: tkraus/el-build:1.1.5
+    volumeMounts:
+    - name: tools
+      mountPath: /opt/tools
+    - name: volume-known-hosts
+      mountPath: /home/jenkins/.ssh      
+    - name: settings-xml
+      mountPath: /home/jenkins/.m2/settings.xml
+      subPath: settings.xml
+      readOnly: true
+    - name: toolchains-xml
+      mountPath: /home/jenkins/.m2/toolchains.xml
+      subPath: toolchains.xml
+      readOnly: true
+    - name: settings-security-xml
+      mountPath: /home/jenkins/.m2/settings-security.xml
+      subPath: settings-security.xml
+      readOnly: true
+    - name: m2-repo
+      mountPath: /home/jenkins/.m2/repository
+    tty: true
+    command:
+    - cat
+"""
+        }
+    }
+    stages {
+        // Initialize build environment
+        stage('Init') {
+            steps {
+                container('el-build') {
+                    git branch: '${GIT_BRANCH}', url: '${GIT_REPOSITORY_URL}'
+                    sshagent(['projects-storage.eclipse.org-bot-ssh']) {
+                        sh """
+                            mkdir -p ${HOME}/etc/jenkins
+                            cp -r ${WORKSPACE}/etc/jenkins/* ${HOME}/etc/jenkins
+                            cp ${WORKSPACE}/buildsystem/ant_customizations.jar ${HOME}/etc/jenkins
+                            ${HOME}/etc/jenkins/promote_init.sh
+                            """
+                    }
+
+                    withCredentials([file(credentialsId: 'secret-subkeys.asc', variable: 'KEYRING')]) {
+                        sh label: '', script: '''
+                            gpg --batch --import "${KEYRING}"
+                            for fpr in $(gpg --list-keys --with-colons  | awk -F: \'/fpr:/ {print $10}\' | sort -u);
+                            do
+                                echo -e "5\\ny\\n" |  gpg --batch --command-fd 0 --expert --edit-key $fpr trust;
+                            done'''
+                    }
+                }
+            }
+        }
+        // Build
+        stage('Promote') {
+            steps {
+                container('el-build') {
+                    sh """
+                            . /etc/profile
+                            curl --version
+                            echo ${RELEASE}
+                            echo ${MAJOR_VERSION}
+                            echo ${NIGHTLY_BUILD_ID}
+                            echo ${RELEASE_CANDIDATE_ID}
+                            echo ${MAJOR_VERSION}
+                            echo ${SIGN}
+                            echo ${DEBUG}
+                            if [ ${RELEASE} == 'false' ]
+                            then
+                                echo calling "promote.sh ${NIGHTLY_BUILD_ID} ${RELEASE_CANDIDATE_ID} ${MAJOR_VERSION} ${SIGN} ${DEBUG}"
+                                ${HOME}/etc/jenkins/promote.sh ${NIGHTLY_BUILD_ID} ${RELEASE_CANDIDATE_ID} ${MAJOR_VERSION} ${SIGN} ${DEBUG}
+                            else
+                                echo calling "promote.sh release ${RELEASE_CANDIDATE_ID} ${MAJOR_VERSION} ${SIGN} ${DEBUG}"
+                                ${HOME}/etc/jenkins/promote.sh release ${RELEASE_CANDIDATE_ID} ${MAJOR_VERSION} ${SIGN} ${DEBUG}
+                            fi
+                        """
+                }
+            }
+        }
+    }
+}

--- a/etc/jenkins/promote.groovy
+++ b/etc/jenkins/promote.groovy
@@ -65,7 +65,7 @@ spec:
       requests:
         memory: "2Gi"
         cpu: "1"
-    image: tkraus/el-build:1.1.7
+    image: tkraus/el-build:1.1.8
     volumeMounts:
     - name: tools
       mountPath: /opt/tools

--- a/etc/jenkins/promote.sh
+++ b/etc/jenkins/promote.sh
@@ -1,0 +1,571 @@
+#!/usr/bin/env bash
+#****************************************************************************************
+# Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+# which accompanies this distribution.
+#
+# The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+# and the Eclipse Distribution License is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+# Contributors:
+#  - egwin - 13 September 2012 - Initial implementation
+#  - egwin - 07 March 2013     - Updates for staging to SonatypeOSS
+#  - rfelcman - August 2019    - Migration to new Eclipse.org CI infrastructure
+#****************************************************************************************
+
+#----------------------------------------------------------------------------------------
+#    This script is designed to be run interactively to promote an existing published
+#    build to a milestone, or a Milestone build to a release. It expects to be run from
+#    the 'build.eclipse.com' server.
+#----------------------------------------------------------------------------------------
+
+#==========================
+#   Basic Env Setup
+#
+. ${HOME}/etc/jenkins/setEnvironment.sh
+
+#Define common variables
+THIS=$0
+PROGNAME=`basename ${THIS}`
+CUR_DIR=`dirname ${THIS}`
+umask 0002
+BUILD=$1
+MILESTONE=$2
+BRANCH_NM=$3
+SIGN=$4
+DEBUG_ARG=$5
+
+ANT_ARGS=" "
+START_DATE=`date '+%y%m%d-%H%M'`
+
+#Directories
+EXEC_DIR=${HOME_DIR}
+LOG_DIR=${HOME_DIR}/logs
+RELENG_REPO=${HOME}/etc/jenkins
+RUNTIME_REPO=${WORKSPACE}
+
+#ANT Invokation Variables
+BUILDFILE=${RUNTIME_REPO}/autobuild.xml
+ANT_TARGET=build-milestone
+
+#Global Variables
+RELEASE=false
+
+PATH=${JAVA_HOME}/bin:${ANT_HOME}/bin:${RELENG_REPO}:/usr/bin:/usr/local/bin:${PATH}
+
+# Export necessary global environment variables
+export ANT_ARGS ANT_OPTS ANT_HOME HOME_DIR JAVA_HOME LOG_DIR PATH
+#==========================
+#   Functions Definitions
+#
+unset usage
+usage() {
+    echo "Usage: ${PROGNAME} (BUILD |'release') MILESTONE BRANCH_NM SIGN [debug]"
+    echo "   BUILD     - full build identifier, or 'release' (example: 2.4.1.v201209013-98ef31a). Used to generate branch,"
+    echo "               version, date and hash info needed. If 'release', tells promote to release the specified"
+    echo "               MILESTONE."
+    echo "   MILESTONE - a milestone (exampe: M4) to promote the specified build to. Also used in dir storage, and maven."
+    echo "               storage, and Maven publishing."
+    echo "   BRANCH_NM - The git branchname for the branch the build was based upon (Example: master, 2.4, 2.3, etc.)"
+    echo "   SIGN      - Sing content of promoted jar files"
+    echo "                  true - sign"
+    echo "                  false - don't sign"
+    echo "   DEBUG_ARG - if defined, designates a run should be 'debug'."
+}
+
+unset createPath
+createPath() {
+    # Usage: createPath path
+    path=$1
+
+    if [ "${DEBUG}" = "true" ] ; then
+        echo "createPath: Attempting to create '${path}' path."
+    fi
+    newdir=
+    for directory in `echo ${path} | tr '/' ' '`
+    do
+        newdir=${newdir}/${directory}
+        if [ ! -d "${newdir}" ] ; then
+            if [ "${DEBUG}" = "true" ] ; then
+                echo "createPath: Creating subdir: '${newdir}'"
+            fi
+            mkdir ${newdir}
+            if [ $? -ne 0 ]
+            then
+                echo "   Error (createPath):  Creation of ${newdir} failed!"
+                exit
+            fi
+        fi
+    done
+}
+
+unset genSafeTmpDir
+genSafeTmpDir() {
+    tmp=${TMPDIR-/tmp}
+    tmp=$tmp/somedir.$RANDOM.$RANDOM.$RANDOM.$$
+    (umask 077 && mkdir $tmp) || {
+      echo "Could not create temporary directory! Exiting." 1>&2
+      exit 1
+    }
+    echo "results stored in: '${tmp}'"
+}
+
+unset parseBuild
+parseBuild() {
+    build=$1
+
+    echo "- parseBuild -"
+
+    # cut parameters: -s: only print if delimeter exists in input; -d delimeter; -f field(s) to print
+    BRANCH=`echo ${build} | cut -s -d'.' -f1-2`
+    if [ "${BRANCH}" = "" ] ; then
+        usage
+        echo "BRANCH Error: There is something wrong with BUILD. ('$build' should be VERSION.QUALIFIER)!"
+        echo "              VERSION should be in the 3 part OSGi standard - Major.Minor.patch"
+        echo " "
+        exit 2
+    fi
+
+    VERSION=`echo ${build} | cut -s -d'.' -f1-3`
+    if [ "${VERSION}" = "" ] ; then
+        usage
+        echo "VERSION Error: There is something wrong with BUILD. ('$build' should be VERSION.QUALIFIER)!"
+        echo "               VERSION should be in the 3 part OSGi standard - Major.Minor.patch"
+        echo " "
+        exit 2
+    fi
+
+    QUALIFIER=`echo ${build} | cut -s -d'.' -f4`
+    if [ "${QUALIFIER}" = "" ] ; then
+        usage
+        echo "QUALIFIER Error: There is something wrong with BUILD. ('$build' should be VERSION.QUALIFIER)!"
+        echo "                 QUALIFIER should be in the form: vDATE-HASH where DATE is YYYYMMDD"
+        echo " "
+        exit 2
+    fi
+
+    # assign value of first field delimited by '-' (only use values containing '-' (-s)), with 'v' stripped, to DATE
+    BLD_DATE=`echo ${QUALIFIER} | cut -s -d'-' -f1 | cut -s -d'v' -f2`
+    if [ "${BLD_DATE}" = "" ] ; then
+        usage
+        echo "BLD_DATE Error: There is something wrong with QUALIFIER!"
+        echo "                '$qualifier' should be in the form:"
+        echo "                     vDATE-HASH where DATE is YYYYMMDD"
+        echo " "
+        exit 2
+    fi
+
+    # assign value of 2nd field delimited by '-' (only use values containing '-' (-s)), to HASH
+    GIT_HASH=`echo ${QUALIFIER} | cut -s -d'-' -f2`
+    if [ "${GIT_HASH}" = "" ] ; then
+        usage
+        echo "GIT_HASH Error: There is something wrong with QUALIFIER!"
+        echo "                '$qualifier' should be in the form:"
+        echo "                     vDATE-HASH where DATE is YYYYMMDD"
+        echo " "
+        exit 2
+    fi
+
+    if [ "$DEBUG" = "true" ] ; then
+        echo "build    ='$build'"
+        echo "BRANCH   ='$BRANCH'"
+        echo "VERSION  ='$VERSION'"
+        echo "QUALIFIER='$QUALIFIER'"
+        echo "BLD_DATE ='$BLD_DATE'"
+        echo "GIT_HASH ='$GIT_HASH'"
+    fi
+}
+
+unset validateGitRepo
+validateGitRepo() {
+
+    echo "- validateGitRepo -"
+
+    #Must run git commands from Git repo dir so, store current dir, and switch to repo
+    curdir=`pwd`
+    cd ${RUNTIME_REPO}
+
+    # parse status of repo for current branch
+    ststus_msg=`${GIT_EXEC} status`
+    gitbranch=`echo $ststus_msg | grep -m1 "#" | cut -s -d' ' -f4`
+    echo "Currently on '${gitbranch}' in '${RUNTIME_REPO}'"
+
+    # is current branch the desired branch?
+    error_cnt=0
+    if [ "${BRANCH_NM}" = "${gitbranch}" ] ; then
+       echo "Git repo already on branch '$BRANCH_NM'."
+    else
+       # switch to desired branch
+       ${GIT_EXEC} checkout ${BRANCH_NM}
+       if [ "$?" = "0" ] ; then
+           # parse status of repo for current branch
+           ststus_msg=`${GIT_EXEC} status`
+           gitbranch=`echo $ststus_msg | grep -m1 "#" | cut -s -d' ' -f4`
+           echo "Now on '${gitbranch}' in '${RUNTIME_REPO}'"
+           echo "Git checkout complete."
+       else
+           # if encountered error, increment error_cnt
+           error_cnt=`expr ${error_cnt} + 1`
+       fi
+    fi
+
+    # verify switch took place
+    if [ "$error_cnt" = "0" ] ; then
+        echo "Git Repo on correct branch for promotion to continue..."
+    else
+        echo "Error detected switching branches. exiting..."
+        exit 1
+    fi
+
+    # ensure repo is up-to-date
+    # has to occur after setting the correct banch because "git pull" only grabs changes on the active branch.
+    echo "Ensuring repo is up-to-date."
+    ${GIT_EXEC} pull
+
+    cd $curdir
+}
+
+unset validateBuild
+validateBuild() {
+    echo "- validateBuild -"
+
+    if [ -d ${DNLD_DIR}/nightly/${VERSION}/${BLD_DATE} ] ; then
+        echo "Valid build dir: '${DNLD_DIR}/nightly/${VERSION}/${BLD_DATE}'"
+        if [ -e ${DNLD_DIR}/nightly/${VERSION}/${BLD_DATE}/eclipselink-${VERSION}.${QUALIFIER}.zip ] ; then
+            echo "Valid build: '${DNLD_DIR}/nightly/${VERSION}/${BLD_DATE}/eclipselink-${VERSION}.${QUALIFIER}.zip' found."
+        else
+            echo "Invalid build: '${DNLD_DIR}/nightly/${VERSION}/${BLD_DATE}/eclipselink-${VERSION}.${QUALIFIER}.zip' not found."
+            echo "Valid builds are:"
+            ls ${DNLD_DIR}/nightly/${VERSION}/${BLD_DATE}/eclipselink-${VERSION}*.zip
+            exit 1
+        fi
+    else
+            echo "Invalid build dir: '${DNLD_DIR}/nightly/${VERSION}/${BLD_DATE}'"
+            echo "Valid build dates are:"
+            ls ${DNLD_DIR}/nightly/${VERSION}
+            exit 1
+   fi
+   #cd $curdir
+
+}
+
+# TODO: again NEED branch to verify instead of branch_NM, but need branch_NM to interact with Git
+unset validateMilestone
+validateMilestone() {
+    milestone=$1
+    echo "- validateMilestone -"
+
+    # TODO: Verify ${milestone} is 'release', or starts with M# or RC#
+    if [ -d ${DNLD_DIR}/milestones/${VERSION}/${milestone} ] ; then
+        echo "Milestone dir: '${DNLD_DIR}/milestones/${VERSION}/${milestone}' already exists."
+        if [ -e ${DNLD_DIR}/milestones/${VERSION}/${milestone}/eclipselink-${VERSION}.${QUALIFIER}.zip ] ; then
+            echo "     Milestone ${milestone} Build: '${DNLD_DIR}/milestones/${VERSION}/${milestone}/eclipselink-${VERSION}.${QUALIFIER}.zip' already promoted."
+        else
+            promotedBuild=`ls ${DNLD_DIR}/milestones/${VERSION}/${milestone}/eclipselink-${VERSION}*.zip`
+            echo "     Milestone ${milestone} Build: '${promotedBuild}' found."
+        fi
+        echo "     You should either choose another Milestone number, or clean previous promote (if partial) before running again."
+        exit 1
+    else
+        echo "Milestone dir: '${DNLD_DIR}/milestone/${VERSION}/${milestone}' not preexisting."
+        echo "Continuing..."
+    fi
+}
+
+unset parseVersion
+parseVersion() {
+    branch_nm=$1
+    echo "- parseVersion -"
+
+    if [ -d ${DNLD_DIR}/milestones ] ; then
+        if [ "$branch_nm" = "master" ] ; then
+            # Version is 'highest' dir ending in '0'
+            VERSION=`ls -r ${DNLD_DIR}/milestones | grep -m1 0$`
+        else
+            # Version is 'highest' dir begining with value of $branch_nm
+            VERSION=`ls -r ${DNLD_DIR}/milestones | grep -m1 $branch_nm`
+        fi
+    else
+        echo "Cannot find milestones. '${DNLD_DIR}/milestones' not found."
+    fi
+    echo "Version= '$VERSION'"
+}
+
+unset validateReleaseMilestone
+validateReleaseMilestone() {
+    milestone=$1
+    echo "- validateReleaseMilestone -"
+
+    # if milestone begins with either "M" or "RC" (doesn't (not begin with M) and (not begin with RC))
+    test1=`echo $milestone | grep -m1 ^M`
+    test2=`echo $milestone | grep -m1 ^RC`
+    if [ ! \( \( "$test1" = "" \) -a \( "$test2" = "" \) \) ] ; then
+        if [ -d ${DNLD_DIR}/milestones/${VERSION}/${milestone} ] ; then
+            echo " Target Milestone dir: '${DNLD_DIR}/milestones/${VERSION}/${milestone}' exists. Continuing..."
+        else
+            echo "Milestone dir: '${DNLD_DIR}/milestones/${VERSION}/${milestone}' doesn't exist."
+            exit 1
+        fi
+    else
+        usage
+        echo "Invalid Milestone detected: '$milestone' doesn't begin with 'M' or 'RC'"
+        exit 1
+    fi
+}
+
+unset parseReleaseMilestone
+parseReleaseMilestone() {
+    #find 'build' data from published milestone
+    echo "Target Milestone: '${MILESTONE}'"
+
+    BUILD=`ls ${DNLD_DIR}/milestones/${VERSION}/${MILESTONE} | grep -m1 P2signed | cut -d'-' -f3-4 | cut -d'.' -f1-4`
+    echo "BUILD: '${BUILD}'"
+
+    # set Milestone to 'release' for ant script
+    # TODO: fix ant so will promote from published milestone rather than nightly
+    MILESTONE=RELEASE
+    parseBuild ${BUILD}
+}
+
+#TODO Must have Git validation and setup completed first
+unset callAnt
+callAnt() {
+    #Need milestine branch, version, qualifier, date, githash
+    milestone=$1
+    branch=$2
+    branch_nm=$3
+    version=$4
+    qualifier=$5
+    blddate=$6
+    githash=$7
+
+    echo " "
+    echo "- callAnt -"
+
+    # Define SYSTEM variables needed
+    BldDepsDir=$HOME/extension.lib.external    # Needed for Eclipse dependencies when publishing/promoting
+    if [ ! -d "${BldDepsDir}" ] ; then
+        echo "${BldDepsDir} not found!"
+    fi
+    if [ ! -d "${RELENG_REPO}" ] ; then
+        echo "${RELENG_REPO} not found!"
+    fi
+
+    #verify src, root dest, and needed variables exist before proceeding
+    if [ \( ! "${milestone}" = "" \) -a \( ! "${branch}" = "" \) -a \( ! "${blddate}" = "" \) -a \( ! "${version}" = "" \) -a \( ! "${qualifier}" = "" \) ] ; then
+        echo "Preparing to promote ${milestone} for ${version}...."
+        if [ "${DEBUG}" = "true" ] ; then
+            echo "callAnt: Required data verified... proceeding..."
+            echo "   milestone = '${milestone}'"
+            echo "   branch    = '${branch}'"
+            echo "   blddate   = '${blddate}'"
+            echo "   version   = '${version}'"
+            echo "   qualifier = '${qualifier}'"
+            echo "   githash   = '${githash}'"
+        fi
+
+        #Invoke Antscript for Branch specific promotion
+        arguments="-Dbuild.deps.dir=${BldDepsDir} -Dreleng.repo.dir=${RELENG_REPO} -Dgit.exec=${GIT_EXEC} -Declipselink.root.download.dir=${DNLD_DIR} -Dsigning.dir=${SIGN_DIR}"
+        arguments="${arguments} -Dbranch.name=${branch_nm} -Drelease.version=${version} -Dbuild.type=${milestone} -Dbranch=${branch}"
+        arguments="${arguments} -Dversion.qualifier=${qualifier} -Dbuild.date=${blddate} -Dgit.hash=${githash}"
+        echo "   sign   = '${SIGN}'"
+        if [ "${SIGN}" = "true" ] ; then
+          arguments="${arguments} -Dsigning.script=${RELENG_REPO}/sign.sh"
+        else
+          arguments="${arguments} -Dsigning.script=${RELENG_REPO}/noSign.sh"
+        fi
+
+        # Run Ant from ${exec_location} using ${buildfile} ${arguments}
+        echo "pwd='`pwd`"
+        echo "ant ${BUILDFILE} ${arguments} ${ANT_TARGET}"
+        if [ -f ${BUILDFILE} ] ; then
+            ant -f ${BUILDFILE} ${arguments} ${ANT_TARGET}
+            if [ "$?" = "0" ]
+            then
+                echo "Ant promote complete."
+            else
+                echo "Ant Promote Failed!"
+            fi
+        else
+            echo "'${BUILDFILE}' doesn't exist. Aborting ant run..."
+        fi
+    else
+        # Something is not right! skipping.."
+        echo "    Required locations and data failed to verify... aborting Promote...."
+        ERROR=true
+        if [ "${DEBUG}" = "true" ] ; then
+            echo "callAnt: Required locations and data:"
+            echo "   milestone = '${milestone}'"
+            echo "   branch    = '${branch}'"
+            echo "   blddate   = '${blddate}'"
+            echo "   version   = '${version}'"
+            echo "   qualifier = '${qualifier}'"
+            echo "   githash   = '${githash}'"
+        fi
+    fi
+}
+
+
+
+#==========================
+#   Main Begins
+
+#==========================
+#   Validate run parameters
+if [ "${BUILD}" = "" ] ; then
+    usage
+    echo " "
+    echo "BUILD not specified! Exiting..."
+    exit 1
+fi
+if [ "${MILESTONE}" = "" ] ; then
+    usage
+    echo " "
+    echo "MILESTONE not specified! Exiting..."
+    exit 1
+fi
+if [ "${BRANCH_NM}" = "" ] ; then
+    usage
+    echo " "
+    echo "BRANCH_NM not specified! Exiting..."
+    exit 1
+fi
+#  If anything is in DEBUG_ARG then do a dummy "DEBUG" run
+#  (Do not call ant, do not modify or create files, do report variable states)
+DEBUG=false
+if [ -n "$DEBUG_ARG" ] ; then
+    DEBUG=true
+    echo "Debug is on!"
+fi
+
+#==========================
+#     Define Environment
+echo "-= Validate Environment =- "
+if [ ! -d ${JAVA_HOME} ] ; then
+    echo "Expecting Java at: '${JAVA_HOME}', but is not there!"
+    JAVA_HOME=/shared/common/jdk1.6.0_05
+    if [ ! -d ${JAVA_HOME} ] ; then
+        echo "Tried again. Expecting Java at: '${JAVA_HOME}', but is not there!"
+        #exit
+    fi
+fi
+echo "JAVA_HOME verified at: '${JAVA_HOME}'"
+
+if [ ! -d ${ANT_HOME} ] ; then
+    echo "Expecting Ant at: '${ANT_HOME}', but is not there!"
+    #exit
+fi
+echo "ANT_HOME verified at: '${ANT_HOME}'"
+
+if [ ! -d ${HOME_DIR} ] ; then
+    echo "Need to create HOME_DIR '${HOME_DIR}'"
+    if [ "${DEBUG}" = "false" ] ; then
+        echo "DEBUG=$DEBUG"
+        createPath ${HOME_DIR}
+    else
+        echo "    Debug on, No actual work being done."
+    fi
+fi
+if [ ! -d ${LOG_DIR} ] ; then
+    echo "Need to create LOG_DIR '${LOG_DIR}'"
+    if [ "${DEBUG}" = "false" ] ; then
+        createPath ${LOG_DIR}
+    else
+        echo "    Debug on, No actual work being done."
+    fi
+fi
+GIT_EXEC=/usr/local/bin/git
+if [ ! -x ${GIT_EXEC} ] ; then
+    echo "Cannot find Git executable using default value '$GIT_EXEC'. Attempting Autofind..."
+    GIT_EXEC=`which git`
+    if [ $? -ne 0 ] ; then
+        echo "Error: Unable to find GIT executable! Git functionality disabled."
+        GIT_EXEC=false
+        exit 1
+    else
+        echo "Found: ${GIT_EXEC}"
+    fi
+else
+    echo "Found: ${GIT_EXEC}"
+fi
+if [ ! -d ${RELENG_REPO} ] ; then
+    echo "Releng repo missing! Will try to clone."
+    echo "${GIT_EXEC} clone ssh://git.eclipse.org:29418/eclipselink/eclipselink.releng.git"
+    if [ ! -d ${RELENG_REPO} ] ; then
+        echo "Still cannot find '${RELENG_REPO}'. Something went wrong... aborting."
+        exit 1
+    else
+        echo "Cloning successful."
+    fi
+else
+    echo "Releng repo '${RELENG_REPO}' found."
+fi
+if [ ! -d ${RUNTIME_REPO} ] ; then
+    echo "EclipseLink Runtime repo missing! Will try to clone."
+    echo "${GIT_EXEC} clone git@github.com:eclipse-ee4j/eclipselink.git eclipselink.runtime"
+    if [ ! -d ${RUNTIME_REPO} ] ; then
+        echo "Still cannot find '${RUNTIME_REPO}'. Something went wrong... aborting."
+        exit 1
+    else
+        echo "Cloning successful."
+    fi
+else
+    echo "EclipseLink Runtime repo '${RUNTIME_REPO}' found."
+fi
+echo "   Validated."
+echo " "
+
+## Convert "BRANCH" to BRANCH_NM (version or trunk) and BRANCH (svn branch path)
+#    BRANCH_NM is used for reporting and naming purposes
+#    BRANCH    is used to quailify the actual Branch path
+
+#==========================
+#   Begin WORK
+echo "Promote begin at: ${START_DATE}"
+
+#Determine if 'release' run or regular Milestone promotion
+if [ "$BUILD" = "release" ] ; then
+    RELEASE=true
+    # Figure out VERSION based upon BRANCH_NM
+    parseVersion $BRANCH_NM
+
+    # verify that specified milestone exists.
+    validateReleaseMilestone $MILESTONE
+
+    # relevant build coordinats from Milestone artifacts
+    parseReleaseMilestone
+
+    # Ensure we are on the correct branch in the repo, if build info is good
+    validateGitRepo
+else
+    # Get needed info from BUILD
+    parseBuild $BUILD
+
+    # Validate BUILD Exists
+    validateBuild
+
+    # Ensure we are on the correct branch in the repo, if build info is good
+    validateGitRepo
+
+    # Validate MILESTONE against convention, and verify not preexisting
+    validateMilestone $MILESTONE
+fi
+
+echo "BUILD      ='${BUILD}'"
+echo "  BRANCH   ='$BRANCH'"
+echo "  VERSION  ='$VERSION'"
+echo "QUALIFIER  ='$QUALIFIER'"
+echo "  BLD_DATE ='$BLD_DATE'"
+echo "  GIT_HASH ='$GIT_HASH'"
+echo "MILESTONE  ='${MILESTONE}'"
+echo "BRANCH_NM  ='${BRANCH_NM}'"
+
+callAnt $MILESTONE $BRANCH $BRANCH_NM $VERSION $QUALIFIER $BLD_DATE $GIT_HASH
+
+echo "Promote complete at: `date '+%y%m%d-%H%M'`"
+echo " "
+echo " "

--- a/etc/jenkins/promote_init.sh
+++ b/etc/jenkins/promote_init.sh
@@ -1,0 +1,54 @@
+#!/bin/bash -e
+#
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Distribution License v. 1.0, which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+#
+# Arguments:
+#  N/A
+
+echo '-[ EclipseLink Promotion Init ]-----------------------------------------------------------'
+. ${HOME}/etc/jenkins/setEnvironment.sh
+mkdir -p ${DNLD_DIR}/nightly/${VERSION}
+mkdir -p ${RELEASE_SITE_DIR}
+mkdir -p ${MILESTONE_SITE_DIR}
+mkdir -p ${NIGHTLY_SITE_DIR}
+mkdir -p ${SIGN_DIR}
+scp -r genie.eclipselink@projects-storage.eclipse.org:${DNLD_DIR_REMOTE}/nightly/${VERSION}/* ${DNLD_DIR}/nightly/${VERSION}
+
+echo '-[ EclipseLink Init ]-----------------------------------------------------------'
+
+mkdir -p $HOME/extension.lib.external/mavenant
+
+#DOWNLOAD SOME DEPENDENCIES
+wget -nc http://repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar -O $HOME/extension.lib.external/junit-4.12.jar
+wget -nc http://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar -O $HOME/extension.lib.external/hamcrest-core-1.3.jar
+wget -nc http://repo1.maven.org/maven2/org/jmockit/jmockit/1.35/jmockit-1.35.jar -O $HOME/extension.lib.external/jmockit-1.35.jar
+wget -nc http://repo1.maven.org/maven2/org/hibernate/validator/hibernate-validator/6.0.7.Final/hibernate-validator-6.0.7.Final.jar -O $HOME/extension.lib.external/hibernate-validator-6.0.7.Final.jar
+wget -nc http://repo1.maven.org/maven2/org/jboss/logging/jboss-logging/3.3.0.Final/jboss-logging-3.3.0.Final.jar -O $HOME/extension.lib.external/jboss-logging-3.3.0.Final.jar
+wget -nc http://repo1.maven.org/maven2/org/glassfish/javax.el/3.0.1-b08/javax.el-3.0.1-b08.jar -O $HOME/extension.lib.external/javax.el-3.0.1-b08.jar
+wget -nc http://repo1.maven.org/maven2/com/fasterxml/classmate/1.3.1/classmate-1.3.1.jar -O $HOME/extension.lib.external/classmate-1.3.1.jar
+wget -nc http://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.48/mysql-connector-java-5.1.48.jar -O $HOME/extension.lib.external/mysql-connector-java-5.1.48.jar
+wget -nc https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.tar.gz -O $HOME/extension.lib.external/apache-ant-1.10.5-bin.tar.gz
+wget -nc http://archive.apache.org/dist/maven/ant-tasks/2.1.3/binaries/maven-ant-tasks-2.1.3.jar -O $HOME/extension.lib.external/mavenant/maven-ant-tasks-2.1.3.jar
+wget -nc https://download.eclipse.org/eclipse/downloads/drops4/R-4.10-201812060815/eclipse-SDK-4.10-linux-gtk-x86_64.tar.gz -O $HOME/extension.lib.external/eclipse-SDK-4.10-linux-gtk-x86_64.tar.gz
+
+#UNPACK SOME  DEPENDENCIES
+tar -x -z -C $HOME/extension.lib.external -f $HOME/extension.lib.external/eclipse-SDK-4.10-linux-gtk-x86_64.tar.gz
+
+#PREPARE build.properties FILE
+echo "extensions.depend.dir=$HOME/extension.lib.external" >> $HOME/build.properties
+echo "junit.lib=$HOME/extension.lib.external/junit-4.12.jar:$HOME/extension.lib.external/hamcrest-core-1.3.jar" >> $HOME/build.properties
+echo 'jdbc.driver.jar=$HOME/extension.lib.external/mysql-connector-java-5.1.48.jar' >> $HOME/build.properties
+echo 'db.driver=com.mysql.jdbc.Driver' >> $HOME/build.properties
+echo "db.url=$TEST_DB_URL" >> $HOME/build.properties
+echo "db.user=$TEST_DB_USERNAME" >> $HOME/build.properties
+echo "db.pwd=$TEST_DB_PASSWORD" >> $HOME/build.properties
+echo 'db.platform=org.eclipse.persistence.platform.database.MySQLPlatform' >> $HOME/build.properties
+echo 'eclipse.install.dir=$HOME/extension.lib.external/eclipse' >> $HOME/build.properties
+echo hudson.workspace=$WORKSPACE

--- a/etc/jenkins/promote_init.sh
+++ b/etc/jenkins/promote_init.sh
@@ -34,7 +34,7 @@ wget -nc http://repo1.maven.org/maven2/org/jboss/logging/jboss-logging/3.3.0.Fin
 wget -nc http://repo1.maven.org/maven2/org/glassfish/javax.el/3.0.1-b08/javax.el-3.0.1-b08.jar -O $HOME/extension.lib.external/javax.el-3.0.1-b08.jar
 wget -nc http://repo1.maven.org/maven2/com/fasterxml/classmate/1.3.1/classmate-1.3.1.jar -O $HOME/extension.lib.external/classmate-1.3.1.jar
 wget -nc http://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.48/mysql-connector-java-5.1.48.jar -O $HOME/extension.lib.external/mysql-connector-java-5.1.48.jar
-wget -nc https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.tar.gz -O $HOME/extension.lib.external/apache-ant-1.10.5-bin.tar.gz
+wget -nc https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.7-bin.tar.gz -O $HOME/extension.lib.external/apache-ant-1.10.7-bin.tar.gz
 wget -nc http://archive.apache.org/dist/maven/ant-tasks/2.1.3/binaries/maven-ant-tasks-2.1.3.jar -O $HOME/extension.lib.external/mavenant/maven-ant-tasks-2.1.3.jar
 wget -nc https://download.eclipse.org/eclipse/downloads/drops4/R-4.10-201812060815/eclipse-SDK-4.10-linux-gtk-x86_64.tar.gz -O $HOME/extension.lib.external/eclipse-SDK-4.10-linux-gtk-x86_64.tar.gz
 

--- a/etc/jenkins/publish_nightly.sh
+++ b/etc/jenkins/publish_nightly.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -e
+#
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Distribution License v. 1.0, which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+#
+# Arguments:
+#  N/A
+
+if [ ${CONTINUOUS_BUILD} = "true" ]; then
+    echo '-[ EclipseLink Continuous Build -> No publishing any artifacts]-------------------------------'
+else
+    echo '-[ EclipseLink Publish to Nightly ]-----------------------------------------------------------'
+    scp -r $WORKSPACE/exported_builds/build/* genie.eclipselink@projects-storage.eclipse.org:$BUILD_RESULTS_TARGET_DIR
+    scp -r $WORKSPACE/exported_builds/test/* genie.eclipselink@projects-storage.eclipse.org:$TEST_RESULTS_TARGET_DIR
+fi

--- a/etc/jenkins/setEnvironment.sh
+++ b/etc/jenkins/setEnvironment.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+#****************************************************************************************
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+# which accompanies this distribution.
+#
+# The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+# and the Eclipse Distribution License is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# Contributors:
+#  - rfelcman - 16 August 2019 - Initial implementation
+#****************************************************************************************
+
+# This script sets environment variables used by other scripts in eclipselink.releng.
+
+ANT_HOME_DEFAULT=/opt/java/ant
+M2_HOME_DEFAULT=/opt/java/maven
+HOME_DIR_DEFAULT=${WORKSPACE}
+JAVA_HOME_DEFAULT=/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.222.b10-0.fc30.x86_64
+ANT_OPTS_DEFAULT="-Xms512m -Xmx1024m"
+START_DATE_DEFAULT=`date '+%y%m%d-%H%M'`
+
+DNLD_DIR_DEFAULT=${WORKSPACE}/home/data/httpd/download.eclipse.org/rt/eclipselink
+RELEASE_SITE_DIR_DEFAULT=${WORKSPACE}/home/data/httpd/download.eclipse.org/rt/eclipselink/updates
+MILESTONE_SITE_DIR_DEFAULT=${WORKSPACE}/home/data/httpd/download.eclipse.org/rt/eclipselink/milestone-updates
+NIGHTLY_SITE_DIR_DEFAULT=${WORKSPACE}/home/data/httpd/download.eclipse.org/rt/eclipselink/nightly-updates
+
+DNLD_DIR_REMOTE_DEFAULT=/home/data/httpd/download.eclipse.org/rt/eclipselink
+RELEASE_SITE_DIR_REMOTE_DEFAULT=/home/data/httpd/download.eclipse.org/rt/eclipselink/updates
+MILESTONE_SITE_DIR_REMOTE_DEFAULT=/home/data/httpd/download.eclipse.org/rt/eclipselink/milestone-updates
+NIGHTLY_SITE_DIR_REMOTE_DEFAULT=/home/data/httpd/download.eclipse.org/rt/eclipselink/nightly-updates
+
+SIGN_DIR=${HOME}/tmp/signing
+
+
+# Set shell variable if value does not exist
+ # Arguments:
+ #   $1 Variable name
+ #   $2 Value to set if variable is empty
+ set_default_var() {
+   if [ -z "${!1}" ]; then
+     declare -g ${1}="${2}"
+   fi
+ }
+
+set_default_var ANT_HOME ${ANT_HOME_DEFAULT}
+set_default_var M2_HOME ${M2_HOME_DEFAULT}
+set_default_var HOME_DIR ${HOME_DIR_DEFAULT}
+set_default_var JAVA_HOME ${JAVA_HOME_DEFAULT}
+set_default_var ANT_OPTS ${ANT_OPTS_DEFAULT}
+set_default_var START_DATE ${START_DATE_DEFAULT}
+set_default_var DNLD_DIR ${DNLD_DIR_DEFAULT}
+set_default_var RELEASE_SITE_DIR ${RELEASE_SITE_DIR_DEFAULT}
+set_default_var MILESTONE_SITE_DIR ${MILESTONE_SITE_DIR_DEFAULT}
+set_default_var NIGHTLY_SITE_DIR ${NIGHTLY_SITE_DIR_DEFAULT}
+set_default_var DNLD_DIR_REMOTE ${DNLD_DIR_REMOTE_DEFAULT}
+set_default_var RELEASE_SITE_DIR_REMOTE ${RELEASE_SITE_DIR_REMOTE_DEFAULT}
+set_default_var MILESTONE_SITE_DIR_REMOTE ${MILESTONE_SITE_DIR_REMOTE_DEFAULT}
+set_default_var NIGHTLY_SITE_DIR_REMOTE ${NIGHTLY_SITE_DIR_REMOTE_DEFAULT}

--- a/etc/jenkins/sign.sh
+++ b/etc/jenkins/sign.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Distribution License v. 1.0, which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+PRESIGNED_ZIP=$1
+SIGNED_OUTPUT=$3
+
+rm -rf presign_jars signed_jars $SIGNED_OUTPUT
+
+#extracting presigned zip
+unzip -q $PRESIGNED_ZIP -d presign_jars
+find presign_jars -type d |sed 's/presign_jars/signed_jars/g' |xargs mkdir -p
+
+#signing the jars
+for j in `find presign_jars -type f -name "*.jar"`
+do
+    echo "signing $j ..."
+    signed_jar=`echo $j |sed 's/presign_jars/signed_jars/g'`
+    curl -s -o ${signed_jar} -F file=@${j} http://build.eclipse.org:31338/sign
+done
+
+mkdir -p $SIGNED_OUTPUT
+cd signed_jars
+zip -q -r ../${SIGNED_OUTPUT}/${PRESIGNED_ZIP} *

--- a/pom.xml.template
+++ b/pom.xml.template
@@ -15,6 +15,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.eclipse.ee4j</groupId>
+    <artifactId>project</artifactId>
+    <version>1.0.5</version>
+  </parent>
+
   <groupId>@groupId@</groupId>
   <artifactId>@artifactId@</artifactId>
   <version>@version@</version>
@@ -22,15 +29,19 @@
   <name>@artifactName@</name>
   <description>EclipseLink build based upon Git transaction @git.hash@</description>
   <url>http://www.eclipse.org/eclipselink</url>
+
   <organization>
     <name>Eclipse.org - EclipseLink Project</name>
     <url>http://www.eclipse.org/eclipselink</url>
   </organization>
+
   <issueManagement>
     <system>bugzilla</system>
     <url>https://bugs.eclipse.org/bugs</url>
   </issueManagement>
+
   <inceptionYear>2007</inceptionYear>
+
   <mailingLists>
     <mailingList>
       <name>EclipseLink Developer List</name>
@@ -43,6 +54,7 @@
       <archive>http://dev.eclipse.org/mhonarc/lists/eclipselink-users</archive>
     </mailingList>
   </mailingLists>
+
   <licenses>
     <license>
       <name>Eclipse Public License v. 2.0</name>
@@ -57,10 +69,12 @@
       <comments>Standard Eclipse Distribution License</comments>
     </license>
   </licenses>
+
   <scm>
     <connection>scm:git:https://github.com/eclipse-ee4j/eclipselink.git</connection>
     <url>https://github.com/eclipse-ee4j/eclipselink.git</url>
   </scm>
+
   <developers>
     <developer>
       <id>PeterKrogh</id>

--- a/uploadToNexus.xml
+++ b/uploadToNexus.xml
@@ -73,12 +73,13 @@
              classpathref="maven-ant-tasks.classpath" />
 
     <!-- Tool version definitions -->
-    <property name="gpg.plugin.version"   value="1.4"/>
-    <property name="wagon.http.version"   value="2.6"/>
+    <property name="gpg.plugin.version"   value="1.6"/>
+    <property name="wagon.http.version"   value="3.3.3"/>
 
     <!-- The repository info of where maven artifacts will be uploaded -->
     <!--    Override value to change defaults                          -->
-    <property name="stagingId"   value="sonatype-nexus-staging"/>
+    <property name="stagingId"   value="ossrh"/>
+    <!--<property name="stagingId"   value="sonatype-nexus-staging"/>-->
     <property name="stagingURL"  value="https://oss.sonatype.org/service/local/staging/deploy/maven2"/>
     <property name="snapshotId"  value="sonatype-nexus-snapshots"/>
     <property name="snapshotURL" value="https://oss.sonatype.org/content/repositories/snapshots"/>
@@ -592,39 +593,21 @@
 
     <!-- Staging targets -->
     <target name="ua-staging" if="sign">
-        <!-- sign and deploy the main artifact -->
-        <artifact:mvn>
-            <arg value="org.apache.maven.plugins:maven-gpg-plugin:${gpg.plugin.version}:sign-and-deploy-file"/>
-            <arg value="-Durl=${stagingURL}"/>
-            <arg value="-DrepositoryId=${stagingId}"/>
-            <arg value="-DpomFile=${maven.build.location}/pom.xml"/>
-            <arg value="-Dfile=${artifact}"/>
-            <arg value="-Pgpg"/>
-        </artifact:mvn>
+        <exec dir="${maven.build.location}" executable="sh">
+            <arg line="-c '${M2_HOME}/bin/mvn clean gpg:sign-and-deploy-file -Dfile=${artifact} -DpomFile=${maven.build.location}/pom.xml -Durl=${stagingURL} -DrepositoryId=${stagingId} -Poss-release'" />
+        </exec>
     </target>
     <target name="us-staging" if="sign">
         <!-- sign and deploy the sources artifact -->
-        <artifact:mvn>
-            <arg value="org.apache.maven.plugins:maven-gpg-plugin:${gpg.plugin.version}:sign-and-deploy-file"/>
-            <arg value="-Durl=${stagingURL}"/>
-            <arg value="-DrepositoryId=${stagingId}"/>
-            <arg value="-DpomFile=${maven.build.location}/pom.xml"/>
-            <arg value="-Dfile=${artifactSrc}"/>
-            <arg value="-Dclassifier=sources"/>
-            <arg value="-Pgpg"/>
-        </artifact:mvn>
+        <exec dir="${maven.build.location}" executable="sh">
+            <arg line="-c '${M2_HOME}/bin/mvn clean gpg:sign-and-deploy-file -Dfile=${artifactSrc} -DpomFile=${maven.build.location}/pom.xml -Durl=${stagingURL} -DrepositoryId=${stagingId} -Dclassifier=sources -Poss-release'" />
+        </exec>
     </target>
     <target name="uj-staging" if="sign">
         <!-- sign and deploy the javadoc artifact -->
-        <artifact:mvn>
-            <arg value="org.apache.maven.plugins:maven-gpg-plugin:${gpg.plugin.version}:sign-and-deploy-file"/>
-            <arg value="-Durl=${stagingURL}"/>
-            <arg value="-DrepositoryId=${stagingId}"/>
-            <arg value="-DpomFile=${maven.build.location}/pom.xml"/>
-            <arg value="-Dfile=${artifactJavadoc}"/>
-            <arg value="-Dclassifier=javadoc"/>
-            <arg value="-Pgpg"/>
-        </artifact:mvn>
+        <exec dir="${maven.build.location}" executable="sh">
+            <arg line="-c '${M2_HOME}/bin/mvn clean gpg:sign-and-deploy-file -Dfile=${artifactJavadoc} -DpomFile=${maven.build.location}/pom.xml -Durl=${stagingURL} -DrepositoryId=${stagingId} -Dclassifier=javadoc -Poss-release,staging'" />
+        </exec>
     </target>
 
     <!-- ************************************* NOT USED **************************************** -->

--- a/uploadToNexus.xml
+++ b/uploadToNexus.xml
@@ -79,7 +79,6 @@
     <!-- The repository info of where maven artifacts will be uploaded -->
     <!--    Override value to change defaults                          -->
     <property name="stagingId"   value="ossrh"/>
-    <!--<property name="stagingId"   value="sonatype-nexus-staging"/>-->
     <property name="stagingURL"  value="https://oss.sonatype.org/service/local/staging/deploy/maven2"/>
     <property name="snapshotId"  value="sonatype-nexus-snapshots"/>
     <property name="snapshotURL" value="https://oss.sonatype.org/content/repositories/snapshots"/>
@@ -606,7 +605,7 @@
     <target name="uj-staging" if="sign">
         <!-- sign and deploy the javadoc artifact -->
         <exec dir="${maven.build.location}" executable="sh">
-            <arg line="-c '${M2_HOME}/bin/mvn clean gpg:sign-and-deploy-file -Dfile=${artifactJavadoc} -DpomFile=${maven.build.location}/pom.xml -Durl=${stagingURL} -DrepositoryId=${stagingId} -Dclassifier=javadoc -Poss-release,staging'" />
+            <arg line="-c '${M2_HOME}/bin/mvn clean gpg:sign-and-deploy-file -Dfile=${artifactJavadoc} -DpomFile=${maven.build.location}/pom.xml -Durl=${stagingURL} -DrepositoryId=${stagingId} -Dclassifier=javadoc -Poss-release'" />
         </exec>
     </target>
 


### PR DESCRIPTION
This is patch related with migration to new cloud based Eclipse.org build infrastructure and
" The end of an era: shell access".
There are Jenkins pipelines 
This jobs contains two pipelines:
1. Build part - _build.groovy, init.sh, build.sh, publish_nightly.sh ..._
   Build project, execute test, publish to nightly builds.
   These files are common for nightly and ci builds. There is parameter CONTINUOUS_BUILD specified (true - continuous build, false - full nightly build)  
2. Promotion part - _promote.groovy, promote_init.sh, promote.sh ..._
   Publish Maven artifacts to the Maven repository (OSS staging). This is Jenkins replacement of _promote.sh_ called in shell available at build.eclipse.org infrastructure.
  Due this part, there are modifications in some current files in the project root. They are:
_autobuild.xml_ : Switch to Maven 3 and some check. _promote.sh_ used Maven 2 and JDK 6 before.
_pom.xml.template_ : EE4J parent pom added . This pom file is used as a template for poms of Maven artifacts published to the Maven Central.
_ uploadToNexus.xml _ : There is change how Maven is called. Before this change tool _maven-ant-tasks-2.1.3.jar_ was used, but there was troubles with GPG call (required interactive env). After this fix command line call is used.


Signed-off-by: Radek Felcman <radek.felcman@oracle.com>