### PR TITLE
[master] Bug 546533 - QueryKeyExpression.printSQL writes no value 2.0 - Unit test fix

### DIFF
--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/jpql/SimpleConcatTestWithConstantsLiteralFirst.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/jpql/SimpleConcatTestWithConstantsLiteralFirst.java
@@ -27,13 +27,12 @@ public class SimpleConcatTestWithConstantsLiteralFirst extends JPQLTestCase {
         Employee emp = (Employee)getSomeEmployees().firstElement();
 
         String partOne;
-        String partTwo;
         String ejbqlString;
 
         partOne = emp.getFirstName();
 
         ExpressionBuilder builder = new ExpressionBuilder();
-        Expression whereClause = builder.literal("\"Smith\"").concat(builder.get("firstName")).like("Smith" + partOne);
+        Expression whereClause = builder.literal("'Smith'").concat(builder.get("firstName")).like("Smith" + partOne);
 
         ReadAllQuery raq = new ReadAllQuery();
         raq.setReferenceClass(Employee.class);

--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/jpql/SimpleConcatTestWithConstantsLiteralSecond.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/jpql/SimpleConcatTestWithConstantsLiteralSecond.java
@@ -25,7 +25,6 @@ public class SimpleConcatTestWithConstantsLiteralSecond extends org.eclipse.pers
         Employee emp = (Employee)getSomeEmployees().firstElement();
 
         String partOne;
-        String partTwo;
         String ejbqlString;
 
         partOne = emp.getFirstName();


### PR DESCRIPTION
Bug 546533 - QueryKeyExpression.printSQL writes no value 2.0 - Unit test fix

In the unit test were used double quotas character as wrapper for string literal.
It was functional against MySQL but was not in the Oracle DB.
Unused variable removal.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>