### PR TITLE
[2.6_WAS] Update .classpath and antbuild.xml files to reference ASM 7.1 jar.

### DIFF
--- a/dbws/org.eclipse.persistence.dbws/.classpath
+++ b/dbws/org.eclipse.persistence.dbws/.classpath
@@ -3,7 +3,7 @@
 	<classpathentry excluding="**/.svn/**" kind="src" path="src"/>
 	<classpathentry excluding="**/.svn/**" kind="src" path="resource"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
-	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm_7.0.0.v201811131354.jar" sourcepath="/ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm.source_7.0.0.v201811131354.jar"/>
+	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm_7.1.0.v201909181055.jar" sourcepath="/ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm.source_7.1.0.v201909181055.jar"/>
 	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/javax.ws.rs_1.1.1.v20101004-1200.jar" sourcepath="/ECLIPSELINK_HOME/plugins/javax.ws.rs.source_1.1.1.v20101004-1200.jar"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="target/classes"/>

--- a/foundation/org.eclipse.persistence.core/.classpath
+++ b/foundation/org.eclipse.persistence.core/.classpath
@@ -9,7 +9,7 @@
 	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/javax.mail_1.4.0.v201005080615.jar"/>
 	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/javax.resource_1.6.0.v201204270900.jar"/>
 	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/javax.transaction_1.1.0.v201002051055.jar"/>
-	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm_7.0.0.v201811131354.jar" sourcepath="/ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm.source_7.0.0.v201811131354.jar"/>
+	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm_7.1.0.v201909181055.jar" sourcepath="/ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm.source_7.1.0.v201909181055.jar"/>
 	<classpathentry kind="var" path="ECLIPSELINK_HOME/jpa/plugins/javax.persistence_2.1.1.v201509150925.jar" sourcepath="/ECLIPSELINK_HOME/jpa/plugins/javax.persistence.source_2.1.1.v201509150925.jar"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="target/classes"/>

--- a/jpa/eclipselink.jpa.test.jse/.classpath
+++ b/jpa/eclipselink.jpa.test.jse/.classpath
@@ -10,6 +10,6 @@
 	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/javax.validation_1.1.0.v201304101302.jar"/>
 	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/javax.transaction_1.1.0.v201002051055.jar" sourcepath="/ECLIPSELINK_HOME/plugins/javax.transaction/src"/>
 	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/org.eclipse.persistence.antlr_3.2.0.v201302191141.jar" sourcepath="/ECLIPSELINK_HOME/plugins/org.eclipse.persistence.antlr.source_3.2.0.v201302191141.jar"/>
-	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm_7.0.0.v201811131354.jar" sourcepath="/ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm.source_7.0.0.v201811131354.jar"/>
+	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm_7.1.0.v201909181055.jar" sourcepath="/ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm.source_7.1.0.v201909181055.jar"/>
 	<classpathentry kind="output" path="classes"/>
 </classpath>

--- a/jpa/eclipselink.jpa.test.jse/antbuild.xml
+++ b/jpa/eclipselink.jpa.test.jse/antbuild.xml
@@ -42,7 +42,7 @@
         <pathelement path="${jse.classes.dir}" />
         <!-- <pathelement path="${jse.eclipselink.jar}" /> -->
         <pathelement path="${jse.el.plugins.dir}/org.eclipse.persistence.antlr_3.2.0.v201302191141.jar" />
-        <pathelement path="${jse.el.plugins.dir}/org.eclipse.persistence.asm_7.0.0.v201811131354.jar" />
+        <pathelement path="${jse.el.plugins.dir}/org.eclipse.persistence.asm_7.1.0.v201909181055.jar" />
         <pathelement path="${jse.el.plugins.dir}/org.eclipse.persistence.core_2.6.8.WAS.jar" />
         <pathelement path="${jse.el.plugins.dir}/org.eclipse.persistence.jpa_2.6.8.WAS.jar" />
         <pathelement path="${jse.el.plugins.dir}/org.eclipse.persistence.jpa.jpql_2.6.8.WAS.jar" />

--- a/jpa/eclipselink.jpars.test/.classpath
+++ b/jpa/eclipselink.jpars.test/.classpath
@@ -18,7 +18,7 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/javax.ejb_3.1.0.v201205171433.jar" sourcepath="/ECLIPSELINK_HOME/plugins/javax.ejb/src"/>
-	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm_7.0.0.v201811131354.jar" sourcepath="/ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm.source_7.0.0.v201811131354.jar"/>
+	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm_7.1.0.v201909181055.jar" sourcepath="/ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm.source_7.1.0.v201909181055.jar"/>
 	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/org.eclipse.persistence.antlr_3.2.0.v201302191141.jar" sourcepath="/ECLIPSELINK_HOME/plugins/org.eclipse.persistence.antlr.source_3.2.0.v201302191141.jar"/>
 	<classpathentry kind="output" path="classes"/>
 </classpath>

--- a/jpa/org.eclipse.persistence.jpa/.classpath
+++ b/jpa/org.eclipse.persistence.jpa/.classpath
@@ -5,7 +5,7 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/javax.transaction_1.1.0.v201002051055.jar"/>
 	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/javax.validation_1.1.0.v201304101302.jar"/>
-	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm_7.0.0.v201811131354.jar" sourcepath="/ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm.source_7.0.0.v201811131354.jar"/>
+	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm_7.1.0.v201909181055.jar" sourcepath="/ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm.source_7.1.0.v201909181055.jar"/>
 	<classpathentry kind="var" path="ECLIPSELINK_HOME/jpa/plugins/javax.persistence_2.1.1.v201509150925.jar" sourcepath="/ECLIPSELINK_HOME/jpa/plugins/javax.persistence.source_2.1.1.v201509150925.jar"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="target/classes"/>

--- a/moxy/eclipselink.moxy.test/.classpath
+++ b/moxy/eclipselink.moxy.test/.classpath
@@ -12,7 +12,7 @@
 	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/javax.ws.rs_1.1.1.v20101004-1200.jar" sourcepath="/ECLIPSELINK_HOME/plugins/javax.ws.rs.source_1.1.1.v20101004-1200.jar"/>
 	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/javax.xml.bind_2.2.12.v201410011542.jar"/>
 	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/org.glassfish.javax.json_1.0.4.v201311181159.jar" sourcepath="/ECLIPSELINK_HOME/plugins/org.glassfish.javax.json.source_1.0.4.v201311181159.jar"/>
-	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm_7.0.0.v201811131354.jar" sourcepath="/ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm.source_7.0.0.v201811131354.jar"/>
+	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm_7.1.0.v201909181055.jar" sourcepath="/ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm.source_7.1.0.v201909181055.jar"/>
 	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/jaxb-core_2.2.11.v201407311112.jar" sourcepath="/ECLIPSELINK_HOME/plugins/jaxb-core.source_2.2.11.v201407311112.jar"/>
 	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/javax.validation_1.1.0.v201304101302.jar"/>
 	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/jaxb-xjc_2.2.11.v201407311112.jar" sourcepath="/ECLIPSELINK_HOME/plugins/jaxb-xjc.source_2.2.11.v201407311112.jar"/>

--- a/moxy/eclipselink.moxy.test/antbuild.properties
+++ b/moxy/eclipselink.moxy.test/antbuild.properties
@@ -26,7 +26,7 @@ resource.jar=javax.resource_1.6.0.v201204270900.jar
 ejb.jar=javax.ejb_3.1.0.v201205171433.jar
 jms.jar=javax.jms_1.1.0.v200906010428.jar
 transaction.jar=javax.transaction_1.1.0.v201002051055.jar
-asm.jar=org.eclipse.persistence.asm_7.0.0.v201811131354.jar
+asm.jar=org.eclipse.persistence.asm_7.1.0.v201909181055.jar
 
 eclipselink.core.depend=${activation.jar},${resource.jar},${ejb.jar},${jms.jar},${stax_api.jar},${transaction.jar},${mail.jar},${javax.validation.jar}
 

--- a/moxy/org.eclipse.persistence.moxy/.classpath
+++ b/moxy/org.eclipse.persistence.moxy/.classpath
@@ -4,7 +4,7 @@
 	<classpathentry kind="lib" path="resource"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/javax.ws.rs_1.1.1.v20101004-1200.jar" sourcepath="/ECLIPSELINK_HOME/plugins/javax.ws.rs.source_1.1.1.v20101004-1200.jar"/>
-	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm_7.0.0.v201811131354.jar" sourcepath="/ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm.source_7.0.0.v201811131354.jar"/>
+	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm_7.1.0.v201909181055.jar" sourcepath="/ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm.source_7.1.0.v201909181055.jar"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/performance/eclipselink.perf.test/.classpath
+++ b/performance/eclipselink.perf.test/.classpath
@@ -4,7 +4,7 @@
 	<classpathentry kind="src" path="resource"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
-	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm_7.0.0.v201811131354.jar" sourcepath="/ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm.source_7.0.0.v201811131354.jar"/>
+	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm_7.1.0.v201909181055.jar" sourcepath="/ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm.source_7.1.0.v201909181055.jar"/>
 	<classpathentry kind="var" path="EXTENSION_LIB_EXTERNAL/jmh-core-0.9.3.jar"/>
 	<classpathentry kind="var" path="EXTENSION_LIB_EXTERNAL/jmh-generator-annprocess-0.9.3.jar"/>
 	<classpathentry kind="var" path="EXTENSION_LIB_EXTERNAL/commons-math3-3.3.jar"/>

--- a/performance/eclipselink.perf.test/antbuild.properties
+++ b/performance/eclipselink.perf.test/antbuild.properties
@@ -14,7 +14,7 @@ classes.dir=classes
 resource.dir=resource
 report.dir=reports
 
-asm.jar=org.eclipse.persistence.asm_7.0.0.v201811131354.jar
+asm.jar=org.eclipse.persistence.asm_7.1.0.v201909181055.jar
 persistence21.jar=javax.persistence_2.1.1.v201509150925.jar
 json.jar=org.glassfish.javax.json_1.0.4.v201311181159.jar
 jmh-core.jar=jmh-core-0.9.3.jar

--- a/sdo/eclipselink.sdo.test/antbuild.properties
+++ b/sdo/eclipselink.sdo.test/antbuild.properties
@@ -37,7 +37,7 @@ classes.dir=classes
 resource.dir=resource
 report.dir=reports
 
-asm=org.eclipse.persistence.asm_7.0.0.v201811131354.jar
+asm=org.eclipse.persistence.asm_7.1.0.v201909181055.jar
 
 xml.platform=org.eclipse.persistence.platform.xml.jaxp.JAXPPlatform
 parser=org.eclipse.persistence.platform.xml.jaxp.JAXPParser

--- a/utils/eclipselink.dbws.builder.test.oracle/.classpath
+++ b/utils/eclipselink.dbws.builder.test.oracle/.classpath
@@ -8,7 +8,7 @@
 	<classpathentry excluding="**/.svn/**" kind="src" path="src"/>
 	<classpathentry kind="var" path="ECLIPSELINK_HOME/utils/plugins/javax.wsdl_1.6.2.v201012040545.jar" sourcepath="/ECLIPSELINK_HOME/utils/plugins/wsdl4j-src-1.6.2.zip"/>
 	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/org.eclipse.persistence.antlr_3.2.0.v201302191141.jar" sourcepath="/ECLIPSELINK_HOME/plugins/org.eclipse.persistence.antlr.source_3.2.0.v201302191141.jar"/>
-	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm_7.0.0.v201811131354.jar" sourcepath="/ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm.source_7.0.0.v201811131354.jar"/>
+	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm_7.1.0.v201909181055.jar" sourcepath="/ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm.source_7.1.0.v201909181055.jar"/>
 	<classpathentry kind="var" path="ECLIPSELINK_HOME/utils/plugins/org.eclipse.persistence.oracleddlparser_1.0.0.v20141020.jar" sourcepath="/ECLIPSELINK_HOME/utils/plugins/org.eclipse.persistence.oracleddlparser.source_1.0.0.v20141020.jar"/>
 	<classpathentry kind="lib" path="/oracle.libs/xdb.jar"/>
 	<classpathentry kind="lib" path="/oracle.libs/xmlparserv2.jar"/>

--- a/utils/eclipselink.utils.sigcompare/.classpath
+++ b/utils/eclipselink.utils.sigcompare/.classpath
@@ -3,6 +3,6 @@
 	<classpathentry excluding="**/.svn/**" kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
-	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm_7.0.0.v201811131354.jar" sourcepath="/ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm.source_7.0.0.v201811131354.jar"/>
+	<classpathentry kind="var" path="ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm_7.1.0.v201909181055.jar" sourcepath="/ECLIPSELINK_HOME/plugins/org.eclipse.persistence.asm.source_7.1.0.v201909181055.jar"/>
 	<classpathentry kind="output" path="classes"/>
 </classpath>

--- a/utils/org.eclipse.persistence.dbws.builder/antbuild.properties
+++ b/utils/org.eclipse.persistence.dbws.builder/antbuild.properties
@@ -23,6 +23,6 @@ plugins.dir=plugins
 
 #     Variable Definitions (execution location dependent)
 # -----------------------------------
-asm.jar=org.eclipse.persistence.asm_7.0.0.v201811131354.jar
+asm.jar=org.eclipse.persistence.asm_7.1.0.v201909181055.jar
 servlet.jar=javax.servlet_2.4.0.v200806031604.jar
 wsdl.jar=javax.wsdl_1.6.2.v201012040545.jar


### PR DESCRIPTION
Noticed that my changes to various .classpath and antbuild.xml files to point to the ASM 7.1 jar (PR #537) did not make it into the pull request.  Correcting the oversight with this PR.