### PR TITLE
Jenkins jobs - JUnit test split into smaller parts

### DIFF
--- a/etc/jenkins/build.groovy
+++ b/etc/jenkins/build.groovy
@@ -133,7 +133,10 @@ spec:
                 junit allowEmptyResults: true, testResults: 'dbws/**/reports/**/TESTS-TestSuites.xml'
                 junit allowEmptyResults: true, testResults: 'foundation/**/reports/**/TESTS-TestSuites.xml'
                 junit allowEmptyResults: true, testResults: 'jpa/**/reports/**/TESTS-TestSuites.xml'
-                junit allowEmptyResults: true, testResults: 'moxy/**/reports/**/TESTS-TestSuites.xml'
+                junit allowEmptyResults: true, testResults: 'moxy/**/reports/installer/TESTS-TestSuites.xml'
+                junit allowEmptyResults: true, testResults: 'moxy/**/reports/jaxb/TESTS-TestSuites.xml'
+                junit allowEmptyResults: true, testResults: 'moxy/**/reports/oxm/TESTS-TestSuites.xml'
+                junit allowEmptyResults: true, testResults: 'moxy/**/reports/srg/TESTS-TestSuites.xml'
                 junit allowEmptyResults: true, testResults: 'sdo/**/reports/**/TESTS-TestSuites.xml'
                 junit allowEmptyResults: true, testResults: 'utils/**/reports/**/TESTS-TestSuites.xml'
             }


### PR DESCRIPTION
MOXy junit reports collection divided into smaller parts due remaining errors in Eclipse.org build infra.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>