### PR TITLE
[2.7] Core MIN/MAX test failure on Oracle RDBMS fix

### DIFF
--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/jpql/AggregateTest.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/jpql/AggregateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -80,7 +80,7 @@ public class AggregateTest extends JPQLTestCase {
         ReportQuery rq = getNewReportQueryForTest(test);
         ExpressionBuilder builder = rq.getExpressionBuilder();
         Expression exp = builder.get("salary").distinct();
-        rq.addMaximum("salary", exp);
+        rq.addMaximum("salary", exp, Integer.class);
 
         return test;
     }
@@ -92,7 +92,7 @@ public class AggregateTest extends JPQLTestCase {
         ReportQuery rq = getNewReportQueryForTest(test);
         ExpressionBuilder builder = rq.getExpressionBuilder();
         Expression exp = builder.get("salary").distinct();
-        rq.addMinimum("salary", exp);
+        rq.addMinimum("salary", exp, Integer.class);
 
 
         return test;

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/ReportQuery.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/ReportQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -444,10 +444,30 @@ public class ReportQuery extends ReadAllQuery {
      * PUBLIC:
      * Add the maximum value of the attribute to be included in the result.
      * Aggregation functions can be used with a group by, or on the entire result set.
+     * EXAMPLE: reportQuery.addMaximum("salary", Integer.class);
+     */
+    public void addMaximum(String itemName, Class resultType) {
+        addMaximum(itemName, getExpressionBuilder().get(itemName), resultType);
+    }
+
+    /**
+     * PUBLIC:
+     * Add the maximum value of the attribute to be included in the result.
+     * Aggregation functions can be used with a group by, or on the entire result set.
      * EXAMPLE: reportQuery.addMaximum("managerSalary", expBuilder.get("manager").get("salary"));
      */
     public void addMaximum(String itemName, Expression attributeExpression) {
         addItem(itemName, attributeExpression.maximum());
+    }
+
+    /**
+     * PUBLIC:
+     * Add the maximum value of the attribute to be included in the result.
+     * Aggregation functions can be used with a group by, or on the entire result set.
+     * EXAMPLE: reportQuery.addMaximum("managerSalary", expBuilder.get("manager").get("salary"), Integer.class);
+     */
+    public void addMaximum(String itemName, Expression attributeExpression, Class resultType) {
+        addItem(itemName, attributeExpression.maximum(), resultType);
     }
 
     /**
@@ -464,10 +484,30 @@ public class ReportQuery extends ReadAllQuery {
      * PUBLIC:
      * Add the minimum value of the attribute to be included in the result.
      * Aggregation functions can be used with a group by, or on the entire result set.
+     * EXAMPLE: reportQuery.addMinimum("salary", Integer.class);
+     */
+    public void addMinimum(String itemName, Class resultType) {
+        addMinimum(itemName, getExpressionBuilder().get(itemName), resultType);
+    }
+
+    /**
+     * PUBLIC:
+     * Add the minimum value of the attribute to be included in the result.
+     * Aggregation functions can be used with a group by, or on the entire result set.
      * EXAMPLE: reportQuery.addMinimum("managerSalary", expBuilder.get("manager").get("salary"));
      */
     public void addMinimum(String itemName, Expression attributeExpression) {
         addItem(itemName, attributeExpression.minimum());
+    }
+
+    /**
+     * PUBLIC:
+     * Add the minimum value of the attribute to be included in the result.
+     * Aggregation functions can be used with a group by, or on the entire result set.
+     * EXAMPLE: reportQuery.addMinimum("managerSalary", expBuilder.get("manager").get("salary"), Integer.class);
+     */
+    public void addMinimum(String itemName, Expression attributeExpression, Class resultType) {
+        addItem(itemName, attributeExpression.minimum(), resultType);
     }
 
     /**


### PR DESCRIPTION
This is fix for core tests of MIN/MAX expression. Before this fix, test return type
was database dependent but expected value in assertion java.lang.Integer.
In MySQL these tests correctly passed, but in the Oracle return type was BigDecimal.
This bug is related with EclipseLink core only. In JPA it returns expected data type.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>