### PR TITLE
[2.7] Bug 546533 - QueryKeyExpression.printSQL writes no value 3.0 - JPA Unit test fix

### DIFF
--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/criteria/JUnitCriteriaSimpleTestSuiteBase.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/criteria/JUnitCriteriaSimpleTestSuiteBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -629,7 +629,7 @@ public abstract class JUnitCriteriaSimpleTestSuiteBase<T> extends JUnitTestCase 
             String partOne = emp.getFirstName();
 
             ExpressionBuilder builder = new ExpressionBuilder();
-            Expression whereClause = builder.literal("\"Smith\"").concat(builder.get("firstName")).like("Smith" + partOne);
+            Expression whereClause = builder.literal("'Smith'").concat(builder.get("firstName")).like("Smith" + partOne);
 
             ReadAllQuery raq = new ReadAllQuery();
             raq.setReferenceClass(Employee.class);

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/jpql/JUnitJPQLSimpleTestSuite.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/jpql/JUnitJPQLSimpleTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -573,7 +573,7 @@ public class JUnitJPQLSimpleTestSuite extends JUnitTestCase {
         partOne = emp.getFirstName();
 
         ExpressionBuilder builder = new ExpressionBuilder();
-        Expression whereClause = builder.literal("\"Smith\"").concat(builder.get("firstName")).like("Smith" + partOne);
+        Expression whereClause = builder.literal("'Smith'").concat(builder.get("firstName")).like("Smith" + partOne);
 
         ReadAllQuery raq = new ReadAllQuery();
         raq.setReferenceClass(Employee.class);


### PR DESCRIPTION
[2.7] Bug 546533 - QueryKeyExpression.printSQL writes no value 3.0 - JPA Unit test fix

This is additional fix for JPA tests.
In the unit test were used double quotas character as wrapper for string literal.
It was functional against MySQL but was not in the Oracle DB.
Sorry I forgot to fix it in previous PR #548 .

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>