### PR TITLE
[2.7] JPA MIN/MAX test failure on Oracle RDBMS fix

### DIFF
--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/jpql/JUnitJPQLComplexAggregateTestSuite.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/jpql/JUnitJPQLComplexAggregateTestSuite.java
@@ -461,7 +461,7 @@ public class JUnitJPQLComplexAggregateTestSuite extends JUnitTestCase
         rq.setReferenceClass(Employee.class);
         rq.returnSingleAttribute();
         rq.dontRetrievePrimaryKeys();
-        rq.addAttribute("salary", expbldr.get("salary").distinct().maximum());
+        rq.addAttribute("salary", expbldr.get("salary").distinct().maximum(), Integer.class);
         Vector expectedResultVector = (Vector) getServerSession().executeQuery(rq);
         Number expectedResult = (Number) expectedResultVector.get(0);
 
@@ -484,7 +484,7 @@ public class JUnitJPQLComplexAggregateTestSuite extends JUnitTestCase
         rq.setReferenceClass(Employee.class);
         rq.returnSingleAttribute();
         rq.dontRetrievePrimaryKeys();
-        rq.addAttribute("salary", expbldr.get("salary").distinct().minimum());
+        rq.addAttribute("salary", expbldr.get("salary").distinct().minimum(), Integer.class);
         Vector expectedResultVector = (Vector) getServerSession().executeQuery(rq);
         Number expectedResult = (Number) expectedResultVector.get(0);
 


### PR DESCRIPTION
[2.7] JPA MIN/MAX test failure on Oracle RDBMS fix

This is fix for JPA test of MIN/MAX expression. Before this fix test return type
was database dependent but expected was java.lang.Integer.
In MySQL these tests correctly passed, but in the Oracle return type was BigDecimal.
JPA test using there core methods to get expected value/results and this one has incorrect type.
JPA itself is OK.
Sorry I forgot to fix it in previous PR #557 

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>