### PR TITLE
[2.7] Jenkins jobs - release promotion v 2.0

### DIFF
--- a/etc/jenkins/promote.groovy
+++ b/etc/jenkins/promote.groovy
@@ -135,6 +135,7 @@ spec:
                             then
                                 echo calling "promote.sh ${NIGHTLY_BUILD_ID} ${RELEASE_CANDIDATE_ID} ${MAJOR_VERSION} ${SIGN} ${DEBUG}"
                                 ${HOME}/etc/jenkins/promote.sh ${NIGHTLY_BUILD_ID} ${RELEASE_CANDIDATE_ID} ${MAJOR_VERSION} ${SIGN} ${DEBUG}
+                                ${HOME}/etc/jenkins/publish_milestone.sh
                             else
                                 echo calling "promote.sh release ${RELEASE_CANDIDATE_ID} ${MAJOR_VERSION} ${SIGN} ${DEBUG}"
                                 ${HOME}/etc/jenkins/promote.sh release ${RELEASE_CANDIDATE_ID} ${MAJOR_VERSION} ${SIGN} ${DEBUG}

--- a/etc/jenkins/promote.groovy
+++ b/etc/jenkins/promote.groovy
@@ -135,12 +135,27 @@ spec:
                             then
                                 echo calling "promote.sh ${NIGHTLY_BUILD_ID} ${RELEASE_CANDIDATE_ID} ${MAJOR_VERSION} ${SIGN} ${DEBUG}"
                                 ${HOME}/etc/jenkins/promote.sh ${NIGHTLY_BUILD_ID} ${RELEASE_CANDIDATE_ID} ${MAJOR_VERSION} ${SIGN} ${DEBUG}
-                                ${HOME}/etc/jenkins/publish_milestone.sh
                             else
                                 echo calling "promote.sh release ${RELEASE_CANDIDATE_ID} ${MAJOR_VERSION} ${SIGN} ${DEBUG}"
                                 ${HOME}/etc/jenkins/promote.sh release ${RELEASE_CANDIDATE_ID} ${MAJOR_VERSION} ${SIGN} ${DEBUG}
                             fi
                         """
+                }
+            }
+        }
+        // Publish to Eclipse.org downloads (Milestones, ...)
+        stage('Publish to Eclipse.org downloads') {
+            steps {
+                container('el-build') {
+                    sshagent(['projects-storage.eclipse.org-bot-ssh']) {
+                        sh """
+                            echo ${RELEASE}
+                            if [ ${RELEASE} == 'false' ]
+                            then
+                                ${HOME}/etc/jenkins/publish_milestone.sh
+                            fi
+                            """
+                    }
                 }
             }
         }

--- a/etc/jenkins/publish_milestone.sh
+++ b/etc/jenkins/publish_milestone.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -e
+#
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Distribution License v. 1.0, which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+#
+# Arguments:
+#  N/A
+#==========================
+#   Basic Env Setup
+#
+. ${HOME}/etc/jenkins/setEnvironment.sh
+
+
+echo '-[ EclipseLink Publish to Milestones ]-----------------------------------------------------------'
+scp -r $MILESTONE_DNLD_DIR/* genie.eclipselink@projects-storage.eclipse.org:$MILESTONE_DNLD_DIR_REMOTE
+scp -r $MILESTONE_SITE_DIR/* genie.eclipselink@projects-storage.eclipse.org:$MILESTONE_SITE_DIR_REMOTE

--- a/etc/jenkins/setEnvironment.sh
+++ b/etc/jenkins/setEnvironment.sh
@@ -25,11 +25,13 @@ START_DATE_DEFAULT=`date '+%y%m%d-%H%M'`
 
 DNLD_DIR_DEFAULT=${WORKSPACE}/home/data/httpd/download.eclipse.org/rt/eclipselink
 RELEASE_SITE_DIR_DEFAULT=${WORKSPACE}/home/data/httpd/download.eclipse.org/rt/eclipselink/updates
+MILESTONE_DNLD_DIR_DEFAULT=${WORKSPACE}/home/data/httpd/download.eclipse.org/rt/eclipselink/milestones
 MILESTONE_SITE_DIR_DEFAULT=${WORKSPACE}/home/data/httpd/download.eclipse.org/rt/eclipselink/milestone-updates
 NIGHTLY_SITE_DIR_DEFAULT=${WORKSPACE}/home/data/httpd/download.eclipse.org/rt/eclipselink/nightly-updates
 
 DNLD_DIR_REMOTE_DEFAULT=/home/data/httpd/download.eclipse.org/rt/eclipselink
 RELEASE_SITE_DIR_REMOTE_DEFAULT=/home/data/httpd/download.eclipse.org/rt/eclipselink/updates
+MILESTONE_DNLD_DIR_REMOTE_DEFAULT=/home/data/httpd/download.eclipse.org/rt/eclipselink/milestones
 MILESTONE_SITE_DIR_REMOTE_DEFAULT=/home/data/httpd/download.eclipse.org/rt/eclipselink/milestone-updates
 NIGHTLY_SITE_DIR_REMOTE_DEFAULT=/home/data/httpd/download.eclipse.org/rt/eclipselink/nightly-updates
 
@@ -54,9 +56,11 @@ set_default_var ANT_OPTS ${ANT_OPTS_DEFAULT}
 set_default_var START_DATE ${START_DATE_DEFAULT}
 set_default_var DNLD_DIR ${DNLD_DIR_DEFAULT}
 set_default_var RELEASE_SITE_DIR ${RELEASE_SITE_DIR_DEFAULT}
+set_default_var MILESTONE_DNLD_DIR ${MILESTONE_DNLD_DIR_DEFAULT}
 set_default_var MILESTONE_SITE_DIR ${MILESTONE_SITE_DIR_DEFAULT}
 set_default_var NIGHTLY_SITE_DIR ${NIGHTLY_SITE_DIR_DEFAULT}
 set_default_var DNLD_DIR_REMOTE ${DNLD_DIR_REMOTE_DEFAULT}
 set_default_var RELEASE_SITE_DIR_REMOTE ${RELEASE_SITE_DIR_REMOTE_DEFAULT}
+set_default_var MILESTONE_DNLD_DIR_REMOTE ${MILESTONE_DNLD_DIR_REMOTE_DEFAULT}
 set_default_var MILESTONE_SITE_DIR_REMOTE ${MILESTONE_SITE_DIR_REMOTE_DEFAULT}
 set_default_var NIGHTLY_SITE_DIR_REMOTE ${NIGHTLY_SITE_DIR_REMOTE_DEFAULT}


### PR DESCRIPTION
[2.7] Jenkins jobs - release promotion v 2.0

This is fix to publish milestone releases (RC1, RC2....) and P2 update sites to Eclipse.org.