### PR TITLE
[2.7] ProjectXMLStoredFunctionCallTest fix (test.core - Oracle12Platform)

### DIFF
--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/workbenchintegration/ProjectXMLStoredFunctionCallTest.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/workbenchintegration/ProjectXMLStoredFunctionCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -69,18 +69,18 @@ public class ProjectXMLStoredFunctionCallTest extends TestCase {
 
     public void verify() {
       DatabaseRecord row = (DatabaseRecord)((Vector)result).firstElement();
-      Integer p_inout = (Integer)row.get("P_INOUT");
-      if (!p_inout.equals(new Integer(100))) {
+      Long p_inout = (Long)row.get("P_INOUT");
+      if (!p_inout.equals(new Long(100))) {
         throw new TestErrorException(
           "The stored function did not execute correctly. Expected: [P_INOUT = 100]");
       }
-      Integer p_out = (Integer)row.get("P_OUT");
-      if (!p_out.equals(new Integer(99))) {
+        Long p_out = (Long)row.get("P_OUT");
+      if (!p_out.equals(new Long(99))) {
         throw new TestErrorException(
           "The stored function did not execute correctly. Expected: [P_OUT = 99]");
       }
-      Integer returnValue = (Integer)row.getValues().firstElement();
-      if (!returnValue.equals(new Integer(99))) {
+        Long returnValue = (Long)row.getValues().firstElement();
+      if (!returnValue.equals(new Long(99))) {
         throw new TestErrorException(
           "The stored function did not execute correctly. Expected: [return value = 99]");
       }


### PR DESCRIPTION
[2.7] ProjectXMLStoredFunctionCallTest fix (test.core - Oracle12Platform)

In this test (ProjectXMLStoredFunctionCallTest) were wrong query result
types (`java.lang.Integer` instead of `java.lang.Long`).
Project/query definition is loaded in `setup()` method from MWIntegrationCustomSQLEmployeeProject.xml file.
See `<query name="StoredFunctionCallInNamedQuery" xsi:type="data-read-query">` from there.
Procedure arguments specified there are `java.lang.Long`.
This test is executed only on `org.eclipse.persistence.platform.database.oracle.Oracle12Platform`.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>