### PR TITLE
[2.7] Jenkins jobs - release promotion

### DIFF
--- a/etc/jenkins/publish_milestone.sh
+++ b/etc/jenkins/publish_milestone.sh
@@ -18,10 +18,5 @@
 
 
 echo '-[ EclipseLink Publish to Milestones ]-----------------------------------------------------------'
-
-echo "scp -rv ${MILESTONE_DNLD_DIR}/* genie.eclipselink@projects-storage.eclipse.org:${MILESTONE_DNLD_DIR_REMOTE}"
-echo "scp -rv ${MILESTONE_SITE_DIR}/* genie.eclipselink@projects-storage.eclipse.org:${MILESTONE_SITE_DIR_REMOTE}"
-
-
-scp -rv ${MILESTONE_DNLD_DIR}/* genie.eclipselink@projects-storage.eclipse.org:${MILESTONE_DNLD_DIR_REMOTE}
-scp -rv ${MILESTONE_SITE_DIR}/* genie.eclipselink@projects-storage.eclipse.org:${MILESTONE_SITE_DIR_REMOTE}
+scp -r ${MILESTONE_DNLD_DIR}/* genie.eclipselink@projects-storage.eclipse.org:${MILESTONE_DNLD_DIR_REMOTE}
+scp -r ${MILESTONE_SITE_DIR}/* genie.eclipselink@projects-storage.eclipse.org:${MILESTONE_SITE_DIR_REMOTE}

--- a/etc/jenkins/publish_milestone.sh
+++ b/etc/jenkins/publish_milestone.sh
@@ -18,5 +18,10 @@
 
 
 echo '-[ EclipseLink Publish to Milestones ]-----------------------------------------------------------'
-scp -r $MILESTONE_DNLD_DIR/* genie.eclipselink@projects-storage.eclipse.org:$MILESTONE_DNLD_DIR_REMOTE
-scp -r $MILESTONE_SITE_DIR/* genie.eclipselink@projects-storage.eclipse.org:$MILESTONE_SITE_DIR_REMOTE
+
+echo "scp -rv ${MILESTONE_DNLD_DIR}/* genie.eclipselink@projects-storage.eclipse.org:${MILESTONE_DNLD_DIR_REMOTE}"
+echo "scp -rv ${MILESTONE_SITE_DIR}/* genie.eclipselink@projects-storage.eclipse.org:${MILESTONE_SITE_DIR_REMOTE}"
+
+
+scp -rv ${MILESTONE_DNLD_DIR}/* genie.eclipselink@projects-storage.eclipse.org:${MILESTONE_DNLD_DIR_REMOTE}
+scp -rv ${MILESTONE_SITE_DIR}/* genie.eclipselink@projects-storage.eclipse.org:${MILESTONE_SITE_DIR_REMOTE}

--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/workbenchintegration/ProjectXMLStoredFunctionCallTest.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/workbenchintegration/ProjectXMLStoredFunctionCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -69,18 +69,18 @@ public class ProjectXMLStoredFunctionCallTest extends TestCase {
 
     public void verify() {
       DatabaseRecord row = (DatabaseRecord)((Vector)result).firstElement();
-      Integer p_inout = (Integer)row.get("P_INOUT");
-      if (!p_inout.equals(new Integer(100))) {
+      Long p_inout = (Long)row.get("P_INOUT");
+      if (!p_inout.equals(new Long(100))) {
         throw new TestErrorException(
           "The stored function did not execute correctly. Expected: [P_INOUT = 100]");
       }
-      Integer p_out = (Integer)row.get("P_OUT");
-      if (!p_out.equals(new Integer(99))) {
+        Long p_out = (Long)row.get("P_OUT");
+      if (!p_out.equals(new Long(99))) {
         throw new TestErrorException(
           "The stored function did not execute correctly. Expected: [P_OUT = 99]");
       }
-      Integer returnValue = (Integer)row.getValues().firstElement();
-      if (!returnValue.equals(new Integer(99))) {
+        Long returnValue = (Long)row.getValues().firstElement();
+      if (!returnValue.equals(new Long(99))) {
         throw new TestErrorException(
           "The stored function did not execute correctly. Expected: [return value = 99]");
       }


### PR DESCRIPTION
[2.7] Jenkins jobs - release promotion

This is fix to publish milestone releases (RC1, RC2....) and P2 update sites to Eclipse.org.
Due some strange limits in Eclipse.org build infrastructure (sshagent can't be (re)started in
different stages), everything in the pipeline is called in the single stage.