### PR TITLE
Using JAX-RS 2.1.6

### DIFF
--- a/buildsystem/compdeps/pom.xml
+++ b/buildsystem/compdeps/pom.xml
@@ -75,7 +75,7 @@
         <jakarta.servlet.version>4.0.2</jakarta.servlet.version>
         <jakarta.transaction.version>1.3.2</jakarta.transaction.version>
         <jakarta.validation.version>2.0.1</jakarta.validation.version>
-        <jakarta.ws.rs.version>2.1.4</jakarta.ws.rs.version>
+        <jakarta.ws.rs.version>2.1.6</jakarta.ws.rs.version>
         <jakarta.xml.bind.version>2.3.2</jakarta.xml.bind.version>
         <jakarta.xml.soap.version>1.4.1</jakarta.xml.soap.version>
         <jakarta.xml.ws-api.version>2.3.2</jakarta.xml.ws-api.version>


### PR DESCRIPTION
Jakarta EE 8 already contained JAX-RS 2.1.6, not 2.1.4