### PR TITLE
Jenkins jobs - publish releases

### DIFF
--- a/etc/jenkins/promote.groovy
+++ b/etc/jenkins/promote.groovy
@@ -139,6 +139,8 @@ spec:
                             if [ ${RELEASE} == 'false' ]
                             then
                                 ${HOME}/etc/jenkins/publish_milestone.sh
+                            else
+                                ${HOME}/etc/jenkins/publish_release.sh                            
                             fi
                             """
                     }

--- a/etc/jenkins/promote_init.sh
+++ b/etc/jenkins/promote_init.sh
@@ -15,11 +15,14 @@
 echo '-[ EclipseLink Promotion Init ]-----------------------------------------------------------'
 . ${HOME}/etc/jenkins/setEnvironment.sh
 mkdir -p ${DNLD_DIR}/nightly/${VERSION}
+mkdir -p ${MILESTONE_DNLD_DIR}/${VERSION}/${RELEASE_CANDIDATE_ID}
+mkdir -p ${RELEASE_DNLD_DIR}/${VERSION}
 mkdir -p ${RELEASE_SITE_DIR}
 mkdir -p ${MILESTONE_SITE_DIR}
 mkdir -p ${NIGHTLY_SITE_DIR}
 mkdir -p ${SIGN_DIR}
 scp -r genie.eclipselink@projects-storage.eclipse.org:${DNLD_DIR_REMOTE}/nightly/${VERSION}/* ${DNLD_DIR}/nightly/${VERSION}
+scp -r genie.eclipselink@projects-storage.eclipse.org:${MILESTONE_DNLD_DIR_REMOTE}/${VERSION}/${RELEASE_CANDIDATE_ID}/* ${MILESTONE_DNLD_DIR}/${VERSION}/${RELEASE_CANDIDATE_ID}
 
 echo '-[ EclipseLink Init ]-----------------------------------------------------------'
 

--- a/etc/jenkins/publish_release.sh
+++ b/etc/jenkins/publish_release.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -e
+#
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Distribution License v. 1.0, which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+#
+# Arguments:
+#  N/A
+#==========================
+#   Basic Env Setup
+#
+. ${HOME}/etc/jenkins/setEnvironment.sh
+
+
+echo '-[ EclipseLink Publish to Releases ]-----------------------------------------------------------'
+scp -r ${RELEASE_DNLD_DIR}/* genie.eclipselink@projects-storage.eclipse.org:${RELEASE_DNLD_DIR_REMOTE}

--- a/etc/jenkins/setEnvironment.sh
+++ b/etc/jenkins/setEnvironment.sh
@@ -25,12 +25,14 @@ START_DATE_DEFAULT=`date '+%y%m%d-%H%M'`
 
 DNLD_DIR_DEFAULT=${WORKSPACE}/home/data/httpd/download.eclipse.org/rt/eclipselink
 RELEASE_SITE_DIR_DEFAULT=${WORKSPACE}/home/data/httpd/download.eclipse.org/rt/eclipselink/updates
+RELEASE_DNLD_DIR_DEFAULT=${WORKSPACE}/home/data/httpd/download.eclipse.org/rt/eclipselink/releases
 MILESTONE_DNLD_DIR_DEFAULT=${WORKSPACE}/home/data/httpd/download.eclipse.org/rt/eclipselink/milestones
 MILESTONE_SITE_DIR_DEFAULT=${WORKSPACE}/home/data/httpd/download.eclipse.org/rt/eclipselink/milestone-updates
 NIGHTLY_SITE_DIR_DEFAULT=${WORKSPACE}/home/data/httpd/download.eclipse.org/rt/eclipselink/nightly-updates
 
 DNLD_DIR_REMOTE_DEFAULT=/home/data/httpd/download.eclipse.org/rt/eclipselink
 RELEASE_SITE_DIR_REMOTE_DEFAULT=/home/data/httpd/download.eclipse.org/rt/eclipselink/updates
+RELEASE_DNLD_DIR_REMOTE_DEFAULT=/home/data/httpd/download.eclipse.org/rt/eclipselink/releases
 MILESTONE_DNLD_DIR_REMOTE_DEFAULT=/home/data/httpd/download.eclipse.org/rt/eclipselink/milestones
 MILESTONE_SITE_DIR_REMOTE_DEFAULT=/home/data/httpd/download.eclipse.org/rt/eclipselink/milestone-updates
 NIGHTLY_SITE_DIR_REMOTE_DEFAULT=/home/data/httpd/download.eclipse.org/rt/eclipselink/nightly-updates
@@ -56,11 +58,13 @@ set_default_var ANT_OPTS ${ANT_OPTS_DEFAULT}
 set_default_var START_DATE ${START_DATE_DEFAULT}
 set_default_var DNLD_DIR ${DNLD_DIR_DEFAULT}
 set_default_var RELEASE_SITE_DIR ${RELEASE_SITE_DIR_DEFAULT}
+set_default_var RELEASE_DNLD_DIR ${RELEASE_DNLD_DIR_DEFAULT}
 set_default_var MILESTONE_DNLD_DIR ${MILESTONE_DNLD_DIR_DEFAULT}
 set_default_var MILESTONE_SITE_DIR ${MILESTONE_SITE_DIR_DEFAULT}
 set_default_var NIGHTLY_SITE_DIR ${NIGHTLY_SITE_DIR_DEFAULT}
 set_default_var DNLD_DIR_REMOTE ${DNLD_DIR_REMOTE_DEFAULT}
 set_default_var RELEASE_SITE_DIR_REMOTE ${RELEASE_SITE_DIR_REMOTE_DEFAULT}
+set_default_var RELEASE_DNLD_DIR_REMOTE ${RELEASE_DNLD_DIR_REMOTE_DEFAULT}
 set_default_var MILESTONE_DNLD_DIR_REMOTE ${MILESTONE_DNLD_DIR_REMOTE_DEFAULT}
 set_default_var MILESTONE_SITE_DIR_REMOTE ${MILESTONE_SITE_DIR_REMOTE_DEFAULT}
 set_default_var NIGHTLY_SITE_DIR_REMOTE ${NIGHTLY_SITE_DIR_REMOTE_DEFAULT}


### PR DESCRIPTION
This is fix for Jenkins promote/release job to publish final release into right
directory in Eclipse.org download server.
During init phase there is download of specified milestone directory to verify it.