### PR TITLE
[master] Jenkins build fix - post Mavenize

### DIFF
--- a/etc/jenkins/build.sh
+++ b/etc/jenkins/build.sh
@@ -14,7 +14,4 @@
 
 echo '-[ EclipseLink Build ]-----------------------------------------------------------'
 . /etc/profile
-cd buildsystem/mavenize/
-./prepare.sh
-cd ../..
 mvn install -DskipTests -Poss-release


### PR DESCRIPTION
Jenkins build fix - post Mavenize

There is unnecessary call of preparation scripts as a part of Jenkins build.
Before transformation into Maven there were some preparation scripts.
This call will break Jenkins build and must be removed.