### PR TITLE
[master] Fix for #591 - MOXy - invalid XSD generated for @XmlValue from parent class

### DIFF
--- a/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/compiler/SchemaGenerator.java
+++ b/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/compiler/SchemaGenerator.java
@@ -385,7 +385,7 @@ public class SchemaGenerator {
                     extension.setBaseType(parentTypeInfo.getSchemaTypeName());
                 }
 
-                if(CompilerHelper.isSimpleType(parentTypeInfo)){
+                if(parentTypeInfo.getXmlValueProperty() != null){
                     SimpleContent content = new SimpleContent();
                     content.setExtension(extension);
                     type.setSimpleContent(content);

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/schemagen/SchemaGenTestSuite.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/schemagen/SchemaGenTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -22,6 +22,7 @@ import org.eclipse.persistence.testing.jaxb.schemagen.imports.SchemaGenImportTes
 import org.eclipse.persistence.testing.jaxb.schemagen.imports.inheritance.InheritanceImportsTestCases;
 import org.eclipse.persistence.testing.jaxb.schemagen.imports.url.SchemaGenImportURLTestCases;
 import org.eclipse.persistence.testing.jaxb.schemagen.inheritance.InheritanceWithTransientTestCases;
+import org.eclipse.persistence.testing.jaxb.schemagen.inheritance.InheritanceWithXMLValueTestCases;
 import org.eclipse.persistence.testing.jaxb.schemagen.inheritance.SchemaGenInheritanceTestCases;
 import org.eclipse.persistence.testing.jaxb.schemagen.scope.SchemaGenScopeTestCases;
 import org.eclipse.persistence.testing.jaxb.schemagen.typearray.TypeArraySchemaGenTestCases;
@@ -65,6 +66,7 @@ public class SchemaGenTestSuite extends TestSuite {
         suite.addTestSuite(AnonymousTypeInheritanceTestCases.class);
         suite.addTestSuite(SchemaGenInheritanceTestCases.class);
         suite.addTestSuite(InheritanceWithTransientTestCases.class);
+        suite.addTestSuite(InheritanceWithXMLValueTestCases.class);
         suite.addTestSuite(InheritanceImportsTestCases.class);
         suite.addTestSuite(SchemaGenXmlPathTestCases.class);
         suite.addTestSuite(SchemaGenXmlIDTestCases.class);

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/schemagen/inheritance/ChildEntity.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/schemagen/inheritance/ChildEntity.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.testing.jaxb.schemagen.inheritance;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlType(
+        name = "childType",
+        propOrder = {"name"},
+        namespace = "http://www.oracle.com/testSchema/testIdType"
+)
+public class ChildEntity extends ParentEntity {
+
+    @XmlAttribute
+    private String name;
+
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/schemagen/inheritance/ChildEntity.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/schemagen/inheritance/ChildEntity.java
@@ -25,7 +25,6 @@ public class ChildEntity extends ParentEntity {
     @XmlAttribute
     private String name;
 
-
     public String getName() {
         return name;
     }

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/schemagen/inheritance/InheritanceWithXMLValueTestCases.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/schemagen/inheritance/InheritanceWithXMLValueTestCases.java
@@ -76,7 +76,5 @@ public class InheritanceWithXMLValueTestCases extends TestCase {
         private String getSchema() {
             return stringWriter.toString();
         }
-
     }
-
 }

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/schemagen/inheritance/InheritanceWithXMLValueTestCases.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/schemagen/inheritance/InheritanceWithXMLValueTestCases.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,15 +11,13 @@
  */
 
 // Contributors:
-//     Matt MacIvor - 2.3 - Initial implementation
+//     Radek Felcman - 2.7.6 - Initial implementation
 package org.eclipse.persistence.testing.jaxb.schemagen.inheritance;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.StringReader;
-import java.io.StringWriter;
+import junit.framework.TestCase;
+import org.eclipse.persistence.testing.jaxb.JAXBXMLComparer;
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.SchemaOutputResolver;
@@ -27,26 +25,24 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Result;
 import javax.xml.transform.stream.StreamResult;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.io.StringWriter;
 
-import junit.framework.TestCase;
+public class InheritanceWithXMLValueTestCases extends TestCase {
+    private static final String CONTROL_SCHEMA = "org/eclipse/persistence/testing/jaxb/schemagen/inheritance/inheritance_xml_value.xsd";
 
-import org.eclipse.persistence.testing.jaxb.JAXBXMLComparer;
-import org.w3c.dom.Document;
-import org.xml.sax.InputSource;
-
-public class InheritanceWithTransientTestCases extends TestCase {
-    private static final String CONTROL_SCHEMA = "org/eclipse/persistence/testing/jaxb/schemagen/inheritance/transient.xsd";
-
-    public InheritanceWithTransientTestCases(String name) throws Exception {
+    public InheritanceWithXMLValueTestCases(String name) throws Exception {
         super(name);
     }
 
     public String getName() {
-        return "JAXB SchemaGen: Inheritance: With Transient" + super.getName();
+        return "JAXB SchemaGen: Inheritance: With XMLValue" + super.getName();
     }
 
     public void testSchemaGen() throws Exception {
-        JAXBContext jaxbContext = JAXBContext.newInstance(new Class[]{Z.class, X.class, Y.class, X2.class});
+        JAXBContext jaxbContext = JAXBContext.newInstance(new Class[]{ParentEntity.class, ChildEntity.class});
         StringOutputResolver sor = new StringOutputResolver();
         jaxbContext.generateSchema(sor);
 

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/schemagen/inheritance/ParentEntity.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/schemagen/inheritance/ParentEntity.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.testing.jaxb.schemagen.inheritance;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.XmlValue;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(
+        name = "parentType",
+        propOrder = {"id", "value"},
+        namespace = "http://www.oracle.com/testSchema/testIdType"
+)
+@XmlSeeAlso({ChildEntity.class})
+public class ParentEntity {
+
+    @XmlValue
+    private String value;
+
+    public String getValue() {
+        return this.value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @XmlAttribute
+    private int id;
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+
+}

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/schemagen/inheritance/ParentEntity.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/schemagen/inheritance/ParentEntity.java
@@ -49,6 +49,4 @@ public class ParentEntity {
     public void setId(int id) {
         this.id = id;
     }
-
-
 }

--- a/moxy/org.eclipse.persistence.moxy/src/test/resources/org/eclipse/persistence/testing/jaxb/schemagen/inheritance/inheritance_xml_value.xsd
+++ b/moxy/org.eclipse.persistence.moxy/src/test/resources/org/eclipse/persistence/testing/jaxb/schemagen/inheritance/inheritance_xml_value.xsd
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0,
+    or the Eclipse Distribution License v. 1.0 which is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+
+    SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+-->
+
+<xsd:schema xmlns:ns0="http://www.oracle.com/testSchema/testIdType" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.oracle.com/testSchema/testIdType">
+   <xsd:complexType name="childType">
+      <xsd:simpleContent>
+         <xsd:extension base="ns0:parentType">
+            <xsd:attribute name="name" type="xsd:string"/>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="parentType">
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:string">
+            <xsd:attribute name="id" type="xsd:int" use="required"/>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+</xsd:schema>


### PR DESCRIPTION
This is for for bug #591. MOXy generates invalid XSD if @XmlValue is in parent class.
There is fix and unit test too.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>