### PR TITLE
[2.7 - backport from master] Fix for #494 - JPA Weave: File handle leak: persistence.xml not properly closed

### DIFF
--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/deployment/PersistenceUnitProcessor.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/deployment/PersistenceUnitProcessor.java
@@ -635,8 +635,8 @@ public class PersistenceUnitProcessor {
      */
     public static List<SEPersistenceUnitInfo> processPersistenceArchive(Archive archive, ClassLoader loader){
         URL puRootURL = archive.getRootURL();
-        try {
-            return processPersistenceXML(puRootURL, archive.getDescriptorStream(), loader);
+        try (InputStream descriptorStream = archive.getDescriptorStream()) {
+            return processPersistenceXML(puRootURL, descriptorStream, loader);
           } catch (Exception e) {
             throw PersistenceUnitLoadingException.exceptionLoadingFromUrl(puRootURL.toString(), e);
         }


### PR DESCRIPTION
[2.7 - backport from master] Fix for #494 - JPA Weave: File handle leak: persistence.xml not properly closed

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>