### PR TITLE
[2.7] Jenkins build - update/P2 site release fix (bug 545221)

### DIFF
--- a/etc/jenkins/publish_release.sh
+++ b/etc/jenkins/publish_release.sh
@@ -19,3 +19,7 @@
 
 echo '-[ EclipseLink Publish to Releases ]-----------------------------------------------------------'
 scp -r ${RELEASE_DNLD_DIR}/* genie.eclipselink@projects-storage.eclipse.org:${RELEASE_DNLD_DIR_REMOTE}
+cd ${RELEASE_SITE_DIR}
+P2_SITE_NAME=$(ls)
+zip -r "${P2_SITE_NAME}.zip" ${P2_SITE_NAME}/*
+scp -r ${RELEASE_SITE_DIR}/* genie.eclipselink@projects-storage.eclipse.org:${RELEASE_SITE_DIR_REMOTE}


### PR DESCRIPTION
[2.7] Jenkins build - update/P2 site release fix

Before this fix update/P2 site wasn't published during EclipseLink release (final release)
to Eclipse.org download site. It generates zip archive too to make P2 site available for
download (offline usage) from https://download.eclipse.org/rt/eclipselink/updates/ .

This is fix for bug 545221 ( https://bugs.eclipse.org/bugs/show_bug.cgi?id=545221 ) too.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>