### PR TITLE
[2.7] MOXy logging should throw NPE - fix (backport from master)

### DIFF
--- a/jpa/eclipselink.jpars.test/jpars.test.iml
+++ b/jpa/eclipselink.jpars.test/jpars.test.iml
@@ -17,7 +17,6 @@
     <facet type="jpa" name="JPA">
       <configuration>
         <setting name="validation-enabled" value="true" />
-        <setting name="provider-name" value="" />
         <datasource-mapping>
           <factory-entry name="jpars_auction" />
           <factory-entry name="jpars_auction-static" />
@@ -27,6 +26,7 @@
           <factory-entry name="jpars_phonebook" />
           <factory-entry name="jpars_traveler-static" />
         </datasource-mapping>
+        <naming-strategy-map />
         <deploymentDescriptor name="persistence.xml" url="file://$MODULE_DIR$/src/META-INF/persistence.xml" />
       </configuration>
     </facet>

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBContext.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBContext.java
@@ -804,8 +804,12 @@ public class JAXBContext extends javax.xml.bind.JAXBContext {
         public JAXBContextInput(Map properties, ClassLoader classLoader) {
             SessionLog logger = AbstractSessionLog.getLog();
             if (properties != null && logger.shouldLog(SessionLog.FINE, SessionLog.MOXY)) {
-                for (Object key : properties.keySet()) {
-                    logger.log(SessionLog.FINE, SessionLog.MOXY, "moxy_set_jaxb_context_property", new Object[]{key.toString(), properties.get(key).toString()});
+                for (Map.Entry<Object, Object> item : (Set<Map.Entry<Object, Object>>)(properties.entrySet())) {
+                    if (item.getValue() == null) {
+                        logger.log(SessionLog.FINE, SessionLog.MOXY, "moxy_set_jaxb_context_property", new Object[]{item.getKey(), "NULL"});
+                    } else {
+                        logger.log(SessionLog.FINE, SessionLog.MOXY, "moxy_set_jaxb_context_property", new Object[]{item.getKey(), item.getValue()});
+                    }
                 }
             }
             this.properties = properties;

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBMarshaller.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBMarshaller.java
@@ -934,7 +934,11 @@ public class JAXBMarshaller implements javax.xml.bind.Marshaller {
                 } else if (MarshallerProperties.MOXY_LOG_PAYLOAD.equals(key)) {
                     xmlMarshaller.setLogPayload(((Boolean) value));
                 } else if (MarshallerProperties.MOXY_LOGGING_LEVEL.equals(key)) {
-                    AbstractSessionLog.getLog().setLevel(LogLevel.toValue((String) value).getId(), SessionLog.MOXY);
+                    if (value instanceof String) {
+                        AbstractSessionLog.getLog().setLevel(LogLevel.toValue((String) value).getId(), SessionLog.MOXY);
+                    } else {
+                        AbstractSessionLog.getLog().setLevel(((LogLevel) value).getId(), SessionLog.MOXY);
+                    }
                 } else if (SUN_CHARACTER_ESCAPE_HANDLER.equals(key) || SUN_JSE_CHARACTER_ESCAPE_HANDLER.equals(key) || SUN_CHARACTER_ESCAPE_HANDLER_MARSHALLER.equals(key) || SUN_JSE_CHARACTER_ESCAPE_HANDLER_MARSHALLER.equals(key)) {
                     if (value == null) {
                         xmlMarshaller.setCharacterEscapeHandler(null);

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBUnmarshaller.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/JAXBUnmarshaller.java
@@ -924,8 +924,12 @@ public class JAXBUnmarshaller implements Unmarshaller {
             xmlUnmarshaller.setDisableSecureProcessing(disabled);
         } else if (UnmarshallerProperties.MOXY_LOG_PAYLOAD.equals(key)) {
             xmlUnmarshaller.setLogPayload(((boolean) value));
-        } else if (MarshallerProperties.MOXY_LOGGING_LEVEL.equals(key)) {
-            AbstractSessionLog.getLog().setLevel(LogLevel.toValue((String) value).getId(), SessionLog.MOXY);
+        } else if (UnmarshallerProperties.MOXY_LOGGING_LEVEL.equals(key)) {
+            if (value instanceof String) {
+                AbstractSessionLog.getLog().setLevel(LogLevel.toValue((String) value).getId(), SessionLog.MOXY);
+            } else {
+                AbstractSessionLog.getLog().setLevel(((LogLevel) value).getId(), SessionLog.MOXY);
+            }
         } else {
             throw new PropertyException(key, value);
         }


### PR DESCRIPTION
[2.7] MOXy logging should throw NPE - fix (backport from master)

This is fix for bug, when JAXBContext property value is null, MOXy logging
will throw NPE instead of "Setting JAXBContext property (name/value): ....." message.
There is also fix if (Un)MarshallerProperty MOXY_LOGGING_LEVEL is set as
a `java.lang.String` instead of value from `org.eclipse.persistence.logging.LogLevel` enum.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>