### PR TITLE
[master] Bug #618: Oracle positional parameters with ParameterMode.REF_CURSOR out parameter

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabaseCall.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabaseCall.java
@@ -785,8 +785,7 @@ public abstract class DatabaseCall extends DatasourceCall {
                 // outParameter contains all the info for registerOutputParameter call.
                 OutputParameterForCallableStatement outParameter = new OutputParameterForCallableStatement(outField, session, isCursor);
                 this.parameters.set(i, outParameter);
-                // nothing to do during translate method
-                this.parameterTypes.set(i, LITERAL);
+                this.parameterTypes.set(i, parameterType);
             }
         }
         if (this.returnsResultSet == null) {
@@ -1181,9 +1180,6 @@ public abstract class DatabaseCall extends DatasourceCall {
                         parametersValues.add(value);
                     }
                 } else if (parameterType == LITERAL) {
-                    if ((parameter != null) && (parameter instanceof OutputParameterForCallableStatement)) {
-                        ((OutputParameterForCallableStatement) parameter).getOutputField().setIndex(index);
-                    }
                     parametersValues.add(parameter);
                 } else if (parameterType == IN) {
                     Object value = getValueForInParameter(parameter, translationRow, modifyRow, session, true);
@@ -1194,6 +1190,11 @@ public abstract class DatabaseCall extends DatasourceCall {
                 } else if (parameterType == INOUT) {
                     Object value = getValueForInOutParameter(parameter, translationRow, modifyRow, session);
                     parametersValues.add(value);
+                } else if (parameterType == OUT || parameterType == OUT_CURSOR) {
+                    if (parameter != null) {
+                        ((OutputParameterForCallableStatement) parameter).getOutputField().setIndex(index);
+                    }
+                    parametersValues.add(parameter);
                 }
             }
             setParameters(parametersValues);

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabaseCall.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabaseCall.java
@@ -1181,6 +1181,9 @@ public abstract class DatabaseCall extends DatasourceCall {
                         parametersValues.add(value);
                     }
                 } else if (parameterType == LITERAL) {
+                    if ((parameter != null) && (parameter instanceof OutputParameterForCallableStatement)) {
+                        ((OutputParameterForCallableStatement) parameter).getOutputField().setIndex(index);
+                    }
                     parametersValues.add(parameter);
                 } else if (parameterType == IN) {
                     Object value = getValueForInParameter(parameter, translationRow, modifyRow, session, true);

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatasourceCall.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatasourceCall.java
@@ -784,6 +784,11 @@ public abstract class DatasourceCall implements Call {
                         appendParameter(writer, value, session);
                     } else if (parameterType == INLINE) {
                         writer.write((String)parameter);
+                    } else if (parameterType == OUT || parameterType == OUT_CURSOR) {
+                        if (parameter instanceof DatabaseField) {
+                            parameter = null;
+                        }
+                        appendParameter(writer, parameter, session);
                     }
                     lastIndex = tokenIndex + 1;
                     parameterIndex++;

--- a/jpa/eclipselink.jpa.test/pom.xml
+++ b/jpa/eclipselink.jpa.test/pom.xml
@@ -1480,6 +1480,17 @@
 
     <profiles>
         <profile>
+            <id>oracle</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.eclipse.persistence</groupId>
+                    <artifactId>org.eclipse.persistence.oracle</artifactId>
+                    <version>${project.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
             <id>weblogic</id>
             <properties>
                 <server.testrunner.prefix></server.testrunner.prefix>

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa21/advanced/Employee.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa21/advanced/Employee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2018 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -124,7 +124,15 @@ import static javax.persistence.ParameterMode.REF_CURSOR;
         }
     ),
     @NamedStoredProcedureQuery(
-        name="read_using_sys_cursor",
+        name="ReadUsingUnNamedSysCursor",
+        procedureName="Read_Using_Sys_Cursor",
+        parameters = {
+            @StoredProcedureParameter(mode=IN, type=String.class),
+            @StoredProcedureParameter(mode=REF_CURSOR, type=void.class)
+        }
+    ),
+    @NamedStoredProcedureQuery(
+        name="ReadUsingNamedSysCursor",
         procedureName="Read_Using_Sys_Cursor",
         parameters = {
             @StoredProcedureParameter(mode=IN, name="f_name_v", type=String.class),

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa22/advanced/Employee.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa22/advanced/Employee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2018 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -111,7 +111,15 @@ import static javax.persistence.ParameterMode.REF_CURSOR;
         }
 )
 @NamedStoredProcedureQuery(
-        name="read_using_sys_cursor",
+        name="ReadUsingUnNamedSysCursor",
+        procedureName="Read_Using_Sys_Cursor",
+        parameters = {
+                @StoredProcedureParameter(mode=IN, type=String.class),
+                @StoredProcedureParameter(mode=REF_CURSOR, type=void.class)
+        }
+)
+@NamedStoredProcedureQuery(
+        name="ReadUsingNamedSysCursor",
         procedureName="Read_Using_Sys_Cursor",
         parameters = {
                 @StoredProcedureParameter(mode=IN, name="f_name_v", type=String.class),

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa21/advanced/StoredProcedureQueryTestSuite.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa21/advanced/StoredProcedureQueryTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -83,7 +83,8 @@ public class StoredProcedureQueryTestSuite extends JUnitTestCase {
         suite.addTest(new StoredProcedureQueryTestSuite("testStoredProcedureParameterAPI"));
         suite.addTest(new StoredProcedureQueryTestSuite("testStoredProcedureQuerySysCursor_Named"));
         suite.addTest(new StoredProcedureQueryTestSuite("testStoredProcedureQuerySysCursor_Positional"));
-        suite.addTest(new StoredProcedureQueryTestSuite("testStoredProcedureQuerySysCursor2"));
+        suite.addTest(new StoredProcedureQueryTestSuite("testStoredProcedureQuerySysCursor2_Named"));
+        suite.addTest(new StoredProcedureQueryTestSuite("testStoredProcedureQuerySysCursor2_Positional"));
         suite.addTest(new StoredProcedureQueryTestSuite("testStoredProcedureQueryExceptionWrapping1"));
         suite.addTest(new StoredProcedureQueryTestSuite("testStoredProcedureQueryExceptionWrapping2"));
 
@@ -1016,9 +1017,9 @@ public class StoredProcedureQueryTestSuite extends JUnitTestCase {
 
     /**
      * Tests a StoredProcedureQuery using a system cursor. Also tests
-     * getParameters call AFTER query execution.
+     * getParameters call AFTER query execution. Parameters are passed via name.
      */
-    public void testStoredProcedureQuerySysCursor2() {
+    public void testStoredProcedureQuerySysCursor2_Named() {
         if (supportsStoredProcedures() && getPlatform().isOracle() ) {
             EntityManager em = createEntityManager();
 
@@ -1047,13 +1048,40 @@ public class StoredProcedureQueryTestSuite extends JUnitTestCase {
                 // Test now with the named stored procedure. //
                 beginTransaction(em);
 
-                StoredProcedureQuery query2 = em.createNamedStoredProcedureQuery("read_using_sys_cursor");
+                StoredProcedureQuery query2 = em.createNamedStoredProcedureQuery("ReadUsingNamedSysCursor");
                 query2.setParameter("f_name_v", "Fred");
                 Object paramValue = query2.getParameterValue("f_name_v");
 
                 boolean execute2 = query2.execute();
 
                 List<Object[]> employees2 = (List<Object[]>) query2.getOutputParameterValue("p_recordset");
+                assertFalse("No employees were returned from name stored procedure query.", employees2.isEmpty());
+
+                commitTransaction(em);
+            } finally {
+                closeEntityManagerAndTransaction(em);
+            }
+        }
+    }
+
+    /**
+     * Tests a StoredProcedureQuery using a system cursor. Also tests
+     * getParameters call AFTER query execution. Parameters are passed via position.
+     */
+    public void testStoredProcedureQuerySysCursor2_Positional() {
+        if (supportsStoredProcedures() && getPlatform().isOracle() ) {
+            EntityManager em = createEntityManager();
+
+            try {
+                // Test now with the named stored procedure. //
+                beginTransaction(em);
+
+                StoredProcedureQuery query2 = em.createNamedStoredProcedureQuery("ReadUsingUnNamedSysCursor");
+                query2.setParameter(1, "Fred");
+
+                boolean execute2 = query2.execute();
+
+                List<Employee> employees2 = query2.getResultList();
                 assertFalse("No employees were returned from name stored procedure query.", employees2.isEmpty());
 
                 commitTransaction(em);

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa22/advanced/AnnotationsTestSuite.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa22/advanced/AnnotationsTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -142,9 +142,9 @@ public class AnnotationsTestSuite extends JUnitTestCase {
         verifyMetadata(Employee.class, "javax.persistence.NamedQueries", 2);
 
         // @NamedStoredProcedureQuery
-        verifyContainerAnnotation(Employee.class, NamedStoredProcedureQueries.class, 4);
-        verifyAnnotation(Employee.class, NamedStoredProcedureQuery.class, 4);
-        verifyMetadata(Employee.class, "javax.persistence.NamedStoredProcedureQueries", 4);
+        verifyContainerAnnotation(Employee.class, NamedStoredProcedureQueries.class, 5);
+        verifyAnnotation(Employee.class, NamedStoredProcedureQuery.class, 5);
+        verifyMetadata(Employee.class, "javax.persistence.NamedStoredProcedureQueries", 5);
 
         // @PersistenceContext
         verifyContainerAnnotation(AnnotationsTestSuite.class, PersistenceContexts.class, 3);

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa22/advanced/StoredProcedureQueryTestSuite.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa22/advanced/StoredProcedureQueryTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -76,7 +76,8 @@ public class StoredProcedureQueryTestSuite extends JUnitTestCase {
         suite.addTest(new StoredProcedureQueryTestSuite("testStoredProcedureParameterAPI"));
         suite.addTest(new StoredProcedureQueryTestSuite("testStoredProcedureQuerySysCursor_Named"));
         suite.addTest(new StoredProcedureQueryTestSuite("testStoredProcedureQuerySysCursor_Positional"));
-        suite.addTest(new StoredProcedureQueryTestSuite("testStoredProcedureQuerySysCursor2"));
+        suite.addTest(new StoredProcedureQueryTestSuite("testStoredProcedureQuerySysCursor2_Named"));
+        suite.addTest(new StoredProcedureQueryTestSuite("testStoredProcedureQuerySysCursor2_Positional"));
         suite.addTest(new StoredProcedureQueryTestSuite("testStoredProcedureQueryExceptionWrapping1"));
         suite.addTest(new StoredProcedureQueryTestSuite("testStoredProcedureQueryExceptionWrapping2"));
 
@@ -1011,7 +1012,7 @@ public class StoredProcedureQueryTestSuite extends JUnitTestCase {
      * Tests a StoredProcedureQuery using a system cursor. Also tests
      * getParameters call AFTER query execution.
      */
-    public void testStoredProcedureQuerySysCursor2() {
+    public void testStoredProcedureQuerySysCursor2_Named() {
         if (supportsStoredProcedures() && getPlatform().isOracle() ) {
             EntityManager em = createEntityManager();
 
@@ -1040,13 +1041,40 @@ public class StoredProcedureQueryTestSuite extends JUnitTestCase {
                 // Test now with the named stored procedure. //
                 beginTransaction(em);
 
-                StoredProcedureQuery query2 = em.createNamedStoredProcedureQuery("read_using_sys_cursor");
+                StoredProcedureQuery query2 = em.createNamedStoredProcedureQuery("ReadUsingNamedSysCursor");
                 query2.setParameter("f_name_v", "Fred");
                 query2.getParameterValue("f_name_v");
 
                 query2.execute();
 
                 List<Object[]> employees2 = (List<Object[]>) query2.getOutputParameterValue("p_recordset");
+                assertFalse("No employees were returned from name stored procedure query.", employees2.isEmpty());
+
+                commitTransaction(em);
+            } finally {
+                closeEntityManagerAndTransaction(em);
+            }
+        }
+    }
+
+    /**
+     * Tests a StoredProcedureQuery using a system cursor. Also tests
+     * getParameters call AFTER query execution. Parameters are passed via position.
+     */
+    public void testStoredProcedureQuerySysCursor2_Positional() {
+        if (supportsStoredProcedures() && getPlatform().isOracle() ) {
+            EntityManager em = createEntityManager();
+
+            try {
+                // Test now with the named stored procedure. //
+                beginTransaction(em);
+
+                StoredProcedureQuery query2 = em.createNamedStoredProcedureQuery("ReadUsingUnNamedSysCursor");
+                query2.setParameter(1, "Fred");
+
+                boolean execute2 = query2.execute();
+
+                List<Employee> employees2 = query2.getResultList();
                 assertFalse("No employees were returned from name stored procedure query.", employees2.isEmpty());
 
                 commitTransaction(em);

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa22/advanced/StoredProcedureQueryTestSuite.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa22/advanced/StoredProcedureQueryTestSuite.java
@@ -76,8 +76,8 @@ public class StoredProcedureQueryTestSuite extends JUnitTestCase {
         suite.addTest(new StoredProcedureQueryTestSuite("testStoredProcedureParameterAPI"));
         suite.addTest(new StoredProcedureQueryTestSuite("testStoredProcedureQuerySysCursor_Named"));
         suite.addTest(new StoredProcedureQueryTestSuite("testStoredProcedureQuerySysCursor_Positional"));
-        suite.addTest(new StoredProcedureQueryTestSuite("testStoredProcedureQuerySysCursor2_Named"));
-        suite.addTest(new StoredProcedureQueryTestSuite("testStoredProcedureQuerySysCursor2_Positional"));
+        suite.addTest(new StoredProcedureQueryTestSuite("testStoredProcedureQuerySysCursor_ResultList_Named"));
+        suite.addTest(new StoredProcedureQueryTestSuite("testStoredProcedureQuerySysCursor_ResultList_Positional"));
         suite.addTest(new StoredProcedureQueryTestSuite("testStoredProcedureQueryExceptionWrapping1"));
         suite.addTest(new StoredProcedureQueryTestSuite("testStoredProcedureQueryExceptionWrapping2"));
 
@@ -1012,7 +1012,7 @@ public class StoredProcedureQueryTestSuite extends JUnitTestCase {
      * Tests a StoredProcedureQuery using a system cursor. Also tests
      * getParameters call AFTER query execution.
      */
-    public void testStoredProcedureQuerySysCursor2_Named() {
+    public void testStoredProcedureQuerySysCursor_ResultList_Named() {
         if (supportsStoredProcedures() && getPlatform().isOracle() ) {
             EntityManager em = createEntityManager();
 
@@ -1061,7 +1061,7 @@ public class StoredProcedureQueryTestSuite extends JUnitTestCase {
      * Tests a StoredProcedureQuery using a system cursor. Also tests
      * getParameters call AFTER query execution. Parameters are passed via position.
      */
-    public void testStoredProcedureQuerySysCursor2_Positional() {
+    public void testStoredProcedureQuerySysCursor_ResultList_Positional() {
         if (supportsStoredProcedures() && getPlatform().isOracle() ) {
             EntityManager em = createEntityManager();
 

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa22/advanced/StoredProcedureQueryTestSuite.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa22/advanced/StoredProcedureQueryTestSuite.java
@@ -1033,7 +1033,7 @@ public class StoredProcedureQueryTestSuite extends JUnitTestCase {
                 // Test the getParameters call AFTER query execution.
                 assertTrue("The number of paramters returned was incorrect, actual: " + query.getParameters().size() + ", expected 2", query.getParameters().size() == 2);
 
-                List<Object[]> employees = (List<Object[]>) query.getOutputParameterValue("p_recordset");
+                List<Employee> employees = (List<Employee>) query.getResultList();
                 assertFalse("No employees were returned", employees.isEmpty());
 
                 commitTransaction(em);
@@ -1047,7 +1047,7 @@ public class StoredProcedureQueryTestSuite extends JUnitTestCase {
 
                 query2.execute();
 
-                List<Object[]> employees2 = (List<Object[]>) query2.getOutputParameterValue("p_recordset");
+                List<Employee> employees2 = (List<Employee>) query2.getResultList();
                 assertFalse("No employees were returned from name stored procedure query.", employees2.isEmpty());
 
                 commitTransaction(em);
@@ -1066,6 +1066,27 @@ public class StoredProcedureQueryTestSuite extends JUnitTestCase {
             EntityManager em = createEntityManager();
 
             try {
+                // Test stored procedure query created through API. //
+                beginTransaction(em);
+
+                StoredProcedureQuery query = em.createStoredProcedureQuery("Read_Using_Sys_Cursor");
+                query.registerStoredProcedureParameter(1, String.class, ParameterMode.IN);
+                query.registerStoredProcedureParameter(2, void.class, ParameterMode.REF_CURSOR);
+
+                query.setParameter(1, "Fred");
+
+                boolean execute = query.execute();
+
+                assertTrue("Execute returned false.", execute);
+
+                // Test the getParameters call AFTER query execution.
+                assertTrue("The number of paramters returned was incorrect, actual: " + query.getParameters().size() + ", expected 2", query.getParameters().size() == 2);
+
+                List<Employee> employees = (List<Employee>) query.getResultList();
+                assertFalse("No employees were returned", employees.isEmpty());
+
+                commitTransaction(em);
+
                 // Test now with the named stored procedure. //
                 beginTransaction(em);
 

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/StoredProcedureQueryImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/StoredProcedureQueryImpl.java
@@ -527,6 +527,15 @@ public class StoredProcedureQueryImpl extends QueryImpl implements StoredProcedu
         return null;
     }
 
+    private boolean hasPositionalParameters() {
+        for (Parameter parameter: this.getParameters()) {
+            if (parameter.getName() != null) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     /**
      * Execute the query and return the query results as a List.
      * @return a list of the results
@@ -557,7 +566,12 @@ public class StoredProcedureQueryImpl extends QueryImpl implements StoredProcedu
                 if (hasMoreResults()) {
                     if (isOutputCursorResultSet) {
                         // Return result set list for the current outputCursorIndex.
-                        List results = (List) getOutputParameterValue(getCall().getOutputCursors().get(outputCursorIndex++).getName());
+                        List results = null;
+                        if (hasPositionalParameters()) {
+                            results = (List) getOutputParameterValue(getCall().getOutputCursors().get(outputCursorIndex++).getIndex() + 1);
+                        } else {
+                            results = (List) getOutputParameterValue(getCall().getOutputCursors().get(outputCursorIndex++).getName());
+                        }
 
                         // Update the hasMoreResults flag.
                         hasMoreResults = (outputCursorIndex < getCall().getOutputCursors().size());

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/StoredProcedureQueryImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/StoredProcedureQueryImpl.java
@@ -439,16 +439,12 @@ public class StoredProcedureQueryImpl extends QueryImpl implements StoredProcedu
                     field = (DatabaseField) ((Object[]) parameter)[0];
                 } else if (parameterType == getCall().IN) {
                     field = (DatabaseField) parameter;
-                } else if (parameterType == getCall().OUT) {
-                    field = ((OutputParameterForCallableStatement) parameter).getOutputField();
-                } else if (parameterType == getCall().OUT_CURSOR) {
+                } else if (parameterType == getCall().OUT || parameterType == getCall().OUT_CURSOR) {
                     if (parameter instanceof OutputParameterForCallableStatement) {
                         field = ((OutputParameterForCallableStatement) parameter).getOutputField();
                     } else {
                         field = (DatabaseField) parameter;
                     }
-                } else if (parameterType == getCall().LITERAL) {
-                    field = (DatabaseField) parameter;
                 }
 
                 // If field is not null (one we care about) then add it, otherwise continue.


### PR DESCRIPTION
[master] Bug #618: Oracle positional parameters with ParameterMode.REF_CURSOR out parameter

This is fix for bug #618 with additional unit tests. There is small refactoring
(renaming) in test method names and NamedStoredProcedureQuery annotation names.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>