### PR TITLE
[master] Bug 415779 - JpaEntityManager.copy doesn't always preserve object graph

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/core/queries/CoreAttributeGroup.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/core/queries/CoreAttributeGroup.java
@@ -51,6 +51,8 @@ public class CoreAttributeGroup<
      */
     private static final String FIELD_SEP = ", ";
 
+    private int toStringLoopCount = 0;
+
     /**
      * Name of the group. This is used in subclasses where the groups are stored
      * and can be used within a query by name as with FetchGroup. For dynamic
@@ -756,7 +758,6 @@ public class CoreAttributeGroup<
     }
 
     //changed for EclipseLink 415779 to avoid stack overflows when using graphs with circular references
-    private int toStringLoopCount = 0;
     @Override
     public String toString() {
         String className = StringHelper.nonNullString(getClass().getSimpleName());

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/core/queries/CoreAttributeGroup.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/core/queries/CoreAttributeGroup.java
@@ -755,19 +755,29 @@ public class CoreAttributeGroup<
         this.name = name;
     }
 
+    //changed for EclipseLink 415779 to avoid stack overflows when using graphs with circular references
+    private int toStringLoopCount = 0;
     @Override
     public String toString() {
         String className = StringHelper.nonNullString(getClass().getSimpleName());
         String name = StringHelper.nonNullString(getName());
-        String items = StringHelper.nonNullString(toStringItems());
-        String additionalInfo = StringHelper.nonNullString(toStringAdditionalInfo());
-        StringBuilder str = new StringBuilder(className.length() + name.length()
-                + additionalInfo.length() + items.length() + 4);
-        str.append(className);
-        str.append(StringHelper.LEFT_BRACKET).append(name).append(StringHelper.RIGHT_BRACKET);
-        str.append(additionalInfo);
-        str.append(StringHelper.LEFT_BRACE).append(items).append(StringHelper.RIGHT_BRACE);
-        return str.toString();
+        if (toStringLoopCount >1) {
+            return className+StringHelper.LEFT_BRACKET+name+ " Loop detected "+ StringHelper.RIGHT_BRACKET;
+        }
+        try {
+            toStringLoopCount++;
+            String items = StringHelper.nonNullString(toStringItems());
+            String additionalInfo = StringHelper.nonNullString(toStringAdditionalInfo());
+            StringBuilder str = new StringBuilder(className.length() + name.length()
+                    + additionalInfo.length() + items.length() + 4);
+            str.append(className);
+            str.append(StringHelper.LEFT_BRACKET).append(name).append(StringHelper.RIGHT_BRACKET);
+            str.append(additionalInfo);
+            str.append(StringHelper.LEFT_BRACE).append(items).append(StringHelper.RIGHT_BRACE);
+            return str.toString();
+        } finally {
+            toStringLoopCount--;
+        }
     }
 
     /**

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/fetchgroups/SimpleSerializeFetchGroupTests.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/fetchgroups/SimpleSerializeFetchGroupTests.java
@@ -1058,11 +1058,10 @@ public class SimpleSerializeFetchGroupTests extends BaseFetchGroupTests {
     }
 
     public void copyGroupObjectGraph() {
-        // Search for an Department with Employees
         EntityManager em = createEntityManager();
         try {
             beginTransaction(em);
-            TypedQuery<Department> query = em.createQuery("SELECT d FROM Department d WHERE d.id IN (SELECT MIN(dd.id) FROM Department dd)", Department.class);
+            TypedQuery<Department> query = em.createQuery("SELECT d FROM ADV_DEPT d WHERE d.id IN (SELECT MIN(dd.id) FROM ADV_DEPT dd)", Department.class);
             Department dept = query.getSingleResult();
 
             CopyGroup group = new CopyGroup();

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/fetchgroups/SimpleSerializeFetchGroupTests.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/fetchgroups/SimpleSerializeFetchGroupTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -47,6 +47,7 @@ import org.eclipse.persistence.queries.FetchGroup;
 import org.eclipse.persistence.sessions.CopyGroup;
 import org.eclipse.persistence.sessions.server.ServerSession;
 import org.eclipse.persistence.testing.models.jpa.advanced.Address;
+import org.eclipse.persistence.testing.models.jpa.advanced.Department;
 import org.eclipse.persistence.testing.models.jpa.advanced.Employee;
 import org.eclipse.persistence.testing.models.jpa.advanced.EmploymentPeriod;
 import org.eclipse.persistence.testing.models.jpa.advanced.PhoneNumber;
@@ -94,6 +95,7 @@ public class SimpleSerializeFetchGroupTests extends BaseFetchGroupTests {
             suite.addTest(new SimpleSerializeFetchGroupTests("verifyUnfetchedAttributes"));
             suite.addTest(new SimpleSerializeFetchGroupTests("simpleSerializeAndMerge"));
             suite.addTest(new SimpleSerializeFetchGroupTests("partialMerge"));
+            suite.addTest(new SimpleSerializeFetchGroupTests("copyGroupObjectGraph"));
             suite.addTest(new SimpleSerializeFetchGroupTests("copyGroupMerge"));
             suite.addTest(new SimpleSerializeFetchGroupTests("copyGroupMerge2"));
             suite.addTest(new SimpleSerializeFetchGroupTests("copyWithPk"));
@@ -1054,6 +1056,31 @@ public class SimpleSerializeFetchGroupTests extends BaseFetchGroupTests {
             closeEntityManager(em);
         }
     }
+
+    public void copyGroupObjectGraph() {
+        // Search for an Department with Employees
+        EntityManager em = createEntityManager();
+        try {
+            beginTransaction(em);
+            TypedQuery<Department> query = em.createQuery("SELECT d FROM Department d WHERE d.id IN (SELECT MIN(dd.id) FROM Department dd)", Department.class);
+            Department dept = query.getSingleResult();
+
+            CopyGroup group = new CopyGroup();
+            group.addAttribute("name");
+            group.addAttribute("employees", new CopyGroup());
+            group.getGroup("employees").addAttribute("name");
+            group.getGroup("employees").addAttribute("department", new CopyGroup());
+            group.getGroup("employees").getGroup("department").addAttribute("name");
+            Department deptCopy = (Department) em.unwrap(JpaEntityManager.class).copy(dept, group);
+
+            String reportCG = group.toString();
+            assertNotNull(reportCG);
+        } finally {
+            rollbackTransaction(em);
+            closeEntityManager(em);
+        }
+    }
+
 
     public void copyGroupMerge() {
         // Search for an Employee with an Address and Phone Numbers


### PR DESCRIPTION
 [master] Bug 415779 - JpaEntityManager.copy doesn't always preserve object graph

This is partial fix for bug 415779 with unit test. There is fix in CoreAttributeGroup.toString() method.
Before this fix this method can fail if object graph is copied by JpaEntityManager.copy.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>