### PR TITLE
[2.7] Travis Maven configuration change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,6 @@ cache:
     - $HOME/extension.lib.external
 
 before_install:
-  - ls -al /usr/local
   - sudo mysql_upgrade
   - sudo mysql -u root -e "use mysql; update user set authentication_string=PASSWORD('root') where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;CREATE DATABASE IF NOT EXISTS ecltest;"
   - sudo service mysql restart

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ services:
 env:
   global:
     - ANT_HOME=$HOME/apache-ant-1.10.5
-    - M2_HOME=/usr/local/maven-3.6.0
+    - M2_HOME=/usr/local/maven-3.6.2
   matrix:
     - TEST_TARGET=test-core
     - TEST_TARGET=test-jpa22
@@ -51,6 +51,7 @@ cache:
     - $HOME/extension.lib.external
 
 before_install:
+  - ls -al /usr/local
   - sudo mysql_upgrade
   - sudo mysql -u root -e "use mysql; update user set authentication_string=PASSWORD('root') where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;CREATE DATABASE IF NOT EXISTS ecltest;"
   - sudo service mysql restart


### PR DESCRIPTION
[2.7] Travis Maven configuration change

There is Maven ($M2_HOME) change due Travis environment upgrade.
Today (12-DEC-2019) Travis-CI upgraded Maven from 3.6.0 to 3.6.2.
This is fix for 2.7 branch only to catch up this environment change.
Without this fix 2.7 tests/builds against Travis-CI PR will fail.