### PR TITLE
[2.6_WAS] Bug 558283: Missing parameter markers from DB2z Stored Procedures

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatabaseCall.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatabaseCall.java
@@ -283,7 +283,7 @@ public abstract class DatabaseCall extends DatasourceCall {
             if (parameter instanceof OutputParameterForCallableStatement) {
                 OutputParameterForCallableStatement outParameter = (OutputParameterForCallableStatement)parameter;
                 if (!outParameter.isCursor() || !isCursorOutputProcedure()) {
-                    Object value = getObject(statement, index);
+                    Object value = getOutputParameterValue(statement, index, session);
                     DatabaseField field = outParameter.getOutputField();
                     if (value instanceof Struct){
                         ClassDescriptor descriptor = session.getDescriptor(field.getType());
@@ -1365,11 +1365,26 @@ public abstract class DatabaseCall extends DatasourceCall {
     }
 
     /**
-     * Get the return object from the statement. Use the index to determine what return object to get.
+     * 
+     * INTERNAL:
+     * 
+     * Get the return object from the statement. Use the parameter index to determine what return object to get.
      * @param index - 0-based index in the argument list
      * @return
      */
-    protected Object getObject(CallableStatement statement, int index) throws SQLException {
-        return statement.getObject(index + 1);
+    public Object getOutputParameterValue(CallableStatement statement, int index, AbstractSession session) throws SQLException {
+        return session.getPlatform().getParameterValueFromDatabaseCall(statement, index + 1, session);
+    }
+
+    /**
+     * 
+     * INTERNAL:
+     * 
+     * Get the return object from the statement. Use the parameter name to determine what return object to get.
+     * @param index - 0-based index in the argument list
+     * @return
+     */
+    public Object getOutputParameterValue(CallableStatement statement, String name, AbstractSession session) throws SQLException {
+        return session.getPlatform().getParameterValueFromDatabaseCall(statement, name, session);
     }
 }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
@@ -2296,8 +2296,7 @@ public class DatabasePlatform extends DatasourcePlatform {
     public boolean shouldPrintOutputTokenAtStart() {
         return false;
     }
-    
-    
+
     /**
      * INTERNAL:
      * Should the variable name of a stored procedure call be printed as part of the procedure call
@@ -2441,7 +2440,7 @@ public class DatabasePlatform extends DatasourcePlatform {
             if (dbCall.isCursorOutputProcedure()) {
                 result = accessor.executeNoSelect(dbCall, statement, session);
                 int index = dbCall.getCursorOutIndex();
-                resultSet = (ResultSet)dbCall.getObject((CallableStatement)statement, index - 1);
+                resultSet = (ResultSet)dbCall.getOutputParameterValue((CallableStatement)statement, index - 1, session);
             } else {
                 accessor.executeDirectNoSelect(statement, dbCall, session);
                 
@@ -2720,6 +2719,23 @@ public class DatabasePlatform extends DatasourcePlatform {
             int jdbcType = getJDBCTypeForSetNull(databaseField);
             statement.setNull(name, jdbcType);
         }
+    }
+
+    /**
+     * INTERNAL
+     * Get the parameter from the JDBC statement with the given index.
+     * @param index - 1-based index in the argument list
+     */
+    public Object getParameterValueFromDatabaseCall(CallableStatement statement, int index, AbstractSession session) throws SQLException {
+        return statement.getObject(index);
+    }
+
+    /**
+     * INTERNAL
+     * Get the parameter from the JDBC statement with the given name.
+     */
+    public Object getParameterValueFromDatabaseCall(CallableStatement statement, String name, AbstractSession session) throws SQLException {
+        return statement.getObject(name);
     }
 
     public boolean usesBatchWriting() {

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/DB2Platform.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/DB2Platform.java
@@ -420,13 +420,14 @@ public class DB2Platform extends org.eclipse.persistence.platform.database.Datab
     }
 
     /**
-     * INTERNAL:
-     * Should the variable name of a stored procedure call be printed as part of the procedure call
-     * e.g. EXECUTE PROCEDURE MyStoredProc(myvariable = ?)
+     * Obtain the platform specific argument string
      */
     @Override
-    public boolean shouldPrintStoredProcedureArgumentNameInCall() {
-        return false;
+    public String getProcedureArgument(String name, Object parameter, Integer parameterType, StoredProcedureCall call, AbstractSession session) {
+        if (name != null && shouldPrintStoredProcedureArgumentNameInCall()) {
+            return getProcedureArgumentString() + name + " => " + "?";
+        }
+        return "?";
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/DB2ZPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/DB2ZPlatform.java
@@ -16,7 +16,6 @@ package org.eclipse.persistence.platform.database;
 import java.io.ByteArrayInputStream;
 import java.io.CharArrayReader;
 import java.io.StringWriter;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -90,7 +89,7 @@ public class DB2ZPlatform extends DB2Platform {
         if (name != null && shouldPrintStoredProcedureArgumentNameInCall()) {
             return ":" + name;
         }
-        return "";
+        return "?";
     }
 
     @Override
@@ -180,7 +179,7 @@ public class DB2ZPlatform extends DB2Platform {
                 Object o = statement.unwrap(clazz);
                 PrivilegedAccessHelper.invokeMethod(method, o, parameters);
             }
-        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+        } catch (ReflectiveOperationException e) {
             AbstractSessionLog.getLog().logThrowable(SessionLog.WARNING, null, e);
             //Didn't work, fall back. This most likely still won't work, but the driver exception from there will be helpful.
             super.registerOutputParameter(statement, name, jdbcType);
@@ -219,7 +218,7 @@ public class DB2ZPlatform extends DB2Platform {
                 Object o = statement.unwrap(clazz);
                 PrivilegedAccessHelper.invokeMethod(method, o, parameters);
             }
-        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+        } catch (ReflectiveOperationException e) {
             AbstractSessionLog.getLog().logThrowable(SessionLog.WARNING, null, e);
             //Didn't work, fall back. This most likely still won't work, but the driver exception from there will be helpful.
             super.registerOutputParameter(statement, name, jdbcType, typeName);
@@ -419,7 +418,7 @@ public class DB2ZPlatform extends DB2Platform {
                     Object o = statement.unwrap(clazz);
                     PrivilegedAccessHelper.invokeMethod(method, o, parameters);
                 }
-            } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            } catch (ReflectiveOperationException e) {
                 AbstractSessionLog.getLog().logThrowable(SessionLog.WARNING, null, e);
                 //Didn't work, fall back. This most likely still won't work, but the driver exception from there will be helpful.
                 super.setParameterValueInDatabaseCall(parameter, statement, name, session);
@@ -467,10 +466,53 @@ public class DB2ZPlatform extends DB2Platform {
                 Object o = statement.unwrap(clazz);
                 PrivilegedAccessHelper.invokeMethod(method, o, parameters);
             }
-        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+        } catch (ReflectiveOperationException e) {
             AbstractSessionLog.getLog().logThrowable(SessionLog.WARNING, null, e);
             //Didn't work, fall back. This most likely still won't work, but the driver exception from there will be helpful.
             super.setNullFromDatabaseField(databaseField, statement, name);
         }
+    }
+
+    @Override
+    public Object getParameterValueFromDatabaseCall(CallableStatement statement, String name, AbstractSession session)
+                throws SQLException {
+        String methodName = null;
+        Class[] methodArgs = null;
+        Object[] parameters = null;
+
+        methodName = "getJccObjectAtName";
+        methodArgs = new Class[] {String.class};
+        parameters = new Object[] {name};
+
+        if(methodName != null) {
+            try {
+                Class clazz = null;
+                Method method = null;
+                if (PrivilegedAccessHelper.shouldUsePrivilegedAccess()) {
+                    try {
+                        ClassLoader cl = AccessController.doPrivileged(new PrivilegedGetContextClassLoader(Thread.currentThread()));
+                        clazz = AccessController.doPrivileged(new PrivilegedClassForName(DB2_CALLABLESTATEMENT_CLASS, true, cl));
+                        method = AccessController.doPrivileged(new PrivilegedGetMethod(clazz, methodName, methodArgs, true));
+                        Object o = statement.unwrap(clazz);
+                        return AccessController.doPrivileged(new PrivilegedMethodInvoker(method, o, parameters));
+                    } catch (PrivilegedActionException ex) {
+                        if (ex.getCause() instanceof ClassNotFoundException) {
+                            throw (ClassNotFoundException) ex.getCause();
+                        }
+                        throw (RuntimeException) ex.getCause();
+                    }
+                } else {
+                    ClassLoader cl = PrivilegedAccessHelper.getContextClassLoader(Thread.currentThread());
+                    clazz = PrivilegedAccessHelper.getClassForName(DB2_CALLABLESTATEMENT_CLASS, true, cl);
+                    method = PrivilegedAccessHelper.getMethod(clazz, methodName, methodArgs, true);
+                    Object o = statement.unwrap(clazz);
+                    return PrivilegedAccessHelper.invokeMethod(method, o, parameters);
+                }
+            } catch (ReflectiveOperationException e) {
+                AbstractSessionLog.getLog().logThrowable(SessionLog.WARNING, null, e);
+            }
+        }
+        //Didn't work, fall back. This most likely still won't work, but the driver exception from there will be helpful.
+        return super.getParameterValueFromDatabaseCall(statement, name, session);
     }
 }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/oracle/plsql/PLSQLStoredProcedureCall.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/oracle/plsql/PLSQLStoredProcedureCall.java
@@ -1295,8 +1295,8 @@ public class PLSQLStoredProcedureCall extends StoredProcedureCall {
     }
 
     @Override
-    protected Object getObject(CallableStatement statement, int index) throws SQLException {
-        return statement.getObject(index + 1);
+    public Object getOutputParameterValue(CallableStatement statement, int index, AbstractSession session) throws SQLException {
+        return session.getPlatform().getParameterValueFromDatabaseCall(statement, index + 1, session);
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/StoredProcedureCall.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/StoredProcedureCall.java
@@ -1041,20 +1041,15 @@ public class StoredProcedureCall extends DatabaseCall {
         this.optionalArguments = optionalArguments;
     }
 
-    /**
-     * Get the return object from the statement. Use the index to determine what return object to get.
-     * @param index - 0-based index in the argument list
-     * @return
-     */
     @Override
-    protected Object getObject(CallableStatement statement, int index) throws SQLException {
+    public Object getOutputParameterValue(CallableStatement statement, int index, AbstractSession session) throws SQLException {
         List<String> procedureArgs = getProcedureArgumentNames();
         if(procedureArgs.size() == 0 || procedureArgs.get(0) == null) {
-            return super.getObject(statement, index);
+            return super.getOutputParameterValue(statement, index, session);
         }
 
         String name = procedureArgs.get(index);
-        return statement.getObject(name);
+        return getOutputParameterValue(statement, name, session);
     }
 
     /**

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/jpql/TestComplexJPQL.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/jpql/TestComplexJPQL.java
@@ -160,7 +160,7 @@ public class TestComplexJPQL {
         }
     }
 
-    private DatabasePlatform getPlatform(EntityManagerFactory emf) {
+    private static DatabasePlatform getPlatform(EntityManagerFactory emf) {
         return ((EntityManagerFactoryImpl)emf).getServerSession().getPlatform();
     }
 }

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/storedproc/TestStoredProcedures.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/storedproc/TestStoredProcedures.java
@@ -19,89 +19,58 @@ import javax.persistence.ParameterMode;
 import javax.persistence.StoredProcedureQuery;
 
 import org.eclipse.persistence.internal.databaseaccess.Platform;
+import org.eclipse.persistence.internal.jpa.EntityManagerFactoryImpl;
 import org.eclipse.persistence.internal.jpa.EntityManagerImpl;
 import org.eclipse.persistence.jpa.test.framework.DDLGen;
 import org.eclipse.persistence.jpa.test.framework.Emf;
 import org.eclipse.persistence.jpa.test.framework.EmfRunner;
 import org.eclipse.persistence.jpa.test.framework.Property;
+import org.eclipse.persistence.platform.database.DatabasePlatform;
 import org.eclipse.persistence.sessions.DatabaseSession;
 import org.eclipse.persistence.tools.schemaframework.SchemaManager;
 import org.eclipse.persistence.tools.schemaframework.StoredProcedureDefinition;
 import org.junit.Assert;
 import org.junit.Assume;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(EmfRunner.class)
-//Tests for Oracle stored procedures only
 public class TestStoredProcedures {
 
-    @Emf(name = "orderedStoredProcedureEmf", createTables = DDLGen.DROP_CREATE,
+    @Emf(name = "storedProcedureEmf", createTables = DDLGen.DROP_CREATE,
             //This property ('enableNamedParameterMarkers') is needed for DB2Z named parameters
             properties = { @Property(name = "eclipselink.jdbc.property.enableNamedParameterMarkers", value = "true") } )
-    private EntityManagerFactory orderedStoredProcedureEmf;
+    private EntityManagerFactory storedProcedureEmf;
+
+    @Before
+    public void setup() {
+        //Attempt to setup the stored procedure for testing.
+        Assume.assumeTrue("Platform " + getPlatform(storedProcedureEmf) + " is not supported for this test", 
+                createSimpleStoredProcedure(storedProcedureEmf));
+    }
 
     /**
      * Tests stored procedure using indexed parameters
      */
     @Test
-    public void testStoredProcedureOrderWithIndexParameter() {
-
-        //Setup a stored procedure
-        EntityManager em = orderedStoredProcedureEmf.createEntityManager();
-        try {
-            StoredProcedureDefinition proc = new StoredProcedureDefinition();
-            proc.setName("simple_order_procedure");
-
-            proc.addArgument("in_param_one", String.class, 10);
-            proc.addArgument("in_param_two", String.class, 10);
-            proc.addArgument("in_param_three", String.class, 10);
-            proc.addOutputArgument("out_param_one", String.class, 30);
-
-            DatabaseSession dbs = ((EntityManagerImpl)em).getDatabaseSession();
-            SchemaManager manager = new SchemaManager(dbs);
-            Platform platform = dbs.getDatasourcePlatform();
-
-            //Add more platform specific diction to support more platforms
-            if(platform.isOracle()) {
-                proc.addStatement("out_param_one := 'One: ' || in_param_one || ' Two: ' || in_param_two || ' Three: ' || in_param_three");
-            } else if (platform.isDB2() || platform.isDB2Z()) {
-                proc.addStatement("SET out_param_one = 'One: ' || in_param_one || ' Two: ' || in_param_two || ' Three: ' || in_param_three");
-            } else {
-                Assume.assumeTrue("Platform " + platform + " is not supported for this test", false);
-            }
-
-            try {
-                manager.dropObject(proc);
-            } catch(Exception e) {
-                //Ignore any drop exceptions since the procedure may not exist yet
-            }
-
-            manager.createObject(proc);
-        } finally {
-            if (em.getTransaction().isActive()) {
-                em.getTransaction().rollback();
-            }
-            if(em.isOpen()) {
-                em.close();
-            }
-        }
-
-        em = orderedStoredProcedureEmf.createEntityManager();
+    public void testStoredProcedure_SetOrdered_IndexParameters() {
+        EntityManager em = storedProcedureEmf.createEntityManager();
         try {
             StoredProcedureQuery storedProcedure = em.createStoredProcedureQuery("simple_order_procedure");
             storedProcedure.registerStoredProcedureParameter(1, String.class, ParameterMode.IN);
             storedProcedure.registerStoredProcedureParameter(2, String.class, ParameterMode.IN);
             storedProcedure.registerStoredProcedureParameter(3, String.class, ParameterMode.IN);
             storedProcedure.registerStoredProcedureParameter(4, String.class, ParameterMode.OUT);
+
             storedProcedure.setParameter(1, "One");
             storedProcedure.setParameter(2, "Two");
             storedProcedure.setParameter(3, "Three");
+
             storedProcedure.execute();
 
             String returnValue =  (String) storedProcedure.getOutputParameterValue(4);
-            Assert.assertEquals("", "One: One Two: Two Three: Three", returnValue);
-
+            Assert.assertEquals("One: One Two: Two Three: Three", returnValue);
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -110,23 +79,29 @@ public class TestStoredProcedures {
                 em.close();
             }
         }
+    }
 
-        //Make sure changing the order does change the result
-        em = orderedStoredProcedureEmf.createEntityManager();
+    /**
+     * Tests stored procedure using indexed parameters, but alter the order to make sure the result doesn't change.
+     */
+    @Test
+    public void testStoredProcedure_SetUnordered_IndexParameters() {
+        EntityManager em = storedProcedureEmf.createEntityManager();
         try {
-            StoredProcedureQuery             storedProcedure = em.createStoredProcedureQuery("simple_order_procedure");
-            storedProcedure.registerStoredProcedureParameter(2, String.class, ParameterMode.IN);
+            StoredProcedureQuery storedProcedure = em.createStoredProcedureQuery("simple_order_procedure");
             storedProcedure.registerStoredProcedureParameter(1, String.class, ParameterMode.IN);
+            storedProcedure.registerStoredProcedureParameter(2, String.class, ParameterMode.IN);
             storedProcedure.registerStoredProcedureParameter(3, String.class, ParameterMode.IN);
             storedProcedure.registerStoredProcedureParameter(4, String.class, ParameterMode.OUT);
+
             storedProcedure.setParameter(2, "Two");
             storedProcedure.setParameter(1, "One");
             storedProcedure.setParameter(3, "Three");
+
             storedProcedure.execute();
 
             String returnValue =  (String) storedProcedure.getOutputParameterValue(4);
-            Assert.assertEquals("", "One: Two Two: One Three: Three", returnValue);
-
+            Assert.assertEquals("One: One Two: Two Three: Three", returnValue);
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -141,10 +116,71 @@ public class TestStoredProcedures {
      * Tests stored procedure using named parameters
      */
     @Test
-    public void testStoredProcedureOrderWithNamedParameter() {
+    public void testStoredProcedure_SetOrdered_NamedParameters() {
+        EntityManager em = storedProcedureEmf.createEntityManager();
+        try {
+            StoredProcedureQuery storedProcedure = em.createStoredProcedureQuery("simple_order_procedure");
+            storedProcedure.registerStoredProcedureParameter("in_param_one", String.class, ParameterMode.IN);
+            storedProcedure.registerStoredProcedureParameter("in_param_two", String.class, ParameterMode.IN);
+            storedProcedure.registerStoredProcedureParameter("in_param_three", String.class, ParameterMode.IN);
+            storedProcedure.registerStoredProcedureParameter("out_param_one", String.class, ParameterMode.OUT);
 
+            storedProcedure.setParameter("in_param_one", "One");
+            storedProcedure.setParameter("in_param_two", "Two");
+            storedProcedure.setParameter("in_param_three", "Three");
+
+            storedProcedure.execute();
+
+            String returnValue =  (String) storedProcedure.getOutputParameterValue("out_param_one");
+            Assert.assertEquals("One: One Two: Two Three: Three", returnValue);
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if(em.isOpen()) {
+                em.close();
+            }
+        }
+    }
+
+    /**
+     * Tests stored procedure using named parameters, but alter the order to make sure the result doesn't change.
+     */
+    @Test
+    public void testStoredProcedure_SetUnordered_NamedParameters() {
+        EntityManager em = storedProcedureEmf.createEntityManager();
+        try {
+            StoredProcedureQuery storedProcedure = em.createStoredProcedureQuery("simple_order_procedure");
+            storedProcedure.registerStoredProcedureParameter("in_param_one", String.class, ParameterMode.IN);
+            storedProcedure.registerStoredProcedureParameter("in_param_two", String.class, ParameterMode.IN);
+            storedProcedure.registerStoredProcedureParameter("in_param_three", String.class, ParameterMode.IN);
+            storedProcedure.registerStoredProcedureParameter("out_param_one", String.class, ParameterMode.OUT);
+
+            storedProcedure.setParameter("in_param_three", "Three");
+            storedProcedure.setParameter("in_param_two", "Two");
+            storedProcedure.setParameter("in_param_one", "One");
+
+            storedProcedure.execute();
+
+            String returnValue =  (String) storedProcedure.getOutputParameterValue("out_param_one");
+            Assert.assertEquals("One: One Two: Two Three: Three", returnValue);
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if(em.isOpen()) {
+                em.close();
+            }
+        }
+    }
+
+    /**
+     * Creates a simple stored procedure for the given EntityManagerFactory
+     * @return boolean indicating if storedProcedure was created
+     */
+    private static boolean createSimpleStoredProcedure(EntityManagerFactory emf) {
         //Setup a stored procedure
-        EntityManager em = orderedStoredProcedureEmf.createEntityManager();
+        EntityManager em = emf.createEntityManager();
         try {
             StoredProcedureDefinition proc = new StoredProcedureDefinition();
             proc.setName("simple_order_procedure");
@@ -158,13 +194,15 @@ public class TestStoredProcedures {
             SchemaManager manager = new SchemaManager(dbs);
             Platform platform = dbs.getDatasourcePlatform();
 
-            //NOTE: Add more platform specific diction to support more platforms
-            if(platform.isOracle()) {
+            //Add more platform specific diction to support more platforms
+            if(platform.isMySQL()) {
+                proc.addStatement("SET out_param_one = CONCAT('One: ',in_param_one,' Two: ',in_param_two,' Three: ',in_param_three)");
+            } else if(platform.isOracle()) {
                 proc.addStatement("out_param_one := 'One: ' || in_param_one || ' Two: ' || in_param_two || ' Three: ' || in_param_three");
             } else if (platform.isDB2() || platform.isDB2Z()) {
                 proc.addStatement("SET out_param_one = 'One: ' || in_param_one || ' Two: ' || in_param_two || ' Three: ' || in_param_three");
             } else {
-                Assume.assumeTrue("Platform " + platform + " is not supported for this test", false);
+                return false;
             }
 
             try {
@@ -174,6 +212,7 @@ public class TestStoredProcedures {
             }
 
             manager.createObject(proc);
+            return true;
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -182,54 +221,9 @@ public class TestStoredProcedures {
                 em.close();
             }
         }
+    }
 
-        em = orderedStoredProcedureEmf.createEntityManager();
-        try {
-            StoredProcedureQuery storedProcedure = em.createStoredProcedureQuery("simple_order_procedure");
-            storedProcedure.registerStoredProcedureParameter("in_param_one", String.class, ParameterMode.IN);
-            storedProcedure.registerStoredProcedureParameter("in_param_two", String.class, ParameterMode.IN);
-            storedProcedure.registerStoredProcedureParameter("in_param_three", String.class, ParameterMode.IN);
-            storedProcedure.registerStoredProcedureParameter("out_param_one", String.class, ParameterMode.OUT);
-            storedProcedure.setParameter("in_param_one", "One");
-            storedProcedure.setParameter("in_param_two", "Two");
-            storedProcedure.setParameter("in_param_three", "Three");
-            storedProcedure.execute();
-
-            String returnValue =  (String) storedProcedure.getOutputParameterValue("out_param_one");
-            Assert.assertEquals("", "One: One Two: Two Three: Three", returnValue);
-
-        } finally {
-            if (em.getTransaction().isActive()) {
-                em.getTransaction().rollback();
-            }
-            if(em.isOpen()) {
-                em.close();
-            }
-        }
-
-        //Make sure changing the order doesn't change the result
-        em = orderedStoredProcedureEmf.createEntityManager();
-        try {
-            StoredProcedureQuery storedProcedure = em.createStoredProcedureQuery("simple_order_procedure");
-            storedProcedure.registerStoredProcedureParameter("out_param_one", String.class, ParameterMode.OUT);
-            storedProcedure.registerStoredProcedureParameter("in_param_two", String.class, ParameterMode.IN);
-            storedProcedure.registerStoredProcedureParameter("in_param_one", String.class, ParameterMode.IN);
-            storedProcedure.registerStoredProcedureParameter("in_param_three", String.class, ParameterMode.IN);
-            storedProcedure.setParameter("in_param_two", "Two");
-            storedProcedure.setParameter("in_param_one", "One");
-            storedProcedure.setParameter("in_param_three", "Three");
-            storedProcedure.execute();
-
-            String returnValue =  (String) storedProcedure.getOutputParameterValue("out_param_one");
-            Assert.assertEquals("", "One: One Two: Two Three: Three", returnValue);
-
-        } finally {
-            if (em.getTransaction().isActive()) {
-                em.getTransaction().rollback();
-            }
-            if(em.isOpen()) {
-                em.close();
-            }
-        }
+    private static DatabasePlatform getPlatform(EntityManagerFactory emf) {
+        return ((EntityManagerFactoryImpl)emf).getServerSession().getPlatform();
     }
 }

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa21/advanced/StoredProcedureQueryTestSuite.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa21/advanced/StoredProcedureQueryTestSuite.java
@@ -373,11 +373,18 @@ public class StoredProcedureQueryTestSuite extends JUnitTestCase {
                 } catch (IllegalArgumentException e) {
                     // Expected, swallow.
                 }
-                
+
                 // Check output parameters by position.
-                Integer outputParamValueFromPosition = (Integer) query.getOutputParameterValue(3);
+                Object outputParamValueFromPosition = query.getOutputParameterValue(3);
+
+                // TODO: See previous investigate todo. A Long is returned here instead of an Integer on MySQL.
+                // This test also mixes index and named parameters, so this test my be invalid to begin with.
                 assertNotNull("The output parameter was null.", outputParamValueFromPosition);
-                assertTrue("Incorrect value returned, expected " + numberOfEmployes + ", got: " + outputParamValueFromPosition, outputParamValueFromPosition.equals(numberOfEmployes));
+                if (outputParamValueFromName instanceof Long) {
+                    assertTrue("Incorrect value returned, expected " + numberOfEmployes + ", got: " + outputParamValueFromPosition, outputParamValueFromPosition.equals(new Long(numberOfEmployes)));
+                } else if (outputParamValueFromName instanceof Integer) {
+                    assertTrue("Incorrect value returned, expected " + numberOfEmployes + ", got: " + outputParamValueFromPosition, outputParamValueFromPosition.equals(numberOfEmployes));
+                }
 
                 // Do some negative tests ...
                 try {
@@ -530,11 +537,18 @@ public class StoredProcedureQueryTestSuite extends JUnitTestCase {
                 } catch (IllegalArgumentException e) {
                     // Expected, swallow.
                 }
-                
+
                 // Check output parameters by position.
-                Integer outputParamValueFromPosition = (Integer) query.getOutputParameterValue(3);
+                Object outputParamValueFromPosition = query.getOutputParameterValue(3);
+
+                // TODO: See previous investigate todo. A Long is returned here instead of an Integer on MySQL.
+                // This test also mixes index and named parameters, so this test my be invalid to begin with.
                 assertNotNull("The output parameter was null.", outputParamValueFromPosition);
-                assertTrue("Incorrect value returned, expected " + numberOfEmployes + ", got: " + outputParamValueFromPosition, outputParamValueFromPosition.equals(numberOfEmployes));
+                if (outputParamValueFromName instanceof Long) {
+                    assertTrue("Incorrect value returned, expected " + numberOfEmployes + ", got: " + outputParamValueFromPosition, outputParamValueFromPosition.equals(new Long(numberOfEmployes)));
+                } else if (outputParamValueFromName instanceof Integer) {
+                    assertTrue("Incorrect value returned, expected " + numberOfEmployes + ", got: " + outputParamValueFromPosition, outputParamValueFromPosition.equals(numberOfEmployes));
+                }
 
                 // Do some negative tests ...
                 try {

--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/StoredProcedureQueryImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/StoredProcedureQueryImpl.java
@@ -469,17 +469,17 @@ public class StoredProcedureQueryImpl extends QueryImpl implements StoredProcedu
      * and OUT parameters. For portability, all results corresponding to result 
      * sets and update counts must be retrieved before the values of output 
      * parameters. 
-     * @param position parameter position
+     * @param position parameter position - 1-based index 
      * @return the result that is passed back through the parameter
      * @throws IllegalArgumentException if the position does not correspond to a 
      * parameter of the query or is not an INOUT or OUT parameter
      */
     public Object getOutputParameterValue(int position) {
         entityManager.verifyOpen();
-        
+
         if (isValidCallableStatement()) {
             try {
-                Object obj = ((CallableStatement) executeStatement).getObject(position);
+                Object obj = executeCall.getOutputParameterValue((CallableStatement) executeStatement, position - 1, entityManager.getAbstractSession());
 
                 if (obj instanceof ResultSet) {
                     // If a result set is returned we have to build the objects.
@@ -491,7 +491,7 @@ public class StoredProcedureQueryImpl extends QueryImpl implements StoredProcedu
                 throw new IllegalArgumentException(ExceptionLocalization.buildMessage("jpa21_invalid_parameter_position", new Object[] { position, exception.getMessage() }), exception);
             }
         }
-        
+
         return null;
     }
 
@@ -508,10 +508,10 @@ public class StoredProcedureQueryImpl extends QueryImpl implements StoredProcedu
      */
     public Object getOutputParameterValue(String parameterName) {
         entityManager.verifyOpen();
-        
+
         if (isValidCallableStatement()) {
             try {
-                Object obj = ((CallableStatement) executeStatement).getObject(parameterName);
+                Object obj = executeCall.getOutputParameterValue((CallableStatement) executeStatement, parameterName, entityManager.getAbstractSession());
 
                 if (obj instanceof ResultSet) {
                     // If a result set is returned we have to build the objects.


### PR DESCRIPTION
for #636 

Also, contains
for #648
While writing tests for this fix, I noticed that StoredProcedure OUT parameters don't work on DB2zPlatform. This is due to needing to call the DB2z CallableStatement API `getJccObjectAtName` instead of the JDBC API call. This was a change missing from Bug 543846.

So, I moved the java.sql.CallableStatement.getObject() calls from StoredProcedureQueryImpl to DatabasePlatform so that Platform classes can override this CallableStatement method. Currently, DB2zPlatform needs to override this to get OUT values, with named parameters. Other platforms way want to override this in the future.

I am making this change as part of THIS change so that the testing can be delivered for both.

Signed-off-by: Will Dazey <dazeydev.3@gmail.com>