### PR TITLE
[2.7] Dependencies upgrade

### DIFF
--- a/buildsystem/compdeps/pom.xml
+++ b/buildsystem/compdeps/pom.xml
@@ -57,41 +57,46 @@
         <eclipse.drop>2018-12</eclipse.drop>
 
         <!-- DEPENDENCY Versions -->
+        <!-- CQ #21139, 21140 -->
         <ch.qos.logback.version>1.2.3</ch.qos.logback.version>
         <com.sun.istack.version>3.0.8</com.sun.istack.version>
         <com.sun.xml.bind.version>2.3.2</com.sun.xml.bind.version>
         <jakarta.activation.version>1.2.1</jakarta.activation.version>
-        <jakarta.annotation.version>1.3.4</jakarta.annotation.version>
-        <jakarta.ejb.version>3.2.4</jakarta.ejb.version>
-        <jakarta.el.version>3.0.2</jakarta.el.version>
-        <jakarta.enterprise.cdi.version>2.0.1</jakarta.enterprise.cdi.version>
-        <jakarta.inject.version>2.5.0</jakarta.inject.version>
-        <jakarta.interceptor.version>1.2.3</jakarta.interceptor.version>
-        <jakarta.jms.version>2.0.2</jakarta.jms.version>
-        <jakarta.json.version>1.1.5</jakarta.json.version>
-        <jakarta.mail.version>1.6.3 </jakarta.mail.version>
+        <jakarta.annotation.version>1.3.5</jakarta.annotation.version>
+        <jakarta.ejb.version>3.2.6</jakarta.ejb.version>
+        <jakarta.el.version>3.0.3</jakarta.el.version>
+        <jakarta.enterprise.cdi.version>2.0.2</jakarta.enterprise.cdi.version>
+        <jakarta.inject.version>2.6.1</jakarta.inject.version>
+        <jakarta.interceptor.version>1.2.5</jakarta.interceptor.version>
+        <jakarta.jms.version>2.0.3</jakarta.jms.version>
+        <jakarta.json.version>1.1.6</jakarta.json.version>
+        <jakarta.mail.version>1.6.4</jakarta.mail.version>
         <jakarta.persistence.version>2.2.3</jakarta.persistence.version>
         <jakarta.resource.version>1.7.3</jakarta.resource.version>
-        <jakarta.servlet.version>4.0.2</jakarta.servlet.version>
-        <jakarta.transaction.version>1.3.2</jakarta.transaction.version>
-        <jakarta.validation.version>2.0.1</jakarta.validation.version>
+        <jakarta.servlet.version>4.0.3</jakarta.servlet.version>
+        <jakarta.transaction.version>1.3.3</jakarta.transaction.version>
+        <jakarta.validation.version>2.0.2</jakarta.validation.version>
         <jakarta.ws.rs.version>2.1.6</jakarta.ws.rs.version>
         <jakarta.xml.bind.version>2.3.2</jakarta.xml.bind.version>
         <jakarta.xml.soap.version>1.4.1</jakarta.xml.soap.version>
         <jakarta.xml.ws-api.version>2.3.2</jakarta.xml.ws-api.version>
-        <org.apache.ant.version>1.10.5_1</org.apache.ant.version>
-        <org.glassfish.corba.version>4.2.0</org.glassfish.corba.version>
+        <!-- CQ #21133 -->
+        <org.apache.ant.version>1.10.7_1</org.apache.ant.version>
+        <org.glassfish.corba.version>4.2.1</org.glassfish.corba.version>
         <org.glassfish.gmbal.version>4.0.0</org.glassfish.gmbal.version>
-        <org.glassfish.hk2.version>2.5.0</org.glassfish.hk2.version>
-        <org.glassfish.jersey.version>2.28</org.glassfish.jersey.version>
-        <org.glassfish.management-api.version>3.2.1</org.glassfish.management-api.version>
-        <org.glassfish.pfl.version>4.0.1</org.glassfish.pfl.version>
-        <org.mongodb.version>3.2.0</org.mongodb.version>
+        <org.glassfish.hk2.version>2.6.1</org.glassfish.hk2.version>
+        <org.glassfish.jersey.version>2.29.1</org.glassfish.jersey.version>
+        <org.glassfish.management-api.version>3.2.2</org.glassfish.management-api.version>
+        <org.glassfish.pfl.version>4.1.0</org.glassfish.pfl.version>
+        <!-- CQ #21138 -->
+        <org.mongodb.version>3.11.2</org.mongodb.version>
+        <!-- CQ #21142 -->
         <org.osgi.version>4.3.1</org.osgi.version>
-        <org.slf4j.version>1.7.25</org.slf4j.version>
-        <wsdl4j.version>1.6.2</wsdl4j.version>
-        <!-- CQ #7143 (Workswith) JGroups 3.2.8+ -->
-        <org.jgroups.version>4.1.0.Final</org.jgroups.version>
+        <!-- CQ #21339 -->
+        <org.slf4j.version>1.7.30</org.slf4j.version>
+        <wsdl4j.version>1.6.3</wsdl4j.version>
+        <!-- CQ #21122 -->
+        <org.jgroups.version>4.1.8.Final</org.jgroups.version>
     </properties>
 
     <build>

--- a/moxy/eclipselink.moxy.test/pom.xml
+++ b/moxy/eclipselink.moxy.test/pom.xml
@@ -24,9 +24,17 @@
     <version>2.7.6-SNAPSHOT</version>
 
     <properties>
-        <exam.version>4.11.0</exam.version>
+        <!-- CQ #21132 -->
+        <apache.felix.framework.version>6.0.3</apache.felix.framework.version>
+        <!-- CQ #21134, 21135, 21136, 21137 -->
+        <exam.version>4.13.1</exam.version>
+        <!-- CQ #3571 -->
+        <hibernate.version>6.1.0.Final</hibernate.version>
+        <log4j.version>2.13.0</log4j.version>
+        <!-- CQ #21139, 21140 -->
+        <logback.version>1.3.0-alpha5</logback.version>
         <url.version>2.5.2</url.version>
-        <logback.version>1.1.3</logback.version>
+        <validation.version>2.0.2</validation.version>
         <eclipselink.version>2.7.6-SNAPSHOT</eclipselink.version>
     </properties>
 
@@ -42,24 +50,25 @@
 
         <!-- Bean validation API -->
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation</artifactId>
-            <version>2.0.1</version>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>${validation.version}</version>
             <scope>system</scope>
             <systemPath>${javax.validation.lib}</systemPath>
         </dependency>
 
         <!-- Hibernate validator and it's dependencies -->
+        <!-- CQ #3571 -->
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>6.0.7.Final</version>
+            <version>${hibernate.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.3</version>
+            <version>${log4j.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -74,7 +83,7 @@
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.framework</artifactId>
-            <version>5.6.10</version>
+            <version>${apache.felix.framework.version}</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
org.osgi is not upgraded to 6.0.0 due troubles with osgi.cmpn in MANIFEST.MF is following
```
Require-Capability: osgi.compile.time.only;filter:="(&(must.not.resolve=
 *)(!(must.not.resolve=*)))",osgi.ee;filter:="(&(osgi.ee=JavaSE)(version
 =1.5))"
```
slf4j is not upgraded to 2.0.0-alpha1 but only to 1.7.30 due ch.qos.logback 
ch.qos.logback is not upgraded to 1.3.0-alpha5 due troubles with
```
Provide-Capability: osgi.serviceloader;osgi.serviceloader="org.slf4j.s
 pi.SLF4JServiceProvider"
Require-Capability: osgi.extender;filter:="(osgi.extender=osgi.service
 loader.registrar)"
```

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>