### PR TITLE
[master] Update GIT ignore for Eclipse generated artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .DS_Store
 *.class
+*.classpath
+*.settings
+*.project
 *test.jar
 *model.jar
 eclipselink*.jar


### PR DESCRIPTION
Importing EclipseLink projects into Eclipse as "Existing Maven Projects" causes a bunch of .project/.settings/.classpath files to be generated. These files then show up as new files unstaged in Git. Updating the ignore so that we don't track these generated files on master

Signed-off-by: Will Dazey <dazeydev.3@gmail.com>