### PR TITLE
[master] Maven build - MS SQL Server support

### DIFF
--- a/buildsystem/mavenize/test.properties/el-test.mssql.properties
+++ b/buildsystem/mavenize/test.properties/el-test.mssql.properties
@@ -1,0 +1,16 @@
+# DB Connection properties
+db.driver=com.microsoft.sqlserver.jdbc.SQLServerDriver
+db.xa.driver=com.microsoft.sqlserver.jdbc.SQLServerDriver
+db.url=jdbc:sqlserver://localhost:1433;database=ecltests
+db.user=SA
+db.pwd=SA
+db.platform=org.eclipse.persistence.platform.database.SQLServerPlatform
+db.properties=url=jdbc:sqlserver://localhost:1433;database=ecltests
+#db.ddl.debug=true
+datasource.type=java.sql.Driver
+#datasource.type=javax.sql.XADataSource
+datasource.transactionsupport=LOCAL_TRANSACTION
+#datasource.transactionsupport=XA_TRANSACTION
+
+# Logging option for debugging
+logging.level=info

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
         <test.oracle.properties.file>el-test.oracle.properties</test.oracle.properties.file>
         <test.mongodb.properties.file>el-test.mongodb.properties</test.mongodb.properties.file>
         <test.derby.properties.file>el-test.derby.properties</test.derby.properties.file>
+        <test.mssql.properties.file>el-test.mssql.properties</test.mssql.properties.file>
 
         <!--Default test DB is Derby-->
         <test.properties.file>${user.home}/${test.derby.properties.file}</test.properties.file>
@@ -157,6 +158,7 @@
         <!-- CQ #21138 -->
         <mongodb.version>3.11.2</mongodb.version>
         <mysql.version>5.1.44</mysql.version>
+        <mssql.version>7.4.1.jre8</mssql.version>
         <!-- CQ #21139, 21140 -->
         <logback.version>1.3.0-alpha5</logback.version>
         <oracle.jdbc.version>19.3.0.0</oracle.jdbc.version>
@@ -501,6 +503,11 @@
                 <groupId>org.apache.derby</groupId>
                 <artifactId>derbyclient</artifactId>
                 <version>${derby.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microsoft.sqlserver</groupId>
+                <artifactId>mssql-jdbc</artifactId>
+                <version>${mssql.version}</version>
             </dependency>
             <!--For Oracle DB driver see Oracle proprietary dependencies part. It's not limited to tests only-->
             <!-- Hibernate validator and it's dependencies -->
@@ -1122,6 +1129,18 @@
                 <db.driver.groupId>mysql</db.driver.groupId>
                 <db.driver.artifactId>mysql-connector-java</db.driver.artifactId>
                 <db.driver.version>${mysql.version}</db.driver.version>
+                <test.skip.in-memory.db>true</test.skip.in-memory.db>
+            </properties>
+        </profile>
+        <profile>
+            <id>mssql</id>
+            <properties>
+                <test.properties.file>${user.home}/${test.mssql.properties.file}</test.properties.file>
+                <test.properties.fileName>${test.mssql.properties.file}</test.properties.fileName>
+                <!--Used by sql-maven-plugin-->
+                <db.driver.groupId>com.microsoft.sqlserver</db.driver.groupId>
+                <db.driver.artifactId>mssql-jdbc</db.driver.artifactId>
+                <db.driver.version>${mssql.version}</db.driver.version>
                 <test.skip.in-memory.db>true</test.skip.in-memory.db>
             </properties>
         </profile>


### PR DESCRIPTION
This fix adds support for MS SQL Server.
After this one various tests can be executed against MS SQL server e.g.
`mvn verify -pl :org.eclipse.persistence.jpa.jse.test -Pmssql`
`mvn verify -pl :org.eclipse.persistence.core.test -Pmssql`

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>