### PR TITLE
[master] Bug #625 - NullPointerException QueryBasedValueHolder getValue(UnitOfWorkImpl uow) not thread safe

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/indirection/UnitOfWorkValueHolder.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/indirection/UnitOfWorkValueHolder.java
@@ -163,10 +163,10 @@ public abstract class UnitOfWorkValueHolder extends DatabaseValueHolder implemen
                         return wrapped.instantiateForUnitOfWorkValueHolder(this);
                     }
                 }
-                if (!((DatabaseValueHolder)this.wrappedValueHolder).isInstantiated()){
+                if (!wrapped.isInstantiated()){
                     //if not instantiated then try and load the UOW versions to prevent the whole loading from the cache and cloning
                     //process
-                    Object result = ((DatabaseValueHolder)this.wrappedValueHolder).getValue((UnitOfWorkImpl) this.session);
+                    Object result = wrapped.getValue((UnitOfWorkImpl) this.session);
                     if (result != null){
                         return result;
                     }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/indirection/UnitOfWorkValueHolder.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/indirection/UnitOfWorkValueHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -142,10 +142,11 @@ public abstract class UnitOfWorkValueHolder extends DatabaseValueHolder implemen
      * sometimes triggered directly without triggering the underlying valueholder.
      */
     protected Object instantiateImpl() {
-        if (this.wrappedValueHolder instanceof DatabaseValueHolder) {
-            // Bug 3835202 - Ensure access to valueholders is thread safe.  Several of the methods
-            // called below are not threadsafe alone.
-            synchronized (this.wrappedValueHolder) {
+        Object value;
+        // Bug 3835202 - Ensure access to valueholders is thread safe.  Several of the methods
+        // called below are not threadsafe alone.
+        synchronized (this.wrappedValueHolder) {
+            if (this.wrappedValueHolder instanceof DatabaseValueHolder) {
                 DatabaseValueHolder wrapped = (DatabaseValueHolder)this.wrappedValueHolder;
                 UnitOfWorkImpl unitOfWork = getUnitOfWork();
                 if (!wrapped.isEasilyInstantiated()) {
@@ -162,17 +163,18 @@ public abstract class UnitOfWorkValueHolder extends DatabaseValueHolder implemen
                         return wrapped.instantiateForUnitOfWorkValueHolder(this);
                     }
                 }
-            }
-            if (!this.wrappedValueHolder.isInstantiated()){
-                //if not instantiated then try and load the UOW versions to prevent the whole loading from the cache and cloning
-                //process
-                Object result = ((DatabaseValueHolder)this.wrappedValueHolder).getValue((UnitOfWorkImpl) this.session);
-                if (result != null){
-                    return result;
+                if (!((DatabaseValueHolder)this.wrappedValueHolder).isInstantiated()){
+                    //if not instantiated then try and load the UOW versions to prevent the whole loading from the cache and cloning
+                    //process
+                    Object result = ((DatabaseValueHolder)this.wrappedValueHolder).getValue((UnitOfWorkImpl) this.session);
+                    if (result != null){
+                        return result;
+                    }
                 }
             }
+            value = this.wrappedValueHolder.getValue();
         }
-        return buildCloneFor(this.wrappedValueHolder.getValue());
+        return buildCloneFor(value);
     }
 
     /**


### PR DESCRIPTION
This is fix for bug #625 - NullPointerException QueryBasedValueHolder getValue(UnitOfWorkImpl uow) not thread safe

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>