### PR TITLE
Fix Bug 548125 ** - SDO Types generation is very slow for big schemas…

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/util/NamespaceResolverStorage.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/util/NamespaceResolverStorage.java
@@ -1,0 +1,159 @@
+package org.eclipse.persistence.internal.oxm.util;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.Vector;
+import java.util.function.BiFunction;
+
+import org.eclipse.persistence.internal.oxm.Namespace;
+
+import static org.eclipse.persistence.internal.oxm.util.VectorUtils.emptyVector;
+import static org.eclipse.persistence.internal.oxm.util.VectorUtils.unmodifiableVector;
+
+public class NamespaceResolverStorage extends LinkedHashMap<String, String> {
+    private static final long serialVersionUID = -4697397620139076774L;
+    private transient Vector namespaces = emptyVector();
+    private transient boolean modified = false;
+
+    public NamespaceResolverStorage() {
+        super();
+    }
+
+    public NamespaceResolverStorage(int initialCapacity) {
+        super(initialCapacity);
+    }
+
+    private void readObject(java.io.ObjectInputStream in)
+            throws IOException, ClassNotFoundException {
+        in.defaultReadObject();
+        namespaces = emptyVector();
+        modified = true;
+    }
+
+    @Override
+    public String put(String key, String value) {
+        String response = super.put(key, value);
+        setModified();
+        return response;
+    }
+
+    private void setModified() {
+        setModified(true);
+    }
+
+    @Override
+    public void putAll(Map<? extends String, ? extends String> m) {
+        super.putAll(m);
+        setModified();
+    }
+
+    @Override
+    public String remove(Object key) {
+        if (containsKey(key)) {
+            setModified();
+        }
+
+        return super.remove(key);
+    }
+
+    @Override
+    public String putIfAbsent(String key, String value) {
+        String response = super.putIfAbsent(key, value);
+        setModified();
+        return response;
+    }
+
+    @Override
+    public boolean remove(Object key, Object value) {
+        boolean response = super.remove(key, value);
+        if (response) {
+            setModified();
+        }
+        return response;
+    }
+
+    @Override
+    public boolean replace(String key, String oldValue, String newValue) {
+        boolean response = super.replace(key, oldValue, newValue);
+        if (response) {
+            setModified(response);
+        }
+        return response;
+    }
+
+    @Override
+    public String replace(String key, String value) {
+        String response = super.replace(key, value);
+        setModified();
+        return response;
+    }
+
+    public Vector getNamespaces() {
+        if (isModified()) {
+            namespaces = buildNamespacesUnmodifiable();
+            setModified(false);
+        }
+        return namespaces;
+    }
+
+    public void setNamespaces(Vector namespaces) {
+        super.clear();
+        for (Namespace namespace : (Vector<Namespace>) namespaces) {
+            if ((namespace.getPrefix() != null) && (namespace.getNamespaceURI() != null)) {
+                super.put(namespace.getPrefix(), namespace.getNamespaceURI());
+            }
+        }
+        setModified();
+    }
+
+    private boolean isModified() {
+        return modified;
+    }
+
+    private void setModified(boolean modified) {
+        this.modified = modified;
+    }
+
+    private Vector buildNamespacesUnmodifiable() {
+        Vector names = new Vector(size());
+        for (Map.Entry<String, String> entry : entrySet()) {
+            Namespace namespace = new Namespace(entry.getKey(), entry.getValue());
+            names.addElement(namespace);
+        }
+        return unmodifiableVector(names);
+    }
+
+    /**
+     * Unmodifiable set of keys
+     */
+    @Override
+    public Set<String> keySet() {
+        return Collections.unmodifiableSet(super.keySet());
+    }
+
+    /**
+     * Unmodifiable collection of values
+     */
+    @Override
+    public Collection<String> values() {
+        return Collections.unmodifiableCollection(super.values());
+    }
+
+    /**
+     * Unmodifiable set of entries
+     */
+    @Override
+    public Set<Map.Entry<String, String>> entrySet() {
+        return Collections.unmodifiableSet(super.entrySet());
+    }
+
+    @Override
+    public void replaceAll(BiFunction<? super String, ? super String, ? extends String> function) {
+        super.replaceAll(function);
+        setModified();
+    }
+}

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/util/VectorUtils.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/util/VectorUtils.java
@@ -1,0 +1,243 @@
+package org.eclipse.persistence.internal.oxm.util;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Objects;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.Vector;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+
+import static java.util.Collections.emptyIterator;
+import static java.util.Collections.emptyListIterator;
+
+/**
+ * This class provides "empty" and "unmodifiable" wrappers for the Vector class.
+ * The functionality is similar the Collections class and mostly copy-paste from the class.
+ * Unfortunately, the standard Collections class does not provides wrappers for the outdated Vector class.
+ *
+ * @see Collections
+ */
+public class VectorUtils {
+    /**
+     * The empty vector (immutable).
+     * @see #emptyVector()
+     */
+    public static final Vector EMPTY_VECTOR = new EmptyVector();
+
+    /**
+     * Returns an unmodifiable view of the specified vector.  This method allows
+     * modules to provide users with "read-only" access to internal
+     * vectors.  Query operations on the returned vector "read through" to the
+     * specified vector, and attempts to modify the returned vector, whether
+     * direct or via its iterator, result in an
+     * <tt>UnsupportedOperationException</tt>.<p>
+     *
+     * @param <T> the class of the objects in the vector
+     * @param vector the vector for which an unmodifiable view is to be returned.
+     * @return an unmodifiable view of the specified vector.
+     */
+    public static <T> Vector<T> unmodifiableVector(Vector<? extends T> vector) {
+        if (vector == null) {
+            throw new IllegalArgumentException("Input value must not be NULL!");
+        }
+        return new UnmodifiableVector<>(vector);
+    }
+
+    /**
+     * Returns an empty vector (immutable).
+     *
+     * <p>This example illustrates the type-safe way to obtain an empty vector:
+     * <pre>
+     *     Vector&lt;String&gt; s = VectorUtils.emptyVector();
+     * </pre>
+     * @param <T> type of elements, if there were any, in the vector
+     * @return an empty immutable vector
+     * @implNote Implementations of this method need not create a separate <tt>Vector</tt>
+     * object for each call.   Using this method is likely to have comparable
+     * cost to using the like-named field.  (Unlike this method, the field does
+     * not provide type safety.)
+     * @see #EMPTY_VECTOR
+     */
+    @SuppressWarnings("unchecked")
+    public static final <T> Vector<T> emptyVector() {
+        return (Vector<T>) EMPTY_VECTOR;
+    }
+
+    private VectorUtils() {}
+
+    private static class EmptyVector<E> extends Vector<E> {
+        private static final long serialVersionUID = 5020332176914113951L;
+
+        @Override
+        public int size() {return 0;}
+
+        @Override
+        public boolean isEmpty() {return true;}
+
+        @Override
+        public boolean contains(Object obj) {return false;}
+
+        @Override
+        public Object[] toArray() { return new Object[0]; }
+
+        @Override
+        public <T> T[] toArray(T[] a) {
+            if (a.length > 0) {
+                a[0] = null;
+            }
+            return a;
+        }
+
+        @Override
+        public E get(int index) {
+            throw new IndexOutOfBoundsException("Index: " + index);
+        }
+
+        @Override
+        public void add(int index, E element) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean containsAll(Collection<?> c) { return c.isEmpty(); }
+
+        @Override
+        public boolean equals(Object o) {
+            return (o instanceof Vector) && ((Vector<?>) o).isEmpty();
+        }
+
+        @Override
+        public int hashCode() { return 1; }
+
+        @Override
+        public ListIterator<E> listIterator(int index) {
+            return emptyListIterator();
+        }
+
+        @Override
+        public ListIterator<E> listIterator() {
+            return emptyListIterator();
+        }
+
+        @Override
+        public Iterator<E> iterator() {
+            return emptyIterator();
+        }
+
+        // Override default methods in Collection
+        @Override
+        public void forEach(Consumer<? super E> action) {
+            Objects.requireNonNull(action);
+        }
+
+        @Override
+        public boolean removeIf(Predicate<? super E> filter) {
+            Objects.requireNonNull(filter);
+            return false;
+        }
+
+        @Override
+        public void replaceAll(UnaryOperator<E> operator) {
+            Objects.requireNonNull(operator);
+        }
+
+        @Override
+        public void sort(Comparator<? super E> c) {
+        }
+
+        @Override
+        public Spliterator<E> spliterator() { return Spliterators.emptySpliterator(); }
+
+        // Preserves singleton property
+        private Object readResolve() {
+            return EMPTY_VECTOR;
+        }
+    }
+
+    /**
+     * @serial include
+     */
+    static class UnmodifiableVector<E> extends Vector<E> {
+        private static final long serialVersionUID = -8378199697360550972L;
+
+        UnmodifiableVector(Vector<? extends E> vector) {
+            super(vector);
+        }
+
+        public E set(int index, E element) {
+            throw new UnsupportedOperationException();
+        }
+
+        public void add(int index, E element) {
+            throw new UnsupportedOperationException();
+        }
+
+        public E remove(int index) {
+            throw new UnsupportedOperationException();
+        }
+
+        public boolean addAll(int index, Collection<? extends E> c) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<E> subList(int fromIndex, int toIndex) {
+            return Collections.unmodifiableList(subList(fromIndex, toIndex));
+        }
+
+        public ListIterator<E> listIterator(final int index) {
+            return new ListIterator<E>() {
+                private final ListIterator<? extends E> i
+                        = listIterator(index);
+
+                public boolean hasNext() {return i.hasNext();}
+
+                public E next() {return i.next();}
+
+                public boolean hasPrevious() {return i.hasPrevious();}
+
+                public E previous() {return i.previous();}
+
+                public int nextIndex() {return i.nextIndex();}
+
+                public int previousIndex() {return i.previousIndex();}
+
+                public void remove() {
+                    throw new UnsupportedOperationException();
+                }
+
+                public void set(E e) {
+                    throw new UnsupportedOperationException();
+                }
+
+                public void add(E e) {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public void forEachRemaining(Consumer<? super E> action) {
+                    i.forEachRemaining(action);
+                }
+            };
+        }
+
+        public ListIterator<E> listIterator() {return listIterator(0);}
+
+        @Override
+        public void replaceAll(UnaryOperator<E> operator) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void sort(Comparator<? super E> c) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #467

Performance fixes:

Avoid creating a Vector object for each NamespaceResolver#getNamespaces() call
Use a simpler List structure instead LinkedHashMap for the interim buffer in the NamespaceResolver#put(String, String) method.

Signed-off-by: Tianyi Li jamielee5277@gmail.com