### PR TITLE
Bug 558283: Missing parameter markers from DB2 Stored Procedures - Javadoc fix

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatabaseCall.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatabaseCall.java
@@ -1391,7 +1391,9 @@ public abstract class DatabaseCall extends DatasourceCall {
      * INTERNAL:
      * 
      * Get the return object from the statement. Use the parameter index to determine what return object to get.
-     * @param index - 0-based index in the argument list
+     * @param statement SQL/JDBC statement to call stored procedure/function
+     * @param index 0-based index in the argument list
+     * @param session Active database session (in connected state).
      * @return
      */
     public Object getOutputParameterValue(CallableStatement statement, int index, AbstractSession session) throws SQLException {
@@ -1403,7 +1405,9 @@ public abstract class DatabaseCall extends DatasourceCall {
      * INTERNAL:
      * 
      * Get the return object from the statement. Use the parameter name to determine what return object to get.
-     * @param index - 0-based index in the argument list
+     * @param statement SQL/JDBC statement to call stored procedure/function
+     * @param name parameter name
+     * @param session Active database session (in connected state).
      * @return
      */
     public Object getOutputParameterValue(CallableStatement statement, String name, AbstractSession session) throws SQLException {


### PR DESCRIPTION
There is small fix in Javadoc comments.
Before this following Maven command `mvn install -DskipTests -Poss-release` failed.
Line 1415 contained incorrect parameter name (index -> name).
See
https://ci.eclipse.org/eclipselink/view/Current%20Jobs/job/eclipselink-cb-master/48/
https://ci.eclipse.org/eclipselink/view/Current%20Jobs/job/eclipselink-nightly-master/76/

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>