### PR TITLE
[master] Maven build - Oracle platform fix

### DIFF
--- a/foundation/org.eclipse.persistence.corba/pom.xml
+++ b/foundation/org.eclipse.persistence.corba/pom.xml
@@ -259,6 +259,18 @@
 
     <profiles>
         <profile>
+            <id>oracle</id>
+            <dependencies>
+                <!--db.platform=org.eclipse.persistence.platform.database.oracle.Oracle12Platform comes from there-->
+                <dependency>
+                    <groupId>org.eclipse.persistence</groupId>
+                    <artifactId>org.eclipse.persistence.oracle</artifactId>
+                    <version>${project.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
             <id>java11-dependencies</id>
             <activation>
                 <jdk>[11,)</jdk>

--- a/foundation/org.eclipse.persistence.oracle.nosql/pom.xml
+++ b/foundation/org.eclipse.persistence.oracle.nosql/pom.xml
@@ -191,6 +191,9 @@
                         <goals>
                             <goal>verify</goal>
                         </goals>
+                        <configuration>
+                            <skip>${integration.test.skip.verify}</skip>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/jpa/eclipselink.jpa.spring.test/pom.xml
+++ b/jpa/eclipselink.jpa.spring.test/pom.xml
@@ -240,6 +240,18 @@
 
     <profiles>
         <profile>
+            <id>oracle</id>
+            <dependencies>
+                <!--db.platform=org.eclipse.persistence.platform.database.oracle.Oracle12Platform comes from there-->
+                <dependency>
+                    <groupId>org.eclipse.persistence</groupId>
+                    <artifactId>org.eclipse.persistence.oracle</artifactId>
+                    <version>${project.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
             <id>test-jpa-spring</id>
             <properties>
                 <test-skip-jpa-spring>false</test-skip-jpa-spring>

--- a/jpa/eclipselink.jpa.wdf.test/pom.xml
+++ b/jpa/eclipselink.jpa.wdf.test/pom.xml
@@ -358,6 +358,15 @@
         </profile>
         <profile>
             <id>oracle</id>
+            <dependencies>
+                <!--db.platform=org.eclipse.persistence.platform.database.oracle.Oracle12Platform comes from there-->
+                <dependency>
+                    <groupId>org.eclipse.persistence</groupId>
+                    <artifactId>org.eclipse.persistence.oracle</artifactId>
+                    <version>${project.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
             <build>
                 <plugins>
                     <plugin>

--- a/jpa/org.eclipse.persistence.jpars/pom.xml
+++ b/jpa/org.eclipse.persistence.jpars/pom.xml
@@ -189,6 +189,18 @@
 
     <profiles>
         <profile>
+            <id>oracle</id>
+            <dependencies>
+                <!--db.platform=org.eclipse.persistence.platform.database.oracle.Oracle12Platform comes from there-->
+                <dependency>
+                    <groupId>org.eclipse.persistence</groupId>
+                    <artifactId>org.eclipse.persistence.oracle</artifactId>
+                    <version>${project.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
             <id>java11-dependencies</id>
             <activation>
                 <jdk>[11,)</jdk>


### PR DESCRIPTION
This is fix for oracle profile in Maven build to add dependency to org.eclipse.persistence.oracle artifact/module.
Without this fix integration tests in the modified modules failed with ClassNotFoundException for oracle Maven profile and test property db.platform=org.eclipse.persistence.platform.database.oracle.Oracle12Platform.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>