### PR TITLE
[master] Change UoW reference to WeakReference for GC

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/descriptors/changetracking/AttributeChangeListener.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/descriptors/changetracking/AttributeChangeListener.java
@@ -15,6 +15,7 @@
 package org.eclipse.persistence.internal.descriptors.changetracking;
 
 import java.beans.*;
+import java.lang.ref.WeakReference;
 
 import org.eclipse.persistence.descriptors.ClassDescriptor;
 import org.eclipse.persistence.descriptors.changetracking.*;
@@ -35,8 +36,8 @@ import org.eclipse.persistence.exceptions.ValidationException;
  * ChangeRecords for the changed attributes.
  */
 public class AttributeChangeListener extends ObjectChangeListener {
-    protected transient ClassDescriptor descriptor;
-    protected transient UnitOfWorkImpl uow;
+    protected transient WeakReference<ClassDescriptor> descriptor;
+    protected transient WeakReference<UnitOfWorkImpl> uow;
     protected org.eclipse.persistence.internal.sessions.ObjectChangeSet objectChangeSet;
     protected Object owner;
 
@@ -46,8 +47,8 @@ public class AttributeChangeListener extends ObjectChangeListener {
      */
     public AttributeChangeListener(ClassDescriptor descriptor, UnitOfWorkImpl uow, Object owner) {
         super();
-        this.descriptor = descriptor;
-        this.uow = uow;
+        this.descriptor = new WeakReference<ClassDescriptor>(descriptor);
+        this.uow = new WeakReference<UnitOfWorkImpl>(uow);
         this.owner = owner;
     }
 
@@ -72,7 +73,7 @@ public class AttributeChangeListener extends ObjectChangeListener {
      * Return the descriptor associated with this listener
      */
     public ClassDescriptor getDescriptor() {
-        return descriptor;
+        return descriptor.get();
     }
 
     /**
@@ -80,7 +81,7 @@ public class AttributeChangeListener extends ObjectChangeListener {
      * Set the descriptor associated with this listener
      */
     public void setDescriptor(ClassDescriptor descriptor) {
-        this.descriptor = descriptor;
+        this.descriptor = new WeakReference<ClassDescriptor>(descriptor);
     }
 
     /**
@@ -88,7 +89,7 @@ public class AttributeChangeListener extends ObjectChangeListener {
      * Return the unit of work associated with this listener
      */
     public UnitOfWorkImpl getUnitOfWork() {
-        return uow;
+        return uow.get();
     }
 
     /**
@@ -96,7 +97,7 @@ public class AttributeChangeListener extends ObjectChangeListener {
      * Set the unit of work associated with this listener
      */
     public void setUnitOfWork(UnitOfWorkImpl uow) {
-        this.uow = uow;
+        this.uow = new WeakReference<UnitOfWorkImpl>(uow);
     }
 
     /**
@@ -125,36 +126,45 @@ public class AttributeChangeListener extends ObjectChangeListener {
             return;
         }
 
-        DatabaseMapping mapping = descriptor.getObjectBuilder().getMappingForAttributeName(evt.getPropertyName());
-        //Bug#4127952 Throw an exception indicating there is no mapping for the property name.
-        if (mapping == null) {
-            throw ValidationException.wrongPropertyNameInChangeEvent(owner.getClass(), evt.getPropertyName());
-        }
-        if (mapping instanceof AbstractDirectMapping || mapping instanceof AbstractTransformationMapping) {
-            //If both newValue and oldValue are null, or newValue is not null and newValue equals oldValue, don't build ChangeRecord
-            if (((evt.getNewValue() == null) && (evt.getOldValue() == null)) || ((evt.getNewValue() != null) && (evt.getNewValue()).equals(evt.getOldValue()))) {
-                return;
+        ClassDescriptor descriptor = getDescriptor();
+        DatabaseMapping mapping = null;
+        if(descriptor != null) {
+            mapping = descriptor.getObjectBuilder().getMappingForAttributeName(evt.getPropertyName());
+            //Bug#4127952 Throw an exception indicating there is no mapping for the property name.
+            if (mapping == null) {
+                throw ValidationException.wrongPropertyNameInChangeEvent(owner.getClass(), evt.getPropertyName());
+            }
+            if (mapping instanceof AbstractDirectMapping || mapping instanceof AbstractTransformationMapping) {
+                //If both newValue and oldValue are null, or newValue is not null and newValue equals oldValue, don't build ChangeRecord
+                if (((evt.getNewValue() == null) && (evt.getOldValue() == null)) || ((evt.getNewValue() != null) && (evt.getNewValue()).equals(evt.getOldValue()))) {
+                    return;
+                }
             }
         }
 
         super.internalPropertyChange(evt);
 
-        if (uow.getUnitOfWorkChangeSet() == null) {
-            uow.setUnitOfWorkChangeSet(new UnitOfWorkChangeSet(uow));
-        }
-        if (objectChangeSet == null) {//only null if new or if in a new UOW
-            //add to tracker list to prevent GC of clone if using weak references
-            //put it in here so that it only occurs on the 1st change for a particular UOW
-            uow.addToChangeTrackedHardList(owner);
-            objectChangeSet = getDescriptor().getObjectBuilder().createObjectChangeSet(owner, (UnitOfWorkChangeSet) uow.getUnitOfWorkChangeSet(), false, uow);
+        UnitOfWorkImpl uow = getUnitOfWork();
+        if(uow != null) {
+            if (uow.getUnitOfWorkChangeSet() == null) {
+                uow.setUnitOfWorkChangeSet(new UnitOfWorkChangeSet(uow));
+            }
+            if (objectChangeSet == null) {//only null if new or if in a new UOW
+                //add to tracker list to prevent GC of clone if using weak references
+                //put it in here so that it only occurs on the 1st change for a particular UOW
+                uow.addToChangeTrackedHardList(owner);
+                objectChangeSet = getDescriptor().getObjectBuilder().createObjectChangeSet(owner, (UnitOfWorkChangeSet) uow.getUnitOfWorkChangeSet(), false, uow);
+            }
         }
 
-        if (evt.getClass().equals(ClassConstants.PropertyChangeEvent_Class)) {
-            mapping.updateChangeRecord(evt.getSource(), evt.getNewValue(), evt.getOldValue(), objectChangeSet, getUnitOfWork());
-        } else if (evt.getClass().equals(ClassConstants.CollectionChangeEvent_Class) || (evt.getClass().equals(ClassConstants.MapChangeEvent_Class))) {
-            mapping.updateCollectionChangeRecord((CollectionChangeEvent)evt, objectChangeSet, getUnitOfWork());
-        } else {
-            throw ValidationException.wrongChangeEvent(evt.getClass());
+        if(mapping != null) {
+            if (evt.getClass().equals(ClassConstants.PropertyChangeEvent_Class)) {
+                mapping.updateChangeRecord(evt.getSource(), evt.getNewValue(), evt.getOldValue(), objectChangeSet, getUnitOfWork());
+            } else if (evt.getClass().equals(ClassConstants.CollectionChangeEvent_Class) || (evt.getClass().equals(ClassConstants.MapChangeEvent_Class))) {
+                mapping.updateCollectionChangeRecord((CollectionChangeEvent)evt, objectChangeSet, getUnitOfWork());
+            } else {
+                throw ValidationException.wrongChangeEvent(evt.getClass());
+            }
         }
     }
 


### PR DESCRIPTION
When EntityManager is closed, we de-reference the workingClones and the RepeatableUnitOfWork. We store the UoW reference in the EntityManagerImpl and the AttributeChangeListeners weaved into the workingClones. 

If the application chooses to hold the weaved entities in memory AFTER em.close(), you can see the large memory footprint as the AttributeChangeListeners keep the UoW from being garbage collected! If the attribute is changed to a WeakReference, then I can see the garbage collector de-referencing the UoW once the EntityManager gets closed! 

However, I'm not sure what the further ramifications of this might be... It seems safe enough since the EntityManager should hold the UoW reference alive and the UoW is transient anyway in the AttributeChangeListener so no issues with serialization. 

Also, I'm not sure how to enable runtime weaving for our testing buckets, so I'm not sure how to configure a test for this. The test itself should be pretty easy as it checks that the weaved UoW is garbage collected after em.close()

Signed-off-by: Will Dazey <dazeydev.3@gmail.com>