### PR TITLE
[master] OSGi manifest tuning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ p2repo/
 /jpa/eclipselink.jpa.test/jpa-performance2.jar
 foundation/targets/target.oracle/oracle.libs/*.jar
 *.iml
+.attach_pid*
 .idea/
 out/
 eclipselink_extracted/*

--- a/dbws/org.eclipse.persistence.dbws/pom.xml
+++ b/dbws/org.eclipse.persistence.dbws/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -47,15 +47,30 @@
             <artifactId>org.eclipse.persistence.moxy</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <!--API dependencies-->
+        <!--API and other dependencies-->
+        <dependency>
+            <groupId>com.sun.activation</groupId>
+            <artifactId>jakarta.activation</artifactId>
+            <optional>true</optional>
+        </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>${persistence.artifactId}</artifactId>
             <optional>true</optional>
         </dependency>
         <!--Test dependencies-->
@@ -76,6 +91,32 @@
 
     <build>
         <plugins>
+            <!--Generate OSGi bundle/manifest-->
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Import-Package>
+                            javax.naming.*;resolution:=optional,
+                            javax.sql.*;resolution:=optional,
+                            javax.xml.*;resolution:=optional,
+                            org.w3c.dom.*;resolution:=optional,
+                            org.xml.sax.*;resolution:=optional,
+                            *
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/foundation/org.eclipse.persistence.core/pom.xml
+++ b/foundation/org.eclipse.persistence.core/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -54,7 +54,7 @@
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
-        <!--API dependecies-->
+        <!--API/Implementation dependencies-->
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
@@ -76,13 +76,18 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.persistence</groupId>
-            <artifactId>jakarta.persistence</artifactId>
+            <groupId>jakarta.resource</groupId>
+            <artifactId>jakarta.resource-api</artifactId>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>jakarta.resource</groupId>
-            <artifactId>jakarta.resource-api</artifactId>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>jakarta.persistence</artifactId>
             <optional>true</optional>
         </dependency>
     </dependencies>
@@ -141,6 +146,17 @@
                     <instructions>
                         <!-- Java packages specified there comes from "Class.forName(...),  maven-bundle-plugin >= 4.2.0 index them as mandatory -->
                         <Import-Package>
+                            javax.activation.*;resolution:=optional,
+                            javax.crypto.*;resolution:=optional,
+                            javax.imageio.*;resolution:=optional,
+                            javax.management.*;resolution:=optional,
+                            javax.naming.*;resolution:=optional,
+                            javax.rmi.*;resolution:=optional,
+                            javax.sql.*;resolution:=optional,
+                            javax.xml.*;resolution:=optional,
+                            org.omg.CORBA*;resolution:=optional,
+                            org.w3c.dom.*;resolution:=optional,
+                            org.xml.sax.*;resolution:=optional,
                             org.eclipse.persistence.eis.adapters.xmlfile.*;resolution:=optional,
                             org.eclipse.persistence.sessions.coordination.corba.sun.*;resolution:=optional,
                             org.eclipse.persistence.internal.sessions.coordination.rmi.iiop.*;resolution:=optional,

--- a/foundation/org.eclipse.persistence.nosql/pom.xml
+++ b/foundation/org.eclipse.persistence.nosql/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -113,6 +113,29 @@
 
     <build>
         <plugins>
+            <!--Generate OSGi bundle/manifest-->
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Import-Package>
+                            javax.naming.*;resolution:=optional,
+                            org.w3c.dom.*;resolution:=optional,
+                            *
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <!--Pack test classes due dependency to other modules (JPA)-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/foundation/org.eclipse.persistence.oracle.nosql/pom.xml
+++ b/foundation/org.eclipse.persistence.oracle.nosql/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -142,6 +142,30 @@
 
     <build>
         <plugins>
+            <!--Generate OSGi bundle/manifest-->
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Import-Package>
+                            javax.naming.*;resolution:=optional,
+                            javax.sql.*;resolution:=optional,
+                            org.w3c.dom.*;resolution:=optional,
+                            *
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/foundation/org.eclipse.persistence.oracle/pom.xml
+++ b/foundation/org.eclipse.persistence.oracle/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -55,27 +55,58 @@
         <dependency>
             <groupId>com.oracle.ojdbc</groupId>
             <artifactId>ojdbc8</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.oracle.ojdbc</groupId>
             <artifactId>xmlparserv2</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.oracle.ojdbc</groupId>
             <artifactId>ucp</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.oracle.ojdbc</groupId>
             <artifactId>xdb</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.oracle.ojdbc</groupId>
             <artifactId>dms</artifactId>
+            <optional>true</optional>
         </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <!--Generate OSGi bundle/manifest-->
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Import-Package>
+                            javax.naming.*;resolution:=optional,
+                            javax.sql.*;resolution:=optional,
+                            javax.xml.*;resolution:=optional,
+                            org.w3c.dom.*;resolution:=optional,
+                            org.xml.sax.*;resolution:=optional,
+                            *
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>

--- a/jpa/org.eclipse.persistence.jpa.modelgen/pom.xml
+++ b/jpa/org.eclipse.persistence.jpa.modelgen/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -52,6 +52,28 @@
 
     <build>
         <plugins>
+            <!--Generate OSGi bundle/manifest-->
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Import-Package>
+                            javax.*;resolution:=optional,
+                            *
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/jpa/org.eclipse.persistence.jpa/pom.xml
+++ b/jpa/org.eclipse.persistence.jpa/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -82,6 +82,14 @@
                         <Premain-Class>org.eclipse.persistence.internal.jpa.deployment.JavaSEC
                             MPInitializerAgent
                         </Premain-Class>
+                        <Import-Package>
+                            javax.sql;resolution:=optional,
+                            javax.transaction.xa.*;resolution:=optional,
+                            javax.xml.*;resolution:=optional,
+                            org.w3c.dom.*;resolution:=optional,
+                            org.xml.sax.*;resolution:=optional,
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
                 <executions>

--- a/moxy/org.eclipse.persistence.moxy/pom.xml
+++ b/moxy/org.eclipse.persistence.moxy/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -120,6 +120,36 @@
 
     <build>
         <plugins>
+            <!--Generate OSGi bundle/manifest-->
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Import-Package>
+                            javax.activation.*;resolution:=optional,
+                            javax.naming.*;resolution:=optional,
+                            javax.xml.bind.*,
+                            javax.xml.namespace;resolution:=optional,
+                            javax.xml.stream;resolution:=optional,
+                            javax.xml.transform.*;resolution:=optional,
+                            javax.xml.validation.*;resolution:=optional,
+                            org.w3c.dom.*;resolution:=optional,
+                            org.xml.sax.*;resolution:=optional,
+                            *
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>

--- a/sdo/org.eclipse.persistence.sdo/pom.xml
+++ b/sdo/org.eclipse.persistence.sdo/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -50,6 +50,11 @@
         </dependency>
         <!--Other libraries dependencies-->
         <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>commonj.sdo</artifactId>
         </dependency>
@@ -71,7 +76,15 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Import-Package>commonj.sdo.impl</Import-Package>
+                        <Import-Package>
+                            commonj.sdo.impl,
+                            javax.management.*;resolution:=optional,
+                            javax.naming.*;resolution:=optional,
+                            javax.xml.*;resolution:=optional,
+                            org.w3c.dom.*;resolution:=optional,
+                            org.xml.sax.*;resolution:=optional,
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
                 <executions>

--- a/utils/org.eclipse.persistence.dbws.builder/pom.xml
+++ b/utils/org.eclipse.persistence.dbws.builder/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -77,6 +77,11 @@
             <groupId>wsdl4j</groupId>
             <artifactId>wsdl4j</artifactId>
         </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!--Test dependencies-->
         <!--Test framework-->
         <dependency>
@@ -101,6 +106,30 @@
 
     <build>
         <plugins>
+            <!--Generate OSGi bundle/manifest-->
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Import-Package>
+                            javax.tools.*;resolution:=optional,
+                            javax.xml.namespace;resolution:=optional,
+                            org.w3c.dom.*;resolution:=optional,
+                            *
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
This is change of maven-bundle-plugin configuration used to generate OSGi headers in MANIFEST.MF.
OSGi optional packages in the Import-Package are mostly controlled by Maven dependencies marked as `<optional>true</optional>` with some exceptions.
Most OSGi directives in the `<Import-Package>` instruction points to Java packages provided by JDK/JRE system library.
There are some comments about selected Maven modules:

**org.eclipse.persistence.core**
`javax.*, org.omg*, org.w3c.dom.*, org.xml.sax.*` are packages from JDK/JRE system library.
``
org.eclipse.persistence.eis.adapters.xmlfile.*;resolution:=optional,
org.eclipse.persistence.sessions.coordination.corba.sun.*;resolution:=optional,
org.eclipse.persistence.internal.sessions.coordination.rmi.iiop.*;resolution:=optional,
`` are required for OSGi installer tests in the `org.eclipse.persistence.distribution` Maven module.
`weblogic.*;resolution:=optional` is there, because in the code is indirect dependency based on `Class.forName("weblogic....`.

**org.eclipse.persistence.moxy**
In compare with 2.7 manifest `javax.json` isn't there, because, there is no any usage in the code.

**org.eclipse.persistence.jpa.modelgen.processor**
In compare with 2.7 branch OSGi instructions are newly created in `MANIFEST.MF`.

**org.eclipse.persistence.jpa**
`javax.transaction.xa.*;resolution:=optional` is required due `javax.transaction.xa.XAResource` from JDK

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>