### PR TITLE
[2.6] JPA Eclipselink Application Throws IllegalArgumentException With Coherence Enabled

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/descriptors/CMPPolicy.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/descriptors/CMPPolicy.java
@@ -434,7 +434,7 @@ public class CMPPolicy implements java.io.Serializable, Cloneable {
                         			break;
                         		}
                         	}
-                        }else {
+                        } else {
                         	mapping = nestedMapping;
                         }
                     }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/descriptors/CMPPolicy.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/descriptors/CMPPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2014 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -21,6 +21,7 @@ package org.eclipse.persistence.descriptors;
 import java.io.Serializable;
 import java.security.AccessController;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.eclipse.persistence.annotations.CacheKeyType;
@@ -396,13 +397,25 @@ public class CMPPolicy implements java.io.Serializable, Cloneable {
             }
         } else {
             keyInstance = getPKClassInstance();
-
+            ObjectBuilder objectBuilder = getDescriptor().getObjectBuilder();
             //get clone of Key so we can remove values.
             for (int index = 0; index < pkElementArray.length; index++) {
                 KeyElementAccessor accessor = pkElementArray[index];
                 DatabaseMapping mapping = getDescriptor().getObjectBuilder().getMappingForAttributeName(accessor.getAttributeName());
                 if (mapping == null) {
-                    mapping = getDescriptor().getObjectBuilder().getMappingForField(accessor.getDatabaseField());
+                    mapping = objectBuilder.getMappingForField(accessor.getDatabaseField());
+                    if (! mapping.isAggregateObjectMapping() && ! mapping.isAbstractDirectMapping()) {
+                    	// Found a mapping for the database field but it's not an aggregate (embedded ID) or a direct mapping so maybe the mappings
+                    	// have been mapped multiple times.  Check read-only mappings for dtf or aggregate
+                    	List<DatabaseMapping> readOnlyMappings = objectBuilder.getReadOnlyMappingsForField(accessor.getDatabaseField());
+                    	for (DatabaseMapping readOnlyMapping : readOnlyMappings) {
+                    		if (readOnlyMapping.isAggregateObjectMapping() || readOnlyMapping.isDirectToFieldMapping()) {
+                    			mapping = readOnlyMapping;
+                    			break;
+                    		}
+                    	}
+                    	
+                    }
                 }
                 
                 if (accessor.isNestedAccessor()) {
@@ -411,7 +424,19 @@ public class CMPPolicy implements java.io.Serializable, Cloneable {
                 } else {
                     // Not nested but may be a single layer aggregate so check.
                     if (mapping.isAggregateMapping()) {
-                        mapping = mapping.getReferenceDescriptor().getObjectBuilder().getMappingForField(accessor.getDatabaseField());
+                        DatabaseMapping nestedMapping = mapping.getReferenceDescriptor().getObjectBuilder().getMappingForField(accessor.getDatabaseField());
+                        if (nestedMapping == null) {
+                        	//must be a read only mapping
+                        	List<DatabaseMapping> readOnlyMappings = mapping.getReferenceDescriptor().getObjectBuilder().getReadOnlyMappingsForField(accessor.getDatabaseField());
+                        	for (DatabaseMapping readOnlyMapping : readOnlyMappings) {
+                        		if (readOnlyMapping.isAbstractDirectMapping()) {
+                        			mapping = readOnlyMapping;
+                        			break;
+                        		}
+                        	}
+                        }else {
+                        	mapping = nestedMapping;
+                        }
                     }
                     
                     setFieldValue(accessor, keyInstance, mapping, session, elementIndex, keyElements);

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/ExpressionQueryMechanism.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/ExpressionQueryMechanism.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2014 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the 
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0 
  * which accompanies this distribution. 
@@ -517,11 +517,26 @@ public class ExpressionQueryMechanism extends StatementQueryMechanism {
         SQLInsertStatement insertStatement = new SQLInsertStatement();
         insertStatement.setTable(table);
         insertStatement.setModifyRow(getModifyRow());
-        if (getDescriptor().hasReturningPolicy()) {
-            insertStatement.setReturnFields(getDescriptor().getReturningPolicy().getFieldsToGenerateInsert(table));
-        }
+        insertStatement.setReturnFields(getReturnFieldsInsert(getDescriptor(), table));
         insertStatement.setHintString(getQuery().getHintString());
         return insertStatement;
+    }
+
+    // Prepare/collect return fields from main and aggregated object descriptors for Insert operation
+    private Vector getReturnFieldsInsert(ClassDescriptor descriptor, DatabaseTable table) {
+        Vector result = new NonSynchronizedVector();
+
+        if (descriptor.hasReturningPolicy()) {
+            Vector returnFieldsMain = getDescriptor().getReturningPolicy().getFieldsToGenerateInsert(table);
+            result.addAll(returnFieldsMain);
+        }
+        for (DatabaseMapping databaseMapping :descriptor.getMappings()) {
+            ClassDescriptor referenceDescriptor = databaseMapping.getReferenceDescriptor();
+            if (referenceDescriptor != null && referenceDescriptor.hasReturningPolicy()) {
+                result.addAll(referenceDescriptor.getReturningPolicy().getFieldsToGenerateInsert(table));
+            }
+        }
+        return (result.size() > 0) ? result : null;
     }
 
     /**
@@ -793,13 +808,28 @@ public class ExpressionQueryMechanism extends StatementQueryMechanism {
 
         updateStatement.setModifyRow(getModifyRow());
         updateStatement.setTranslationRow(getTranslationRow());
-        if (getDescriptor().hasReturningPolicy()) {
-            updateStatement.setReturnFields(getDescriptor().getReturningPolicy().getFieldsToGenerateUpdate(table));
-        }
+        updateStatement.setReturnFields(getReturnFieldsUpdate(getDescriptor(), table));
         updateStatement.setTable(table);
         updateStatement.setWhereClause(getDescriptor().getObjectBuilder().buildUpdateExpression(table, getTranslationRow(), getModifyRow()));
         updateStatement.setHintString(getQuery().getHintString());
         return updateStatement;
+    }
+
+    // Prepare/collect return fields from main and aggregated object descriptors for Update operation
+    private Vector getReturnFieldsUpdate(ClassDescriptor descriptor, DatabaseTable table) {
+        Vector result = new NonSynchronizedVector();
+
+        if (descriptor.hasReturningPolicy()) {
+            Vector returnFieldsMain = getDescriptor().getReturningPolicy().getFieldsToGenerateUpdate(table);
+            result.addAll(returnFieldsMain);
+        }
+        for (DatabaseMapping databaseMapping :descriptor.getMappings()) {
+            ClassDescriptor referenceDescriptor = databaseMapping.getReferenceDescriptor();
+            if (referenceDescriptor != null && referenceDescriptor.hasReturningPolicy()) {
+                result.addAll(referenceDescriptor.getReturningPolicy().getFieldsToGenerateUpdate(table));
+            }
+        }
+        return (result.size() > 0) ? result : null;
     }
 
     /**


### PR DESCRIPTION
This is fix for #709 .

Signed-off-by: Radek Felcman radek.felcman@oracle.com