### PR TITLE
[master] Bug 559613 - StoredProcedureQuery named parameters

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/PersistenceUnitProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/PersistenceUnitProperties.java
@@ -3884,6 +3884,29 @@ public class PersistenceUnitProperties {
     public static final String SQL_CALL_DEFERRAL = "eclipselink.jpa.sql-call-deferral";
 
     /**
+     * The "<code>eclipselink.jpa.naming_into_indexed</code>" property defines if stored procedure parameters passed by name
+     * should be transformed into positional/index based passing if property value will be <code>true</code>. e.g.
+     * For stored procedure:
+     * <code>CREATE PROCEDURE test_stored_proc1( IN param1 TEXT, IN param2 INTEGER )</code>
+     * following Java call
+     * <code>query.registerStoredProcedureParameter( "param1",Integer.class,ParameterMode.IN );</code>
+     * <code>query.registerStoredProcedureParameter( "param2",String.class,ParameterMode.IN );</code>
+     * will be transformed into following e.g.
+     * <code>{call test_stored_proc1(10, 'abcd')}</code>
+     * instead of default
+     * <code>{call test_stored_proc1(param1 => 10, param2 => 'abcd')}</code>
+     * It's important to register parameters in Java in a same order as they specified in the stored procedure.
+     * This code was added there to ensure backward compatibility with older EclipseLink releases.
+     * <p>
+     * <b>Allowed Values</b> (String)<b>:</b>
+     * <ul>
+     * <li>"<code>false</code>" (DEFAULT)
+     * <li>"<code>true</code>"
+     * </ul>
+     */
+    public static final String NAMING_INTO_INDEXED = "eclipselink.jpa.naming_into_indexed";
+
+    /**
      * INTERNAL: The following properties will not be displayed through logging
      * but instead have an alternate value shown in the log.
      */

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/PersistenceUnitProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/PersistenceUnitProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2019 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/PropertiesHandler.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/PropertiesHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2018 IBM Corporation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/PropertiesHandler.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/PropertiesHandler.java
@@ -237,6 +237,7 @@ public class PropertiesHandler {
             addProp(new PessimisticLockTimeoutUnitProp());
             addProp(new BooleanProp(PersistenceUnitProperties.USE_LOCAL_TIMESTAMP, "false"));
             addProp(new BooleanProp(PersistenceUnitProperties.SQL_CALL_DEFERRAL, "true"));
+            addProp(new BooleanProp(PersistenceUnitProperties.NAMING_INTO_INDEXED, "false"));
         }
 
         Prop(String name) {

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/StoredProcedureCall.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/StoredProcedureCall.java
@@ -20,6 +20,7 @@ package org.eclipse.persistence.queries;
 import java.io.IOException;
 import java.io.Writer;
 import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
@@ -891,7 +892,11 @@ public class StoredProcedureCall extends DatabaseCall {
         DatabasePlatform platform = session.getPlatform();
         //Both lists should be the same size
         for (int index = 0; index < size; index++) {
-            platform.setParameterValueInDatabaseCall(parameters.get(index), (CallableStatement)statement, procedureArgs.get(index), session);
+            if (session.getProject().namingIntoIndexed()) {
+                platform.setParameterValueInDatabaseCall(parameters.get(index), (PreparedStatement) statement, index+1, session);
+            } else {
+                platform.setParameterValueInDatabaseCall(parameters.get(index), (CallableStatement) statement, procedureArgs.get(index), session);
+            }
         }
 
         return statement;

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/StoredProcedureCall.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/StoredProcedureCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/Project.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/Project.java
@@ -155,6 +155,9 @@ public class Project extends CoreProject<ClassDescriptor, Login, DatabaseSession
     /** Flag that allows call deferral to be disabled */
     protected boolean allowSQLDeferral = true;
 
+    /** Flag that allows transform named stored procedure parameters into positional/index based */
+    protected boolean namingIntoIndexed = false;
+
     /**
      * Mapped Superclasses (JPA 2) collection of parent non-relational descriptors keyed on MetadataClass
      * without creating a compile time dependency on JPA.
@@ -1289,6 +1292,14 @@ public class Project extends CoreProject<ClassDescriptor, Login, DatabaseSession
     }
 
     /**
+     * INTERNAL:
+     * Return true is allowed to transform named stored procedure parameters into positional/index based.
+     */
+    public boolean namingIntoIndexed() {
+        return this.namingIntoIndexed;
+    }
+
+    /**
      * PUBLIC:
      * Return the descriptor for  the alias
      */
@@ -1333,6 +1344,14 @@ public class Project extends CoreProject<ClassDescriptor, Login, DatabaseSession
      */
     public void setAllowSQLDeferral(boolean allowSQLDeferral) {
         this.allowSQLDeferral = allowSQLDeferral;
+    }
+
+    /**
+     * INTERNAL:
+     * Set whether named stored procedure parameters is allowed to transform into positional/index based.
+     */
+    public void setNamingIntoIndexed(boolean namingIntoIndexed) {
+        this.namingIntoIndexed = namingIntoIndexed;
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/Project.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/Project.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa22/advanced/NamedStoredProcedureQueryTestSuite.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa22/advanced/NamedStoredProcedureQueryTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -29,7 +29,9 @@
 //       - 350487: JPA 2.1 Specification defined support for Stored Procedure Calls
 package org.eclipse.persistence.testing.tests.jpa22.advanced;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.persistence.EntityManager;
 import javax.persistence.StoredProcedureQuery;
@@ -37,7 +39,9 @@ import javax.persistence.StoredProcedureQuery;
 import junit.framework.TestSuite;
 import junit.framework.Test;
 
+import org.eclipse.persistence.config.PersistenceUnitProperties;
 import org.eclipse.persistence.internal.jpa.StoredProcedureQueryImpl;
+import org.eclipse.persistence.testing.framework.QuerySQLTracker;
 import org.eclipse.persistence.testing.framework.junit.JUnitTestCase;
 
 import org.eclipse.persistence.testing.models.jpa22.advanced.Address;
@@ -64,6 +68,7 @@ public class NamedStoredProcedureQueryTestSuite extends JUnitTestCase {
         suite.addTest(new NamedStoredProcedureQueryTestSuite("testQueryGetResultListWithNamedCursors"));
         suite.addTest(new NamedStoredProcedureQueryTestSuite("testQueryWithMultipleResults"));
         suite.addTest(new NamedStoredProcedureQueryTestSuite("testQueryWithNamedColumnResult"));
+        suite.addTest(new NamedStoredProcedureQueryTestSuite("testQueryWithNamedColumnResultTranslationIntoNumbered"));
         suite.addTest(new NamedStoredProcedureQueryTestSuite("testQueryWithNamedFieldResult"));
         suite.addTest(new NamedStoredProcedureQueryTestSuite("testQueryWithNumberedFieldResult"));
         suite.addTest(new NamedStoredProcedureQueryTestSuite("testQueryWithResultClass"));
@@ -302,6 +307,52 @@ public class NamedStoredProcedureQueryTestSuite extends JUnitTestCase {
                 assertTrue("Address data not found or returned using stored procedure", ((values != null) && (values.length == 6)));
                 assertNotNull("No results returned from store procedure call", values[1]);
                 assertTrue("Address not found using stored procedure", address.getStreet().equals(values[1]));
+            } catch (RuntimeException e) {
+                if (isTransactionActive(em)){
+                    rollbackTransaction(em);
+                }
+
+                throw e;
+            } finally {
+                closeEntityManager(em);
+            }
+        }
+    }
+
+    /**
+     * Tests a NamedStoredProcedureQuery annotation using a result-set mapping.
+     */
+    public void testQueryWithNamedColumnResultTranslationIntoNumbered() {
+        if (supportsStoredProcedures() && getPlatform().isMySQL()) {
+            Map<String, String> properties = new HashMap<String, String>();
+            properties.put(PersistenceUnitProperties.NAMING_INTO_INDEXED, "true");
+            EntityManager em = createEntityManager(properties);
+            QuerySQLTracker querySQLTracker = new QuerySQLTracker(((org.eclipse.persistence.jpa.JpaEntityManager)em).getServerSession());
+
+            try {
+                beginTransaction(em);
+
+                Address address = new Address();
+                address.setCity("Ottawa");
+                address.setPostalCode("K1G 6P3");
+                address.setProvince("ON");
+                address.setStreet("123 Street");
+                address.setCountry("Canada");
+                em.persist(address);
+                commitTransaction(em);
+
+                // Clear the cache
+                em.clear();
+                clearCache();
+
+                Object[] values = (Object[]) em.createNamedStoredProcedureQuery("ReadAddressMappedNamedColumnResult").setParameter("address_id_v", address.getId()).getSingleResult();
+                assertTrue("Address data not found or returned using stored procedure", ((values != null) && (values.length == 6)));
+                assertNotNull("No results returned from store procedure call", values[1]);
+                assertTrue("Address not found using stored procedure", address.getStreet().equals(values[1]));
+
+                String sqlStatement = querySQLTracker.getSqlStatements().get(0);
+                int count = (sqlStatement.split("=>", -1).length) - 1;
+                assertEquals("Transformation into numbered parameters was not called", 1, count);
             } catch (RuntimeException e) {
                 if (isTransactionActive(em)){
                     rollbackTransaction(em);

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa22/advanced/StoredProcedureQueryTestSuite.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa22/advanced/StoredProcedureQueryTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,7 +15,9 @@
 //       - 350487: JPA 2.1 Specification defined support for Stored Procedure Calls
 package org.eclipse.persistence.testing.tests.jpa22.advanced;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.persistence.EntityManager;
 import javax.persistence.ParameterMode;
@@ -25,6 +27,7 @@ import javax.persistence.TransactionRequiredException;
 import junit.framework.TestSuite;
 import junit.framework.Test;
 
+import org.eclipse.persistence.config.PersistenceUnitProperties;
 import org.eclipse.persistence.queries.ResultSetMappingQuery;
 import org.eclipse.persistence.queries.ColumnResult;
 import org.eclipse.persistence.queries.ConstructorResult;
@@ -33,6 +36,7 @@ import org.eclipse.persistence.queries.FieldResult;
 import org.eclipse.persistence.queries.SQLResultSetMapping;
 import org.eclipse.persistence.queries.StoredProcedureCall;
 
+import org.eclipse.persistence.testing.framework.QuerySQLTracker;
 import org.eclipse.persistence.testing.models.jpa22.advanced.Address;
 import org.eclipse.persistence.testing.models.jpa22.advanced.AdvancedTableCreator;
 import org.eclipse.persistence.testing.models.jpa22.advanced.EmployeeDetails;
@@ -70,6 +74,7 @@ public class StoredProcedureQueryTestSuite extends JUnitTestCase {
         suite.addTest(new StoredProcedureQueryTestSuite("testQueryGetResultList"));
         suite.addTest(new StoredProcedureQueryTestSuite("testQueryWithMultipleResultsFromCode"));
         suite.addTest(new StoredProcedureQueryTestSuite("testQueryWithNamedFieldResult"));
+        suite.addTest(new StoredProcedureQueryTestSuite("testQueryWithNamedFieldResultTranslationIntoNumbered"));
         suite.addTest(new StoredProcedureQueryTestSuite("testQueryWithNumberedFieldResult"));
         suite.addTest(new StoredProcedureQueryTestSuite("testQueryWithResultClass"));
         suite.addTest(new StoredProcedureQueryTestSuite("testQueryWithOutParam"));
@@ -804,6 +809,49 @@ public class StoredProcedureQueryTestSuite extends JUnitTestCase {
                 assertTrue("Address data not found or returned using stored procedure", ((values != null) && (values.length == 6)));
                 assertNotNull("No results returned from store procedure call", values[1]);
                 assertTrue("Address not found using stored procedure", address.getStreet().equals(values[1]));
+            } finally {
+                closeEntityManagerAndTransaction(em);
+            }
+        }
+    }
+
+    /**
+     * Tests a StoredProcedureQuery using a result-set mapping though EM API
+     */
+    public void testQueryWithNamedFieldResultTranslationIntoNumbered() {
+        if (supportsStoredProcedures() && getPlatform().isMySQL()) {
+            Map<String, String> properties = new HashMap<String, String>();
+            properties.put(PersistenceUnitProperties.NAMING_INTO_INDEXED, "true");
+            EntityManager em = createEntityManager(properties);
+            QuerySQLTracker querySQLTracker = new QuerySQLTracker(((org.eclipse.persistence.jpa.JpaEntityManager)em).getServerSession());
+
+            try {
+                beginTransaction(em);
+
+                Address address = new Address();
+                address.setCity("Winnipeg");
+                address.setPostalCode("R3B 1B9");
+                address.setProvince("MB");
+                address.setStreet("510 Main Street");
+                address.setCountry("Canada");
+                em.persist(address);
+                em.flush();
+
+                // Clear the cache
+                em.clear();
+                clearCache();
+
+                StoredProcedureQuery query = em.createStoredProcedureQuery("Read_Address_Mapped_Named", "address-column-result-map");
+                query.registerStoredProcedureParameter("address_id_v", Integer.class, ParameterMode.IN);
+
+                Object[] values = (Object[]) query.setParameter("address_id_v", address.getId()).getSingleResult();
+                assertTrue("Address data not found or returned using stored procedure", ((values != null) && (values.length == 6)));
+                assertNotNull("No results returned from store procedure call", values[1]);
+                assertTrue("Address not found using stored procedure", address.getStreet().equals(values[1]));
+
+                String sqlStatement = querySQLTracker.getSqlStatements().get(0);
+                int count = (sqlStatement.split("=>", -1).length) - 1;
+                assertEquals("Transformation into numbered parameters was not called", 1, count);
             } finally {
                 closeEntityManagerAndTransaction(em);
             }

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
@@ -2896,6 +2896,7 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
             updateQueryTimeoutUnit(m);
             updateLockingTimestampDefault(m);
             updateSQLCallDeferralDefault(m);
+            updateNamingIntoIndexed(m);
             if (!session.hasBroker()) {
                 updateCacheCoordination(m, loader);
             }
@@ -3721,6 +3722,19 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
                 this.session.getProject().setAllowSQLDeferral(false);
             } else {
                 this.session.handleException(ValidationException.invalidBooleanValueForProperty(defer, PersistenceUnitProperties.SQL_CALL_DEFERRAL));
+            }
+        }
+    }
+
+    private void updateNamingIntoIndexed(Map persistenceProperties) {
+        String namingIntoIndexed = EntityManagerFactoryProvider.getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.NAMING_INTO_INDEXED, persistenceProperties, this.session);
+        if (namingIntoIndexed != null) {
+            if (namingIntoIndexed.equalsIgnoreCase("true")) {
+                this.session.getProject().setNamingIntoIndexed(true);
+            } else if (namingIntoIndexed.equalsIgnoreCase("false")) {
+                this.session.getProject().setNamingIntoIndexed(false);
+            } else {
+                this.session.handleException(ValidationException.invalidBooleanValueForProperty(namingIntoIndexed, PersistenceUnitProperties.NAMING_INTO_INDEXED));
             }
         }
     }

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2019 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the


### PR DESCRIPTION
This is fix for a regression "bug" which is started from 2.7.5 due following:
Until 2.7.4 EclipseLink didn't really passed stored procedure parameters by name like `param1 => value` but there was a bug and EclipseLink transformed stored proc calls (parameter passing) into index based and passed by position.
There is a problem with backward compatibility and people used this way how to call stored procedures although there wasn't support at DB or JDBC level like https://github.com/eclipse-ee4j/eclipselink/issues/623 .
Solution is based on new JPA property which must be added to `persistence.xml` or passed to `javax.persistence.EntityManagerFactory`
e.g. 
`persistence.xml`
```
<properties>
    ...
    <property name="eclipselink.jpa.naming_into_indexed" value="true"/>
    ...
<properties>
```
or
`javax.persistence.EntityManagerFactory`
```
...
Map<String, String> properties = new HashMap<String, String>();
properties.put(PersistenceUnitProperties.NAMING_INTO_INDEXED, "true");
EntityManagerFactory emfactory = Persistence.createEntityManagerFactory("MyTest_PU", properties);
...
```
If this property is not specified or passed with `false` value EclipseLink will not translate naming parameters into index based as usual from 2.7.5.
There is some small change in logging too, because before this fix it wasn't possible to identify from log output if parameters were passed by index or by name. Now log output for parameters passed by name looks like:
```
{ CALL stored_proc1(?, ?) }
	bind => [param1=>strVal1, param2=>100]
```
By position remains same as before this fix:
```
{ CALL TestSourceNames(?, ?) }
	bind => [strVal1, 100]
```
