### PR TITLE
[master] PersistenceUnitProperties.QUERY_TIMEOUT Javadoc fix.

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/PersistenceUnitProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/PersistenceUnitProperties.java
@@ -3182,7 +3182,7 @@ public class PersistenceUnitProperties {
 
     /**
      * The "<code>javax.persistence.query.timeout</code>" property configures
-     * the default query timeout value. Defaults to seconds, but is configurable
+     * the default query timeout value. Defaults to milliseconds, but is configurable
      * with PersistenceUnitProperties.QUERY_TIMEOUT_UNIT
      * <p>
      * <b>Allowed Values:</b>


### PR DESCRIPTION
PersistenceUnitProperties.QUERY_TIMEOUT Javadoc fix for #702 .