### PR TITLE
[2.7] Bug 537657 - Inserting empty or null varchar arrays doesn't work with PostgreSQL since driver version 42.2.4

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/PostgreSQLPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/PostgreSQLPlatform.java
@@ -19,6 +19,8 @@
 package org.eclipse.persistence.platform.database;
 
 import java.io.*;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.sql.Types;
 import java.util.*;
 


### PR DESCRIPTION
Bug fix