### PR TITLE
[2.7] Fix for a bug 553439 - JAXB Unmarshaller with Schema does not show location of error.

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/record/XMLStreamReaderReader.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/record/XMLStreamReaderReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -135,7 +135,7 @@ public class XMLStreamReaderReader extends XMLReaderAdapter {
                         contentHandler.startElement(namespaceURI, localName, prefix + Constants.COLON + localName, indexedAttributeList.reset());
                     }
                 } else {
-                    contentHandler.startElement(namespaceURI, localName, null, indexedAttributeList.reset());
+                    contentHandler.startElement(namespaceURI, localName, localName, indexedAttributeList.reset());
                 }
                 break;
             }


### PR DESCRIPTION
Bug fix a 553439