### PR TITLE
[2.7] Fix for a bug 559613 - StoredProcedureQuery does not work in 2.7.5, same code & configuration worked fine in 2.7.4

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/PersistenceUnitProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/PersistenceUnitProperties.java
@@ -3863,6 +3863,29 @@ public class PersistenceUnitProperties {
     public static final String SQL_CALL_DEFERRAL = "eclipselink.jpa.sql-call-deferral";
 
     /**
+     * The "<code>eclipselink.jpa.naming_into_indexed</code>" property defines if stored procedure parameters passed by name
+     * should be transformed into positional/index based passing if property value will be <code>true</code>. e.g.
+     * For stored procedure:
+     * <code>CREATE PROCEDURE test_stored_proc1( IN param1 TEXT, IN param2 INTEGER )</code>
+     * following Java call
+     * <code>query.registerStoredProcedureParameter( "param1",Integer.class,ParameterMode.IN );</code>
+     * <code>query.registerStoredProcedureParameter( "param2",String.class,ParameterMode.IN );</code>
+     * will be transformed into following e.g.
+     * <code>{call test_stored_proc1(10, 'abcd')}</code>
+     * instead of default
+     * <code>{call test_stored_proc1(param1 => 10, param2 => 'abcd')}</code>
+     * It's important to register parameters in Java in a same order as they specified in the stored procedure.
+     * This code was added there to ensure backward compatibility with older EclipseLink releases.
+     * <p>
+     * <b>Allowed Values</b> (String)<b>:</b>
+     * <ul>
+     * <li>"<code>false</code>" (DEFAULT)
+     * <li>"<code>true</code>"
+     * </ul>
+     */
+    public static final String NAMING_INTO_INDEXED = "eclipselink.jpa.naming_into_indexed";
+
+    /**
      * INTERNAL: The following properties will not be displayed through logging
      * but instead have an alternate value shown in the log.
      */

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/sessions/PropertiesHandler.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/sessions/PropertiesHandler.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 1998, 2019 IBM Corporation and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 IBM Corporation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -236,6 +236,7 @@ public class PropertiesHandler {
             addProp(new PessimisticLockTimeoutUnitProp());
             addProp(new BooleanProp(PersistenceUnitProperties.USE_LOCAL_TIMESTAMP, "false"));
             addProp(new BooleanProp(PersistenceUnitProperties.SQL_CALL_DEFERRAL, "true"));
+            addProp(new BooleanProp(PersistenceUnitProperties.NAMING_INTO_INDEXED, "false"));
         }
 
         Prop(String name) {

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/sessions/Project.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/sessions/Project.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -154,6 +154,9 @@ public class Project extends CoreProject<ClassDescriptor, Login, DatabaseSession
 
     /** Flag that allows call deferral to be disabled */
     protected boolean allowSQLDeferral = true;
+
+    /** Flag that allows transform named stored procedure parameters into positional/index based */
+    protected boolean namingIntoIndexed = false;
 
     /**
      * Mapped Superclasses (JPA 2) collection of parent non-relational descriptors keyed on MetadataClass
@@ -1319,6 +1322,14 @@ public class Project extends CoreProject<ClassDescriptor, Login, DatabaseSession
     }
 
     /**
+     * INTERNAL:
+     * Return true is allowed to transform named stored procedure parameters into positional/index based.
+     */
+    public boolean namingIntoIndexed() {
+        return this.namingIntoIndexed;
+    }
+
+    /**
      * PUBLIC:
      * Return the descriptor for  the alias
      */
@@ -1371,6 +1382,14 @@ public class Project extends CoreProject<ClassDescriptor, Login, DatabaseSession
      */
     public void setAllowSQLDeferral(boolean allowSQLDeferral) {
         this.allowSQLDeferral = allowSQLDeferral;
+    }
+
+    /**
+     * INTERNAL:
+     * Set whether named stored procedure parameters is allowed to transform into positional/index based.
+     */
+    public void setNamingIntoIndexed(boolean namingIntoIndexed) {
+        this.namingIntoIndexed = namingIntoIndexed;
     }
 
     /**

--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 1998, 2019 IBM Corporation. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -2855,6 +2855,7 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
             updateQueryTimeoutUnit(m);
             updateLockingTimestampDefault(m);
             updateSQLCallDeferralDefault(m);
+            updateNamingIntoIndexed(m);
             if (!session.hasBroker()) {
                 updateCacheCoordination(m, loader);
             }
@@ -3696,6 +3697,19 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
                 this.session.getProject().setAllowSQLDeferral(false);
             } else {
                 this.session.handleException(ValidationException.invalidBooleanValueForProperty(defer, PersistenceUnitProperties.SQL_CALL_DEFERRAL));
+            }
+        }
+    }
+
+    private void updateNamingIntoIndexed(Map persistenceProperties) {
+        String namingIntoIndexed = EntityManagerFactoryProvider.getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.NAMING_INTO_INDEXED, persistenceProperties, this.session);
+        if (namingIntoIndexed != null) {
+            if (namingIntoIndexed.equalsIgnoreCase("true")) {
+                this.session.getProject().setNamingIntoIndexed(true);
+            } else if (namingIntoIndexed.equalsIgnoreCase("false")) {
+                this.session.getProject().setNamingIntoIndexed(false);
+            } else {
+                this.session.handleException(ValidationException.invalidBooleanValueForProperty(namingIntoIndexed, PersistenceUnitProperties.NAMING_INTO_INDEXED));
             }
         }
     }


### PR DESCRIPTION
This is fixed by persistence.xml property "eclipselink.jpa.naming_into_indexed" to enable translation from name
based parameters into index based.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>