### PR TITLE
[master] Javadoc bugfix and JDK 14 build fix

### DIFF
--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/models/aggregate/Job.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/models/aggregate/Job.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -76,7 +76,7 @@ public class Job {
      * @return java.sql.Time[]
      * @param row org.eclipse.persistence.sessions.DatabaseRecord
      */
-    public Time[] getNormalHoursFromRow(Record row) {
+    public Time[] getNormalHoursFromRow(org.eclipse.persistence.sessions.Record row) {
         Time[] hours = new Time[2];
         hours[0] = (Time)row.get("START_TIME");
         hours[1] = (Time)row.get("END_TIME");

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/models/employee/domain/Employee.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/models/employee/domain/Employee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -172,7 +172,7 @@ public class Employee implements org.eclipse.persistence.testing.models.employee
      * IMPORTANT: This method builds the value but does not set it.
      * The mapping will set it using method or direct access as defined in the descriptor.
      */
-    public Time[] buildNormalHours(Record row, Session session) {
+    public Time[] buildNormalHours(org.eclipse.persistence.sessions.Record row, Session session) {
         Time[] hours = new Time[2];
 
         /** This conversion allows for the database type not to match, i.e. may be a Timestamp or String. */

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/models/inheritance/Computer.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/models/inheritance/Computer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -116,7 +116,7 @@ public class Computer implements Serializable {
         return mainframe;
     }
 
-    public static Class getClassFromRow(Record row) {
+    public static Class getClassFromRow(org.eclipse.persistence.sessions.Record row) {
         if (row.get("CTYPE").equals("PC")) {
             if (row.get("PCTYPE").equals("IBM")) {
                 return org.eclipse.persistence.testing.models.inheritance.IBMPC.class;

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/models/mapping/Address.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/models/mapping/Address.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -75,7 +75,7 @@ public class Address implements Serializable {
         return province;
     }
 
-    public String getProvinceFromRow(Record row, Session session) {
+    public String getProvinceFromRow(org.eclipse.persistence.sessions.Record row, Session session) {
         String code = (String)row.get("PROVINCE");
         String provinceString = null;
 

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/models/mapping/Employee.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/models/mapping/Employee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -491,7 +491,7 @@ public class Employee implements Serializable {
         return rank;
     }
 
-    public String getRankFromRow(Record row, Session aSession) {
+    public String getRankFromRow(org.eclipse.persistence.sessions.Record row, Session aSession) {
         if (row.get("RANK") == null) {
             return null;
         }
@@ -557,7 +557,7 @@ public class Employee implements Serializable {
         this.computer = computer;
     }
 
-    public java.util.Date setDateAndTime(Record row, org.eclipse.persistence.sessions.Session session) {
+    public java.util.Date setDateAndTime(org.eclipse.persistence.sessions.Record row, org.eclipse.persistence.sessions.Session session) {
         java.sql.Date sqlDateOfBirth = (java.sql.Date)ConversionManager.getDefaultManager().convertObject(row.get("BDAY"), java.sql.Date.class);
         java.sql.Time timeOfBirth = (java.sql.Time)session.getLogin().getPlatform().convertObject(row.get("BTIME"), java.sql.Time.class);
         if ((timeOfBirth == null) || (sqlDateOfBirth == null)) {

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/models/transparentindirection/AbstractOrder.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/models/transparentindirection/AbstractOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -153,13 +153,13 @@ public abstract class AbstractOrder implements Serializable {
         return ((Integer)total.getValue()).intValue();
     }
 
-    public int getTotalFromRow(Record row, Session session) {
+    public int getTotalFromRow(org.eclipse.persistence.sessions.Record row, Session session) {
         int tens = ((Number)row.get("TOTT")).intValue();
         int ones = ((Number)row.get("TOTO")).intValue();
         return (tens * 10) + ones;
     }
 
-    public int getTotalFromRow2(Record row, Session session) {
+    public int getTotalFromRow2(org.eclipse.persistence.sessions.Record row, Session session) {
         int tens = ((Number)row.get("TOTT2")).intValue();
         int ones = ((Number)row.get("TOTO2")).intValue();
         return (tens * 10) + ones;

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/feature/SequenceFieldRemovalForAcquireValueAfterInsertTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/feature/SequenceFieldRemovalForAcquireValueAfterInsertTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -138,7 +138,7 @@ public class SequenceFieldRemovalForAcquireValueAfterInsertTest extends TestCase
         public static final String OMISSION_MARKER = "omit_this_field";
 
         public void aboutToInsert(DescriptorEvent event) {
-            Record modifyRow = event.getRecord();
+            org.eclipse.persistence.sessions.Record modifyRow = event.getRecord();
             Object[] keys = modifyRow.keySet().toArray();
             for (int i = 0; i < keys.length; i++) {
                 Object key = keys[i];

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/nls/japanese/NLSEmployee.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/nls/japanese/NLSEmployee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -123,7 +123,7 @@ public class NLSEmployee implements org.eclipse.persistence.testing.models.emplo
      * IMPORTANT: This method builds the value but does not set it.
      * The mapping will set it using method or direct access as defined in the descriptor.
      */
-    public Time[] buildNormalHours(Record row, Session session) {
+    public Time[] buildNormalHours(org.eclipse.persistence.sessions.Record row, Session session) {
         Time[] hours = new Time[2];
 
         /** This conversion allows for the database type not to match, i.e. may be a Timestamp or String. */

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/DataReadQueryTest1.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/DataReadQueryTest1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -71,7 +71,7 @@ public class DataReadQueryTest1 extends AutoVerifyTestCase {
 
         stack = (Stack)getSession().executeQuery(query);
         // if we get here, we must not have generated a ClassCastException
-        Record row = (Record)stack.peek();
+        org.eclipse.persistence.sessions.Record row = (org.eclipse.persistence.sessions.Record)stack.peek();
         if (row.get("F_NAME") == null) {
             throw new TestErrorException("missing data");
         }

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/DoNotRedirectDefaultRedirectorTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/DoNotRedirectDefaultRedirectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -59,7 +59,7 @@ public class DoNotRedirectDefaultRedirectorTest extends TestCase {
      * Below are the methods called by the redirectors for various toplink queries
      */
 
-    public static Object readObject(DatabaseQuery query, Record row, org.eclipse.persistence.sessions.Session session) {
+    public static Object readObject(DatabaseQuery query, org.eclipse.persistence.sessions.Record row, org.eclipse.persistence.sessions.Session session) {
         throw new TestErrorException("Query setting doNotRedirect was ignored");
     }
 

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/OrderingByExpressionTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/OrderingByExpressionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -40,7 +40,7 @@ public class OrderingByExpressionTest extends OrderingTest {
 
     protected void verify() {
         for (int i = 0; i < orderedQueryObjects.size(); i++) {
-            Record row = (Record)customSQLRows.elementAt(i);
+            org.eclipse.persistence.sessions.Record row = (org.eclipse.persistence.sessions.Record)customSQLRows.elementAt(i);
             Employee employee = (Employee)orderedQueryObjects.elementAt(i);
             String city = (String)row.get("CITY");
             String street = (String)row.get("STREET");

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/OrderingMutipleTableTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/OrderingMutipleTableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -41,12 +41,12 @@ public class OrderingMutipleTableTest extends OrderingTest {
     }
 
     protected void verify() {
-        Record row;
+        org.eclipse.persistence.sessions.Record row;
         org.eclipse.persistence.testing.models.employee.domain.Project project;
         String name;
 
         for (int i = 0; i < orderedQueryObjects.size(); i++) {
-            row = (Record)customSQLRows.elementAt(i);
+            row = (org.eclipse.persistence.sessions.Record)customSQLRows.elementAt(i);
             project = (org.eclipse.persistence.testing.models.employee.domain.Project)orderedQueryObjects.elementAt(i);
             name = (String)row.get("PROJ_NAME");
 

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/OrderingTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/OrderingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -46,13 +46,13 @@ public class OrderingTest extends TestCase {
     }
 
     protected void verify() {
-        Record row;
+        org.eclipse.persistence.sessions.Record row;
         Employee employee;
         String firstName;
         String lastName;
 
         for (int i = 0; i < orderedQueryObjects.size(); i++) {
-            row = (Record)customSQLRows.elementAt(i);
+            row = (org.eclipse.persistence.sessions.Record)customSQLRows.elementAt(i);
             employee = (Employee)orderedQueryObjects.elementAt(i);
             firstName = (String)row.get("F_NAME");
             lastName = (String)row.get("L_NAME");

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/OrderingWithAnyOfTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/OrderingWithAnyOfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -42,7 +42,7 @@ public class OrderingWithAnyOfTest extends OrderingTest {
 
     protected void verify() {
         for (int i = 0; i < orderedQueryObjects.size(); i++) {
-            Record row = (Record)customSQLRows.elementAt(i);
+            org.eclipse.persistence.sessions.Record row = (org.eclipse.persistence.sessions.Record)customSQLRows.elementAt(i);
             Employee employee = (Employee)orderedQueryObjects.elementAt(i);
             String city = (String)row.get("CITY");
             String name = (String)row.get("F_NAME");

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/RedirectorOnDescriptorTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/RedirectorOnDescriptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -159,27 +159,27 @@ public class RedirectorOnDescriptorTest extends TestCase {
      */
     public static
 
-    Object deleteObject(DatabaseQuery query, Record row, org.eclipse.persistence.sessions.Session session) {
+    Object deleteObject(DatabaseQuery query, org.eclipse.persistence.sessions.Record row, org.eclipse.persistence.sessions.Session session) {
         redirectedDeleteObject = true;
         return null;
     }
 
-    public static Object insertObject(DatabaseQuery query, Record row, org.eclipse.persistence.sessions.Session session) {
+    public static Object insertObject(DatabaseQuery query, org.eclipse.persistence.sessions.Record row, org.eclipse.persistence.sessions.Session session) {
         redirectedInsert = true;
         return null;
     }
 
-    public static Object readAll(DatabaseQuery query, Record row, org.eclipse.persistence.sessions.Session session) {
+    public static Object readAll(DatabaseQuery query, org.eclipse.persistence.sessions.Record row, org.eclipse.persistence.sessions.Session session) {
         redirectedReadAll = true;
         return null;
     }
 
-    public static Object readObject(DatabaseQuery query, Record row, org.eclipse.persistence.sessions.Session session) {
+    public static Object readObject(DatabaseQuery query, org.eclipse.persistence.sessions.Record row, org.eclipse.persistence.sessions.Session session) {
         redirectedReadObject = true;
         return null;
     }
 
-    public static Object updateObject(DatabaseQuery query, Record row, org.eclipse.persistence.sessions.Session session) {
+    public static Object updateObject(DatabaseQuery query, org.eclipse.persistence.sessions.Record row, org.eclipse.persistence.sessions.Session session) {
         redirectedUpdate = true;
         return null;
     }

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/returning/model/AdapterForReturningProject.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/returning/model/AdapterForReturningProject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -208,8 +208,8 @@ public class AdapterForReturningProject extends AdapterWithReturnObjectControl {
         session.executeQuery(query);
     }
 
-    protected Record getRowForInsert(Record rowToInsert) {
-        Record row = new DatabaseRecord();
+    protected org.eclipse.persistence.sessions.Record getRowForInsert(org.eclipse.persistence.sessions.Record rowToInsert) {
+        org.eclipse.persistence.sessions.Record row = new DatabaseRecord();
         Enumeration insertFields = insertInfos.keys();
         while (insertFields.hasMoreElements()) {
             DatabaseField field = (DatabaseField)insertFields.nextElement();
@@ -222,8 +222,8 @@ public class AdapterForReturningProject extends AdapterWithReturnObjectControl {
         return row;
     }
 
-    protected Record getRowForUpdate(Record rowChange) {
-        Record row = new DatabaseRecord();
+    protected org.eclipse.persistence.sessions.Record getRowForUpdate(org.eclipse.persistence.sessions.Record rowChange) {
+        org.eclipse.persistence.sessions.Record row = new DatabaseRecord();
         Enumeration updateFields = updateInfos.keys();
         while (updateFields.hasMoreElements()) {
             DatabaseField field = (DatabaseField)updateFields.nextElement();

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/returning/model/AdapterWithReturnObjectControl.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/returning/model/AdapterWithReturnObjectControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -38,10 +38,10 @@ public abstract class AdapterWithReturnObjectControl implements ProjectAndDataba
 
     public Object getObjectForInsert(Session session, Object objectToInsert) {
         ClassDescriptor desc = session.getClassDescriptor(objectToInsert);
-        Record rowToInsert = desc.getObjectBuilder().buildRow(objectToInsert, (AbstractSession)session, WriteType.INSERT);
-        Record rowReturn = getRowForInsert(rowToInsert);
+        org.eclipse.persistence.sessions.Record rowToInsert = desc.getObjectBuilder().buildRow(objectToInsert, (AbstractSession)session, WriteType.INSERT);
+        org.eclipse.persistence.sessions.Record rowReturn = getRowForInsert(rowToInsert);
         if (rowReturn != null && !rowReturn.isEmpty()) {
-            Record row = new DatabaseRecord(rowToInsert.size());
+            org.eclipse.persistence.sessions.Record row = new DatabaseRecord(rowToInsert.size());
             row.putAll(rowToInsert);
             row.putAll(rowReturn);
             return readObjectFromRow(session, desc, row);
@@ -52,13 +52,13 @@ public abstract class AdapterWithReturnObjectControl implements ProjectAndDataba
 
     public Object getObjectForUpdate(Session session, Object objectToUpdateBeforeChange, Object objectToUpdateAfterChange, boolean useUOW) {
         ClassDescriptor desc = session.getClassDescriptor(objectToUpdateBeforeChange);
-        Record rowBeforeChange = desc.getObjectBuilder().buildRow(objectToUpdateBeforeChange, (AbstractSession)session, WriteType.UPDATE);
-        Record rowAfterChange = desc.getObjectBuilder().buildRow(objectToUpdateAfterChange, (AbstractSession)session, WriteType.UPDATE);
-        Record rowChange = new DatabaseRecord();
+        org.eclipse.persistence.sessions.Record rowBeforeChange = desc.getObjectBuilder().buildRow(objectToUpdateBeforeChange, (AbstractSession)session, WriteType.UPDATE);
+        org.eclipse.persistence.sessions.Record rowAfterChange = desc.getObjectBuilder().buildRow(objectToUpdateAfterChange, (AbstractSession)session, WriteType.UPDATE);
+        org.eclipse.persistence.sessions.Record rowChange = new DatabaseRecord();
         getChange(rowChange, session, objectToUpdateBeforeChange, objectToUpdateAfterChange, desc, useUOW, WriteType.UPDATE);
-        Record rowReturn = getRowForUpdate(rowChange);
+        org.eclipse.persistence.sessions.Record rowReturn = getRowForUpdate(rowChange);
         if (rowReturn != null && !rowReturn.isEmpty()) {
-            Record row = new DatabaseRecord(rowAfterChange.size());
+            org.eclipse.persistence.sessions.Record row = new DatabaseRecord(rowAfterChange.size());
             row.putAll(rowAfterChange);
             row.putAll(rowReturn);
             return readObjectFromRow(session, desc, row);
@@ -67,7 +67,7 @@ public abstract class AdapterWithReturnObjectControl implements ProjectAndDataba
         }
     }
 
-    public void getChange(Record row, Session session, Object object1, Object object2, ClassDescriptor desc, boolean useUOW, WriteType writeType) {
+    public void getChange(org.eclipse.persistence.sessions.Record row, Session session, Object object1, Object object2, ClassDescriptor desc, boolean useUOW, WriteType writeType) {
         for (Enumeration mappings = desc.getMappings().elements(); mappings.hasMoreElements(); ) {
             DatabaseMapping mapping = (DatabaseMapping)mappings.nextElement();
             if (!mapping.isReadOnly()) {
@@ -76,7 +76,7 @@ public abstract class AdapterWithReturnObjectControl implements ProjectAndDataba
         }
     }
 
-    public void getChange(Record row, DatabaseMapping mapping, Session session, Object object1, Object object2, boolean useUOW, WriteType writeType) {
+    public void getChange(org.eclipse.persistence.sessions.Record row, DatabaseMapping mapping, Session session, Object object1, Object object2, boolean useUOW, WriteType writeType) {
         if (mapping.isAggregateObjectMapping()) {
             Object aggregate1 = mapping.getAttributeValueFromObject(object1);
             Object aggregate2 = mapping.getAttributeValueFromObject(object2);
@@ -91,8 +91,8 @@ public abstract class AdapterWithReturnObjectControl implements ProjectAndDataba
                 mapping.writeFromObjectIntoRow(object2, (DatabaseRecord)row, (AbstractSession)session, writeType);
             }
         } else {
-            Record row1 = new DatabaseRecord();
-            Record row2 = new DatabaseRecord();
+            org.eclipse.persistence.sessions.Record row1 = new DatabaseRecord();
+            org.eclipse.persistence.sessions.Record row2 = new DatabaseRecord();
             mapping.writeFromObjectIntoRow(object1, (DatabaseRecord)row1, (AbstractSession)session, writeType);
             mapping.writeFromObjectIntoRow(object2, (DatabaseRecord)row2, (AbstractSession)session, writeType);
 
@@ -113,7 +113,7 @@ public abstract class AdapterWithReturnObjectControl implements ProjectAndDataba
         }
     }
 
-    protected Object readObjectFromRow(Session session, ClassDescriptor desc, Record row) {
+    protected Object readObjectFromRow(Session session, ClassDescriptor desc, org.eclipse.persistence.sessions.Record row) {
         if (desc.hasInheritance()) {
             Class newClass = desc.getInheritancePolicy().classFromRow((DatabaseRecord)row, (AbstractSession)session);
             desc = session.getClassDescriptor(newClass);
@@ -128,11 +128,11 @@ public abstract class AdapterWithReturnObjectControl implements ProjectAndDataba
         return object;
     }
 
-    protected Record getRowForInsert(Record rowToInsert) {
+    protected org.eclipse.persistence.sessions.Record getRowForInsert(org.eclipse.persistence.sessions.Record rowToInsert) {
         return null;
     }
 
-    protected Record getRowForUpdate(Record rowChange) {
+    protected org.eclipse.persistence.sessions.Record getRowForUpdate(org.eclipse.persistence.sessions.Record rowChange) {
         return null;
     }
 }

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/returning/model/BaseClass.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/returning/model/BaseClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -77,7 +77,7 @@ public abstract class BaseClass implements Cloneable {
         }
     }
 
-    public BigDecimal[] build_a_plus_minus_b_BigDecimal(Record row, Session session) {
+    public BigDecimal[] build_a_plus_minus_b_BigDecimal(org.eclipse.persistence.sessions.Record row, Session session) {
         BigDecimal[] a_plus_minus_b_BigDecimal = new BigDecimal[2];
         BigDecimal a = (BigDecimal)session.getDatasourcePlatform().convertObject(row.get(getFieldAName()), BigDecimal.class);
         BigDecimal b = (BigDecimal)session.getDatasourcePlatform().convertObject(row.get(getFieldBName()), BigDecimal.class);

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/transparentindirection/RemoteDataReadQueryTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/transparentindirection/RemoteDataReadQueryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -63,7 +63,7 @@ public class RemoteDataReadQueryTest extends AutoVerifyTestCase {
         int count = 0;
         while (stream.hasMoreElements()) {
             count++;
-            Record row = (Record)stream.nextElement();
+            org.eclipse.persistence.sessions.Record row = (org.eclipse.persistence.sessions.Record)stream.nextElement();
             if (row.get("CUSTNAME") == null) {
                 throw new TestErrorException("missing data");
             }
@@ -79,7 +79,7 @@ public class RemoteDataReadQueryTest extends AutoVerifyTestCase {
 
         stack = (Stack)getSession().executeQuery(query);
         // if we get here, we must not have generated a ClassCastException
-        Record row = (Record)stack.peek();
+        org.eclipse.persistence.sessions.Record row = (org.eclipse.persistence.sessions.Record)stack.peek();
         if (row.get("CUSTNAME") == null) {
             throw new TestErrorException("missing data");
         }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/PersistenceUnitProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/PersistenceUnitProperties.java
@@ -3894,7 +3894,7 @@ public class PersistenceUnitProperties {
      * will be transformed into following e.g.
      * <code>{call test_stored_proc1(10, 'abcd')}</code>
      * instead of default
-     * <code>{call test_stored_proc1(param1 => 10, param2 => 'abcd')}</code>
+     * <code>{call test_stored_proc1(param1 ={@literal >} 10, param2 ={@literal >} 'abcd')}</code>
      * It's important to register parameters in Java in a same order as they specified in the stored procedure.
      * This code was added there to ensure backward compatibility with older EclipseLink releases.
      * <p>

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/descriptors/ClassExtractor.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/descriptors/ClassExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -32,7 +32,7 @@ public abstract class ClassExtractor {
      * Map is used as the public interface to database row, the key is the field name,
      * the value is the database value.
      */
-    public abstract Class extractClassFromRow(Record databaseRow, Session session);
+    public abstract Class extractClassFromRow(org.eclipse.persistence.sessions.Record databaseRow, Session session);
 
     /**
      * Allow for any initialization.

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/descriptors/copying/CloneCopyPolicy.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/descriptors/copying/CloneCopyPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -122,7 +122,7 @@ public class CloneCopyPolicy extends AbstractCopyPolicy {
      * Create a new instance, unless a workingCopyClone method is specified, then build a new instance and clone it.
      */
     @Override
-    public Object buildWorkingCopyCloneFromRow(Record row, ObjectBuildingQuery query, Object primaryKey, UnitOfWork uow) throws DescriptorException {
+    public Object buildWorkingCopyCloneFromRow(org.eclipse.persistence.sessions.Record row, ObjectBuildingQuery query, Object primaryKey, UnitOfWork uow) throws DescriptorException {
         // For now must preserve CMP code which builds heavy clones with a context.
         // Also preserve for clients who use the copy policy.
         ObjectBuilder builder = getDescriptor().getObjectBuilder();

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/descriptors/copying/CopyPolicy.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/descriptors/copying/CopyPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -51,7 +51,7 @@ public interface CopyPolicy extends Cloneable, Serializable {
     /**
      * Return an instance with the primary key set from the row, used for building a working copy during a unit of work transactional read.
      */
-    Object buildWorkingCopyCloneFromRow(Record row, ObjectBuildingQuery query, Object primaryKey, UnitOfWork uow) throws DescriptorException;
+    Object buildWorkingCopyCloneFromRow(org.eclipse.persistence.sessions.Record row, ObjectBuildingQuery query, Object primaryKey, UnitOfWork uow) throws DescriptorException;
 
     /**
      * Clone the CopyPolicy.

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/eis/DOMRecord.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/eis/DOMRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -31,7 +31,7 @@ import org.w3c.dom.Node;
  * @author James
  * @since OracleAS TopLink 10<i>g</i> (10.0.3)
  */
-public interface DOMRecord extends Record {
+public interface DOMRecord extends javax.resource.cci.Record {
     Node getDOM();
 
     void setDOM(Element dom);

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/eis/EISDOMRecord.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/eis/EISDOMRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -37,7 +37,7 @@ import org.eclipse.persistence.oxm.record.XMLRecord;
 public class EISDOMRecord extends org.eclipse.persistence.oxm.record.DOMRecord implements DOMRecord, MappedRecord {
 
     /** The original adapter record. */
-    protected Record record;
+    protected javax.resource.cci.Record record;
 
     /** The record name. */
     protected String recordName;
@@ -60,7 +60,7 @@ public class EISDOMRecord extends org.eclipse.persistence.oxm.record.DOMRecord i
     /**
      * Create a TopLink record from the JCA adapter record and DOM tree.
      */
-    public EISDOMRecord(Record record, Element dom) {
+    public EISDOMRecord(javax.resource.cci.Record record, Element dom) {
         super(dom);
         this.record = record;
         this.recordName = record.getRecordName();
@@ -83,7 +83,7 @@ public class EISDOMRecord extends org.eclipse.persistence.oxm.record.DOMRecord i
      * Create a TopLink record from the JCA adapter record.
      * This attempts to introspect the record to retrieve the DOM tree.
      */
-    public EISDOMRecord(Record record) {
+    public EISDOMRecord(javax.resource.cci.Record record) {
         this.record = record;
         this.recordName = record.getRecordName();
         this.recordShortDescription = record.getRecordShortDescription();
@@ -135,14 +135,14 @@ public class EISDOMRecord extends org.eclipse.persistence.oxm.record.DOMRecord i
     /**
      * Return the JCA adapter record.
      */
-    public Record getRecord() {
+    public javax.resource.cci.Record getRecord() {
         return record;
     }
 
     /**
      * Set the JCA adapter record.
      */
-    public void setRecord(Record record) {
+    public void setRecord(javax.resource.cci.Record record) {
         this.record = record;
         this.recordName = record.getRecordName();
         this.recordShortDescription = record.getRecordShortDescription();

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/eis/EISPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/eis/EISPlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -203,8 +203,8 @@ public class EISPlatform extends DatasourcePlatform {
     /**
      * Allow the platform to create the appropriate type of record for the interaction.
      */
-    public Record createInputRecord(EISInteraction interaction, EISAccessor accessor) {
-        Record input = interaction.createInputRecord(accessor);
+    public javax.resource.cci.Record createInputRecord(EISInteraction interaction, EISAccessor accessor) {
+        javax.resource.cci.Record input = interaction.createInputRecord(accessor);
         if (getRecordConverter() != null) {
             input = getRecordConverter().converterToAdapterRecord(input);
         }
@@ -215,7 +215,7 @@ public class EISPlatform extends DatasourcePlatform {
      * Allow the platform to create the appropriate type of record for the interaction.
      * If an output record is not required then null is returned.
      */
-    public Record createOutputRecord(EISInteraction interaction, AbstractRecord translationRow, EISAccessor accessor) {
+    public javax.resource.cci.Record createOutputRecord(EISInteraction interaction, AbstractRecord translationRow, EISAccessor accessor) {
         return null;
     }
 
@@ -223,8 +223,8 @@ public class EISPlatform extends DatasourcePlatform {
      * INTERNAL:
      * Allow the platform to handle record to row conversion.
      */
-    public AbstractRecord buildRow(Record record, EISInteraction interaction, EISAccessor accessor) {
-        Record output = record;
+    public AbstractRecord buildRow(javax.resource.cci.Record record, EISInteraction interaction, EISAccessor accessor) {
+        javax.resource.cci.Record output = record;
         if (getRecordConverter() != null) {
             output = getRecordConverter().converterFromAdapterRecord(output);
         }
@@ -234,8 +234,8 @@ public class EISPlatform extends DatasourcePlatform {
     /**
      * Allow the platform to handle record to row conversion.
      */
-    public Vector buildRows(Record record, EISInteraction interaction, EISAccessor accessor) {
-        Record output = record;
+    public Vector buildRows(javax.resource.cci.Record record, EISInteraction interaction, EISAccessor accessor) {
+        javax.resource.cci.Record output = record;
         if (getRecordConverter() != null) {
             output = getRecordConverter().converterFromAdapterRecord(output);
         }
@@ -246,7 +246,7 @@ public class EISPlatform extends DatasourcePlatform {
      * Allow the platform to handle the creation of the DOM record.
      * By default create a mapped record an assume it implements DOM as well.
      */
-    public Record createDOMRecord(String recordName, EISAccessor accessor) {
+    public javax.resource.cci.Record createDOMRecord(String recordName, EISAccessor accessor) {
         try {
             return accessor.getRecordFactory().createMappedRecord(recordName);
         } catch (ResourceException exception) {
@@ -259,7 +259,7 @@ public class EISPlatform extends DatasourcePlatform {
      * Allow the platform to handle the creation of the Record for the DOM record.
      * By default instantiate an EISDOMRecord which introspects the record for a getDOM method.
      */
-    public AbstractRecord createDatabaseRowFromDOMRecord(Record record, EISInteraction call, EISAccessor accessor) {
+    public AbstractRecord createDatabaseRowFromDOMRecord(javax.resource.cci.Record record, EISInteraction call, EISAccessor accessor) {
         return new EISDOMRecord(record);
     }
 
@@ -275,7 +275,7 @@ public class EISPlatform extends DatasourcePlatform {
      * Stores the XML DOM value into the record.
      * This must be implemented by the platform if it support XML/DOM records.
      */
-    public void setDOMInRecord(Element dom, Record record, EISInteraction call, EISAccessor accessor) {
+    public void setDOMInRecord(Element dom, javax.resource.cci.Record record, EISInteraction call, EISAccessor accessor) {
         if (domMethod == null) {
             Class[] argumentTypes = new Class[1];
             argumentTypes[0] = Element.class;
@@ -320,7 +320,7 @@ public class EISPlatform extends DatasourcePlatform {
      */
     public void setValueInRecord(String key, Object value, MappedRecord record, EISAccessor accessor) {
         Object recordValue = value;
-        if (shouldConvertDataToStrings() && !(value instanceof Record) && !(value instanceof Collection)) {
+        if (shouldConvertDataToStrings() && !(value instanceof javax.resource.cci.Record) && !(value instanceof Collection)) {
             recordValue = getConversionManager().convertObject(value, ClassConstants.STRING);
         }
         record.put(key, recordValue);

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/eis/RecordConverter.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/eis/RecordConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -27,7 +27,7 @@ import javax.resource.cci.*;
  * @since OracleAS TopLink 10<i>g</i> (10.0.3)
  */
 public interface RecordConverter {
-    Record converterFromAdapterRecord(Record record);
+    javax.resource.cci.Record converterFromAdapterRecord(javax.resource.cci.Record record);
 
-    Record converterToAdapterRecord(Record record);
+    javax.resource.cci.Record converterToAdapterRecord(javax.resource.cci.Record record);
 }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/eis/interactions/EISInteraction.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/eis/interactions/EISInteraction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -346,28 +346,28 @@ public abstract class EISInteraction extends DatasourceCall {
      * Create the appropriate input record for this interaction.
      * Populate the data into the record from this interaction's arguments.
      */
-    public abstract Record createInputRecord(EISAccessor accessor);
+    public abstract javax.resource.cci.Record createInputRecord(EISAccessor accessor);
 
     /**
      * INTERNAL:
      * Build a database row from the record returned from the interaction.
      */
-    public abstract AbstractRecord buildRow(Record record, EISAccessor accessor);
+    public abstract AbstractRecord buildRow(javax.resource.cci.Record record, EISAccessor accessor);
 
     /**
      * Build a collection of database rows from the Record returned from the interaction.
      * This handles IndexedRecords used as sets of result records,
      * and a single MappedRecord with a list of result records.
      */
-    public Vector buildRows(Record record, EISAccessor accessor) {
+    public Vector buildRows(javax.resource.cci.Record record, EISAccessor accessor) {
         Vector rows = null;
         if (record instanceof IndexedRecord) {
             IndexedRecord indexedRecord = (IndexedRecord)record;
             rows = new Vector(indexedRecord.size());
             for (int index = 0; index < indexedRecord.size(); index++) {
                 Object element = indexedRecord.get(index);
-                if (element instanceof Record) {
-                    rows.addElement(buildRow((Record)element, accessor));
+                if (element instanceof javax.resource.cci.Record) {
+                    rows.addElement(buildRow((javax.resource.cci.Record)element, accessor));
                 } else {
                     // It is a single row record.
                     rows.add(buildRow(record, accessor));
@@ -391,8 +391,8 @@ public abstract class EISInteraction extends DatasourceCall {
                     rows = new Vector(elements.size());
                     for (int index = 0; index < elements.size(); index++) {
                         Object elementValue = elements.get(index);
-                        if (elementValue instanceof Record) {
-                            rows.addElement(buildRow((Record)elementValue, accessor));
+                        if (elementValue instanceof javax.resource.cci.Record) {
+                            rows.addElement(buildRow((javax.resource.cci.Record)elementValue, accessor));
                         } else {
                             rows.add(elementValue);
                         }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/eis/interactions/IndexedInteraction.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/eis/interactions/IndexedInteraction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -106,7 +106,7 @@ public class IndexedInteraction extends EISInteraction {
      * Populate the data into the record from this interaction's arguments.
      */
     @Override
-    public Record createInputRecord(EISAccessor accessor) {
+    public javax.resource.cci.Record createInputRecord(EISAccessor accessor) {
         try {
             IndexedRecord record = accessor.getRecordFactory().createIndexedRecord(getInputRecordName());
             for (int index = 0; index < getParameters().size(); index++) {
@@ -126,7 +126,7 @@ public class IndexedInteraction extends EISInteraction {
      * Also handles MappedRecords for case of input being indexed but mapped ouput.
      */
     @Override
-    public AbstractRecord buildRow(Record record, EISAccessor accessor) {
+    public AbstractRecord buildRow(javax.resource.cci.Record record, EISAccessor accessor) {
         AbstractRecord row = null;
         if (record instanceof IndexedRecord) {
             IndexedRecord indexedRecord = (IndexedRecord)record;

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/eis/interactions/MappedInteraction.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/eis/interactions/MappedInteraction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -125,7 +125,7 @@ public class MappedInteraction extends EISInteraction {
      * Populate the data into the record from this interaction's arguments.
      */
     @Override
-    public Record createInputRecord(EISAccessor accessor) {
+    public javax.resource.cci.Record createInputRecord(EISAccessor accessor) {
         try {
             MappedRecord record = null;
 
@@ -166,7 +166,7 @@ public class MappedInteraction extends EISInteraction {
      * Create a mapped input record for this interaction.
      * Populate the data into the record from this interaction's translation row.
      */
-    public Record createTranslationRecord(AbstractRecord transaltionRow, EISAccessor accessor) {
+    public javax.resource.cci.Record createTranslationRecord(AbstractRecord transaltionRow, EISAccessor accessor) {
         return (MappedRecord)createRecordElement(getInputRecordName(), transaltionRow, accessor);
     }
 
@@ -174,7 +174,7 @@ public class MappedInteraction extends EISInteraction {
      * Build a database row from the record returned from the interaction.
      */
     @Override
-    public AbstractRecord buildRow(Record record, EISAccessor accessor) {
+    public AbstractRecord buildRow(javax.resource.cci.Record record, EISAccessor accessor) {
         if (record == null) {
             return  null;
         }
@@ -185,8 +185,8 @@ public class MappedInteraction extends EISInteraction {
             if (indexedRecord.isEmpty()) {
                 return null;
             }
-            if (indexedRecord.get(0) instanceof Record) {
-                return buildRow((Record)indexedRecord.get(0), accessor);
+            if (indexedRecord.get(0) instanceof javax.resource.cci.Record) {
+                return buildRow((javax.resource.cci.Record)indexedRecord.get(0), accessor);
             }
         }
         // If not a mapped record then just put it as a result value in the row.

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/eis/interactions/XMLInteraction.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/eis/interactions/XMLInteraction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -114,8 +114,8 @@ public class XMLInteraction extends MappedInteraction {
      * Convert the database row or arguments into an XML DOM tree.
      */
     @Override
-    public Record createInputRecord(EISAccessor accessor) {
-        Record record = accessor.getEISPlatform().createDOMRecord(getInputRecordName(), accessor);
+    public javax.resource.cci.Record createInputRecord(EISAccessor accessor) {
+        javax.resource.cci.Record record = accessor.getEISPlatform().createDOMRecord(getInputRecordName(), accessor);
         Element dom = createInputDOM(accessor);
         accessor.getEISPlatform().setDOMInRecord(dom, record, this, accessor);
         if (record instanceof XMLRecord) {
@@ -176,7 +176,7 @@ public class XMLInteraction extends MappedInteraction {
      * Build a database row from the record returned from the interaction.
      */
     @Override
-    public AbstractRecord buildRow(Record record, EISAccessor accessor) {
+    public AbstractRecord buildRow(javax.resource.cci.Record record, EISAccessor accessor) {
         if (record == null) {
             return null;
         }
@@ -201,7 +201,7 @@ public class XMLInteraction extends MappedInteraction {
      * Build a collection of database rows from the Record returned from the interaction.
      */
     @Override
-    public Vector buildRows(Record record, EISAccessor accessor) {
+    public Vector buildRows(javax.resource.cci.Record record, EISAccessor accessor) {
         Vector rows = null;
         if (record == null) {
             return new Vector(0);

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/MethodBaseQueryRedirector.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/MethodBaseQueryRedirector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -197,7 +197,7 @@ public class MethodBaseQueryRedirector implements QueryRedirector {
      * Call the static method to execute the query.
      */
     @Override
-    public Object invokeQuery(DatabaseQuery query, Record arguments, Session session) {
+    public Object invokeQuery(DatabaseQuery query, org.eclipse.persistence.sessions.Record arguments, Session session) {
         if (getMethod() == null) {
             initializeMethod(query);
         }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/QueryRedirector.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/QueryRedirector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -48,5 +48,5 @@ public interface QueryRedirector extends Serializable {
      * Perform the query.
      * This must execute the query base on the arguments and return a valid result for the query.
      */
-    Object invokeQuery(DatabaseQuery query, Record arguments, Session session);
+    Object invokeQuery(DatabaseQuery query, org.eclipse.persistence.sessions.Record arguments, Session session);
 }

--- a/foundation/org.eclipse.persistence.nosql/src/it/java/org/eclipse/persistence/testing/tests/eis/xmlfile/DirectInteractionTest.java
+++ b/foundation/org.eclipse.persistence.nosql/src/it/java/org/eclipse/persistence/testing/tests/eis/xmlfile/DirectInteractionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -66,7 +66,7 @@ public class DirectInteractionTest extends DirectConnectTest {
         spec.setInteractionType(XMLFileInteractionSpec.READ);
         spec.setFileName("xml-file-insert-test.xml");
 
-        Record output = interaction.execute(spec, null);
+        javax.resource.cci.Record output = interaction.execute(spec, null);
 
         getSession().logMessage("output: " + output);
         interaction.close();
@@ -94,7 +94,7 @@ public class DirectInteractionTest extends DirectConnectTest {
         spec.setInteractionType(XMLFileInteractionSpec.DELETE);
         spec.setFileName("xml-file-insert-test.xml");
 
-        Record output = interaction.execute(spec, null);
+        javax.resource.cci.Record output = interaction.execute(spec, null);
 
         interaction.close();
 

--- a/foundation/org.eclipse.persistence.nosql/src/main/java/org/eclipse/persistence/eis/adapters/jms/JMSPlatform.java
+++ b/foundation/org.eclipse.persistence.nosql/src/main/java/org/eclipse/persistence/eis/adapters/jms/JMSPlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -195,7 +195,7 @@ public class JMSPlatform extends EISPlatform {
      * Creates an indexed record (mapped records are not supported).
      */
     @Override
-    public Record createDOMRecord(String recordName, EISAccessor accessor) {
+    public javax.resource.cci.Record createDOMRecord(String recordName, EISAccessor accessor) {
         try {
             return accessor.getRecordFactory().createIndexedRecord(recordName);
         } catch (ResourceException exception) {
@@ -208,7 +208,7 @@ public class JMSPlatform extends EISPlatform {
      * Convert the DOM to text and add to the indexed record.
      */
     @Override
-    public void setDOMInRecord(Element dom, Record record, EISInteraction call, EISAccessor accessor) {
+    public void setDOMInRecord(Element dom, javax.resource.cci.Record record, EISInteraction call, EISAccessor accessor) {
         IndexedRecord indexedRecord = (IndexedRecord)record;
         indexedRecord.add(new org.eclipse.persistence.oxm.record.DOMRecord(dom).transformToXML());
     }
@@ -218,7 +218,7 @@ public class JMSPlatform extends EISPlatform {
      * Translate the indexed record text into a DOM record.
      */
     @Override
-    public AbstractRecord createDatabaseRowFromDOMRecord(Record record, EISInteraction call, EISAccessor accessor) {
+    public AbstractRecord createDatabaseRowFromDOMRecord(javax.resource.cci.Record record, EISInteraction call, EISAccessor accessor) {
         IndexedRecord indexedRecord = (IndexedRecord)record;
         if (indexedRecord.size() == 0) {
             return null;

--- a/foundation/org.eclipse.persistence.nosql/src/main/java/org/eclipse/persistence/internal/eis/adapters/jms/CciJMSInteraction.java
+++ b/foundation/org.eclipse.persistence.nosql/src/main/java/org/eclipse/persistence/internal/eis/adapters/jms/CciJMSInteraction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -46,7 +46,7 @@ public class CciJMSInteraction implements Interaction {
      * @throws EISException
      */
     @Override
-    public Record execute(InteractionSpec spec, Record input) throws EISException {
+    public javax.resource.cci.Record execute(InteractionSpec spec, javax.resource.cci.Record input) throws EISException {
         CciJMSRecord record = new CciJMSRecord();
         execute(spec, input, record);
         return record;
@@ -63,7 +63,7 @@ public class CciJMSInteraction implements Interaction {
      * @throws EISException
      */
     @Override
-    public boolean execute(InteractionSpec spec, Record input, Record output) throws EISException {
+    public boolean execute(InteractionSpec spec, javax.resource.cci.Record input, javax.resource.cci.Record output) throws EISException {
         if (!(spec instanceof CciJMSInteractionSpec)) {
             throw EISException.invalidInteractionSpecType();
         }

--- a/foundation/org.eclipse.persistence.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/mongo/MongoInteraction.java
+++ b/foundation/org.eclipse.persistence.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/mongo/MongoInteraction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -62,7 +62,7 @@ public class MongoInteraction implements Interaction {
      * Output records are not supported/required.
      */
     @Override
-    public boolean execute(InteractionSpec spec, Record input, Record output) throws ResourceException {
+    public boolean execute(InteractionSpec spec, javax.resource.cci.Record input, javax.resource.cci.Record output) throws ResourceException {
         if (!(spec instanceof MongoInteractionSpec)) {
             throw EISException.invalidInteractionSpecType();
         }
@@ -102,7 +102,7 @@ public class MongoInteraction implements Interaction {
      * The spec is either GET, PUT or DELETE interaction.
      */
     @Override
-    public Record execute(InteractionSpec spec, Record record) throws ResourceException {
+    public javax.resource.cci.Record execute(InteractionSpec spec, javax.resource.cci.Record record) throws ResourceException {
         if (!(spec instanceof MongoInteractionSpec)) {
             throw EISException.invalidInteractionSpecType();
         }


### PR DESCRIPTION
This PR contains two fixes:
1. Javadoc generation fix in `org.eclipse.persistence.config.PersistenceUnitProperties`
2. Fix to allow build on JDK 14
    In JDK 14 is new class `java.lang.Record` which leads into compilation errors like
     `....error: reference to Record is ambiguous....`
    There is collision with:
    `org.eclipse.persistence.sessions.Record` in `org.eclipse.persistence.core` and `org.eclipse.persistence.core.test` modules
    and
    `javax.resource.cci.Record` in `org.eclipse.persistence.nosql` module 
     Usage/declaration of `Record` class is transformed into qualified form like  `org.eclipse.persistence.sessions.Record` or `javax.resource.cci.Record` to exactly specify this class.