### PR TITLE
Upgrade to Jakarta Validation 3.0

### DIFF
--- a/bundles/distribution/pom.xml
+++ b/bundles/distribution/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -143,68 +143,55 @@
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>org.eclipse.persistence.oracleddlparser</artifactId>
-            <version>${oracle.ddlparser.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>commonj.sdo</artifactId>
-            <version>${commonj.sdo.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>jakarta.persistence</artifactId>
-            <version>${persistence22.version}</version>
         </dependency>
         <!--Other APIs/libraries-->
         <dependency>
             <groupId>com.sun.activation</groupId>
             <artifactId>jakarta.activation</artifactId>
-            <version>${activation.version}</version>
         </dependency>
         <dependency>
             <groupId>com.sun.mail</groupId>
             <artifactId>jakarta.mail</artifactId>
-            <version>${mail.version}</version>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-osgi</artifactId>
-            <version>${jaxb.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.jms</groupId>
             <artifactId>jakarta.jms-api</artifactId>
-            <version>${jms.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.resource</groupId>
             <artifactId>jakarta.resource-api</artifactId>
-            <version>${resource.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
-            <version>${servlet.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
-            <version>${validation.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>${ws-rs.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>${jaxb.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
-            <version>${ant.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
@@ -214,30 +201,25 @@
         <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.json</artifactId>
-            <version>${json.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.corba</groupId>
             <artifactId>glassfish-corba-omgapi</artifactId>
-            <version>${org.glassfish.corba.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.corba</groupId>
             <artifactId>glassfish-corba-orb</artifactId>
-            <version>${org.glassfish.corba.version}</version>
         </dependency>
         <!--NoSQL DBs-->
         <!--Mongo DB-->
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongo-java-driver</artifactId>
-            <version>${mongodb.version}</version>
         </dependency>
         <!--Oracle NoSQL DB-->
         <dependency>
             <groupId>com.oracle.kv</groupId>
             <artifactId>oracle-nosql-client</artifactId>
-            <version>${oracle.nosql.version}</version>
         </dependency>
         <!--Test dependencies (used for assembly of eclipselink test classes and framework).-->
         <!--EclipseLink Core test framework-->
@@ -267,7 +249,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <!--API dependecies-->
@@ -280,6 +261,7 @@
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
+            <scope>test</scope>
         </dependency>
         <!--Other dependencies-->
         <dependency>
@@ -703,7 +685,7 @@
                                 <jaxrs.jar>jakarta.ws.rs-api.jar</jaxrs.jar>
                                 <asm.jar>org.eclipse.persistence.asm_${release.version}.${build.type}.jar</asm.jar>
                                 <asm.version>${asm.bundle.version}</asm.version>
-                                <javax.validation.lib>${project.build.directory}/${osgi.test.plugins.dir}/jakarta.validation-api.jar</javax.validation.lib>
+                                <jakarta.validation.lib>${project.build.directory}/${osgi.test.plugins.dir}/jakarta.validation-api.jar</jakarta.validation.lib>
                             </systemProperties>
                             <includes>
                                 <include>org.eclipse.persistence.testing.osgi.beanvalidation.NoBeanValidationTest</include>

--- a/bundles/distribution/src/test/java/org/eclipse/persistence/testing/osgi/OSGITestHelper.java
+++ b/bundles/distribution/src/test/java/org/eclipse/persistence/testing/osgi/OSGITestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -22,10 +22,6 @@ import static org.ops4j.pax.exam.CoreOptions.junitBundles;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.CoreOptions.options;
 import static org.ops4j.pax.exam.CoreOptions.systemProperty;
-import static org.ops4j.pax.exam.CoreOptions.vmOptions;
-import static org.ops4j.pax.exam.CoreOptions.when;
-
-import org.eclipse.persistence.internal.helper.JavaSEPlatform;
 
 /**
  * Helper class with PAX options for different kind of OSGi tests.
@@ -43,7 +39,7 @@ public class OSGITestHelper {
     private static final String JAXRS_JAR = System.getProperty("jaxrs.jar", "jakarta.ws.rs-api.jar");
     private static final String ASM_JAR = System.getProperty("asm.jar", "org.eclipse.persistence.asm_7.1.0.v201909231337.jar");
     private static final String ASM_VERSION = System.getProperty("asm.version", "7.1.0.v201909231337");
-    private static final String BEAN_VALIDATION_LIB = System.getProperty("javax.validation.lib", "jakarta.validation-api.jar");
+    private static final String BEAN_VALIDATION_LIB = System.getProperty("jakarta.validation.lib", "jakarta.validation-api.jar");
 
     public static Option[] getDefaultOptions() {
         return options(
@@ -66,9 +62,9 @@ public class OSGITestHelper {
 
     public static Option[] getOptionsWithBeanValidation() {
         return options(
-                mavenBundle().groupId("org.hibernate.validator").artifactId("hibernate-validator").version("6.0.7.Final"),
+                mavenBundle().groupId("org.hibernate.validator").artifactId("hibernate-validator").version("7.0.0.Alpha1"),
                 mavenBundle().groupId("com.fasterxml").artifactId("classmate").version("1.3.1"),
-                mavenBundle().groupId("org.glassfish").artifactId("javax.el").version("3.0.1-b08"),
+                mavenBundle().groupId("org.glassfish").artifactId("jakarta.el").version("4.0.0-RC1"),
                 mavenBundle().groupId("org.jboss.logging").artifactId("jboss-logging").version("3.3.0.Final"),
 
                 // JAXB API

--- a/bundles/distribution/src/test/java/org/eclipse/persistence/testing/osgi/beanvalidation/BeanValidationTest.java
+++ b/bundles/distribution/src/test/java/org/eclipse/persistence/testing/osgi/beanvalidation/BeanValidationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -28,10 +28,10 @@ import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
 
-import javax.validation.Validation;
-import javax.validation.ValidationProviderResolver;
-import javax.validation.ValidatorFactory;
-import javax.validation.spi.ValidationProvider;
+import jakarta.validation.Validation;
+import jakarta.validation.ValidationProviderResolver;
+import jakarta.validation.ValidatorFactory;
+import jakarta.validation.spi.ValidationProvider;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;

--- a/bundles/distribution/src/test/java/org/eclipse/persistence/testing/osgi/beanvalidation/Customer.java
+++ b/bundles/distribution/src/test/java/org/eclipse/persistence/testing/osgi/beanvalidation/Customer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,14 +14,14 @@
 //     Dmitry Kornilov - initial implementation
 package org.eclipse.persistence.testing.osgi.beanvalidation;
 
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 /**
- * Test class for OSGi tests with javax.validation in class path and without it.
+ * Test class for OSGi tests with jakarta.validation in class path and without it.
  *
  * @author Dmitry Kornilov
  * @since 2.7

--- a/bundles/distribution/src/test/java/org/eclipse/persistence/testing/osgi/beanvalidation/NoBeanValidationTest.java
+++ b/bundles/distribution/src/test/java/org/eclipse/persistence/testing/osgi/beanvalidation/NoBeanValidationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * Marshal/unmarshal tests in OSGi container without installed bean validation implementation bundles.
- * The purpose of these tests is to make sure that javax.validation import is optional.
+ * The purpose of these tests is to make sure that jakarta.validation import is optional.
  *
  * @author Dmitry Kornilov
  * @since 2.7.0

--- a/bundles/others/src/main/resources/nonfiltered/eclipselink-test-src.zip/antbuild.xml
+++ b/bundles/others/src/main/resources/nonfiltered/eclipselink-test-src.zip/antbuild.xml
@@ -1043,7 +1043,7 @@
                 <include name="${eclipselink.sdo.test}/**"/>
                 <include name="${eclipselink.sdo.base}/eclipselink.sdo.test.server/**"/>
                 <include name="plugins/eclipselink-jpa-modelgen_*.jar"/>
-                <include name="plugins/javax.validation.api_*.jar"/>
+                <include name="plugins/jakarta.validation.api_*.jar"/>
                 <include name="jpa/plugins/javax.persistence_2.*.jar"/>
                 <include name="sdo/plugins/commonj.sdo_*.jar"/>
                 <exclude name="**/.settings/**"/>

--- a/bundles/others/src/main/resources/nonfiltered/eclipselink-test-src.zip/jpa/eclipselink.jpa.test/antbuild.properties
+++ b/bundles/others/src/main/resources/nonfiltered/eclipselink-test-src.zip/jpa/eclipselink.jpa.test/antbuild.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at
@@ -176,9 +176,9 @@ eclipselink.jpa.spring.test=../eclipselink.jpa.spring.test
 
 # BeanValidationJUnitTest Dependency Definitions
 ----------------------------------------------
-javax.validation.jar=jakarta.validation-api.jar
+jakarta.validation.jar=jakarta.validation-api.jar
 validation-impl.jar=hibernate-validator-6.0.7.Final.jar
 # Hibernate-validator dependencies.
 jboss-logging.jar=jboss-logging-3.3.0.Final.jar
-javax.el.jar=javax.el-3.0.1-b08.jar
+jakarta.el.jar=jakarta.el-4.0.0-RC1.jar
 classmate.jar=classmate-1.3.1.jar

--- a/bundles/others/src/main/resources/nonfiltered/eclipselink-test-src.zip/jpa/eclipselink.jpa.test/antbuild.xml
+++ b/bundles/others/src/main/resources/nonfiltered/eclipselink-test-src.zip/jpa/eclipselink.jpa.test/antbuild.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -193,7 +193,7 @@
             <and>
                 <available file="${extensions.depend.dir}/${validation-impl.jar}" />
                 <available file="${extensions.depend.dir}/${jboss-logging.jar}" />
-                <available file="${extensions.depend.dir}/${javax.el.jar}" />
+                <available file="${extensions.depend.dir}/${jakarta.el.jar}" />
                 <available file="${extensions.depend.dir}/${classmate.jar}" />
             </and>
         </condition>
@@ -246,7 +246,7 @@
         <path id="run.common.path" cache="true">
             <path refid="jpa.compile.common.path"/>
 <!--            <pathelement path="${jpatest.2.common.plugins.dir}/${transaction.jar}"/>
-            <pathelement path="${jpatest.2.common.plugins.dir}/${javax.validation.jar}"/>
+            <pathelement path="${jpatest.2.common.plugins.dir}/${jakarta.validation.jar}"/>
             <pathelement path="${jpatest.2.coretest.dir}/${coretest.framework.jar}"/>
             <pathelement path="${junit.lib}"/>
             <pathelement path="${jpatest.2.coretest.dir}/${coretest.jar}"/>
@@ -380,9 +380,9 @@
             <path refid="jpa22.run.common.path" />
             <pathelement path="${extensions.depend.dir}/${validation-impl.jar}"/>
             <pathelement path="${extensions.depend.dir}/${jboss-logging.jar}"/>
-            <pathelement path="${extensions.depend.dir}/${javax.el.jar}"/>
+            <pathelement path="${extensions.depend.dir}/${jakarta.el.jar}"/>
             <pathelement path="${extensions.depend.dir}/${classmate.jar}"/>
-            <!--<pathelement path="${extensions.depend.dir}/${javax.validation.jar}"/>-->
+            <!--<pathelement path="${extensions.depend.dir}/${jakarta.validation.jar}"/>-->
         </path>
         <path id="run.bean.validation.classpath">
             <path refid="run.bean.validation.classpath.common"/>
@@ -544,7 +544,7 @@
         <property name="test.junit.jvm.modules.prop" value=""/>
         <path id="jpatest.compile.core.deps" cache="true">
             <pathelement path="${jpatest.2.common.plugins.dir}/${transaction.jar}"/>
-            <pathelement path="${jpatest.2.common.plugins.dir}/${javax.validation.jar}"/>
+            <pathelement path="${jpatest.2.common.plugins.dir}/${jakarta.validation.jar}"/>
         </path>
         <path id="jpatest.compile.module.path" cache="true"></path>
         <path id="jpatest.upgrade.module.path" cache="true"></path>
@@ -561,7 +561,7 @@
         <path id="jpatest.compile.core.deps" cache="true"/>
         <path id="jpatest.compile.module.path" cache="true">
             <!--<pathelement path="${jpatest.2.jpa.plugins.dir}/${persistence22.jar}"/>-->
-            <pathelement path="${jpatest.2.common.plugins.dir}/${javax.validation.jar}"/>
+            <pathelement path="${jpatest.2.common.plugins.dir}/${jakarta.validation.jar}"/>
         </path>
         <path id="jpatest.upgrade.module.path" cache="true">
             <pathelement path="${jpatest.2.common.plugins.dir}/${transaction.jar}"/>

--- a/bundles/others/src/main/resources/nonfiltered/eclipselink-test-src.zip/moxy/eclipselink.moxy.test/antbuild.properties
+++ b/bundles/others/src/main/resources/nonfiltered/eclipselink-test-src.zip/moxy/eclipselink.moxy.test/antbuild.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at
@@ -42,7 +42,7 @@ transaction.jar=jakarta.transaction-api.jar
 asm.jar=org.eclipse.persistence.asm_7.1.0.v201909231337.jar
 asm.version=7.1.0.v201909231337
 
-eclipselink.core.depend=${resource.jar},${ejb.jar},${jms.jar},${transaction.jar},${mail.jar},${javax.validation.jar}
+eclipselink.core.depend=${resource.jar},${ejb.jar},${jms.jar},${transaction.jar},${mail.jar},${jakarta.validation.jar}
 
 eclipselink.jar=eclipselink.jar
 eclipselink.core=../../foundation/org.eclipse.persistence.core
@@ -69,11 +69,11 @@ xml.parser.jar=dummy_xml_parser.jar
 
 # JSR-303/349/380 Dependency Definitions
 ----------------------------------------------
-javax.validation.jar=jakarta.validation-api.jar
+jakarta.validation.jar=jakarta.validation-api.jar
 validation-impl.jar=hibernate-validator-6.0.7.Final.jar
 # Hibernate-validator dependencies.
 jboss-logging.jar=jboss-logging-3.3.0.Final.jar
-javax.el.jar=javax.el-3.0.1-b08.jar
+jakarta.el.jar=jakarta.el-4.0.0-RC1.jar
 classmate.jar=classmate-1.3.1.jar
 
 #JMockit

--- a/bundles/others/src/main/resources/nonfiltered/eclipselink-test-src.zip/moxy/eclipselink.moxy.test/antbuild.xml
+++ b/bundles/others/src/main/resources/nonfiltered/eclipselink-test-src.zip/moxy/eclipselink.moxy.test/antbuild.xml
@@ -92,10 +92,10 @@
     <property name="eclipselink.lib" value="${moxytest.2.trunk.dir}/${eclipselink.jar}"/>
     <property name="jaxb-api.lib" value="${moxytest.2.common.plugins.dir}/${jaxb-api.jar}"/>
     <property name="jaxb-impl.lib" value="${moxytest.2.common.plugins.dir}/${jaxb-impl.jar}"/>
-    <property name="javax.validation.lib" value="${moxytest.2.common.plugins.dir}/${javax.validation.jar}"/>
+    <property name="jakarta.validation.lib" value="${moxytest.2.common.plugins.dir}/${jakarta.validation.jar}"/>
     <property name="validation-impl.lib" value="${extensions.depend.dir}/${validation-impl.jar}"/>
     <property name="jboss-logging.lib" value="${extensions.depend.dir}/${jboss-logging.jar}"/>
-    <property name="javax.el.lib" value="${extensions.depend.dir}/${javax.el.jar}"/>
+    <property name="jakarta.el.lib" value="${extensions.depend.dir}/${jakarta.el.jar}"/>
     <property name="classmate.lib" value="${extensions.depend.dir}/${classmate.jar}"/>
     <property name="jmockit.lib" value="${extensions.depend.dir}/${jmockit.jar}"/>
     <property name="jacocoagent.lib" value="${extensions.depend.dir}/${jacocoagent.jar}"/>
@@ -104,7 +104,7 @@
         <and>
             <available file="${extensions.depend.dir}/${validation-impl.jar}"/>
             <available file="${extensions.depend.dir}/${jboss-logging.jar}"/>
-            <available file="${extensions.depend.dir}/${javax.el.jar}"/>
+            <available file="${extensions.depend.dir}/${jakarta.el.jar}"/>
             <available file="${extensions.depend.dir}/${classmate.jar}"/>
         </and>
     </condition>
@@ -147,7 +147,7 @@
         <pathelement path="${moxytest.2.core.dir}/target/${classes.dir}"/>
         <pathelement path="${jaxb-impl.lib}"/>
         <pathelement path="${jaxb-core.lib}"/>
-        <pathelement path="${javax.validation.lib}"/>
+        <pathelement path="${jakarta.validation.lib}"/>
         <pathelement path="${moxytest.2.common.plugins.dir}/${activation.jar}"/>
     </path>
     <path id="jaxb.run.path">
@@ -170,9 +170,9 @@
         <pathelement path="${junit.lib}"/>
         <pathelement path="${validation-impl.lib}"/>
         <pathelement path="${jboss-logging.lib}"/>
-        <pathelement path="${javax.el.lib}"/>
+        <pathelement path="${jakarta.el.lib}"/>
         <pathelement path="${classmate.lib}"/>
-        <pathelement path="${javax.validation.lib}"/>
+        <pathelement path="${jakarta.validation.lib}"/>
         <pathelement path="${moxytest.2.common.plugins.dir}/${activation.jar}"/>
     </path>
     <path id="oxm.compile.path">
@@ -224,7 +224,7 @@
         <pathelement path="${eclipselink.lib}"/>
         <pathelement path="${jaxb-impl.lib}"/>
         <pathelement path="${jaxb-core.lib}"/>
-        <pathelement path="${javax.validation.lib}"/>
+        <pathelement path="${jakarta.validation.lib}"/>
         <pathelement path="${moxytest.2.common.plugins.dir}/${activation.jar}"/>
     </path>
     <path id="jaxb.run.against.jar.path">
@@ -242,10 +242,10 @@
         <pathelement path="${eclipselink.lib}"/>
         <pathelement path="${jaxb-impl.lib}"/>
         <pathelement path="${jaxb-core.lib}"/>
-        <pathelement path="${javax.validation.lib}"/>
+        <pathelement path="${jakarta.validation.lib}"/>
         <pathelement path="${validation-impl.lib}"/>
         <pathelement path="${jboss-logging.lib}"/>
-        <pathelement path="${javax.el.lib}"/>
+        <pathelement path="${jakarta.el.lib}"/>
         <pathelement path="${classmate.lib}"/>
         <pathelement path="${moxytest.2.common.plugins.dir}/${activation.jar}"/>
     </path>
@@ -383,7 +383,7 @@
             <!--<arg line="-Dmaven.surefire.debug clean install"/>-->
             <arg line="clean test"/>
             <arg line="-Dmoxytest.2.common.plugins.dir=${basedir}/../../plugins/"/>
-            <arg line="-Djavax.validation.lib=${basedir}/${javax.validation.lib}"/>
+            <arg line="-Djakarta.validation.lib=${basedir}/${jakarta.validation.lib}"/>
             <arg line="-Dbuild.qualifier=${version.qualifier}"/>
             <arg line="-Drelease.version=${release.version}"/>
             <arg line="-Djaxb-api.jar=${jaxb-api.jar}"/>

--- a/bundles/others/src/main/resources/nonfiltered/eclipselink-test-src.zip/moxy/eclipselink.moxy.test/pom.xml
+++ b/bundles/others/src/main/resources/nonfiltered/eclipselink-test-src.zip/moxy/eclipselink.moxy.test/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -28,6 +28,7 @@
         <url.version>2.5.2</url.version>
         <logback.version>1.1.3</logback.version>
         <eclipselink.version>3.0.0-SNAPSHOT</eclipselink.version>
+        <hibernate.version>7.0.0.Alpha1</hibernate.version>
     </properties>
 
     <dependencies>
@@ -49,18 +50,18 @@
 
         <!-- Bean validation API -->
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation</artifactId>
-            <version>2.0.1</version>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>3.0.0-M1</version>
             <scope>system</scope>
-            <systemPath>${javax.validation.lib}</systemPath>
+            <systemPath>${jakarta.validation.lib}</systemPath>
         </dependency>
 
         <!-- Hibernate validator and it's dependencies -->
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>6.0.7.Final</version>
+            <version>${hibernate.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/PersistenceUnitProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/PersistenceUnitProperties.java
@@ -1114,11 +1114,11 @@ public class PersistenceUnitProperties {
     /**
      * The "<code>javax.persistence.validation.factory</code>" property
      * specifies an instance of <a href =
-     * http://docs.oracle.com/javaee/6/api/javax/validation/ValidatorFactory.html>javax.validation.ValidatorFactory</a> used by
+     * http://docs.oracle.com/javaee/6/api/javax/validation/ValidatorFactory.html>jakarta.validation.ValidatorFactory</a> used by
      * EclipseLink to perform Automatic Validation upon Lifecycle Events. If the
      * property is not specified, and if Bean Validation API is visible to
      * EclipseLink, it will try to instantiate an instance of
-     * <code>javax.validation.ValidationFactory</code> by calling
+     * <code>jakarta.validation.ValidationFactory</code> by calling
      * <code>Validation.buildDefaultValidatorFactory()</code>.
      */
     public static final String VALIDATOR_FACTORY = "javax.persistence.validation.factory";

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/beanvalidation/Address.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/beanvalidation/Address.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,7 +15,7 @@
 package org.eclipse.persistence.testing.models.jpa.beanvalidation;
 
 import javax.persistence.Embeddable;
-import javax.validation.constraints.Size;
+import jakarta.validation.constraints.Size;
 
 @Embeddable
 public class Address {

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/beanvalidation/Employee.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/beanvalidation/Employee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,10 +15,10 @@
 package org.eclipse.persistence.testing.models.jpa.beanvalidation;
 
 import javax.persistence.*;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.Size;
-import javax.validation.constraints.Max;
-import javax.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.Valid;
 import java.util.Collection;
 
 @Entity(name = "CMP3_BV_EMPLOYEE")

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/beanvalidation/Project.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/beanvalidation/Project.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,7 +16,7 @@ package org.eclipse.persistence.testing.models.jpa.beanvalidation;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
-import javax.validation.constraints.Size;
+import jakarta.validation.constraints.Size;
 
 @Entity(name="CMP3_BV_PROJECT")
 public class Project {

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/ddlgeneration/Clientes.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/ddlgeneration/Clientes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011, 2015 Xavier Callejas. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -31,8 +31,8 @@ import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/ddlgeneration/Operaciones.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/ddlgeneration/Operaciones.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011, 2015 Xavier Callejas. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -20,7 +20,6 @@ package org.eclipse.persistence.testing.models.jpa.ddlgeneration;
 
 import java.io.Serializable;
 import java.util.Date;
-import javax.persistence.AttributeOverride;
 import javax.persistence.Basic;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -36,7 +35,7 @@ import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 import javax.xml.bind.annotation.XmlRootElement;
 
 /**

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/ddlgeneration/RoutingOrders.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/ddlgeneration/RoutingOrders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011, 2015 Xavier Callejas. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -29,8 +29,6 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinColumns;
-import javax.persistence.JoinTable;
-import javax.persistence.ManyToOne;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.OneToOne;
@@ -38,7 +36,7 @@ import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import javax.persistence.UniqueConstraint;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 import javax.xml.bind.annotation.XmlRootElement;
 
 /**

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/beanvalidation/BeanValidationJunitTest.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/beanvalidation/BeanValidationJunitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -24,8 +24,8 @@ import java.util.Set;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.TypedQuery;
-import javax.validation.ConstraintViolation;
-import javax.validation.ConstraintViolationException;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
 
 import org.eclipse.persistence.logging.SessionLog;
 import org.eclipse.persistence.mappings.ForeignReferenceMapping;

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/beanvalidation/dynamic/BeanValidationDynamicEntityJunitTest.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/beanvalidation/dynamic/BeanValidationDynamicEntityJunitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,8 +14,8 @@ package org.eclipse.persistence.testing.tests.jpa.beanvalidation.dynamic;
 
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
-import javax.validation.ConstraintViolationException;
-import javax.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.ConstraintViolation;
 
 import junit.framework.Test;
 import org.eclipse.persistence.config.PersistenceUnitProperties;

--- a/jpa/eclipselink.jpa.test/src/it/resources/eclipselink-beanvalidation-dynamic-model/employee-constraints.xml
+++ b/jpa/eclipselink.jpa.test/src/it/resources/eclipselink-beanvalidation-dynamic-model/employee-constraints.xml
@@ -19,10 +19,10 @@
     <default-package>org.eclipse.persistence.testing.models.jpa.beanvalidation</default-package>
     <bean class="DynamicEmployee" ignore-annotations="true">
         <getter name="name" ignore-annotations="true">
-            <constraint annotation="javax.validation.constraints.NotNull" />
+            <constraint annotation="jakarta.validation.constraints.NotNull" />
         </getter>
         <getter name="surname" ignore-annotations="true">
-            <constraint annotation="javax.validation.constraints.NotNull" />
+            <constraint annotation="jakarta.validation.constraints.NotNull" />
         </getter>
     </bean>
 </constraint-mappings>

--- a/jpa/eclipselink.jpa.test/src/it/resources/eclipselink-beanvalidation-dynamic-model/server/employee-constraints.xml
+++ b/jpa/eclipselink.jpa.test/src/it/resources/eclipselink-beanvalidation-dynamic-model/server/employee-constraints.xml
@@ -19,10 +19,10 @@
     <default-package>org.eclipse.persistence.testing.models.jpa.beanvalidation</default-package>
     <bean class="DynamicEmployee" ignore-annotations="true">
         <getter name="name" ignore-annotations="true">
-            <constraint annotation="javax.validation.constraints.NotNull" />
+            <constraint annotation="jakarta.validation.constraints.NotNull" />
         </getter>
         <getter name="surname" ignore-annotations="true">
-            <constraint annotation="javax.validation.constraints.NotNull" />
+            <constraint annotation="jakarta.validation.constraints.NotNull" />
         </getter>
     </bean>
 </constraint-mappings>

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
@@ -3746,7 +3746,7 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
     private void addBeanValidationListeners(Map puProperties, ClassLoader appClassLoader) {
         ValidationMode validationMode = getValidationMode(persistenceUnitInfo, puProperties);
         if (validationMode == ValidationMode.AUTO || validationMode == ValidationMode.CALLBACK) {
-            // BeanValidationInitializationHelper contains static reference to javax.validation.* classes. We need to support
+            // BeanValidationInitializationHelper contains static reference to jakarta.validation.* classes. We need to support
             // environment where these classes are not available.
             // To guard against some vms that eagerly resolve, reflectively load class to prevent any static reference to it
             String helperClassName = "org.eclipse.persistence.internal.jpa.deployment.BeanValidationInitializationHelper$BeanValidationInitializationHelperImpl";

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/deployment/BeanValidationInitializationHelper.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/deployment/BeanValidationInitializationHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -20,8 +20,8 @@ import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.util.Map;
 
-import javax.validation.Validation;
-import javax.validation.ValidatorFactory;
+import jakarta.validation.Validation;
+import jakarta.validation.ValidatorFactory;
 
 import org.eclipse.persistence.config.PersistenceUnitProperties;
 import org.eclipse.persistence.descriptors.ClassDescriptor;

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/MetadataDynamicClassWriter.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/MetadataDynamicClassWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -32,7 +32,7 @@ import org.eclipse.persistence.internal.libraries.asm.Type;
 
 /**
  * Custom {@link DynamicClassWriter} adding getter methods for virtual
- * attributes so that 3rd party frameworks such as javax.validation can access
+ * attributes so that 3rd party frameworks such as jakarta.validation can access
  * the attribute values.
  *
  * @author dclarke

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/listeners/BeanValidationListener.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/listeners/BeanValidationListener.java
@@ -28,13 +28,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.ConstraintViolationException;
-import javax.validation.Path;
-import javax.validation.TraversableResolver;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
-import javax.validation.groups.Default;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Path;
+import jakarta.validation.TraversableResolver;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import jakarta.validation.groups.Default;
 
 import org.eclipse.persistence.config.PersistenceUnitProperties;
 import org.eclipse.persistence.descriptors.ClassDescriptor;
@@ -149,7 +149,7 @@ public class BeanValidationListener extends DescriptorEventAdapter {
 
     /**
      * Returns if a bean/entity is constrained by calling the bean validation provider's
-     * #javax.validation.metadata.BeanDescriptor.isBeanConstrained method.
+     * #jakarta.validation.metadata.BeanDescriptor.isBeanConstrained method.
      */
     private boolean isBeanConstrained(final Object source, final Validator validator) {
         // If Java Security is enabled, surround this call with a doPrivileged block.

--- a/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/BeanValidationChecker.java
+++ b/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/BeanValidationChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,7 +15,7 @@
 package org.eclipse.persistence.jaxb;
 
 /**
- * Helper class. Checks that javax.validation API is present.
+ * Helper class. Checks that jakarta.validation API is present.
  *
  * @author Dmitry Kornilov
  * @since 2.7.0
@@ -23,11 +23,11 @@ package org.eclipse.persistence.jaxb;
 public class BeanValidationChecker {
 
     /**
-     * Returns true if javax.validation.api bundle is on the class path.
+     * Returns true if jakarta.validation.api bundle is on the class path.
      */
     static boolean isBeanValidationPresent() {
         try {
-            Class.forName("javax.validation.Validation").newInstance();
+            Class.forName("jakarta.validation.Validation").newInstance();
         } catch (ReflectiveOperationException e) {
             return false;
         }

--- a/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/BeanValidationHelper.java
+++ b/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/BeanValidationHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -33,19 +33,19 @@ import java.util.concurrent.Future;
 
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
-import javax.validation.Constraint;
-import javax.validation.Valid;
-import javax.validation.constraints.AssertFalse;
-import javax.validation.constraints.AssertTrue;
-import javax.validation.constraints.DecimalMax;
-import javax.validation.constraints.DecimalMin;
-import javax.validation.constraints.Digits;
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Past;
-import javax.validation.constraints.Pattern;
-import javax.validation.constraints.Size;
+import jakarta.validation.Constraint;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertFalse;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 import org.eclipse.persistence.internal.cache.AdvancedProcessor;
 import org.eclipse.persistence.internal.cache.ComputableTask;
@@ -96,7 +96,7 @@ final public class BeanValidationHelper {
         knownConstraints.add(Size.class);
         knownConstraints.add(AssertTrue.class);
         knownConstraints.add(AssertFalse.class);
-        knownConstraints.add(javax.validation.constraints.Future.class);
+        knownConstraints.add(jakarta.validation.constraints.Future.class);
         knownConstraints.add(Past.class);
         knownConstraints.add(Max.List.class);
         knownConstraints.add(Min.List.class);
@@ -108,7 +108,7 @@ final public class BeanValidationHelper {
         knownConstraints.add(Size.List.class);
         knownConstraints.add(AssertTrue.List.class);
         knownConstraints.add(AssertFalse.List.class);
-        knownConstraints.add(javax.validation.constraints.Future.List.class);
+        knownConstraints.add(jakarta.validation.constraints.Future.List.class);
         knownConstraints.add(Past.List.class);
     }
 

--- a/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/ConstraintViolationWrapper.java
+++ b/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/ConstraintViolationWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,12 +14,12 @@
 //     Dmitry Kornilov - initial implementation
 package org.eclipse.persistence.jaxb;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Path;
-import javax.validation.metadata.ConstraintDescriptor;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Path;
+import jakarta.validation.metadata.ConstraintDescriptor;
 
 /**
- * Wrapper over {@link ConstraintViolation} class. Required due to optional nature of javax.validation bundle.
+ * Wrapper over {@link ConstraintViolation} class. Required due to optional nature of jakarta.validation bundle.
  *
  * @author Dmitry Kornilov
  * @since 2.7.0

--- a/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/JAXBBeanValidator.java
+++ b/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/JAXBBeanValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -18,14 +18,14 @@ import org.eclipse.persistence.exceptions.BeanValidationException;
 import org.eclipse.persistence.internal.security.PrivilegedAccessHelper;
 import org.eclipse.persistence.jaxb.xmlmodel.XmlBindings;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.ConstraintViolationException;
-import javax.validation.Path;
-import javax.validation.Validation;
-import javax.validation.ValidationException;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
-import javax.validation.groups.Default;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Path;
+import jakarta.validation.Validation;
+import jakarta.validation.ValidationException;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import jakarta.validation.groups.Default;
 import java.security.AccessController;
 import java.security.CodeSource;
 import java.security.PrivilegedAction;
@@ -88,12 +88,12 @@ class JAXBBeanValidator {
     private final JAXBContext context;
 
     /**
-     * Stores the {@link javax.validation.Validator} implementation. Once found, the reference is preserved.
+     * Stores the {@link jakarta.validation.Validator} implementation. Once found, the reference is preserved.
      */
     private Validator validator;
 
     /**
-     * Stores constraint violations returned by last call to {@link javax.validation.Validator#validate(Object, Class[])}.
+     * Stores constraint violations returned by last call to {@link jakarta.validation.Validator#validate(Object, Class[])}.
      * <p>After each {@link #validate(Object, Class[])} call, the reference is replaced.
      */
     private Set<ConstraintViolation<Object>> constraintViolations = Collections.emptySet();
@@ -102,7 +102,7 @@ class JAXBBeanValidator {
      * Computed value saying if the validation can proceed under current conditions, represented by:
      * <blockquote><pre>
      *     - {@link #beanValidationMode}
-     *     - {@link javax.validation.Validator} implementation present on classpath
+     *     - {@link jakarta.validation.Validator} implementation present on classpath
      * </pre></blockquote>
      * <p>
      * Value is recomputed only on {@link #changeInternalState()} call.
@@ -117,11 +117,11 @@ class JAXBBeanValidator {
 
     /**
      * This field will usually be {@code null}. However, user may pass his own instance of
-     * {@link javax.validation.ValidatorFactory} to
+     * {@link jakarta.validation.ValidatorFactory} to
      * {@link #shouldValidate}() method, and it will be assigned to this field.
      * <p>
      * If not null, {@link #validator} field will be assigned only by calling method
-     * {@link javax.validation.ValidatorFactory#getValidator()} the instance assigned to this field.
+     * {@link jakarta.validation.ValidatorFactory#getValidator()} the instance assigned to this field.
      */
     private ValidatorFactory validatorFactory;
 

--- a/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/JAXBContext.java
+++ b/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/JAXBContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -68,7 +68,6 @@ import org.eclipse.persistence.internal.jaxb.WrappedValue;
 import org.eclipse.persistence.internal.jaxb.json.schema.JsonSchemaGenerator;
 import org.eclipse.persistence.internal.jaxb.json.schema.model.JsonSchema;
 import org.eclipse.persistence.internal.jaxb.many.ManyValue;
-import org.eclipse.persistence.internal.localization.JAXBLocalization;
 import org.eclipse.persistence.internal.oxm.Constants;
 import org.eclipse.persistence.internal.oxm.Root;
 import org.eclipse.persistence.internal.oxm.XMLConversionManager;
@@ -235,7 +234,7 @@ public class JAXBContext extends javax.xml.bind.JAXBContext {
     }
 
     /**
-     * Initializes bean validation if javax.validation.api bundle is on the class path.
+     * Initializes bean validation if jakarta.validation.api bundle is on the class path.
      */
     private void initBeanValidation() {
         if (beanValidationPresent == null) {

--- a/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/JAXBContextProperties.java
+++ b/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/JAXBContextProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -345,7 +345,7 @@ public class JAXBContextProperties {
 
     /**
      * Property for setting preferred or custom validator factory.
-     * Mapped value must be of type {@link javax.validation.ValidatorFactory}.
+     * Mapped value must be of type {@link jakarta.validation.ValidatorFactory}.
      *
      * @since 2.6
      * @see org.eclipse.persistence.jaxb.MarshallerProperties#BEAN_VALIDATION_FACTORY

--- a/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/JAXBMarshaller.java
+++ b/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/JAXBMarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -103,7 +103,7 @@ public class JAXBMarshaller implements javax.xml.bind.Marshaller {
 
     private BeanValidationMode beanValidationMode;
 
-    // The actual type is ValidatorFactory. It's done due to optional nature of javax.validation.
+    // The actual type is ValidatorFactory. It's done due to optional nature of jakarta.validation.
     private Object prefValidatorFactory;
     private boolean bvNoOptimisation = false;
     private Class<?>[] beanValidationGroups;

--- a/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/JAXBUnmarshaller.java
+++ b/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/JAXBUnmarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -54,7 +54,6 @@ import org.eclipse.persistence.internal.jaxb.IDResolverWrapper;
 import org.eclipse.persistence.internal.jaxb.ObjectGraphImpl;
 import org.eclipse.persistence.internal.jaxb.WrappedValue;
 import org.eclipse.persistence.internal.jaxb.many.ManyValue;
-import org.eclipse.persistence.internal.localization.JAXBLocalization;
 import org.eclipse.persistence.internal.oxm.Constants;
 import org.eclipse.persistence.internal.oxm.Root;
 import org.eclipse.persistence.internal.oxm.StrBuffer;
@@ -106,7 +105,7 @@ public class JAXBUnmarshaller implements Unmarshaller {
 
     private BeanValidationMode beanValidationMode;
 
-    // The actual type is ValidatorFactory. It's done due to optional nature of javax.validation.
+    // The actual type is ValidatorFactory. It's done due to optional nature of jakarta.validation.
     private Object prefValidatorFactory;
     private boolean bvNoOptimisation = false;
     private Class<?>[] beanValidationGroups;

--- a/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/MarshallerProperties.java
+++ b/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/MarshallerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -306,7 +306,7 @@ public class MarshallerProperties {
 
     /**
      * Property for setting preferred or custom validator factory.
-     * Mapped value must be instance of {@link javax.validation.ValidatorFactory}.
+     * Mapped value must be instance of {@link jakarta.validation.ValidatorFactory}.
      *
      * @since 2.6
      * @see org.eclipse.persistence.jaxb.JAXBContextProperties#BEAN_VALIDATION_FACTORY

--- a/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/UnmarshallerProperties.java
+++ b/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/UnmarshallerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -287,7 +287,7 @@ public class UnmarshallerProperties {
 
     /**
      * Property for setting preferred or custom validator factory.
-     * Mapped value must be instance of {@link javax.validation.ValidatorFactory}.
+     * Mapped value must be instance of {@link jakarta.validation.ValidatorFactory}.
      *
      * @since 2.6
      * @see org.eclipse.persistence.jaxb.JAXBContextProperties#BEAN_VALIDATION_FACTORY

--- a/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/compiler/AnnotationsProcessor.java
+++ b/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/compiler/AnnotationsProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -33,14 +33,14 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import javax.validation.constraints.DecimalMax;
-import javax.validation.constraints.DecimalMin;
-import javax.validation.constraints.Digits;
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
-import javax.validation.constraints.Size;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
 import javax.xml.bind.annotation.XmlAccessorOrder;

--- a/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/compiler/facets/PatternFacet.java
+++ b/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/compiler/facets/PatternFacet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,7 +14,7 @@
 //     Marcel Valovy - 2.6 - initial implementation
 package org.eclipse.persistence.jaxb.compiler.facets;
 
-import javax.validation.constraints.Pattern;
+import jakarta.validation.constraints.Pattern;
 
 /**
  * @author Marcel Valovy - marcel.valovy@oracle.com
@@ -24,7 +24,7 @@ public class PatternFacet implements Facet {
 
     private final String regexp;
 
-    private final javax.validation.constraints.Pattern.Flag[] flags;
+    private final jakarta.validation.constraints.Pattern.Flag[] flags;
 
     public PatternFacet(String regexp, Pattern.Flag[] flags) {
         this.regexp = regexp;

--- a/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/plugins/BeanValidationPlugin.java
+++ b/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/plugins/BeanValidationPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -180,7 +180,7 @@ public class BeanValidationPlugin extends Plugin {
     @Override
     public String getUsage() {
         return "  -" + PLUGIN_OPTION + "           :  convert xsd restrictions to" +
-                " javax.validation annotations. Usage with mods: -" + PLUGIN_OPTION
+                " jakarta.validation annotations. Usage with mods: -" + PLUGIN_OPTION
                 + " " + JSR_303_MOD + " " + SIMPLE_REGEX_MOD;
     }
 
@@ -235,18 +235,18 @@ public class BeanValidationPlugin extends Plugin {
     private static final JCodeModel CODEMODEL = new JCodeModel();
 
     static {
-        ANNOTATION_VALID = CODEMODEL.ref("javax.validation.Valid");
-        ANNOTATION_NOTNULL = CODEMODEL.ref("javax.validation.constraints.NotNull");
-        ANNOTATION_SIZE = CODEMODEL.ref("javax.validation.constraints.Size");
-        ANNOTATION_DECIMALMIN = CODEMODEL.ref("javax.validation.constraints.DecimalMin");
-        ANNOTATION_DECIMALMAX = CODEMODEL.ref("javax.validation.constraints.DecimalMax");
-        ANNOTATION_DIGITS = CODEMODEL.ref("javax.validation.constraints.Digits");
-        ANNOTATION_PATTERN = CODEMODEL.ref("javax.validation.constraints.Pattern");
-        ANNOTATION_PATTERNLIST = CODEMODEL.ref("javax.validation.constraints.Pattern.List");
-        ANNOTATION_ASSERTFALSE = CODEMODEL.ref("javax.validation.constraints.AssertFalse");
-        ANNOTATION_ASSERTTRUE = CODEMODEL.ref("javax.validation.constraints.AssertTrue");
-        ANNOTATION_FUTURE = CODEMODEL.ref("javax.validation.constraints.Future");
-        ANNOTATION_PAST = CODEMODEL.ref("javax.validation.constraints.Past");
+        ANNOTATION_VALID = CODEMODEL.ref("jakarta.validation.Valid");
+        ANNOTATION_NOTNULL = CODEMODEL.ref("jakarta.validation.constraints.NotNull");
+        ANNOTATION_SIZE = CODEMODEL.ref("jakarta.validation.constraints.Size");
+        ANNOTATION_DECIMALMIN = CODEMODEL.ref("jakarta.validation.constraints.DecimalMin");
+        ANNOTATION_DECIMALMAX = CODEMODEL.ref("jakarta.validation.constraints.DecimalMax");
+        ANNOTATION_DIGITS = CODEMODEL.ref("jakarta.validation.constraints.Digits");
+        ANNOTATION_PATTERN = CODEMODEL.ref("jakarta.validation.constraints.Pattern");
+        ANNOTATION_PATTERNLIST = CODEMODEL.ref("jakarta.validation.constraints.Pattern.List");
+        ANNOTATION_ASSERTFALSE = CODEMODEL.ref("jakarta.validation.constraints.AssertFalse");
+        ANNOTATION_ASSERTTRUE = CODEMODEL.ref("jakarta.validation.constraints.AssertTrue");
+        ANNOTATION_FUTURE = CODEMODEL.ref("jakarta.validation.constraints.Future");
+        ANNOTATION_PAST = CODEMODEL.ref("jakarta.validation.constraints.Past");
         ANNOTATION_XMLELEMENT = CODEMODEL.ref("javax.xml.bind.annotation.XmlElement");
     }
 

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/beanvalidation/BeanValidationBindingsTestCase.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/beanvalidation/BeanValidationBindingsTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -19,16 +19,16 @@ import com.sun.tools.xjc.Driver;
 import org.eclipse.persistence.jaxb.compiler.Generator;
 
 import javax.tools.Diagnostic;
-import javax.validation.Valid;
-import javax.validation.constraints.AssertFalse;
-import javax.validation.constraints.AssertTrue;
-import javax.validation.constraints.DecimalMax;
-import javax.validation.constraints.DecimalMin;
-import javax.validation.constraints.Future;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Past;
-import javax.validation.constraints.Pattern;
-import javax.validation.constraints.Size;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertFalse;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 import org.eclipse.persistence.jaxb.javamodel.reflection.JavaModelImpl;
 import org.eclipse.persistence.jaxb.javamodel.reflection.JavaModelInputImpl;

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/beanvalidation/BeanValidationRuntimeTestCase.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/beanvalidation/BeanValidationRuntimeTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -30,9 +30,9 @@ import org.eclipse.persistence.testing.jaxb.beanvalidation.dom.Employee;
 import org.junit.After;
 import org.junit.Before;
 
-import javax.validation.Validation;
-import javax.validation.ValidatorFactory;
-import javax.validation.groups.Default;
+import jakarta.validation.Validation;
+import jakarta.validation.ValidatorFactory;
+import jakarta.validation.groups.Default;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
@@ -55,12 +55,12 @@ import java.util.Set;
 public class BeanValidationRuntimeTestCase extends junit.framework.TestCase {
 
     private static final String RESOURCES_PATH_RELATIVE = "org/eclipse/persistence/testing/jaxb/beanvalidation/rt/";
-    private static final String JAVAX_NOT_NULL_MESSAGE = "{javax.validation.constraints.NotNull.message}";
-    private static final String JAVAX_MIN_MESSAGE = "{javax.validation.constraints.Min.message}";
-    private static final String JAVAX_SIZE_MESSAGE = "{javax.validation.constraints.Size.message}";
-    private static final String JAVAX_PATTERN_MESSAGE = "{javax.validation.constraints.Pattern.message}";
-    private static final String JAVAX_FUTURE_MESSAGE = "{javax.validation.constraints.Future.message}";
-    private static final String JAVAX_DIGITS_MESSAGE = "{javax.validation.constraints.Digits.message}";
+    private static final String JAVAX_NOT_NULL_MESSAGE = "{jakarta.validation.constraints.NotNull.message}";
+    private static final String JAVAX_MIN_MESSAGE = "{jakarta.validation.constraints.Min.message}";
+    private static final String JAVAX_SIZE_MESSAGE = "{jakarta.validation.constraints.Size.message}";
+    private static final String JAVAX_PATTERN_MESSAGE = "{jakarta.validation.constraints.Pattern.message}";
+    private static final String JAVAX_FUTURE_MESSAGE = "{jakarta.validation.constraints.Future.message}";
+    private static final String JAVAX_DIGITS_MESSAGE = "{jakarta.validation.constraints.Digits.message}";
     private static final Class[] EMPLOYEE = new Class[]{Employee.class};
     private static final boolean DEBUG = false;
 

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/beanvalidation/BeanValidationSpecialtiesTestCase.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/beanvalidation/BeanValidationSpecialtiesTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -28,19 +28,19 @@ import org.eclipse.persistence.testing.jaxb.beanvalidation.special.InheritanceAn
 import org.eclipse.persistence.testing.jaxb.beanvalidation.special.MethodAnnotatedEmployee;
 import org.eclipse.persistence.testing.jaxb.beanvalidation.special.NonConstrainedClass;
 
-import javax.validation.ClockProvider;
-import javax.validation.ConstraintValidatorFactory;
-import javax.validation.ConstraintViolation;
-import javax.validation.MessageInterpolator;
-import javax.validation.ParameterNameProvider;
-import javax.validation.Path;
-import javax.validation.TraversableResolver;
-import javax.validation.Validator;
-import javax.validation.ValidatorContext;
-import javax.validation.ValidatorFactory;
-import javax.validation.executable.ExecutableValidator;
-import javax.validation.metadata.BeanDescriptor;
-import javax.validation.metadata.ConstraintDescriptor;
+import jakarta.validation.ClockProvider;
+import jakarta.validation.ConstraintValidatorFactory;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.MessageInterpolator;
+import jakarta.validation.ParameterNameProvider;
+import jakarta.validation.Path;
+import jakarta.validation.TraversableResolver;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorContext;
+import jakarta.validation.ValidatorFactory;
+import jakarta.validation.executable.ExecutableValidator;
+import jakarta.validation.metadata.BeanDescriptor;
+import jakarta.validation.metadata.ConstraintDescriptor;
 import javax.xml.bind.SchemaOutputResolver;
 import javax.xml.transform.Result;
 import javax.xml.transform.stream.StreamResult;
@@ -65,7 +65,7 @@ import static org.eclipse.persistence.testing.jaxb.beanvalidation.ContentCompara
  */
 public class BeanValidationSpecialtiesTestCase extends junit.framework.TestCase {
 
-    private static final String NOT_NULL_MESSAGE = "{javax.validation.constraints.NotNull.message}";
+    private static final String NOT_NULL_MESSAGE = "{jakarta.validation.constraints.NotNull.message}";
     private static final String CUSTOM_ANNOTATION_MESSAGE = "{org.eclipse.persistence.moxy.CustomAnnotation.message}";
 
     private static final String GENERATOR_SCHEMA_WITH_FACETS =

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/beanvalidation/ValidationXMLTestCase.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/beanvalidation/ValidationXMLTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -24,7 +24,7 @@ import org.eclipse.persistence.testing.jaxb.beanvalidation.special.ExternallyCon
 import org.junit.After;
 import org.junit.Before;
 
-import javax.validation.Validation;
+import jakarta.validation.Validation;
 import java.io.StringWriter;
 import java.lang.reflect.Field;
 import java.net.URL;
@@ -36,8 +36,8 @@ import java.util.Set;
  */
 public class ValidationXMLTestCase extends junit.framework.TestCase {
 
-    private static final String NOT_NULL_MESSAGE = "{javax.validation.constraints.NotNull.message}";
-    private static final String MIN_MESSAGE = "{javax.validation.constraints.Min.message}";
+    private static final String NOT_NULL_MESSAGE = "{jakarta.validation.constraints.NotNull.message}";
+    private static final String MIN_MESSAGE = "{jakarta.validation.constraints.Min.message}";
     private static final String MOXY_JAXBCONTEXT_FACTORY = JAXBContextFactory.class.getName();
     private static final String SYSTEM_PROPERTY_JAXBCONTEXT = "javax.xml.bind.JAXBContext";
     private static final String VALIDATION_XML = "META-INF/validation.xml";

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/beanvalidation/dom/DrivingLicense.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/beanvalidation/dom/DrivingLicense.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,8 +14,8 @@
 //     Marcel Valovy - 2.6 - initial implementation
 package org.eclipse.persistence.testing.jaxb.beanvalidation.dom;
 
-import javax.validation.constraints.Digits;
-import javax.validation.constraints.Future;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.Future;
 import javax.xml.bind.annotation.XmlAttribute;
 import java.util.Date;
 

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/beanvalidation/dom/Employee.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/beanvalidation/dom/Employee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,11 +14,11 @@
 //     Marcel Valovy - 2.6.0 - initial implementation
 package org.eclipse.persistence.testing.jaxb.beanvalidation.dom;
 
-import javax.validation.Valid;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
-import javax.validation.constraints.Size;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/beanvalidation/special/ConstructorAnnotatedEmployee.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/beanvalidation/special/ConstructorAnnotatedEmployee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,8 +14,8 @@
 //     Marcel Valovy - 2.6.0 - initial implementation
 package org.eclipse.persistence.testing.jaxb.beanvalidation.special;
 
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
 

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/beanvalidation/special/CustomAnnotation.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/beanvalidation/special/CustomAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,8 +15,8 @@
 // ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 package org.eclipse.persistence.testing.jaxb.beanvalidation.special;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/beanvalidation/special/CustomAnnotationValidator.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/beanvalidation/special/CustomAnnotationValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,8 +14,8 @@
 // Marcel Valovy - initial API and implementation
 package org.eclipse.persistence.testing.jaxb.beanvalidation.special;
 
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 
 /**
  * @author Marcel Valovy

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/beanvalidation/special/MethodAnnotatedEmployee.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/beanvalidation/special/MethodAnnotatedEmployee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,7 +14,7 @@
 //     Marcel Valovy - 2.6.0 - initial implementation
 package org.eclipse.persistence.testing.jaxb.beanvalidation.special;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
 

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/schemagen/classarray/RootElement.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/schemagen/classarray/RootElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,8 +14,8 @@
 // Radek Felcman - 02/2019 - Initial implementation
 package org.eclipse.persistence.testing.jaxb.schemagen.classarray;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/schemagen/employee/Employee.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/schemagen/employee/Employee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,9 +14,9 @@
 //     Oracle - initial API and implementation from Oracle TopLink
 package org.eclipse.persistence.testing.jaxb.schemagen.employee;
 
-import javax.validation.Valid;
-import javax.validation.constraints.DecimalMax;
-import javax.validation.constraints.Size;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.Size;
 import javax.xml.bind.annotation.*;
 
 @XmlRootElement(name="employee-data")

--- a/moxy/org.eclipse.persistence.moxy/src/test/resources/org/eclipse/persistence/testing/jaxb/beanvalidation/constraints.xml
+++ b/moxy/org.eclipse.persistence.moxy/src/test/resources/org/eclipse/persistence/testing/jaxb/beanvalidation/constraints.xml
@@ -20,7 +20,7 @@
     <default-package>org.eclipse.persistence.testing.jaxb.beanvalidation.special</default-package>
     <bean class="ExternallyConstrainedEmployee" ignore-annotations="false">
         <field name="id">
-            <constraint annotation="javax.validation.constraints.NotNull"/>
+            <constraint annotation="jakarta.validation.constraints.NotNull"/>
         </field>
     </bean>
 </constraint-mappings>

--- a/moxy/org.eclipse.persistence.moxy/src/test/resources/org/eclipse/persistence/testing/jaxb/beanvalidation/constraints2.xml
+++ b/moxy/org.eclipse.persistence.moxy/src/test/resources/org/eclipse/persistence/testing/jaxb/beanvalidation/constraints2.xml
@@ -20,7 +20,7 @@
     <default-package>org.eclipse.persistence.testing.jaxb.beanvalidation.special</default-package>
     <bean class="ExternallyConstrainedEmployee2" ignore-annotations="false">
         <field name="age">
-            <constraint annotation="javax.validation.constraints.Min">
+            <constraint annotation="jakarta.validation.constraints.Min">
                 <element name="value">18</element>
             </constraint>
         </field>

--- a/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/beanvalidation/CustomAnnotation.java
+++ b/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/beanvalidation/CustomAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,8 +14,8 @@
 //     Marcel Valovy - 2.6 - initial implementation
 package org.eclipse.persistence.testing.perf.beanvalidation;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/beanvalidation/CustomAnnotationValidator.java
+++ b/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/beanvalidation/CustomAnnotationValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,8 +14,8 @@
 //     Marcel Valovy - 2.6 - initial implementation
 package org.eclipse.persistence.testing.perf.beanvalidation;
 
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 
 public class CustomAnnotationValidator implements ConstraintValidator<CustomAnnotation, Integer> {
 

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <activation.version>1.2.1</activation.version>
         <cdi.version>2.0.2</cdi.version>
         <ejb.version>3.2.6</ejb.version>
-        <el.version>3.0.3</el.version>
+        <el.version>4.0.0-RC1</el.version>
         <glassfish.version>5.1.0</glassfish.version>
         <jaxb.version>2.3.2</jaxb.version>
         <jersey.version>2.29.1</jersey.version>
@@ -131,7 +131,7 @@
         <resource.version>1.7.4</resource.version>
         <servlet.version>4.0.3</servlet.version>
         <transaction.varsion>1.3.3</transaction.varsion>
-        <validation.version>2.0.2</validation.version>
+        <validation.version>3.0.0-M1</validation.version>
         <ws-api.version>2.3.2</ws-api.version>
         <ws-rs.version>2.1.6</ws-rs.version>
 
@@ -150,7 +150,7 @@
         <exam.version>4.13.1</exam.version>
         <hamcrest.version>1.3</hamcrest.version>
         <!-- CQ #3571 -->
-        <hibernate.version>6.1.0.Final</hibernate.version>
+        <hibernate.version>7.0.0.Alpha1</hibernate.version>
         <!-- CQ #21122 -->
         <jgroups.version>4.1.8.Final</jgroups.version>
         <jmh.version>1.21</jmh.version>


### PR DESCRIPTION
Signed-off-by: Gaurav Gupta <gaurav.gupta@payara.fish>

**Component Upgrade:**
- `jakarta.validation:jakarta.validation-api:3.0.0-M1`
- `org.hibernate.validator:hibernate-validator:7.0.0.Alpha1`
- `org.glassfish:jakarta.el:4.0.0-RC1`

