### PR TITLE
proper way to disable non-compilable tests dependend on Jersey for now

### DIFF
--- a/jpa/org.eclipse.persistence.jpars/pom.xml
+++ b/jpa/org.eclipse.persistence.jpars/pom.xml
@@ -132,15 +132,31 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
+
+            <!-- TODO: disable compilation/running tests
+                till Jakarta version of Jersey  becomes available -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+<!--
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
                     <workingDirectory>${project.build.directory}/test-run</workingDirectory>
-                    <!--EclipseLink Weaving is enabled.
-                        When it will be disabled by -Dignore or without arg switch it leads into test errors-->
+                    <!- -EclipseLink Weaving is enabled.
+                        When it will be disabled by -Dignore or without arg switch it leads into test errors- ->
                     <argLine>-javaagent:${org.eclipse.persistence:org.eclipse.persistence.jpa:jar}</argLine>
-                    <!--Set system properties required for tests-->
+                    <!- -Set system properties required for tests- ->
                     <systemPropertiesFile>${test.properties.file}</systemPropertiesFile>
                 </configuration>
                 <executions>
@@ -188,6 +204,7 @@
                     </execution>
                 </executions>
             </plugin>
+-->
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
 
         <module>jpa/org.eclipse.persistence.jpa</module>
         <module>jpa/org.eclipse.persistence.jpa.modelgen</module>
-<!--        <module>jpa/org.eclipse.persistence.jpars</module>--> <!-- TODO: revert after Jersey jakartification -->
+        <module>jpa/org.eclipse.persistence.jpars</module>
         <module>jpa/org.eclipse.persistence.jpa.test.framework</module>
 
         <module>foundation/org.eclipse.persistence.corba</module>
@@ -1293,12 +1293,6 @@
             <properties>
                 <test.skip.in-memory.db>true</test.skip.in-memory.db>
             </properties>
-        </profile>
-        <profile>
-            <id>excluded_due_to_jakartification</id>
-            <modules>
-                <module>jpa/org.eclipse.persistence.jpars</module>
-            </modules>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
this fixes failing build in master after the move to jakarta

Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>