### PR TITLE
[master] EclipseLink release pipeline and script.

### DIFF
--- a/bundles/eclipselink/pom.xml
+++ b/bundles/eclipselink/pom.xml
@@ -31,7 +31,6 @@
     </parent>
 
     <properties>
-        <maven.deploy.skip>false</maven.deploy.skip>
         <archive.tmp.dir>archive-tmp</archive.tmp.dir>
         <test.jars.tmp.dir>eclipselink-test-jars</test.jars.tmp.dir>
 

--- a/bundles/p2site/pom.xml
+++ b/bundles/p2site/pom.xml
@@ -30,6 +30,10 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <skipNexusStagingDeployMojo>false</skipNexusStagingDeployMojo>
+    </properties>
+
     <dependencies>
         <!--Binary dependencies-->
         <!--Other modules-->

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -32,9 +32,6 @@
 
     <modules>
         <module>eclipselink</module>
-        <module>others</module>
-        <module>distribution</module>
-        <module>p2site</module>
     </modules>
 
     <profiles>
@@ -42,6 +39,19 @@
             <id>test-lrg</id>
             <modules>
                 <module>nightly</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>no-deploy</id>
+            <activation>
+                <property>
+                    <name>!deploy</name>
+                </property>
+            </activation>
+            <modules>
+                <module>others</module>
+                <module>distribution</module>
+                <module>p2site</module>
             </modules>
         </profile>
     </profiles>

--- a/dbws/org.eclipse.persistence.dbws/pom.xml
+++ b/dbws/org.eclipse.persistence.dbws/pom.xml
@@ -31,7 +31,6 @@
     </parent>
 
     <properties>
-        <maven.deploy.skip>false</maven.deploy.skip>
         <test-skip-dbws>${skipTests}</test-skip-dbws>
     </properties>
 

--- a/etc/jenkins/release.groovy
+++ b/etc/jenkins/release.groovy
@@ -1,0 +1,131 @@
+// Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Distribution License v. 1.0, which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+// Job input parameters:
+//  GIT_REPOSITORY_URL     - Git repository location (URL)
+//  GIT_BRANCH             - Git branch
+//  RELEASE_VERSION        - Version to release
+//  NEXT_VERSION           - Next snapshot version to set (e.g. 3.0.1-SNAPSHOT).
+//  DRY_RUN                - Do not publish artifacts to OSSRH and code changes to GitHub.
+
+
+pipeline {
+    agent {
+        kubernetes {
+            label 'el-master-agent-pod'
+            yaml """
+apiVersion: v1
+kind: Pod
+spec:
+
+  volumes:
+  - name: tools
+    persistentVolumeClaim:
+      claimName: tools-claim-jiro-eclipselink
+  - name: volume-known-hosts
+    configMap:
+      name: known-hosts      
+  - name: settings-xml
+    secret:
+      secretName: m2-secret-dir
+      items:
+      - key: settings.xml
+        path: settings.xml
+  - name: toolchains-xml
+    configMap:
+      name: m2-dir
+      items:
+      - key: toolchains.xml
+        path: toolchains.xml
+  - name: settings-security-xml
+    secret:
+      secretName: m2-secret-dir
+      items:
+      - key: settings-security.xml
+        path: settings-security.xml
+  - name: m2-repo
+    emptyDir: {}
+    
+  containers:
+
+  - name: el-build
+    resources:
+      limits:
+        memory: "2Gi"
+        cpu: "1"
+      requests:
+        memory: "2Gi"
+        cpu: "1"
+    image: tkraus/el-build:1.1.8
+    volumeMounts:
+    - name: tools
+      mountPath: /opt/tools
+    - name: volume-known-hosts
+      mountPath: /home/jenkins/.ssh      
+    - name: settings-xml
+      mountPath: /home/jenkins/.m2/settings.xml
+      subPath: settings.xml
+      readOnly: true
+    - name: toolchains-xml
+      mountPath: /home/jenkins/.m2/toolchains.xml
+      subPath: toolchains.xml
+      readOnly: true
+    - name: settings-security-xml
+      mountPath: /home/jenkins/.m2/settings-security.xml
+      subPath: settings-security.xml
+      readOnly: true
+    - name: m2-repo
+      mountPath: /home/jenkins/.m2/repository
+    tty: true
+    command:
+    - cat
+"""
+        }
+    }
+    stages {
+
+        // Prepare and promote EclipseLink artifacts to oss.sonatype.org (staging) and to the Eclipse.org Milestone Builds area
+        // Initialize release/build environment
+        stage('Init') {
+            steps {
+                container('el-build') {
+                    git branch: '${GIT_BRANCH}', url: '${GIT_REPOSITORY_URL}'
+                    sshagent(['SSH_CREDENTIALS_ID']) {
+                        sh """
+                            # Directory for JEE server binaries (WildFly, Glassfish)
+                            # Maven build automatically download and unpack them.
+                            mkdir ~/.eclipselinktests
+                            """
+                    }
+                    withCredentials([file(credentialsId: 'secret-subkeys.asc', variable: 'KEYRING')]) {
+                        sh label: '', script: '''
+                            gpg --batch --import "${KEYRING}"
+                            for fpr in $(gpg --list-keys --with-colons  | awk -F: \'/fpr:/ {print $10}\' | sort -u);
+                            do
+                                echo -e "5\\ny\\n" |  gpg --batch --command-fd 0 --expert --edit-key $fpr trust;
+                            done'''
+                    }
+                }
+            }
+        }
+
+        // Build and release EclipseLink by release.sh script
+        stage('Build and release EclipseLink') {
+            steps {
+                container('el-build') {
+                    git branch: '${GIT_BRANCH}', url: '${GIT_REPOSITORY_URL}'
+                    sshagent(['SSH_CREDENTIALS_ID']) {
+                        sh """
+                            etc/jenkins/release.sh "${RELEASE_VERSION}" "${NEXT_VERSION}" "${DRY_RUN}"
+                        """
+                    }
+                }
+            }
+        }
+    }
+}

--- a/etc/jenkins/release.sh
+++ b/etc/jenkins/release.sh
@@ -1,0 +1,67 @@
+#!/bin/bash -e
+#
+# Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Distribution License v. 1.0, which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Maven plugins
+VERSIONS_PLUGIN='org.codehaus.mojo:versions-maven-plugin:2.7'
+HELP_PLUGIN='org.apache.maven.plugins:maven-help-plugin:3.1.0'
+#
+# Arguments:
+# $1 -  RELEASE_VERSION        - Version to release
+# $2 -  NEXT_VERSION           - Next snapshot version to set (e.g. 3.0.1-SNAPSHOT).
+# $3 -  DRY_RUN                - Do not publish artifacts to OSSRH and code changes to GitHub.
+
+echo '-[ EclipseLink Release ]-----------------------------------------------------------'
+. /etc/profile
+
+RELEASE_VERSION="${1}"
+NEXT_VERSION="${2}"
+DRY_RUN="${3}"
+
+CURRENT_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+
+echo "-[ Current Version: ${CURRENT_VERSION} ]-----------------------------------------------------------"
+echo "-[ Release Version: ${RELEASE_VERSION} ]-----------------------------------------------------------"
+
+# Project identifiers
+ARTIFACT_ID=$(mvn -B ${HELP_PLUGIN}:evaluate -Dexpression=project.artifactId -Pstaging | grep -Ev '(^\[)')
+GROUP_ID=$(mvn -B ${HELP_PLUGIN}:evaluate -Dexpression=project.groupId -Pstaging | grep -Ev '(^\[)')
+STAGING_DESC="${GROUP_ID}:${ARTIFACT_ID}:${RELEASE_VERSION}"
+STAGING_KEY=$(echo ${STAGING_DESC} | sed -e 's/\./\\\./g')
+
+if [ ${DRY_RUN} = 'true' ]; then
+  echo '-[ Dry run turned on ]----------------------------------------------------------'
+  MVN_DEPLOY_ARGS='install'
+else
+  MVN_DEPLOY_ARGS='deploy'
+fi
+
+echo '-[ mvn version set ]--------------------------------------'
+mvn --no-transfer-progress -DnewVersion=${RELEASE_VERSION} -DgenerateBackupPoms=false -Doracle.modules.subdirectory=bundles clean org.codehaus.mojo:versions-maven-plugin:2.7:set
+echo '-[ mvn version update-parent oracle]--------------------------------------'
+#Command mvn -N -DgenerateBackupPoms=false -Doracle.modules.subdirectory=bundles clean org.codehaus.mojo:versions-maven-plugin:2.7:update-parent -f bundles/org.eclipse.persistence.oracle/pom.xml
+#doesn't work there because there is path to the module based on property e.g. ${oracle.modules.subdirectory}/org.eclipse.persistence.oracle
+sed -i 's/'${CURRENT_VERSION}'/'${RELEASE_VERSION}'/g' bundles/org.eclipse.persistence.oracle/pom.xml
+echo '-[ mvn version update-parent oracle.nosql]--------------------------------------'
+#Command mvn -N -DgenerateBackupPoms=false -Doracle.modules.subdirectory=bundles clean org.codehaus.mojo:versions-maven-plugin:2.7:update-parent -f bundles/org.eclipse.persistence.oracle.nosql/pom.xml
+#doesn't work there because there is path to the module based on property e.g. ${oracle.modules.subdirectory}/org.eclipse.persistence.oracle.nosql
+sed -i 's/'${CURRENT_VERSION}'/'${RELEASE_VERSION}'/g' bundles/org.eclipse.persistence.oracle.nosql/pom.xml
+echo '-[ mvn version update-parent ALL]--------------------------------------'
+mvn -DparentVersion=${RELEASE_VERSION} -DgenerateBackupPoms=false -Doracle.modules.subdirectory=bundles clean org.codehaus.mojo:versions-maven-plugin:2.7:update-parent
+
+echo '-[ Build project mvn clean install ]-----------------------------'
+#This step is needed to populate local Maven repository with required but not deployed artifacts
+mvn --no-transfer-progress -DskipTests clean install
+#Deploy selected artifacts. There is Maven property -Ddeploy to control which modules will be deployed
+echo '-[ Deploy artifacts to staging repository ]-----------------------------'
+mvn --no-transfer-progress -U -C -B -Poss-release,staging \
+    -DskipTests -Ddoclint=none \
+    -DstagingDescription="${STAGING_DESC}" \
+    -Ddeploy \
+    clean ${MVN_DEPLOY_ARGS}

--- a/foundation/org.eclipse.persistence.corba/pom.xml
+++ b/foundation/org.eclipse.persistence.corba/pom.xml
@@ -31,7 +31,6 @@
     </parent>
 
     <properties>
-        <maven.deploy.skip>false</maven.deploy.skip>
         <!--Properties used for test resources filtering/replacement-->
         <!--DB connection properties-->
         <dbPlatform>${db.platform}</dbPlatform>

--- a/foundation/org.eclipse.persistence.core/pom.xml
+++ b/foundation/org.eclipse.persistence.core/pom.xml
@@ -30,10 +30,6 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <properties>
-        <maven.deploy.skip>false</maven.deploy.skip>
-    </properties>
-
     <dependencies>
         <!--Other modules-->
         <dependency>

--- a/foundation/org.eclipse.persistence.extension/pom.xml
+++ b/foundation/org.eclipse.persistence.extension/pom.xml
@@ -30,10 +30,6 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <properties>
-        <maven.deploy.skip>false</maven.deploy.skip>
-    </properties>
-
     <dependencies>
         <!--Other modules-->
         <dependency>

--- a/foundation/org.eclipse.persistence.nosql/pom.xml
+++ b/foundation/org.eclipse.persistence.nosql/pom.xml
@@ -31,7 +31,6 @@
     </parent>
 
     <properties>
-        <maven.deploy.skip>false</maven.deploy.skip>
         <test-skip-nosql>true</test-skip-nosql>
     </properties>
 

--- a/foundation/org.eclipse.persistence.oracle.nosql/pom.xml
+++ b/foundation/org.eclipse.persistence.oracle.nosql/pom.xml
@@ -31,7 +31,6 @@
     </parent>
 
     <properties>
-        <maven.deploy.skip>false</maven.deploy.skip>
         <!--Distribution directory-->
         <distribution.directory>${project.root.location}/bundles/org.eclipse.persistence.oracle.nosql/src/main/dependencies</distribution.directory>
         <test-skip-oracle-nosql>${skipTests}</test-skip-oracle-nosql>

--- a/foundation/org.eclipse.persistence.oracle/pom.xml
+++ b/foundation/org.eclipse.persistence.oracle/pom.xml
@@ -31,7 +31,6 @@
     </parent>
 
     <properties>
-        <maven.deploy.skip>false</maven.deploy.skip>
         <!--Distribution directory-->
         <distribution.directory>${project.root.location}/bundles/org.eclipse.persistence.oracle/src/main/dependencies</distribution.directory>
     </properties>

--- a/jpa/org.eclipse.persistence.jpa.jpql/pom.xml
+++ b/jpa/org.eclipse.persistence.jpa.jpql/pom.xml
@@ -30,10 +30,6 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <properties>
-        <maven.deploy.skip>false</maven.deploy.skip>
-    </properties>
-
     <dependencies>
         <!--Test dependencies-->
         <dependency>

--- a/jpa/org.eclipse.persistence.jpa.modelgen/pom.xml
+++ b/jpa/org.eclipse.persistence.jpa.modelgen/pom.xml
@@ -31,7 +31,6 @@
     </parent>
 
     <properties>
-        <maven.deploy.skip>false</maven.deploy.skip>
         <test-skip-jpa-modelgen>${skipTests}</test-skip-jpa-modelgen>
     </properties>
 

--- a/jpa/org.eclipse.persistence.jpa/pom.xml
+++ b/jpa/org.eclipse.persistence.jpa/pom.xml
@@ -30,10 +30,6 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <properties>
-        <maven.deploy.skip>false</maven.deploy.skip>
-    </properties>
-
     <dependencies>
         <!--Other modules-->
         <dependency>

--- a/jpa/org.eclipse.persistence.jpars/pom.xml
+++ b/jpa/org.eclipse.persistence.jpars/pom.xml
@@ -30,7 +30,6 @@
     </parent>
 
     <properties>
-        <maven.deploy.skip>false</maven.deploy.skip>
         <!--Properties used for test resources filtering/replacement-->
         <!--DB connection properties-->
         <DB_USER>${db.user}</DB_USER>

--- a/moxy/org.eclipse.persistence.moxy/pom.xml
+++ b/moxy/org.eclipse.persistence.moxy/pom.xml
@@ -31,7 +31,6 @@
     </parent>
 
     <properties>
-        <maven.deploy.skip>false</maven.deploy.skip>
         <test-skip-moxy-jaxb-srg>${skipTests}</test-skip-moxy-jaxb-srg>
         <test-skip-moxy-jaxb>true</test-skip-moxy-jaxb>
         <test-skip-moxy-oxm-srg>${skipTests}</test-skip-moxy-oxm-srg>

--- a/plugins/org.eclipse.persistence.asm/pom.xml
+++ b/plugins/org.eclipse.persistence.asm/pom.xml
@@ -30,10 +30,6 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <properties>
-        <maven.deploy.skip>false</maven.deploy.skip>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.ow2.asm</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,6 @@
         <bundle.version>${project.version}.${build.qualifier}</bundle.version>
         <project.build.testReports.subdirectory>test-reports</project.build.testReports.subdirectory>
         <project.build.testReports.summaryFile>test-summary</project.build.testReports.summaryFile>
-        <!-- In selected/deployed modules asm, core, jpa, moxy... this property will be true -->
-        <maven.deploy.skip>true</maven.deploy.skip>
 
         <!--Common properties-->
         <common.licenceFiles>about.html, license.html, readme.html</common.licenceFiles>
@@ -182,20 +180,15 @@
 
     <!-- Default modules set and added to by all profiles -->
     <modules>
-        <!--Helper parent pom for server side test modules-->
-        <module>pom_test_server.xml</module>
 
         <module>plugins/org.eclipse.persistence.asm</module>
         <module>jpa/org.eclipse.persistence.jpa.jpql</module>
 
         <module>foundation/org.eclipse.persistence.core</module>
-        <module>foundation/org.eclipse.persistence.core.test.framework</module>
-        <module>foundation/eclipselink.core.test</module>
 
         <module>jpa/org.eclipse.persistence.jpa</module>
         <module>jpa/org.eclipse.persistence.jpa.modelgen</module>
         <module>jpa/org.eclipse.persistence.jpars</module>
-        <module>jpa/org.eclipse.persistence.jpa.test.framework</module>
 
         <module>foundation/org.eclipse.persistence.corba</module>
         <module>foundation/org.eclipse.persistence.extension</module>
@@ -207,31 +200,9 @@
         <module>dbws/org.eclipse.persistence.dbws</module>
 
         <module>sdo/org.eclipse.persistence.sdo</module>
-        <module>sdo/eclipselink.sdo.test.server</module>
 
-        <!--JPA test modules-->
-        <!--JPA test module (JSE, JEE tests)-->
-        <module>jpa/eclipselink.jpa.test</module>
-        <!--JPA NoSQL test module-->
-        <module>jpa/eclipselink.jpa.nosql.test</module>
-        <!--JPA JSE test module-->
-        <module>jpa/eclipselink.jpa.test.jse</module>
-        <!--JPA JAXRS test module-->
-        <!--TODO FIXIT Doesn't work well. Temporary disabled.
-        <module>jpa/eclipselink.jaxrs.test</module>
-        -->
-        <!--JPA Spring test module-->
-        <module>jpa/eclipselink.jpa.spring.test</module>
-        <!--JPA WDF test module-->
-        <module>jpa/eclipselink.jpa.wdf.test</module>
-        <!--JPA JPA-RS test module-->
-        <!--TODO FIXIT Doesn't work well. Temporary disabled.
-        <module>jpa/eclipselink.jpars.test</module>
-        -->
         <!--Utility modules-->
         <module>utils/org.eclipse.persistence.dbws.builder</module>
-        <module>utils/eclipselink.utils.rename</module>
-        <module>utils/eclipselink.utils.sigcompare</module>
 
         <!--Oracle Extensions-->
         <module>${oracle.modules.subdirectory}/org.eclipse.persistence.oracle</module>
@@ -927,11 +898,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
                     <version>3.1.2</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-deploy-plugin</artifactId>
-                    <version>3.0.0-M1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -1631,6 +1597,45 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>no-deploy</id>
+            <activation>
+                <property>
+                    <name>!deploy</name>
+                </property>
+            </activation>
+            <modules>
+                <!--Helper parent pom for server side test modules-->
+                <module>pom_test_server.xml</module>
+                <module>foundation/org.eclipse.persistence.core.test.framework</module>
+                <module>foundation/eclipselink.core.test</module>
+                <module>jpa/org.eclipse.persistence.jpa.test.framework</module>
+                <module>sdo/eclipselink.sdo.test.server</module>
+
+                <!--JPA test modules-->
+                <!--JPA test module (JSE, JEE tests)-->
+                <module>jpa/eclipselink.jpa.test</module>
+                <!--JPA NoSQL test module-->
+                <module>jpa/eclipselink.jpa.nosql.test</module>
+                <!--JPA JSE test module-->
+                <module>jpa/eclipselink.jpa.test.jse</module>
+                <!--JPA JAXRS test module-->
+                <!--TODO FIXIT Doesn't work well. Temporary disabled.
+                <module>jpa/eclipselink.jaxrs.test</module>
+                -->
+                <!--JPA Spring test module-->
+                <module>jpa/eclipselink.jpa.spring.test</module>
+                <!--JPA WDF test module-->
+                <module>jpa/eclipselink.jpa.wdf.test</module>
+                <!--JPA JPA-RS test module-->
+                <!--TODO FIXIT Doesn't work well. Temporary disabled.
+                <module>jpa/eclipselink.jpars.test</module>
+                -->
+
+                <module>utils/eclipselink.utils.rename</module>
+                <module>utils/eclipselink.utils.sigcompare</module>
+            </modules>
         </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -203,6 +203,7 @@
 
         <!--Utility modules-->
         <module>utils/org.eclipse.persistence.dbws.builder</module>
+        <module>utils/eclipselink.utils.rename</module>
 
         <!--Oracle Extensions-->
         <module>${oracle.modules.subdirectory}/org.eclipse.persistence.oracle</module>
@@ -1633,7 +1634,6 @@
                 <module>jpa/eclipselink.jpars.test</module>
                 -->
 
-                <module>utils/eclipselink.utils.rename</module>
                 <module>utils/eclipselink.utils.sigcompare</module>
             </modules>
         </profile>

--- a/sdo/org.eclipse.persistence.sdo/pom.xml
+++ b/sdo/org.eclipse.persistence.sdo/pom.xml
@@ -31,7 +31,6 @@
     </parent>
 
     <properties>
-        <maven.deploy.skip>false</maven.deploy.skip>
         <test-skip-sdo-srg>${skipTests}</test-skip-sdo-srg>
         <test-skip-sdo>true</test-skip-sdo>
     </properties>

--- a/utils/org.eclipse.persistence.dbws.builder/pom.xml
+++ b/utils/org.eclipse.persistence.dbws.builder/pom.xml
@@ -31,7 +31,6 @@
     </parent>
 
     <properties>
-        <maven.deploy.skip>false</maven.deploy.skip>
         <test-skip-dbws-builder>true</test-skip-dbws-builder> <!--TODO: revert after jaxws-rt is jakartified -->
     </properties>
 


### PR DESCRIPTION
This PR contains EclipseLink release pipeline and script.
Comments:
- In _release.sh_ RELEASE_VERSION is applied by _versions-maven-plugin_. But there some modules (Oracle) where path is dynamic (based on Maven property) e.g. `${oracle.modules.subdirectory}/org.eclipse.persistence.oracle`. In this case _versions-maven-plugin_ will not update `project.parent.version`. It ignores `-Doracle.modules.subdirectory` command parameter too. _sed_ text editor is used there to change required values in POMs.
- Due a limitations of nexus-staging-maven-plugin there is some change in project POMs. Modules which are not deployed are organized in Maven profile with `<id>no-deploy</id>`. Deploy command is executed with `-Ddeploy` parameter to deactivate this profile.
-git release branch (version change and tagging) in not implemented yet

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>