### PR TITLE
Jersey version jakartified

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <jaxb.version>3.0.0-M1</jaxb.version>
         <jaxb.api.version>3.0.0-RC3</jaxb.api.version>
         <soap.api.version>2.0.0-RC3</soap.api.version>
-        <jersey.version>2.30.1</jersey.version> <!-- TODO : jakartify after release -->
+        <jersey.version>3.0.0-M1</jersey.version> <!-- TODO : jakartify after release -->
         <jms.version>3.0.0-RC1</jms.version>
         <json.version>2.0.0-RC2</json.version>
         <jpa.api.version>3.0.0-RC2</jpa.api.version>


### PR DESCRIPTION
Jersey 3.0.0-M1 is visible in cetral now, so it's possible to update its dependency to jakartified version.

Signed-off-by: Maxim Nesen <maxim.nesen@oracle.com>