### PR TITLE
[2.7] JPA Eclipselink Application Throws IllegalArgumentException With Coherence Enabled - backport

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/descriptors/ClassDescriptor.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/descriptors/ClassDescriptor.java
@@ -171,6 +171,11 @@ public class ClassDescriptor extends CoreDescriptor<AttributeGroup, DescriptorEv
     protected transient Vector<DatabaseField> allFields;
     protected transient List<DatabaseField> selectionFields;
     protected transient List<DatabaseField> allSelectionFields;
+    protected transient Vector<DatabaseField> returnFieldsToGenerateInsert;
+    protected transient Vector<DatabaseField> returnFieldsToGenerateUpdate;
+    protected transient List<DatabaseField> returnFieldsToMergeInsert;
+    protected transient List<DatabaseField> returnFieldsToMergeUpdate;
+
     protected Vector<DatabaseMapping> mappings;
 
     //Used to track which other classes reference this class in cases where
@@ -207,6 +212,7 @@ public class ClassDescriptor extends CoreDescriptor<AttributeGroup, DescriptorEv
     protected WrapperPolicy wrapperPolicy;
     protected ObjectChangePolicy changePolicy;
     protected ReturningPolicy returningPolicy;
+    protected List<ReturningPolicy> returningPolicies;
     protected HistoryPolicy historyPolicy;
     protected String partitioningPolicyName;
     protected PartitioningPolicy partitioningPolicy;
@@ -1396,6 +1402,13 @@ public class ClassDescriptor extends CoreDescriptor<AttributeGroup, DescriptorEv
             clonedDescriptor.setReturningPolicy((ReturningPolicy)getReturningPolicy().clone());
             clonedDescriptor.getReturningPolicy().setDescriptor(clonedDescriptor);
         }
+        if (clonedDescriptor.hasReturningPolicies()) {
+            clonedDescriptor.returningPolicies = new ArrayList<>();
+            for (ReturningPolicy returningPolicy : this.returningPolicies) {
+                clonedDescriptor.returningPolicies.add((ReturningPolicy)returningPolicy.clone());
+            }
+            clonedDescriptor.prepareReturnFields(clonedDescriptor.returningPolicies);
+        }
 
         // The Object builder
         clonedDescriptor.setObjectBuilder((ObjectBuilder)getObjectBuilder().clone());
@@ -2057,6 +2070,38 @@ public class ClassDescriptor extends CoreDescriptor<AttributeGroup, DescriptorEv
         } else {
             return allSelectionFields;
         }
+    }
+
+    /**
+     * INTERNAL:
+     * Return fields used to build insert statement.
+     */
+    public Vector<DatabaseField> getReturnFieldsToGenerateInsert() {
+        return this.returnFieldsToGenerateInsert;
+    }
+
+    /**
+     * INTERNAL:
+     * Return fields used to build update statement.
+     */
+    public Vector<DatabaseField> getReturnFieldsToGenerateUpdate() {
+        return this.returnFieldsToGenerateUpdate;
+    }
+
+    /**
+     * INTERNAL:
+     * Return fields used in to map into entity for insert.
+     */
+    public List<DatabaseField> getReturnFieldsToMergeInsert() {
+        return this.returnFieldsToMergeInsert;
+    }
+
+    /**
+     * INTERNAL:
+     * Return fields used in to map into entity for update.
+     */
+    public List<DatabaseField> getReturnFieldsToMergeUpdate() {
+        return this.returnFieldsToMergeUpdate;
     }
 
     /**
@@ -2777,6 +2822,14 @@ public class ClassDescriptor extends CoreDescriptor<AttributeGroup, DescriptorEv
     }
 
     /**
+     * PUBLIC:
+     * Return returning policy from current descriptor and from mappings
+     */
+    public List<ReturningPolicy> getReturningPolicies() {
+        return returningPolicies;
+    }
+
+    /**
      * INTERNAL:
      * Get sequence number field
      */
@@ -3108,6 +3161,14 @@ public class ClassDescriptor extends CoreDescriptor<AttributeGroup, DescriptorEv
      */
     public boolean hasReturningPolicy() {
         return (returningPolicy != null);
+    }
+
+    /**
+     * INTERNAL:
+     * Return if this descriptor or descriptors from mappings has Returning policy.
+     */
+    public boolean hasReturningPolicies() {
+        return (returningPolicies != null);
     }
 
     /**
@@ -3991,9 +4052,68 @@ public class ClassDescriptor extends CoreDescriptor<AttributeGroup, DescriptorEv
 
         getCachePolicy().postInitialize(this, session);
 
+        postInitializeReturningPolicies();
+
         validateAfterInitialization(session);
 
         checkDatabase(session);
+    }
+
+    private void postInitializeReturningPolicies() {
+        //Initialize ReturningPolicies
+        List<ReturningPolicy> returningPolicies = new ArrayList<>();
+        if (this.hasReturningPolicy()) {
+            returningPolicies.add(this.getReturningPolicy());
+        }
+        browseReturningPolicies(returningPolicies, this.getMappings());
+        if (returningPolicies.size() > 0) {
+            this.returningPolicies = returningPolicies;
+            prepareReturnFields(returningPolicies);
+        }
+    }
+
+    private void browseReturningPolicies(List<ReturningPolicy> returningPolicies, Vector<DatabaseMapping> mappings) {
+        for (DatabaseMapping databaseMapping :mappings) {
+            if (databaseMapping instanceof AggregateObjectMapping) {
+                ClassDescriptor referenceDescriptor = databaseMapping.getReferenceDescriptor();
+                if (referenceDescriptor != null) {
+                    browseReturningPolicies(returningPolicies, referenceDescriptor.getMappings());
+                    if (referenceDescriptor.hasReturningPolicy()) {
+                        returningPolicies.add(referenceDescriptor.getReturningPolicy());
+                    }
+                }
+            }
+        }
+    }
+
+    private void prepareReturnFields(List<ReturningPolicy> returningPolicies) {
+        Vector<DatabaseField> returnFieldsInsert = new NonSynchronizedVector();
+        Vector<DatabaseField> returnFieldsUpdate = new NonSynchronizedVector();
+        List<DatabaseField> returnFieldsToMergeInsert = new ArrayList<>();
+        List<DatabaseField> returnFieldsToMergeUpdate = new ArrayList<>();
+        Collection tmpFields;
+        for (ReturningPolicy returningPolicy: returningPolicies) {
+            tmpFields = returningPolicy.getFieldsToGenerateInsert(this.defaultTable);
+            if (tmpFields != null) {
+                returnFieldsInsert.addAll(tmpFields);
+            }
+            tmpFields = returningPolicy.getFieldsToGenerateUpdate(this.defaultTable);
+            if (tmpFields != null) {
+                returnFieldsUpdate.addAll(tmpFields);
+            }
+            tmpFields = returningPolicy.getFieldsToMergeInsert();
+            if (tmpFields != null) {
+                returnFieldsToMergeInsert.addAll(tmpFields);
+            }
+            tmpFields = returningPolicy.getFieldsToMergeUpdate();
+            if (tmpFields != null) {
+                returnFieldsToMergeUpdate.addAll(tmpFields);
+            }
+        }
+        this.returnFieldsToGenerateInsert = (returnFieldsInsert.isEmpty()) ? null : returnFieldsInsert;
+        this.returnFieldsToGenerateUpdate = (returnFieldsUpdate.isEmpty()) ? null : returnFieldsUpdate;
+        this.returnFieldsToMergeInsert = (returnFieldsToMergeInsert.isEmpty()) ? null : returnFieldsToMergeInsert;
+        this.returnFieldsToMergeUpdate = (returnFieldsToMergeUpdate.isEmpty()) ? null : returnFieldsToMergeUpdate;
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/DatasourceCallQueryMechanism.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/DatasourceCallQueryMechanism.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 1998, 2019 IBM Corporation. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -37,8 +37,10 @@ import org.eclipse.persistence.internal.databaseaccess.DatasourceCall;
 import org.eclipse.persistence.internal.helper.DatabaseField;
 import org.eclipse.persistence.internal.helper.DatabaseTable;
 import org.eclipse.persistence.internal.helper.Helper;
+import org.eclipse.persistence.internal.helper.NonSynchronizedVector;
 import org.eclipse.persistence.internal.sessions.AbstractRecord;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
+import org.eclipse.persistence.mappings.DatabaseMapping;
 import org.eclipse.persistence.mappings.DatabaseMapping.WriteType;
 import org.eclipse.persistence.queries.ConstructorReportItem;
 import org.eclipse.persistence.queries.DatabaseQuery;
@@ -371,8 +373,8 @@ public class DatasourceCallQueryMechanism extends DatabaseQueryMechanism {
             shouldAcquireValueAfterInsert = descriptor.getSequence().shouldAcquireValueAfterInsert();
         }
         Collection returnFields = null;
-        if (descriptor.hasReturningPolicy()) {
-            returnFields = descriptor.getReturningPolicy().getFieldsToMergeInsert();
+        if (descriptor.getReturnFieldsToMergeInsert() != null) {
+            returnFields = descriptor.getReturnFieldsToMergeInsert();
         }
 
         // Check to see if sequence number should be retrieved after insert
@@ -811,10 +813,10 @@ public class DatasourceCallQueryMechanism extends DatabaseQueryMechanism {
      * @return the row count.
      */
     public Integer updateObject() throws DatabaseException {
-        Collection returnFields = null;
         ClassDescriptor descriptor = getDescriptor();
-        if (descriptor.hasReturningPolicy()) {
-            returnFields = descriptor.getReturningPolicy().getFieldsToMergeUpdate();
+        Collection returnFields = null;
+        if (descriptor.getReturnFieldsToMergeUpdate() != null) {
+            returnFields = descriptor.getReturnFieldsToMergeUpdate();
         }
         Integer returnedRowCount = null;
         if (hasMultipleCalls()) {

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/ExpressionQueryMechanism.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/ExpressionQueryMechanism.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 1998, 2019 IBM and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 IBM and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -524,8 +524,8 @@ public class ExpressionQueryMechanism extends StatementQueryMechanism {
         SQLInsertStatement insertStatement = new SQLInsertStatement();
         insertStatement.setTable(table);
         insertStatement.setModifyRow(getModifyRow());
-        if (getDescriptor().hasReturningPolicy()) {
-            insertStatement.setReturnFields(getDescriptor().getReturningPolicy().getFieldsToGenerateInsert(table));
+        if (getDescriptor().hasReturningPolicies() && getDescriptor().getReturnFieldsToGenerateInsert() != null) {
+            insertStatement.setReturnFields(getDescriptor().getReturnFieldsToGenerateInsert());
         }
         insertStatement.setHintString(getQuery().getHintString());
         return insertStatement;
@@ -777,8 +777,8 @@ public class ExpressionQueryMechanism extends StatementQueryMechanism {
 
         updateStatement.setModifyRow(getModifyRow());
         updateStatement.setTranslationRow(getTranslationRow());
-        if (getDescriptor().hasReturningPolicy()) {
-            updateStatement.setReturnFields(getDescriptor().getReturningPolicy().getFieldsToGenerateUpdate(table));
+        if (getDescriptor().hasReturningPolicies() && getDescriptor().getReturnFieldsToGenerateUpdate() != null) {
+            updateStatement.setReturnFields(getDescriptor().getReturnFieldsToGenerateUpdate());
         }
         updateStatement.setTable(table);
         updateStatement.setWhereClause(getDescriptor().getObjectBuilder().buildUpdateExpression(table, getTranslationRow(), getModifyRow()));

--- a/jpa/eclipselink.jpa.test.jse/src/META-INF/persistence.xml
+++ b/jpa/eclipselink.jpa.test.jse/src/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -46,4 +46,17 @@
           <properties>
           </properties>
      </persistence-unit>
+
+     <persistence-unit name="returninsert-pu" transaction-type="RESOURCE_LOCAL">
+          <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+          <exclude-unlisted-classes>true</exclude-unlisted-classes>
+          <class>org.eclipse.persistence.jpa.returninsert.model.ReturnInsertDetail</class>
+          <class>org.eclipse.persistence.jpa.returninsert.model.ReturnInsertDetailEmbedded</class>
+          <class>org.eclipse.persistence.jpa.returninsert.model.ReturnInsertDetailParent</class>
+          <class>org.eclipse.persistence.jpa.returninsert.model.ReturnInsertDetailPK</class>
+          <class>org.eclipse.persistence.jpa.returninsert.model.ReturnInsertMasterPK</class>
+          <class>org.eclipse.persistence.jpa.returninsert.model.ReturnInsertMaster</class>
+          <properties></properties>
+     </persistence-unit>
+
 </persistence>

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/returninsert/TestReturnInsert.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/returninsert/TestReturnInsert.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.jpa.returninsert;
+
+import java.time.Instant;
+import java.util.Date;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+import javax.persistence.Query;
+
+import org.eclipse.persistence.internal.jpa.EntityManagerImpl;
+import org.eclipse.persistence.jpa.returninsert.model.*;
+import org.eclipse.persistence.sessions.DatabaseSession;
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
+
+/**
+ * TestSuite to test entities, that has a @ReturnInsert and @ReturnUpdate annotations.
+ *
+ * @author Radek Felcman
+ */
+public class TestReturnInsert {
+
+    private EntityManagerFactory emf;
+    private EntityManager em;
+
+    @Test
+    public void test() {
+        boolean supported = true;
+        emf = Persistence.createEntityManagerFactory("returninsert-pu");
+        try {
+            EntityManager em = emf.createEntityManager();
+        } catch (Exception e) {
+            supported = false;
+            System.out.println("Non supported platform. This test can be executed on OraclePlatform only!");
+        }
+        if (em != null) {
+            em.close();
+        }
+        if(!supported) {
+            return;
+        }
+        setup();
+        testCreate();
+        testFindUpdate();
+        testQuery();
+        emf.close();
+    }
+
+    public void setup() {
+        EntityManager em = emf.createEntityManager();
+        try {
+            DatabaseSession session = ((EntityManagerImpl) em).getDatabaseSession();
+            try {
+                session.executeNonSelectingSQL("DROP TABLE JPA22_RETURNINSERT_DETAIL");
+            } catch (Exception ignore) {
+            }
+            try {
+                session.executeNonSelectingSQL("DROP TABLE JPA22_RETURNINSERT_MASTER");
+            } catch (Exception ignore) {
+            }
+            try {
+                session.executeNonSelectingSQL("CREATE TABLE JPA22_RETURNINSERT_MASTER  (" +
+                        "    ID_VIRTUAL NUMBER (2) AS ( TO_NUMBER(TO_CHAR(\"ID\",'DD')) ) VIRTUAL NOT NULL ," +
+                        "    ID     DATE NOT NULL ," +
+                        "    COL1     NUMBER (15) NOT NULL," +
+                        "    COL1_VIRTUAL NUMBER (15) AS ( COL1 * 10 ) VIRTUAL)");
+                session.executeNonSelectingSQL("ALTER TABLE JPA22_RETURNINSERT_MASTER ADD CONSTRAINT PKJPA22_RETURNINSERT_MASTER PRIMARY KEY ( ID_VIRTUAL, ID, COL1 )");
+                session.executeNonSelectingSQL("CREATE TABLE JPA22_RETURNINSERT_DETAIL  (" +
+                        "    ID_VIRTUAL NUMBER (2) AS ( TO_NUMBER(TO_CHAR(\"ID\",'DD')) ) VIRTUAL NOT NULL ," +
+                        "    ID     DATE NOT NULL ," +
+                        "    COL1     NUMBER (15) NOT NULL," +
+                        "    COL1_VIRTUAL NUMBER (15) AS ( COL1 * 10 ) VIRTUAL," +
+                        "    COL2     VARCHAR (15) NOT NULL," +
+                        "    COL2_VIRTUAL VARCHAR (100) AS ( COL2 || '_col2' ) VIRTUAL," +
+                        "    COL3     VARCHAR (15) NOT NULL," +
+                        "    COL3_VIRTUAL VARCHAR (100) AS ( COL3 || '_col3' ) VIRTUAL," +
+                        "    COL4     VARCHAR (15) NOT NULL," +
+                        "    COL4_VIRTUAL VARCHAR (100) AS ( COL4 || '_col4' ) VIRTUAL," +
+                        "    COL5     VARCHAR (15) NOT NULL," +
+                        "    COL5_VIRTUAL VARCHAR (100) AS ( COL5 || '_col5' ) VIRTUAL)");
+                session.executeNonSelectingSQL("ALTER TABLE JPA22_RETURNINSERT_DETAIL ADD CONSTRAINT PKJPA22_RETURNINSERT_DETAIL PRIMARY KEY ( ID_VIRTUAL, ID, COL1, COL2 )");
+                session.executeNonSelectingSQL("ALTER TABLE JPA22_RETURNINSERT_DETAIL ADD CONSTRAINT FKJPA22_RETURNINSERT_MASTER_DETAIL FOREIGN KEY ( ID_VIRTUAL, ID, COL1 ) REFERENCES JPA22_RETURNINSERT_MASTER ( ID_VIRTUAL, ID, COL1 ) NOT DEFERRABLE");
+            } catch (Exception ignore) {
+            }
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if (em.isOpen()) {
+                em.close();
+            }
+        }
+    }
+
+    private void testCreate() {
+        ReturnInsertMaster returnInsertMaster = null;
+        ReturnInsertDetail returnInsertDetail = null;
+
+        EntityManager em = emf.createEntityManager();
+        try {
+            em.getTransaction().begin();
+
+            //Prepare data
+            //Test Insert
+            returnInsertMaster = insertReturnInsertMaster(em);
+            returnInsertDetail = insertReturnInsertDetail(em, returnInsertMaster);
+
+        em.getTransaction().commit();
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if (em.isOpen()) {
+                em.close();
+            }
+        }
+
+        assertEquals(1, returnInsertMaster.getId().getIdVirtual());
+        assertEquals(10, returnInsertMaster.getCol1Virtual());
+        assertEquals(1, returnInsertDetail.getId().getIdVirtual());
+        assertEquals(10, returnInsertDetail.getCol1Virtual());
+        assertEquals("abc_col2", returnInsertDetail.getReturnInsertDetailEmbedded().getCol2Virtual());
+        assertEquals("opq_col4", returnInsertDetail.getCol4Virtual());
+        assertEquals("lmn_col5", returnInsertDetail.getReturnInsertDetailEmbedded().getReturnInsertDetailEmbeddedEmbedded().getCol5Virtual());
+    }
+
+    private void testFindUpdate() {
+        //Test find and update
+        ReturnInsertDetail returnInsertDetailMerge = null;
+
+        EntityManager em = emf.createEntityManager();
+        try {
+            em.getTransaction().begin();
+
+            ReturnInsertMasterPK returnInsertMasterPK = createReturnInsertMasterPK();
+            returnInsertMasterPK.setIdVirtual(1L);
+            ReturnInsertDetailPK returnInsertDetailPK = createReturnInsertDetailPK();
+            //Must be set, it's not populated from DB virtual column
+            returnInsertDetailPK.setIdVirtual(1L);
+            ReturnInsertDetail returnInsertDetailFindResult = em.find(ReturnInsertDetail.class, returnInsertDetailPK);
+            assertNotNull(returnInsertDetailFindResult);
+            assertEquals(1, returnInsertDetailFindResult.getId().getIdVirtual());
+            assertEquals("abc_col2", returnInsertDetailFindResult.getReturnInsertDetailEmbedded().getCol2Virtual());
+            //Test update
+            returnInsertDetailFindResult.getReturnInsertDetailEmbedded().setCol3("ijk");
+            returnInsertDetailMerge = em.merge(returnInsertDetailFindResult);
+
+            em.getTransaction().commit();
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if (em.isOpen()) {
+                em.close();
+            }
+        }
+        assertEquals("ijk_col3", returnInsertDetailMerge.getReturnInsertDetailEmbedded().getCol3Virtual());
+    }
+
+    private void testQuery() {
+        ReturnInsertDetail returnInsertDetailQueryResult = null;
+
+        EntityManager em = emf.createEntityManager();
+
+        try {
+            ReturnInsertDetailPK returnInsertDetailPK = createReturnInsertDetailPK();
+            //Must be set, it's not populated from DB virtual column
+            returnInsertDetailPK.setIdVirtual(1L);
+            Query query  = em.createQuery("select t from ReturnInsertDetail t where t.id = :returnInsertDetailId");
+            query.setParameter("returnInsertDetailId", returnInsertDetailPK);
+            returnInsertDetailQueryResult = (ReturnInsertDetail) query.getSingleResult();
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if (em.isOpen()) {
+                em.close();
+            }
+        }
+        assertNotNull(returnInsertDetailQueryResult);
+        assertEquals(1, returnInsertDetailQueryResult.getId().getIdVirtual());
+        assertEquals("abc_col2", returnInsertDetailQueryResult.getReturnInsertDetailEmbedded().getCol2Virtual());
+        assertEquals("opq_col4", returnInsertDetailQueryResult.getCol4Virtual());
+    }
+
+    private ReturnInsertMaster insertReturnInsertMaster(EntityManager em) {
+        //Prepare primary key
+        ReturnInsertMasterPK ReturnInsertMasterPK = createReturnInsertMasterPK();
+
+        //Prepare object/row
+        ReturnInsertMaster tbReciboNfce = new ReturnInsertMaster();
+        tbReciboNfce.setId(ReturnInsertMasterPK);
+
+        em.persist(tbReciboNfce);
+        return tbReciboNfce;
+    }
+
+    //Prepare primary key for ReturnInsertMaster
+    private ReturnInsertMasterPK createReturnInsertMasterPK() {
+        ReturnInsertMasterPK ReturnInsertMasterPK = new ReturnInsertMasterPK();
+        ReturnInsertMasterPK.setId(Date.from(Instant.ofEpochMilli(0)));
+        ReturnInsertMasterPK.setCol1(1L);
+        return ReturnInsertMasterPK;
+    }
+
+    private ReturnInsertDetail insertReturnInsertDetail(EntityManager em, ReturnInsertMaster returnInsertMaster) {
+        //Prepare primary key
+        ReturnInsertDetailPK returnInsertDetailPK = createReturnInsertDetailPK();
+
+        //Prepare object/row
+        ReturnInsertDetail returnInsertDetail = new ReturnInsertDetail();
+        returnInsertDetail.setId(returnInsertDetailPK);
+        returnInsertDetail.setReturnInsertMaster(returnInsertMaster);
+
+        //Prepare embedded embedded part
+        ReturnInsertDetailEmbeddedEmbedded returnInsertDetailEmbeddedEmbedded = new ReturnInsertDetailEmbeddedEmbedded();
+        returnInsertDetailEmbeddedEmbedded.setCol5("lmn");
+
+        //Prepare embedded part
+        ReturnInsertDetailEmbedded returnInsertDetailEmbedded = new ReturnInsertDetailEmbedded();
+        returnInsertDetailEmbedded.setCol3("xyz");
+        returnInsertDetailEmbedded.setReturnInsertDetailEmbeddedEmbedded(returnInsertDetailEmbeddedEmbedded);
+        returnInsertDetail.setReturnInsertDetailEmbedded(returnInsertDetailEmbedded);
+
+        //Inherited field
+        returnInsertDetail.setCol4("opq");
+
+        em.persist(returnInsertDetail);
+        return returnInsertDetail;
+    }
+
+    //Prepare primary key for ReturnInsertDetail
+    private ReturnInsertDetailPK createReturnInsertDetailPK() {
+        ReturnInsertDetailPK returnInsertDetailPK = new ReturnInsertDetailPK();
+        returnInsertDetailPK.setId(Date.from(Instant.ofEpochMilli(0)));
+        returnInsertDetailPK.setCol1(1L);
+        returnInsertDetailPK.setCol2("abc");
+        return returnInsertDetailPK;
+    }
+
+}

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/returninsert/model/ReturnInsertDetail.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/returninsert/model/ReturnInsertDetail.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.jpa.returninsert.model;
+
+import org.eclipse.persistence.annotations.ReturnInsert;
+
+import javax.persistence.*;
+import java.io.Serializable;
+
+/**
+ * The persistent class for the JPA22_RETURNINSERT_DETAIL database table.
+ * 
+ */
+@Entity
+@Table(name = "JPA22_RETURNINSERT_DETAIL")
+@Cacheable(false)
+@NamedQueries({
+	@NamedQuery(name = "ReturnInsertDetail.findAll", query = "SELECT t FROM ReturnInsertDetail t"),
+})
+public class ReturnInsertDetail extends ReturnInsertDetailParent implements Serializable {
+
+	private static final long serialVersionUID = 1712864132706065027L;
+
+	@EmbeddedId
+	private ReturnInsertDetailPK id;
+
+	@ReturnInsert(returnOnly = true)
+	@Column(name = "COL1_VIRTUAL")
+	private long col1Virtual;
+
+	@Embedded
+	private ReturnInsertDetailEmbedded returnInsertDetailEmbedded;
+
+	@OneToOne(cascade = { CascadeType.MERGE, CascadeType.PERSIST })
+	@JoinColumns({
+			@JoinColumn(name = "ID_VIRTUAL", referencedColumnName = "ID_VIRTUAL", insertable = false, updatable = false),
+			@JoinColumn(name = "ID", referencedColumnName = "ID", insertable = false, updatable = false),
+			@JoinColumn(name = "COL1", referencedColumnName = "COL1", insertable = false, updatable = false)
+	})
+	private ReturnInsertMaster returnInsertMaster;
+
+	public ReturnInsertDetail() {
+	}
+
+	public ReturnInsertDetailPK getId() {
+		return this.id;
+	}
+
+	public void setId(ReturnInsertDetailPK id) {
+		this.id = id;
+	}
+
+	public long getCol1Virtual() {
+		return col1Virtual;
+	}
+
+	public void setCol1Virtual(long col1Virtual) {
+		this.col1Virtual = col1Virtual;
+	}
+
+	public ReturnInsertDetailEmbedded getReturnInsertDetailEmbedded() {
+		return returnInsertDetailEmbedded;
+	}
+
+	public void setReturnInsertDetailEmbedded(ReturnInsertDetailEmbedded returnInsertDetailEmbedded) {
+		this.returnInsertDetailEmbedded = returnInsertDetailEmbedded;
+	}
+
+	public ReturnInsertMaster getReturnInsertMaster() {
+		return returnInsertMaster;
+	}
+
+	public void setReturnInsertMaster(ReturnInsertMaster returnInsertMaster) {
+		this.returnInsertMaster = returnInsertMaster;
+	}
+}

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/returninsert/model/ReturnInsertDetailEmbedded.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/returninsert/model/ReturnInsertDetailEmbedded.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.jpa.returninsert.model;
+
+import org.eclipse.persistence.annotations.ReturnInsert;
+import org.eclipse.persistence.annotations.ReturnUpdate;
+
+import javax.persistence.*;
+import java.io.Serializable;
+
+/**
+ * ReturnInsertDetailEmbedded instance to be {@link Embedded} into other entities.
+ */
+@Embeddable
+public class ReturnInsertDetailEmbedded implements Serializable {
+
+	private static final long serialVersionUID = 1712864132706065027L;
+
+
+	@ReturnInsert(returnOnly = true)
+	@Column(name = "COL2_VIRTUAL")
+	private String col2Virtual;
+
+	@Column(name = "COL3")
+	private String col3;
+
+	@ReturnInsert(returnOnly = true)
+	@ReturnUpdate
+	@Column(name = "COL3_VIRTUAL")
+	private String col3Virtual;
+
+	@Embedded
+	private ReturnInsertDetailEmbeddedEmbedded returnInsertDetailEmbeddedEmbedded;
+
+	public ReturnInsertDetailEmbedded() {
+	}
+
+	public String getCol2Virtual() {
+		return col2Virtual;
+	}
+
+	public void setCol2Virtual(String col2Virtual) {
+		this.col2Virtual = col2Virtual;
+	}
+
+	public String getCol3() {
+		return col3;
+	}
+
+	public void setCol3(String col3) {
+		this.col3 = col3;
+	}
+
+	public String getCol3Virtual() {
+		return col3Virtual;
+	}
+
+	public void setCol3Virtual(String col3Virtual) {
+		this.col3Virtual = col3Virtual;
+	}
+
+	public ReturnInsertDetailEmbeddedEmbedded getReturnInsertDetailEmbeddedEmbedded() {
+		return returnInsertDetailEmbeddedEmbedded;
+	}
+
+	public void setReturnInsertDetailEmbeddedEmbedded(ReturnInsertDetailEmbeddedEmbedded returnInsertDetailEmbeddedEmbedded) {
+		this.returnInsertDetailEmbeddedEmbedded = returnInsertDetailEmbeddedEmbedded;
+	}
+}

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/returninsert/model/ReturnInsertDetailEmbeddedEmbedded.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/returninsert/model/ReturnInsertDetailEmbeddedEmbedded.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.jpa.returninsert.model;
+
+import org.eclipse.persistence.annotations.ReturnInsert;
+import org.eclipse.persistence.annotations.ReturnUpdate;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.persistence.Embedded;
+import java.io.Serializable;
+
+/**
+ * ReturnInsertDetailEmbeddedEmbedded instance to be {@link Embedded} into other embedded entities.
+ */
+@Embeddable
+public class ReturnInsertDetailEmbeddedEmbedded implements Serializable {
+
+	private static final long serialVersionUID = 1712864132706065027L;
+
+
+	@Column(name = "COL5")
+	private String col5;
+
+	@ReturnInsert(returnOnly = true)
+	@Column(name = "COL5_VIRTUAL")
+	private String col5Virtual;
+
+	public ReturnInsertDetailEmbeddedEmbedded() {
+	}
+
+	public String getCol5() {
+		return col5;
+	}
+
+	public void setCol5(String col5) {
+		this.col5 = col5;
+	}
+
+	public String getCol5Virtual() {
+		return col5Virtual;
+	}
+
+	public void setCol5Virtual(String col5Virtual) {
+		this.col5Virtual = col5Virtual;
+	}
+}

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/returninsert/model/ReturnInsertDetailPK.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/returninsert/model/ReturnInsertDetailPK.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.jpa.returninsert.model;
+
+import org.eclipse.persistence.annotations.ReturnInsert;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * The primary key class for the TEST_RETURNINSERT_DETAIL database table.
+ * 
+ */
+
+@Embeddable
+public class ReturnInsertDetailPK implements Serializable {
+
+	private static final long serialVersionUID = -7028778781258139822L;
+
+	@ReturnInsert(returnOnly = true)
+	@Column(name = "ID_VIRTUAL")
+	private long idVirtual;
+
+	@Temporal(TemporalType.TIMESTAMP)
+	@Column(name = "ID")
+	private Date id;
+
+	@Column(name = "COL1")
+	private long col1;
+
+	@Column(name = "COL2")
+	private String col2;
+
+	public ReturnInsertDetailPK() {
+	}
+
+	public long getIdVirtual() {
+		return idVirtual;
+	}
+
+	public void setIdVirtual(long idVirtual) {
+		this.idVirtual = idVirtual;
+	}
+
+	public Date getId() {
+		return id;
+	}
+
+	public void setId(Date id) {
+		this.id = id;
+	}
+
+	public long getCol1() {
+		return col1;
+	}
+
+	public void setCol1(long col1) {
+		this.col1 = col1;
+	}
+
+	public String getCol2() {
+		return col2;
+	}
+
+	public void setCol2(String col2) {
+		this.col2 = col2;
+	}
+}

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/returninsert/model/ReturnInsertDetailParent.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/returninsert/model/ReturnInsertDetailParent.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.jpa.returninsert.model;
+
+import org.eclipse.persistence.annotations.ReturnInsert;
+
+import javax.persistence.*;
+import java.io.Serializable;
+
+/**
+ * The parent persistent class for the JPA22_RETURNINSERT_DETAIL database table.
+ * 
+ */
+@MappedSuperclass
+public class ReturnInsertDetailParent implements Serializable {
+
+	private static final long serialVersionUID = 1712864132706165027L;
+
+	@Column(name = "COL4")
+	private String col4;
+
+	@ReturnInsert(returnOnly = true)
+	@Column(name = "COL4_VIRTUAL")
+	private String col4Virtual;
+
+	public String getCol4() {
+		return col4;
+	}
+
+	public void setCol4(String col4) {
+		this.col4 = col4;
+	}
+
+	public String getCol4Virtual() {
+		return col4Virtual;
+	}
+
+	public void setCol4Virtual(String col4Virtual) {
+		this.col4Virtual = col4Virtual;
+	}
+}

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/returninsert/model/ReturnInsertMaster.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/returninsert/model/ReturnInsertMaster.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.jpa.returninsert.model;
+
+import org.eclipse.persistence.annotations.ReturnInsert;
+
+import java.io.Serializable;
+
+import javax.persistence.*;
+
+/**
+ * The persistent class for the TEST_RETURNINSERT_MASTER database table.
+ * 
+ */
+@Entity
+@Table(name = "JPA22_RETURNINSERT_MASTER")
+@Cacheable(false)
+@NamedQueries({ 
+	@NamedQuery(name = "ReturnInsertMaster.findAll", query = "SELECT t FROM ReturnInsertMaster t"),
+})
+public class ReturnInsertMaster implements Serializable {
+
+	private static final long serialVersionUID = 1712864032706065027L;
+
+	@EmbeddedId
+	private ReturnInsertMasterPK id;
+
+	@ReturnInsert(returnOnly = true)
+	@Column(name = "COL1_VIRTUAL")
+	private long col1Virtual;
+
+	public ReturnInsertMaster() {
+	}
+
+	public ReturnInsertMasterPK getId() {
+		return this.id;
+	}
+
+	public void setId(ReturnInsertMasterPK id) {
+		this.id = id;
+	}
+
+	public long getCol1Virtual() {
+		return col1Virtual;
+	}
+
+	public void setCol1Virtual(long col1Virtual) {
+		this.col1Virtual = col1Virtual;
+	}
+
+}

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/returninsert/model/ReturnInsertMasterPK.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/returninsert/model/ReturnInsertMasterPK.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.jpa.returninsert.model;
+
+import java.io.Serializable;
+import java.util.Date;
+
+import javax.persistence.*;
+
+import org.eclipse.persistence.annotations.ReturnInsert;
+
+/**
+ * The primary key class for the TEST_RETURNINSERT_MASTER database table.
+ * 
+ */
+
+@Embeddable
+public class ReturnInsertMasterPK implements Serializable {
+
+	private static final long serialVersionUID = -7028778781258939822L;
+
+	@ReturnInsert(returnOnly = true)
+	@Column(name = "ID_VIRTUAL")
+	private long idVirtual;
+
+	@Temporal(TemporalType.TIMESTAMP)
+	@Column(name = "ID")
+	private java.util.Date id;
+
+	@Column(name = "COL1")
+	private long col1;
+
+	public ReturnInsertMasterPK() {
+	}
+
+	public long getIdVirtual() {
+		return idVirtual;
+	}
+
+	public void setIdVirtual(long idVirtual) {
+		this.idVirtual = idVirtual;
+	}
+
+	public Date getId() {
+		return id;
+	}
+
+	public void setId(Date id) {
+		this.id = id;
+	}
+
+	public long getCol1() {
+		return col1;
+	}
+
+	public void setCol1(long col1) {
+		this.col1 = col1;
+	}
+}


### PR DESCRIPTION
This is fix for #709 . Backport from master.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>