### PR TITLE
Add package-to-scan feature

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/PersistenceUnitProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/PersistenceUnitProperties.java
@@ -3907,6 +3907,15 @@ public class PersistenceUnitProperties {
     public static final String NAMING_INTO_INDEXED = "eclipselink.jpa.naming_into_indexed";
 
     /**
+     * The "<code>eclipselink.packages-to-scan</code>" property
+     * allows you to specify a comma separated list of packages you allow to be scanned.
+     * This could help reducing startup time.
+     * <p>
+     * By default, no restriction will be applied and classes from every packages will be considered.
+     */
+    public static final String PACKAGES_TO_SCAN = "eclipselink.packages-to-scan";
+
+    /**
      * INTERNAL: The following properties will not be displayed through logging
      * but instead have an alternate value shown in the log.
      */

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/advanced/PersistenceUnitProcessorTest.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/advanced/PersistenceUnitProcessorTest.java
@@ -20,6 +20,7 @@ package org.eclipse.persistence.testing.tests.jpa.advanced;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 
+import org.eclipse.persistence.config.PersistenceUnitProperties;
 import org.eclipse.persistence.config.SystemProperties;
 import org.eclipse.persistence.exceptions.ValidationException;
 import org.eclipse.persistence.internal.jpa.deployment.ArchiveFactoryImpl;
@@ -32,8 +33,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import jakarta.persistence.EntityManagerFactory;
 
@@ -222,4 +222,35 @@ public class PersistenceUnitProcessorTest extends JUnitTestCase {
     public static class AF1 extends ArchiveFactoryImpl {}
     public static class AF2 extends ArchiveFactoryImpl {}
 
+    public void testIsEligibleToScan() {
+        Assert.assertTrue(PersistenceUnitProcessor.isEligibleToScan(Collections.emptyList(), "foo/bar/MyClass.class"));
+
+        List<String> pathsToScan = new ArrayList<>();
+        pathsToScan.add("foo/bar/");
+        pathsToScan.add("com/test/");
+
+        Assert.assertTrue(PersistenceUnitProcessor.isEligibleToScan(pathsToScan, "foo/bar/MyClass.class"));
+        Assert.assertTrue(PersistenceUnitProcessor.isEligibleToScan(pathsToScan, "foo/bar/inner/MyClass.class"));
+        Assert.assertFalse(PersistenceUnitProcessor.isEligibleToScan(pathsToScan, "foo/MyClass.class"));
+        Assert.assertFalse(PersistenceUnitProcessor.isEligibleToScan(pathsToScan, "foo/barMyClass.class"));
+
+        Assert.assertTrue(PersistenceUnitProcessor.isEligibleToScan(pathsToScan, "com/test/MyClass.class"));
+
+        Assert.assertFalse(PersistenceUnitProcessor.isEligibleToScan(pathsToScan, "org/apache/SomeClass.class"));
+    }
+
+    public void testPathsToScan() {
+        Assert.assertTrue(PersistenceUnitProcessor.pathsToScan(null).isEmpty());
+        Assert.assertTrue(PersistenceUnitProcessor.pathsToScan("").isEmpty());
+        Assert.assertTrue(PersistenceUnitProcessor.pathsToScan(" ").isEmpty());
+
+        List<String> pathsToScan = PersistenceUnitProcessor.pathsToScan("foo.bar,com.test");
+        Assert.assertEquals(2, pathsToScan.size());
+        Assert.assertTrue(pathsToScan.contains("foo/bar/"));
+        Assert.assertTrue(pathsToScan.contains("com/test/"));
+
+        List<String> pathsToScan2 = PersistenceUnitProcessor.pathsToScan("foo.bar, ");
+        Assert.assertEquals(1, pathsToScan2.size());
+        Assert.assertTrue(pathsToScan2.contains("foo/bar/"));
+    }
 }


### PR DESCRIPTION
# Context

Some applications can have thousands of classes.
When JPA is configured to scan classes (`exclude-unlisted-classes` is `false` in `persistence.xml`), the time used to scan all classes can be quite long.
With reasonable application size, class scanning can take only ten's of milliseconds but for heavy application it can take a few seconds.

In order to help reducing startup time, we can restrict class scanning to a pre-configured list of known packages to avoid loading unnecessary classes metadata.

# What was done

- Introduced a new property `PersistenceUnitProperties.PACKAGES_TO_SCAN`: `eclipselink.packages-to-scan`
- Modified `PersistenceUnitProcessor.getClassNamesFromURL` to only return eligible classes

This new property takes as a value a list of packages as a string: `com.foo.bar, some.other.packages`

# Performance result

I've tested this feature with 2 applications, one with ~1000 classes and another with more than 30k classes.
`MetadataProcessor.initPersistenceUnitClasses` was faster by ~25% for the small application and ~45% for the big one.

**NOTE:** This is a port from a `2.7.4` patched version running in production