### PR TITLE
[master] Nightly build fix

### DIFF
--- a/bundles/distribution/pom.xml
+++ b/bundles/distribution/pom.xml
@@ -33,7 +33,7 @@
     <properties>
         <!--Test properties-->
         <archive.tmp.dir>archive-tmp</archive.tmp.dir>
-        <eclipselink.unzip.dir>${project.build.directory}/stage</eclipselink.unzip.dir>
+        <eclipselink.unzip.dir>${project.build.directory}/${eclipselink.unzip.subdir}</eclipselink.unzip.dir>
         <osgi.test.plugins.dir>osgi-test-plugins/</osgi.test.plugins.dir>
 
         <!--Javadoc properties-->

--- a/bundles/nightly/pom.xml
+++ b/bundles/nightly/pom.xml
@@ -237,14 +237,14 @@
                                 </fileSet>
                                 <fileSet>
                                     <sourceFile>
-                                        ../distribution/target/eclipselink.zip-tmp/eclipselink/jlib/eclipselink.jar
+                                        ../distribution/target//${eclipselink.unzip.subdir}/eclipselink/jlib/eclipselink.jar
                                     </sourceFile>
                                     <destinationFile>${project.build.directory}${nightlyDir}/eclipselink.jar
                                     </destinationFile>
                                 </fileSet>
                                 <fileSet>
                                     <sourceFile>
-                                        ../distribution/target/eclipselink.zip-tmp/eclipselink/jlib/eclipselink-src.jar
+                                        ../distribution/target//${eclipselink.unzip.subdir}/eclipselink/jlib/eclipselink-sources.jar
                                     </sourceFile>
                                     <destinationFile>
                                         ${project.build.directory}${nightlyDir}/eclipselink-src${nightlyVersion}.zip

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -30,6 +30,10 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <eclipselink.unzip.subdir>stage</eclipselink.unzip.subdir>
+    </properties>
+
     <modules>
         <module>eclipselink</module>
         <module>distribution</module>


### PR DESCRIPTION
This is fix for broken nightly build (Maven module `org.eclipse.persistence.nightly`).
Due previous changes there is different path where _eclipselink.zip_ is unzipped. This directory is used by `org.eclipse.persistence.nightly` to prepare files for the upload into "Nightly build" "page" server at Eclipse.org.
See error at https://ci.eclipse.org/eclipselink/view/Current%20Jobs/job/eclipselink-nightly-master/103/console .
Signed-off-by: Radek Felcman <radek.felcman@oracle.com>