### PR TITLE
[master] Nightly build - test status generation

### DIFF
--- a/bundles/nightly/pom.xml
+++ b/bundles/nightly/pom.xml
@@ -322,5 +322,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/bundles/nightly/pom.xml
+++ b/bundles/nightly/pom.xml
@@ -271,9 +271,9 @@
                                 import javax.xml.xpath.XPathFactory
                                 import javax.xml.parsers.DocumentBuilderFactory
 
-                                final NO_OF_TESTS_XPATH = "/html/body/div[@id='bodyColumn']/div/div[2]/table/tr[2]/td[1]/text()"
-                                final NO_OF_ERRORS_XPATH = "/html/body/div[@id='bodyColumn']/div/div[2]/table/tr[2]/td[2]/text()"
-                                final NO_OF_FAILURES_XPATH = "/html/body/div[@id='bodyColumn']/div/div[2]/table/tr[2]/td[3]/text()"
+                                final NO_OF_TESTS_XPATH = "/html/body/div[@id='bodyColumn']/div/section[2]/table/tr[2]/td[1]/text()"
+                                final NO_OF_ERRORS_XPATH = "/html/body/div[@id='bodyColumn']/div/section[2]/table/tr[2]/td[2]/text()"
+                                final NO_OF_FAILURES_XPATH = "/html/body/div[@id='bodyColumn']/div/section[2]/table/tr[2]/td[3]/text()"
                                 final OUTPUT_FILE = "ResultSummary.dat"
 
                                 def resultSummaryFile = new File(properties["nightlyTestReportsDir"] + "/" + OUTPUT_FILE)


### PR DESCRIPTION
It seems, that there is some change (XPath) in test results pages. This fix reflects it to correctly generate ResultSummary.dat used at https://www.eclipse.org/eclipselink/downloads/nightly.php
Signed-off-by: Radek Felcman <radek.felcman@oracle.com>