### PR TITLE
[2.6] Fix for Bug 474956 - RepeatableUnitOfWork linked by Embeddable in shared cache in specific scenario

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,11 @@
 # Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
-# terms of the Eclipse Public License v. 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0,
-# or the Eclipse Distribution License v. 1.0 which is available at
+# terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+# which accompanies this distribution.
+# The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+# and the Eclipse Distribution License is available at
 # http://www.eclipse.org/org/documents/edl-v10.php.
-#
-# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
 
 language: java

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/mappings/AggregateObjectMapping.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/mappings/AggregateObjectMapping.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2014 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the 
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0 
  * which accompanies this distribution. 
@@ -417,11 +417,14 @@ public class AggregateObjectMapping extends AggregateMapping implements Relation
             }
         }
 
-        if (aggregate == null) {
+        // Build a new aggregate if the target object does not reference an existing aggregate.
+        // EL Bug 474956 - build a new aggregate if the the target object references an existing aggregate, and
+        // the passed cacheKey is null from the invalidation of the target object in the IdentityMap.
+        if (aggregate == null || (aggregate != null && cacheKey == null)) {
             aggregate = descriptor.getObjectBuilder().buildNewInstance();
             refreshing = false;
         }
-        
+
         ObjectBuildingQuery nestedQuery = prepareNestedQuery(sourceQuery);
         FetchGroup targetFetchGroup =  null;
         if (nestedQuery.isObjectLevelReadQuery()) {
@@ -438,7 +441,7 @@ public class AggregateObjectMapping extends AggregateMapping implements Relation
         } else {
             descriptor.getObjectBuilder().buildAttributesIntoObject(aggregate, buildWrapperCacheKeyForAggregate(cacheKey, targetIsProtected), databaseRow, nestedQuery, joinManager, nestedQuery.getExecutionFetchGroup(descriptor), refreshing, executionSession);
         }
-        if ((targetFetchGroup != null) && descriptor.hasFetchGroupManager()
+        if ((targetFetchGroup != null) && descriptor.hasFetchGroupManager() && cacheKey != null
                 && !refreshing && sourceQuery.shouldMaintainCache() && !sourceQuery.shouldStoreBypassCache()) {
             // Set the fetch group to the domain object, after built.
             EntityFetchGroup entityFetchGroup = descriptor.getFetchGroupManager().getEntityFetchGroup(targetFetchGroup);
@@ -752,17 +755,15 @@ public class AggregateObjectMapping extends AggregateMapping implements Relation
      */
     @Override
     public void buildCloneFromRow(AbstractRecord databaseRow, JoinedAttributeManager joinManager, Object clone, CacheKey sharedCacheKey, ObjectBuildingQuery sourceQuery, UnitOfWorkImpl unitOfWork, AbstractSession executionSession) {
-        // This method is a combination of buildggregateFromRow and
-        // buildClonePart on the super class.
-        // none of buildClonePart used, as not an orignal new object, nor
-        // do we worry about creating heavy clones for aggregate objects.
-        Object clonedAttributeValue = buildAggregateFromRow(databaseRow, clone, null, joinManager, sourceQuery, false, executionSession, true);
-        ClassDescriptor descriptor = getReferenceDescriptor(clonedAttributeValue, unitOfWork);
+        // This method is a combination of buildggregateFromRow and buildClonePart on the super class.
+        // None of buildClonePart used, as not an orignal new object, nor do we worry about creating heavy clones for aggregate objects.
+        // Ensure that the shared CacheKey is passed, as this will be set to null for a refresh of an invalid object.
+        Object clonedAttributeValue = buildAggregateFromRow(databaseRow, clone, sharedCacheKey, joinManager, sourceQuery, false, executionSession, true);
         if (clonedAttributeValue != null) {
+            ClassDescriptor descriptor = getReferenceDescriptor(clonedAttributeValue, unitOfWork);
             descriptor.getObjectChangePolicy().setAggregateChangeListener(clone, clonedAttributeValue, unitOfWork, descriptor, getAttributeName());
         }
         setAttributeValueInObject(clone, clonedAttributeValue);
-        return;
     }
 
     /**

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/complexaggregate/ComplexAggregateTableCreator.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/complexaggregate/ComplexAggregateTableCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2013 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the 
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0 
  * which accompanies this distribution. 
@@ -46,6 +46,9 @@ public class ComplexAggregateTableCreator extends org.eclipse.persistence.tools.
         addTableDefinition(buildBODYTable());
         
         addTableDefinition(buildPLACETable());
+
+        addTableDefinition(buildHOCKEY_PUCKTable());
+        addTableDefinition(buildHOCKEY_RINKTable());
     }
 
     public TableDefinition buildBODYTable() {
@@ -658,7 +661,88 @@ public class ComplexAggregateTableCreator extends org.eclipse.persistence.tools.
         fieldADDRESS_2.setUnique(false);
         fieldADDRESS_2.setShouldAllowNull(true);
         table.addField(fieldADDRESS_2);
-        
+
+        return table;
+    }
+
+    public TableDefinition buildHOCKEY_RINKTable() {
+        TableDefinition table = new TableDefinition();
+        table.setName("CMP3_HOCKEY_RINK");
+
+        FieldDefinition fieldID = new FieldDefinition();
+        fieldID.setName("ID");
+        fieldID.setTypeName("NUMBER");
+        fieldID.setSize(18);
+        fieldID.setSubSize(0);
+        fieldID.setIsPrimaryKey(true);
+        fieldID.setIsIdentity(false);
+        fieldID.setUnique(false);
+        fieldID.setShouldAllowNull(false);
+        table.addField(fieldID);
+
+        FieldDefinition fieldHOCKEY_PUCK_ID = new FieldDefinition();
+        fieldHOCKEY_PUCK_ID.setName("HOCKEY_PUCK_ID");
+        fieldHOCKEY_PUCK_ID.setTypeName("NUMBER");
+        fieldHOCKEY_PUCK_ID.setSize(18);
+        fieldHOCKEY_PUCK_ID.setSubSize(0);
+        fieldHOCKEY_PUCK_ID.setIsPrimaryKey(false);
+        fieldHOCKEY_PUCK_ID.setIsIdentity(false);
+        fieldHOCKEY_PUCK_ID.setUnique(false);
+        fieldHOCKEY_PUCK_ID.setShouldAllowNull(true);
+        fieldHOCKEY_PUCK_ID.setForeignKeyFieldName("CMP3_HOCKEY_PUCK.ID");
+        table.addField(fieldHOCKEY_PUCK_ID);
+
+        return table;
+    }
+
+    public TableDefinition buildHOCKEY_PUCKTable() {
+        TableDefinition table = new TableDefinition();
+        table.setName("CMP3_HOCKEY_PUCK");
+
+        FieldDefinition fieldID = new FieldDefinition();
+        fieldID.setName("ID");
+        fieldID.setTypeName("NUMBER");
+        fieldID.setSize(18);
+        fieldID.setSubSize(0);
+        fieldID.setIsPrimaryKey(true);
+        fieldID.setIsIdentity(false);
+        fieldID.setUnique(false);
+        fieldID.setShouldAllowNull(false);
+        table.addField(fieldID);
+
+        FieldDefinition fieldNAME = new FieldDefinition();
+        fieldNAME.setName("NAME");
+        fieldNAME.setTypeName("VARCHAR2");
+        fieldNAME.setSize(36);
+        fieldNAME.setSubSize(0);
+        fieldNAME.setIsPrimaryKey(false);
+        fieldNAME.setIsIdentity(false);
+        fieldNAME.setUnique(false);
+        fieldNAME.setShouldAllowNull(true);
+        table.addField(fieldNAME);
+
+        FieldDefinition fieldSPONSOR_NAME = new FieldDefinition();
+        fieldSPONSOR_NAME.setName("SPONSOR_NAME");
+        fieldSPONSOR_NAME.setTypeName("VARCHAR2");
+        fieldSPONSOR_NAME.setSize(36);
+        fieldSPONSOR_NAME.setSubSize(0);
+        fieldSPONSOR_NAME.setIsPrimaryKey(false);
+        fieldSPONSOR_NAME.setIsIdentity(false);
+        fieldSPONSOR_NAME.setUnique(false);
+        fieldSPONSOR_NAME.setShouldAllowNull(true);
+        table.addField(fieldSPONSOR_NAME);
+
+        FieldDefinition fieldSPONSOR_VALUE = new FieldDefinition();
+        fieldSPONSOR_VALUE.setName("SPONSOR_VALUE");
+        fieldSPONSOR_VALUE.setTypeName("NUMBER");
+        fieldSPONSOR_VALUE.setSize(18);
+        fieldSPONSOR_VALUE.setSubSize(0);
+        fieldSPONSOR_VALUE.setIsPrimaryKey(false);
+        fieldSPONSOR_VALUE.setIsIdentity(false);
+        fieldSPONSOR_VALUE.setUnique(false);
+        fieldSPONSOR_VALUE.setShouldAllowNull(true);
+        table.addField(fieldSPONSOR_VALUE);
+
         return table;
     }
 

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/complexaggregate/HockeyPuck.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/complexaggregate/HockeyPuck.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     dminsky - initial API and implementation
+ *     
+ ******************************************************************************/
+package org.eclipse.persistence.testing.models.jpa.complexaggregate;
+
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name="CMP3_HOCKEY_PUCK")
+public class HockeyPuck {
+
+    @Id
+    protected int id; 
+    protected String name;
+    @Embedded
+    protected HockeySponsor sponsor;
+    
+    public HockeyPuck() {
+        super();
+        // the Embeddable must be instantiated with real values
+        sponsor = new HockeySponsor();
+        sponsor.setName("none");
+        sponsor.setSponsorshipValue(1);
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+    
+    public String toString() {
+        return getClass().getSimpleName() + " id:[" + id + "] name:[" + name + "] hashcode:[" + System.identityHashCode(this) + "] embedded: " + sponsor;
+    }
+
+    public HockeySponsor getSponsor() {
+        return sponsor;
+    }
+
+    public void setSponsor(HockeySponsor sponsor) {
+        this.sponsor = sponsor;
+    }
+    
+}

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/complexaggregate/HockeyRink.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/complexaggregate/HockeyRink.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     dminsky - initial API and implementation
+ *     
+ ******************************************************************************/
+package org.eclipse.persistence.testing.models.jpa.complexaggregate;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+
+@Entity
+@Table(name="CMP3_HOCKEY_RINK")
+public class HockeyRink {
+    
+    @Id
+    protected int id;
+    
+    @OneToOne
+    @JoinColumn(name="HOCKEY_PUCK_ID")
+    protected HockeyPuck puck;
+    
+    public HockeyRink() {
+        super();
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public HockeyPuck getPuck() {
+        return puck;
+    }
+
+    public void setPuck(HockeyPuck puck) {
+        this.puck = puck;
+    }
+
+    public String toString() {
+        return getClass().getSimpleName() + " id:[" + id + "] hashcode:[" + System.identityHashCode(this) + "]";
+    }
+    
+}

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/complexaggregate/HockeySponsor.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/complexaggregate/HockeySponsor.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     dminsky - initial API and implementation
+ *     
+ ******************************************************************************/
+package org.eclipse.persistence.testing.models.jpa.complexaggregate;
+
+import java.beans.PropertyChangeListener;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+import org.eclipse.persistence.descriptors.changetracking.ChangeTracker;
+import org.eclipse.persistence.internal.descriptors.changetracking.AttributeChangeListener;
+import org.eclipse.persistence.sessions.UnitOfWork;
+
+@Embeddable
+public class HockeySponsor {
+    
+    @Column(name="SPONSOR_NAME")
+    protected String name;
+    @Column(name="SPONSOR_VALUE")
+    protected int sponsorshipValue;
+    
+    public HockeySponsor() {
+        super();
+    }
+    
+    public String toString() {
+        StringBuffer buffer = new StringBuffer();
+        buffer.append(getClass().getSimpleName() + " hashcode:[" + System.identityHashCode(this) + "]");
+        if (this instanceof ChangeTracker) {
+            PropertyChangeListener listener = ((ChangeTracker)this)._persistence_getPropertyChangeListener();
+            buffer.append(" listener:[" + listener + "]");
+            if (listener != null && listener instanceof AttributeChangeListener) {
+                UnitOfWork uow = ((AttributeChangeListener)listener).getUnitOfWork();
+                buffer.append(" uow:[" + uow + "] uow hashcode: " + System.identityHashCode(uow));
+                buffer.append("]");
+            }
+        }
+        return buffer.toString();
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getSponsorshipValue() {
+        return sponsorshipValue;
+    }
+
+    public void setSponsorshipValue(int sponsorshipValue) {
+        this.sponsorshipValue = sponsorshipValue;
+    }
+
+}

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/complexaggregate/ComplexAggregateTestSuite.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/complexaggregate/ComplexAggregateTestSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2013 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the 
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0 
  * which accompanies this distribution. 
@@ -12,6 +12,7 @@
  ******************************************************************************/  
 package org.eclipse.persistence.testing.tests.jpa.complexaggregate;
 
+import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -25,6 +26,10 @@ import junit.framework.TestSuite;
 import org.eclipse.persistence.annotations.BatchFetchType;
 import org.eclipse.persistence.config.QueryHints;
 import org.eclipse.persistence.descriptors.ClassDescriptor;
+import org.eclipse.persistence.descriptors.changetracking.ChangeTracker;
+import org.eclipse.persistence.internal.descriptors.changetracking.AttributeChangeListener;
+import org.eclipse.persistence.internal.helper.Helper;
+import org.eclipse.persistence.jpa.JpaHelper;
 import org.eclipse.persistence.internal.sessions.DatabaseSessionImpl;
 import org.eclipse.persistence.testing.framework.JoinedAttributeTestHelper;
 import org.eclipse.persistence.testing.framework.QuerySQLTracker;
@@ -38,6 +43,9 @@ import org.eclipse.persistence.testing.models.jpa.complexaggregate.CountryDwelle
 import org.eclipse.persistence.testing.models.jpa.complexaggregate.Heart;
 import org.eclipse.persistence.testing.models.jpa.complexaggregate.HockeyCoach;
 import org.eclipse.persistence.testing.models.jpa.complexaggregate.HockeyPlayer;
+import org.eclipse.persistence.testing.models.jpa.complexaggregate.HockeyPuck;
+import org.eclipse.persistence.testing.models.jpa.complexaggregate.HockeyRink;
+import org.eclipse.persistence.testing.models.jpa.complexaggregate.HockeySponsor;
 import org.eclipse.persistence.testing.models.jpa.complexaggregate.HockeyTeam;
 import org.eclipse.persistence.testing.models.jpa.complexaggregate.Name;
 import org.eclipse.persistence.testing.models.jpa.complexaggregate.PersonalVitals;
@@ -82,6 +90,7 @@ public class ComplexAggregateTestSuite extends JUnitTestCase {
         suite.addTest(new ComplexAggregateTestSuite("testComplexAggregateJoin"));
         suite.addTest(new ComplexAggregateTestSuite("testComplexAggregateBatch"));
         suite.addTest(new ComplexAggregateTestSuite("testAggregateFieldAttributeOverrides"));
+        suite.addTest(new ComplexAggregateTestSuite("testInvalidateAndRefreshEmbeddableParent"));
 
         return suite;
     }
@@ -1107,4 +1116,102 @@ public class ComplexAggregateTestSuite extends JUnitTestCase {
         rollbackTransaction(em);
     }
     
+    /**
+     * Bug 474956 RepeatableUnitOfWork linked by Embeddable in shared cache in specific scenario
+     * Test the invalidation and refresh of a parent object with an Embeddable instantiated
+     * with non-null values. After associating the parent with another object, the Embeddable
+     * should not reference a UnitOfWork (via a change listener) within the shared cache.
+     */
+    public void testInvalidateAndRefreshEmbeddableParent() {
+        // test depends on weaving
+        if (!isWeavingEnabled()) {
+            warning("Test depends on weaving and change tracking");
+            return;
+        }
+
+        HockeyPuck puck = null;
+        HockeyRink rink = null;
+
+        // setup
+        clearCache();
+
+        EntityManager em = createEntityManager();
+        try {
+            beginTransaction(em);
+
+            puck = new HockeyPuck();
+            puck.setId(1);
+            puck.setName("MrWraparound");
+            puck.getSponsor().setName("ACME Cloud Computing Company, Inc.");
+            puck.getSponsor().setSponsorshipValue(1000000);
+            em.persist(puck);
+
+            commitTransaction(em);
+        } finally {
+            closeEntityManager(em);
+        }
+
+        // test
+        em = createEntityManager();
+        try {
+            // 1. invalidate existing Entity in the cache
+            JpaHelper.getDatabaseSession(getEntityManagerFactory()).getIdentityMapAccessor().invalidateObject(puck.getId(), HockeyPuck.class);
+            assertFalse("Existing cached HockeyPuck should not be valid",
+                JpaHelper.getDatabaseSession(getEntityManagerFactory()).getIdentityMapAccessor().isValid(puck.getId(), HockeyPuck.class));
+
+            beginTransaction(em);
+
+            // 2. create new Entity and persist
+            rink = new HockeyRink();
+            rink.setId(1);
+            em.persist(rink);
+
+            // 3. load existing Entity
+            puck = em.createQuery("select object(p) from HockeyPuck p where p.id = " + puck.getId(), HockeyPuck.class).getSingleResult();
+            assertNotNull("HockeyPuck loaded should not be null", puck);
+
+            // 4. associate loaded existing Entity with persisted new Entity
+            rink.setPuck(puck);
+
+            commitTransaction(em);
+        } finally {
+            closeEntityManager(em);
+        }
+
+        // verify, go directly to the shared cache for the parent Entity
+        try {
+            HockeyPuck cachedPuck = (HockeyPuck)JpaHelper.getDatabaseSession(getEntityManagerFactory()).getIdentityMapAccessor().getFromIdentityMap(puck.getId(), HockeyPuck.class);
+            HockeySponsor sponsor = cachedPuck.getSponsor();
+            if (sponsor instanceof ChangeTracker) {
+                PropertyChangeListener listener = ((ChangeTracker)sponsor)._persistence_getPropertyChangeListener();
+                // listener can be null
+                if (listener != null && listener instanceof AttributeChangeListener) {
+                    assertNull("UnitOfWork referenced in Embeddable referenced by an object in the shared cache", ((AttributeChangeListener)listener).getUnitOfWork());
+                }
+            } else {
+                fail("Config error: HockeyPuck/HockeySponsor is not change tracked");
+            }
+        } finally {
+            // reset
+            em = createEntityManager();
+            beginTransaction(em);
+
+            if (puck != null) {
+                puck = em.find(HockeyPuck.class, puck.getId());
+                if (puck != null) {
+                    em.remove(puck);
+                }
+            }
+            if (rink != null) {
+                rink = em.find(HockeyRink.class, rink.getId());
+                if (rink != null) {
+                    em.remove(rink);
+                }
+            }
+
+            commitTransaction(em);
+            closeEntityManager(em);
+        }
+    }
+
 }


### PR DESCRIPTION
- Resolves an issue in AggregateObjectMapping buildAggregateFromRow() by passing in the CacheKey (within buildCloneFromRow()) and checking if the aggregate is referenced within the target object and the CacheKey is null before instantiating a new aggregate instance.
- Added ComplexAggregateTestSuite test: testInvalidateAndRefreshEmbeddableParent within the complex aggregate suite, with new, specialized Entities: HockeyPuck, HockeyRink and HockeySponsor (and associated table creation to ComplexAggregateTableCreator)

Backport from 2.7 https://github.com/eclipse-ee4j/eclipselink/commit/e27a5785c49f790bed1b9d4965f14ffdc0e279c5

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>