### PR TITLE
[2.7] EclipseLink doesn't generate SQL INSERT correctly if @ReturnInsert if used in InheritanceType.JOINED

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/ExpressionQueryMechanism.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/ExpressionQueryMechanism.java
@@ -525,7 +525,16 @@ public class ExpressionQueryMechanism extends StatementQueryMechanism {
         insertStatement.setTable(table);
         insertStatement.setModifyRow(getModifyRow());
         if (getDescriptor().hasReturningPolicies() && getDescriptor().getReturnFieldsToGenerateInsert() != null) {
-            insertStatement.setReturnFields(getDescriptor().getReturnFieldsToGenerateInsert());
+            // In case of RelationalDescriptor only return fields for current table must be used.
+            Vector<DatabaseField> returnFieldsForTable = new NonSynchronizedVector();
+            for (DatabaseField item: getDescriptor().getReturnFieldsToGenerateInsert()) {
+                if (table.equals(item.getTable())) {
+                    returnFieldsForTable.add(item);
+                }
+            }
+            if (!returnFieldsForTable.isEmpty()) {
+                insertStatement.setReturnFields(getDescriptor().getReturnFieldsToGenerateInsert());
+            }
         }
         insertStatement.setHintString(getQuery().getHintString());
         return insertStatement;

--- a/jpa/eclipselink.jpa.test.jse/src/META-INF/persistence.xml
+++ b/jpa/eclipselink.jpa.test.jse/src/META-INF/persistence.xml
@@ -52,10 +52,12 @@
           <exclude-unlisted-classes>true</exclude-unlisted-classes>
           <class>org.eclipse.persistence.jpa.returninsert.model.ReturnInsertDetail</class>
           <class>org.eclipse.persistence.jpa.returninsert.model.ReturnInsertDetailEmbedded</class>
+          <class>org.eclipse.persistence.jpa.returninsert.model.ReturnInsertDetailJoined</class>
           <class>org.eclipse.persistence.jpa.returninsert.model.ReturnInsertDetailParent</class>
           <class>org.eclipse.persistence.jpa.returninsert.model.ReturnInsertDetailPK</class>
           <class>org.eclipse.persistence.jpa.returninsert.model.ReturnInsertMasterPK</class>
           <class>org.eclipse.persistence.jpa.returninsert.model.ReturnInsertMaster</class>
+          <class>org.eclipse.persistence.jpa.returninsert.model.ReturnInsertMasterJoined</class>
           <properties></properties>
      </persistence-unit>
 

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/returninsert/TestReturnInsert.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/returninsert/TestReturnInsert.java
@@ -22,11 +22,8 @@ import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
 import javax.persistence.Query;
 
-import org.eclipse.persistence.internal.jpa.EntityManagerFactoryImpl;
 import org.eclipse.persistence.internal.jpa.EntityManagerImpl;
 import org.eclipse.persistence.jpa.returninsert.model.*;
-import org.eclipse.persistence.platform.database.DatabasePlatform;
-import org.eclipse.persistence.platform.database.OraclePlatform;
 import org.eclipse.persistence.sessions.DatabaseSession;
 import org.junit.Test;
 

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/returninsert/model/ReturnInsertDetailJoined.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/returninsert/model/ReturnInsertDetailJoined.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.jpa.returninsert.model;
+
+import org.eclipse.persistence.annotations.ReturnInsert;
+
+import javax.persistence.*;
+
+/**
+ * The parent persistent class for the JPA22_RETURNINSERT_DETAIL_JOINED database table.
+ * 
+ */
+@Entity
+@Table(name = "JPA22_RETURNINSERT_DETAIL_JOINED")
+@PrimaryKeyJoinColumn(name = "id")
+@DiscriminatorValue("A")
+public class ReturnInsertDetailJoined extends ReturnInsertMasterJoined {
+
+	@Column(name = "detail_nr", nullable = false, unique = true, updatable = false)
+	@ReturnInsert(returnOnly = true)
+	Long detailNumber = null;
+
+	public ReturnInsertDetailJoined() {
+	}
+
+	public ReturnInsertDetailJoined(Long id, String type) {
+		super(id, type);
+	}
+
+	public Long getDetailNumber() {
+		return detailNumber;
+	}
+
+	public void setDetailNumber(Long detailNumber) {
+		this.detailNumber = detailNumber;
+	}
+}

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/returninsert/model/ReturnInsertMasterJoined.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/returninsert/model/ReturnInsertMasterJoined.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.jpa.returninsert.model;
+
+import java.io.Serializable;
+
+import javax.persistence.*;
+
+/**
+ * The persistent class for the JPA22_RETURNINSERT_MASTER_JOINED database table.
+ * 
+ */
+@Entity
+@Table(name = "JPA22_RETURNINSERT_MASTER_JOINED")
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn(name = "type", discriminatorType = DiscriminatorType.STRING)
+@SequenceGenerator(name = "AbstractEntityObjectSEQ_STORE", sequenceName = "TEST_RETURNINSERT_MASTER_JOINED_ID_SEQ", allocationSize = 1)
+public class ReturnInsertMasterJoined implements Serializable {
+
+	@Id
+	private Long id;
+
+	private String type;
+
+	public ReturnInsertMasterJoined() {
+	}
+
+	public ReturnInsertMasterJoined(Long id, String type) {
+		this.id = id;
+		this.type = type;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+}


### PR DESCRIPTION
bugfix + test for bug #803

Backport from master #806 

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>