### PR TITLE
[2.6] EclipseLink doesn't generate SQL INSERT correctly if @ReturnInsert if used in InheritanceType.JOINED

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/ExpressionQueryMechanism.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/ExpressionQueryMechanism.java
@@ -518,7 +518,16 @@ public class ExpressionQueryMechanism extends StatementQueryMechanism {
         insertStatement.setTable(table);
         insertStatement.setModifyRow(getModifyRow());
         if (getDescriptor().hasReturningPolicies() && getDescriptor().getReturnFieldsToGenerateInsert() != null) {
-            insertStatement.setReturnFields(getDescriptor().getReturnFieldsToGenerateInsert());
+            // In case of RelationalDescriptor only return fields for current table must be used.
+            Vector<DatabaseField> returnFieldsForTable = new NonSynchronizedVector();
+            for (DatabaseField item: getDescriptor().getReturnFieldsToGenerateInsert()) {
+                if (table.equals(item.getTable())) {
+                    returnFieldsForTable.add(item);
+                }
+            }
+            if (!returnFieldsForTable.isEmpty()) {
+                insertStatement.setReturnFields(getDescriptor().getReturnFieldsToGenerateInsert());
+            }
         }
         insertStatement.setHintString(getQuery().getHintString());
         return insertStatement;

--- a/jpa/eclipselink.jpa.test.jse/src/META-INF/persistence.xml
+++ b/jpa/eclipselink.jpa.test.jse/src/META-INF/persistence.xml
@@ -41,10 +41,12 @@
           <exclude-unlisted-classes>true</exclude-unlisted-classes>
           <class>org.eclipse.persistence.jpa.test.returninsert.model.ReturnInsertDetail</class>
           <class>org.eclipse.persistence.jpa.test.returninsert.model.ReturnInsertDetailEmbedded</class>
+          <class>org.eclipse.persistence.jpa.test.returninsert.model.ReturnInsertDetailJoined</class>
           <class>org.eclipse.persistence.jpa.test.returninsert.model.ReturnInsertDetailParent</class>
           <class>org.eclipse.persistence.jpa.test.returninsert.model.ReturnInsertDetailPK</class>
           <class>org.eclipse.persistence.jpa.test.returninsert.model.ReturnInsertMasterPK</class>
           <class>org.eclipse.persistence.jpa.test.returninsert.model.ReturnInsertMaster</class>
+          <class>org.eclipse.persistence.jpa.test.returninsert.model.ReturnInsertMasterJoined</class>
           <properties></properties>
      </persistence-unit>
 

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/returninsert/TestReturnInsert.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/returninsert/TestReturnInsert.java
@@ -20,7 +20,6 @@ import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
 import javax.persistence.Query;
 
-import org.eclipse.persistence.internal.jpa.EntityManagerFactoryImpl;
 import org.eclipse.persistence.internal.jpa.EntityManagerImpl;
 import org.eclipse.persistence.jpa.test.returninsert.model.*;
 import org.eclipse.persistence.sessions.DatabaseSession;

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/returninsert/TestReturnInsert.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/returninsert/TestReturnInsert.java
@@ -20,6 +20,7 @@ import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
 import javax.persistence.Query;
 
+import org.eclipse.persistence.internal.jpa.EntityManagerFactoryImpl;
 import org.eclipse.persistence.internal.jpa.EntityManagerImpl;
 import org.eclipse.persistence.jpa.test.returninsert.model.*;
 import org.eclipse.persistence.sessions.DatabaseSession;
@@ -58,6 +59,7 @@ public class TestReturnInsert {
         testCreate();
         testFindUpdate();
         testQuery();
+        testCreateJoined();
         emf.close();
     }
 
@@ -71,6 +73,14 @@ public class TestReturnInsert {
             }
             try {
                 session.executeNonSelectingSQL("DROP TABLE JPA22_RETURNINSERT_MASTER");
+            } catch (Exception ignore) {
+            }
+            try {
+                session.executeNonSelectingSQL("DROP TABLE JPA22_RETURNINSERT_DETAIL_JOINED");
+            } catch (Exception ignore) {
+            }
+            try {
+                session.executeNonSelectingSQL("DROP TABLE JPA22_RETURNINSERT_MASTER_JOINED");
             } catch (Exception ignore) {
             }
             try {
@@ -95,6 +105,12 @@ public class TestReturnInsert {
                         "    COL5_VIRTUAL VARCHAR (100) AS ( COL5 || '_col5' ) VIRTUAL)");
                 session.executeNonSelectingSQL("ALTER TABLE JPA22_RETURNINSERT_DETAIL ADD CONSTRAINT PKJPA22_RETURNINSERT_DETAIL PRIMARY KEY ( ID_VIRTUAL, ID, COL1, COL2 )");
                 session.executeNonSelectingSQL("ALTER TABLE JPA22_RETURNINSERT_DETAIL ADD CONSTRAINT FKJPA22_RETURNINSERT_MASTER_DETAIL FOREIGN KEY ( ID_VIRTUAL, ID, COL1 ) REFERENCES JPA22_RETURNINSERT_MASTER ( ID_VIRTUAL, ID, COL1 ) NOT DEFERRABLE");
+                session.executeNonSelectingSQL("CREATE TABLE JPA22_RETURNINSERT_MASTER_JOINED  (" +
+                        "    ID     NUMBER(15) PRIMARY KEY ," +
+                        "    TYPE   VARCHAR2(50) NOT NULL)");
+                session.executeNonSelectingSQL("CREATE TABLE JPA22_RETURNINSERT_DETAIL_JOINED  (" +
+                        "    ID          NUMBER(15) PRIMARY KEY ," +
+                        "    DETAIL_NR   NUMBER(15) AS ( ID * 10 ) VIRTUAL)");
             } catch (Exception ignore) {
             }
         } finally {
@@ -137,6 +153,29 @@ public class TestReturnInsert {
         assertEquals("abc_col2", returnInsertDetail.getReturnInsertDetailEmbedded().getCol2Virtual());
         assertEquals("opq_col4", returnInsertDetail.getCol4Virtual());
         assertEquals("lmn_col5", returnInsertDetail.getReturnInsertDetailEmbedded().getReturnInsertDetailEmbeddedEmbedded().getCol5Virtual());
+    }
+
+    private void testCreateJoined() {
+        ReturnInsertDetailJoined returnInsertDetailJoined = null;
+
+        EntityManager em = emf.createEntityManager();
+        try {
+            em.getTransaction().begin();
+            returnInsertDetailJoined = new ReturnInsertDetailJoined(1L, "TYPE_A");
+            returnInsertDetailJoined = em.merge(returnInsertDetailJoined);
+
+            em.getTransaction().commit();
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if (em.isOpen()) {
+                em.close();
+            }
+        }
+        assertEquals(Long.valueOf(1L), returnInsertDetailJoined.getId());
+        assertEquals("TYPE_A", returnInsertDetailJoined.getType());
+        assertEquals(Long.valueOf(10L), returnInsertDetailJoined.getDetailNumber());
     }
 
     private void testFindUpdate() {
@@ -252,5 +291,4 @@ public class TestReturnInsert {
         returnInsertDetailPK.setCol2("abc");
         return returnInsertDetailPK;
     }
-
 }

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/returninsert/model/ReturnInsertDetailJoined.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/returninsert/model/ReturnInsertDetailJoined.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     Oracle - initial API and implementation
+ ******************************************************************************/
+package org.eclipse.persistence.jpa.test.returninsert.model;
+
+import org.eclipse.persistence.annotations.ReturnInsert;
+
+import javax.persistence.*;
+
+/**
+ * The parent persistent class for the JPA22_RETURNINSERT_DETAIL_JOINED database table.
+ * 
+ */
+@Entity
+@Table(name = "JPA22_RETURNINSERT_DETAIL_JOINED")
+@PrimaryKeyJoinColumn(name = "id")
+@DiscriminatorValue("A")
+public class ReturnInsertDetailJoined extends ReturnInsertMasterJoined {
+
+	@Column(name = "detail_nr", nullable = false, unique = true, updatable = false)
+	@ReturnInsert(returnOnly = true)
+	Long detailNumber = null;
+
+	public ReturnInsertDetailJoined() {
+	}
+
+	public ReturnInsertDetailJoined(Long id, String type) {
+		super(id, type);
+	}
+
+	public Long getDetailNumber() {
+		return detailNumber;
+	}
+
+	public void setDetailNumber(Long detailNumber) {
+		this.detailNumber = detailNumber;
+	}
+}

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/returninsert/model/ReturnInsertMasterJoined.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/returninsert/model/ReturnInsertMasterJoined.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     Oracle - initial API and implementation
+ ******************************************************************************/
+package org.eclipse.persistence.jpa.test.returninsert.model;
+
+import java.io.Serializable;
+
+import javax.persistence.*;
+
+/**
+ * The persistent class for the JPA22_RETURNINSERT_MASTER_JOINED database table.
+ * 
+ */
+@Entity
+@Table(name = "JPA22_RETURNINSERT_MASTER_JOINED")
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn(name = "type", discriminatorType = DiscriminatorType.STRING)
+@SequenceGenerator(name = "AbstractEntityObjectSEQ_STORE", sequenceName = "TEST_RETURNINSERT_MASTER_JOINED_ID_SEQ", allocationSize = 1)
+public class ReturnInsertMasterJoined implements Serializable {
+
+	@Id
+	private Long id;
+
+	private String type;
+
+	public ReturnInsertMasterJoined() {
+	}
+
+	public ReturnInsertMasterJoined(Long id, String type) {
+		this.id = id;
+		this.type = type;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+}


### PR DESCRIPTION
bugfix + test for bug #803

Backport from master #806

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>