### PR TITLE
[master] Maven build Oracle tests refactoring

### DIFF
--- a/dbws/eclipselink.dbws.test.oracle/pom.xml
+++ b/dbws/eclipselink.dbws.test.oracle/pom.xml
@@ -86,91 +86,98 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <configuration>
-                    <!--Set system properties required for tests-->
-                    <systemPropertiesFile>${test.properties.file}</systemPropertiesFile>
-                    <workingDirectory>${project.build.directory}/test-run</workingDirectory>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>test-dbws-oracle</id>
-                        <goals>
-                            <goal>integration-test</goal>
-                        </goals>
-                        <configuration>
-                            <skipTests>${test-skip-dbws-oracle}</skipTests>
-                            <reportNameSuffix>test-dbws-oracle</reportNameSuffix>
-                            <includes>
-                                <include>dbws.testing.AllTests</include>
-                            </includes>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>verify-integration-tests</id>
-                        <goals>
-                            <goal>verify</goal>
-                        </goals>
-                        <configuration>
-                            <skip>${integration.test.skip.verify}</skip>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <!--This plugin sql-maven-plugin must be after maven-surefire-plugin to call dbteardown*.sql scripts after tests-->
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>sql-maven-plugin</artifactId>
-                <configuration>
-                    <!--all executions are ignored if -DskipTests-->
-                    <skip>${test-skip-dbws-oracle}</skip>
-                </configuration>
-                <executions>
-                    <!-- create db tables after test -->
-                    <execution>
-                        <id>create-tables-before-test</id>
-                        <phase>pre-integration-test</phase>
-                        <goals>
-                            <goal>execute</goal>
-                        </goals>
-                        <configuration>
-                            <autocommit>true</autocommit>
-                            <delimiter>|</delimiter>
-                            <onError>continue</onError>
-                            <srcFiles>
-                                <srcFile>${integration.test.resources.directory}/sql/dbsetup_oracleobjecttype.sql</srcFile>
-                                <srcFile>${integration.test.resources.directory}/sql/dbsetup_plsqlcollection.sql</srcFile>
-                                <srcFile>${integration.test.resources.directory}/sql/dbsetup_veearray.sql</srcFile>
-                            </srcFiles>
-                        </configuration>
-                    </execution>
-                    <!-- drop db tables after test -->
-                    <execution>
-                        <id>drop-tables-after-test</id>
-                        <phase>post-integration-test</phase>
-                        <goals>
-                            <goal>execute</goal>
-                        </goals>
-                        <configuration>
-                            <autocommit>true</autocommit>
-                            <delimiter>|</delimiter>
-                            <onError>continue</onError>
-                            <srcFiles>
-                                <srcFile>${integration.test.resources.directory}/sql/dbteardown_oracleobjecttype.sql</srcFile>
-                                <srcFile>${integration.test.resources.directory}/sql/dbteardown_plsqlcollection.sql</srcFile>
-                                <srcFile>${integration.test.resources.directory}/sql/dbteardown_veearray.sql</srcFile>
-                            </srcFiles>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 
     <profiles>
         <!--DBWS Test Oracle related profiles-->
+        <profile>
+            <id>oracle</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <!--Set system properties required for tests-->
+                            <systemPropertiesFile>${test.properties.file}</systemPropertiesFile>
+                            <workingDirectory>${project.build.directory}/test-run</workingDirectory>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>test-dbws-oracle</id>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                </goals>
+                                <configuration>
+                                    <skipTests>${test-skip-dbws-oracle}</skipTests>
+                                    <reportNameSuffix>test-dbws-oracle</reportNameSuffix>
+                                    <includes>
+                                        <include>dbws.testing.AllTests</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>verify-integration-tests</id>
+                                <goals>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${integration.test.skip.verify}</skip>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!--This plugin sql-maven-plugin must be after maven-surefire-plugin to call dbteardown*.sql scripts after tests-->
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>sql-maven-plugin</artifactId>
+                        <configuration>
+                            <!--all executions are ignored if -DskipTests-->
+                            <skip>${test-skip-dbws-oracle}</skip>
+                        </configuration>
+                        <executions>
+                            <!-- create db tables after test -->
+                            <execution>
+                                <id>create-tables-before-test</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>execute</goal>
+                                </goals>
+                                <configuration>
+                                    <autocommit>true</autocommit>
+                                    <delimiter>|</delimiter>
+                                    <onError>continue</onError>
+                                    <srcFiles>
+                                        <srcFile>${integration.test.resources.directory}/sql/dbsetup_oracleobjecttype.sql</srcFile>
+                                        <srcFile>${integration.test.resources.directory}/sql/dbsetup_plsqlcollection.sql</srcFile>
+                                        <srcFile>${integration.test.resources.directory}/sql/dbsetup_veearray.sql</srcFile>
+                                    </srcFiles>
+                                </configuration>
+                            </execution>
+                            <!-- drop db tables after test -->
+                            <execution>
+                                <id>drop-tables-after-test</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>execute</goal>
+                                </goals>
+                                <configuration>
+                                    <autocommit>true</autocommit>
+                                    <delimiter>|</delimiter>
+                                    <onError>continue</onError>
+                                    <srcFiles>
+                                        <srcFile>${integration.test.resources.directory}/sql/dbteardown_oracleobjecttype.sql</srcFile>
+                                        <srcFile>${integration.test.resources.directory}/sql/dbteardown_plsqlcollection.sql</srcFile>
+                                        <srcFile>${integration.test.resources.directory}/sql/dbteardown_veearray.sql</srcFile>
+                                    </srcFiles>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>test-dbws-oracle</id>
             <properties>

--- a/foundation/org.eclipse.persistence.oracle.nosql/pom.xml
+++ b/foundation/org.eclipse.persistence.oracle.nosql/pom.xml
@@ -149,54 +149,6 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
-            <!--Run specified tests/test suite-->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <configuration>
-                    <!--Set system properties required for tests-->
-                    <systemPropertiesFile>${test.properties.file}</systemPropertiesFile>
-                    <workingDirectory>${project.build.directory}/test-run</workingDirectory>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>test-oracle-nosql</id>
-                        <goals>
-                            <goal>integration-test</goal>
-                        </goals>
-                        <configuration>
-                            <skipTests>${test-skip-oracle-nosql}</skipTests>
-                            <reportNameSuffix>test-oracle-nosql</reportNameSuffix>
-                            <includes>
-                                <include>org.eclipse.persistence.testing.tests.eis.nosql.NoSQLTestSuite</include>
-                                <include>org.eclipse.persistence.testing.tests.jpa.nosql.NoSQLJPATestSuite</include>
-                            </includes>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>test-oracle-aq</id>
-                        <goals>
-                            <goal>integration-test</goal>
-                        </goals>
-                        <configuration>
-                            <skipTests>${test-skip-oracle-nosql}</skipTests>
-                            <reportNameSuffix>test-oracle-aq</reportNameSuffix>
-                            <includes>
-                                <include>org.eclipse.persistence.testing.tests.eis.aq.AQTestSuite</include>
-                            </includes>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>verify-integration-tests</id>
-                        <goals>
-                            <goal>verify</goal>
-                        </goals>
-                        <configuration>
-                            <skip>${integration.test.skip.verify}</skip>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
@@ -240,6 +192,61 @@
 
     <profiles>
         <!--Oracle Extension related profiles-->
+        <profile>
+            <id>oracle</id>
+            <build>
+                <plugins>
+                    <!--Run specified tests/test suite-->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <!--Set system properties required for tests-->
+                            <systemPropertiesFile>${test.properties.file}</systemPropertiesFile>
+                            <workingDirectory>${project.build.directory}/test-run</workingDirectory>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>test-oracle-nosql</id>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                </goals>
+                                <configuration>
+                                    <skipTests>${test-skip-oracle-nosql}</skipTests>
+                                    <reportNameSuffix>test-oracle-nosql</reportNameSuffix>
+                                    <includes>
+                                        <include>org.eclipse.persistence.testing.tests.eis.nosql.NoSQLTestSuite</include>
+                                        <include>org.eclipse.persistence.testing.tests.jpa.nosql.NoSQLJPATestSuite</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>test-oracle-aq</id>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                </goals>
+                                <configuration>
+                                    <skipTests>${test-skip-oracle-nosql}</skipTests>
+                                    <reportNameSuffix>test-oracle-aq</reportNameSuffix>
+                                    <includes>
+                                        <include>org.eclipse.persistence.testing.tests.eis.aq.AQTestSuite</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>verify-integration-tests</id>
+                                <goals>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${integration.test.skip.verify}</skip>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>test-oracle-nosql</id>
             <properties>

--- a/foundation/org.eclipse.persistence.oracle.test/pom.xml
+++ b/foundation/org.eclipse.persistence.oracle.test/pom.xml
@@ -146,209 +146,6 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <configuration>
-                    <dependenciesToScan>
-                        <dependency>org.eclipse.persistence:org.eclipse.persistence.core.test.framework</dependency>
-                    </dependenciesToScan>
-                    <!--Set system properties required for tests-->
-                    <systemPropertiesFile>${test.properties.file}</systemPropertiesFile>
-                    <workingDirectory>${project.build.directory}/test-run</workingDirectory>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>clear-database</id>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>integration-test</goal>
-                        </goals>
-                        <configuration>
-                            <skipTests>${test-skip-oracle-extension}</skipTests>
-                            <reportNameSuffix>clear-database</reportNameSuffix>
-                            <includes>
-                                <test>org.eclipse.persistence.testing.tests.ClearDatabaseSchemaTest</test>
-                            </includes>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>test-oracle-extension</id>
-                        <goals>
-                            <goal>integration-test</goal>
-                        </goals>
-                        <configuration>
-                            <skipTests>${test-skip-oracle-extension}</skipTests>
-                            <reportNameSuffix>test-oracle-extension</reportNameSuffix>
-                            <argLine>-Djava.naming.factory.initial=com.sun.jndi.cosnaming.CNCtxFactory</argLine>
-                            <systemPropertyVariables>
-                                <pa.connection.user>${pa.connection.user}</pa.connection.user>
-                                <pa.connection.password>${pa.connection.password}</pa.connection.password>
-                                <pa.proxyuser>${pa.proxyuser}</pa.proxyuser>
-                                <pa.proxyuser.password>${pa.proxyuser.password}</pa.proxyuser.password>
-                                <pa.proxyuser2>${pa.proxyuser2}</pa.proxyuser2>
-                                <pa.proxyuser2.password>${pa.proxyuser2.password}</pa.proxyuser2.password>
-                                <!--Override db.platform system property loaded from file.
-                                For Oracle DB Extension tests is required: org.eclipse.persistence.platform.database.oracle.Oracle12Platform
-                                instead of: org.eclipse.persistence.platform.database.Oracle12Platform-->
-                                <db.platform>${db.platform.oracle.ext}</db.platform>
-                            </systemPropertyVariables>
-                            <includes>
-                                <include>org.eclipse.persistence.testing.tests.OracleTestModel</include>
-                                <include>org.eclipse.persistence.testing.tests.xdb.XDBTestModel</include>
-                                <include>org.eclipse.persistence.testing.tests.xdb.XDBTestModelMWIntegration</include>
-                                <include>org.eclipse.persistence.testing.tests.unwrappedconnection.UnwrapConnectionXDBTestModel</include>
-                            </includes>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>verify-integration-tests</id>
-                        <goals>
-                            <goal>verify</goal>
-                        </goals>
-                        <configuration>
-                            <skip>${integration.test.skip.verify}</skip>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <!--This plugin sql-maven-plugin must be after maven-surefire-plugin to call dbteardown*.sql scripts after tests-->
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>sql-maven-plugin</artifactId>
-                <!-- common configuration shared by all executions -->
-                <configuration>
-                    <username>${db.sys.user} as sysdba</username>
-                    <password>${db.sys.pwd}</password>
-                    <autocommit>true</autocommit>
-                    <onError>continue</onError>
-                    <!--all executions are ignored if -Dmaven.test.skip=true-->
-                    <skip>${test-skip-oracle-extension}</skip>
-                </configuration>
-                <executions>
-                    <!-- create proxy user and grant permissions -->
-                    <execution>
-                        <id>setup-connuser</id>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>execute</goal>
-                        </goals>
-                        <configuration>
-                            <sqlCommand>
-                                DROP USER ${pa.connection.user} CASCADE;
-
-                                CREATE USER ${pa.connection.user} IDENTIFIED BY ${pa.connection.password} ACCOUNT UNLOCK;
-                                GRANT CONNECT TO ${pa.connection.user};
-                                GRANT RESOURCE TO ${pa.connection.user};
-                                GRANT CREATE SESSION TO ${pa.connection.user};
-                                GRANT UNLIMITED TABLESPACE TO ${pa.connection.user};
-                                GRANT CREATE ANY VIEW TO ${pa.connection.user};
-                                GRANT CREATE ANY context TO ${pa.connection.user};
-                                GRANT DROP ANY context TO ${pa.connection.user};
-                                GRANT EXECUTE ON dbms_flashback TO ${pa.connection.user};
-                                GRANT EXECUTE ON dbms_rls TO ${pa.connection.user};
-                                GRANT EXECUTE ON dbms_session TO ${pa.connection.user};
-                                GRANT change notification TO ${pa.connection.user};
-                                GRANT CREATE ANY directory TO ${pa.connection.user};
-                                GRANT DROP ANY directory TO ${pa.connection.user};
-                            </sqlCommand>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>setup-proxy-authentication</id>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>execute</goal>
-                        </goals>
-                        <configuration>
-                            <sqlCommand>
-                                DROP USER ${pa.proxyuser} CASCADE;
-                                DROP USER ${pa.proxyuser2} CASCADE;
-
-                                CREATE USER ${pa.proxyuser} IDENTIFIED BY ${pa.proxyuser.password} ACCOUNT UNLOCK;
-                                CREATE USER ${pa.proxyuser2} IDENTIFIED BY ${pa.proxyuser2.password} ACCOUNT UNLOCK;
-                                GRANT UNLIMITED TABLESPACE TO ${pa.proxyuser};
-                                GRANT UNLIMITED TABLESPACE TO ${pa.proxyuser2};
-                                GRANT CONNECT TO ${pa.proxyuser};
-                                GRANT CONNECT TO ${pa.proxyuser2};
-                                GRANT RESOURCE TO ${pa.proxyuser};
-                                GRANT CREATE SESSION TO ${pa.proxyuser};
-                                ALTER USER ${pa.proxyuser} GRANT CONNECT THROUGH ${pa.connection.user};
-                                ALTER USER ${pa.proxyuser2} GRANT CONNECT THROUGH ${pa.connection.user};
-                            </sqlCommand>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>setup-proxy-authentication-create-employee-table</id>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>execute</goal>
-                        </goals>
-                        <configuration>
-                            <username>${pa.connection.user}</username>
-                            <password>${pa.connection.password}</password>
-                            <sqlCommand>
-                                CREATE TABLE JPA_PROXY_EMPLOYEE (
-                                    EMP_ID NUMBER (15) NOT NULL,
-                                    F_NAME VARCHAR2 (40) NULL,
-                                    L_NAME VARCHAR2 (40) NULL,
-                                    PRIMARY KEY (EMP_ID)
-                                );
-                                CREATE TABLE PROXY_EMPLOYEE_SEQ (
-                                    SEQ_NAME  VARCHAR2 (50) NOT NULL,
-                                    SEQ_COUNT NUMBER (38) NULL,
-                                    PRIMARY KEY (SEQ_NAME)
-                                );
-                                INSERT INTO PROXY_EMPLOYEE_SEQ (SEQ_NAME, SEQ_COUNT) VALUES ('PROXY_EMPLOYEE_SEQ', 1);
-                            </sqlCommand>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>setup-proxy-authentication-create-phonenumber-table</id>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>execute</goal>
-                        </goals>
-                        <configuration>
-                            <username>${pa.proxyuser}</username>
-                            <password>${pa.proxyuser.password}</password>
-                            <sqlCommand>
-                                CREATE TABLE PROXY_PHONENUMBER (
-                                    OWNER_ID  NUMBER (15) NOT NULL,
-                                    TYPE      VARCHAR2 (15) NOT NULL,
-                                    AREA_CODE VARCHAR2 (3) NULL,
-                                    NUMB      VARCHAR2 (8) NULL,
-                                    PRIMARY KEY (OWNER_ID, TYPE)
-                                );
-                            </sqlCommand>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>grant-permissions-to-proxyuser</id>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>execute</goal>
-                        </goals>
-                        <configuration>
-                            <sqlCommand>
-                                GRANT ALTER ON ${pa.connection.user}.JPA_PROXY_EMPLOYEE TO ${pa.proxyuser};
-                                GRANT DELETE ON ${pa.connection.user}.JPA_PROXY_EMPLOYEE TO ${pa.proxyuser};
-                                GRANT INSERT ON ${pa.connection.user}.JPA_PROXY_EMPLOYEE TO ${pa.proxyuser};
-                                GRANT SELECT ON ${pa.connection.user}.JPA_PROXY_EMPLOYEE TO ${pa.proxyuser};
-                                GRANT UPDATE ON ${pa.connection.user}.JPA_PROXY_EMPLOYEE TO ${pa.proxyuser};
-                                GRANT INDEX ON ${pa.connection.user}.JPA_PROXY_EMPLOYEE TO ${pa.proxyuser};
-
-                                GRANT ALTER ON ${pa.connection.user}.PROXY_EMPLOYEE_SEQ TO ${pa.proxyuser};
-                                GRANT DELETE ON ${pa.connection.user}.PROXY_EMPLOYEE_SEQ TO ${pa.proxyuser};
-                                GRANT INSERT ON ${pa.connection.user}.PROXY_EMPLOYEE_SEQ TO ${pa.proxyuser};
-                                GRANT SELECT ON ${pa.connection.user}.PROXY_EMPLOYEE_SEQ TO ${pa.proxyuser};
-                                GRANT UPDATE ON ${pa.connection.user}.PROXY_EMPLOYEE_SEQ TO ${pa.proxyuser};
-                                GRANT INDEX ON ${pa.connection.user}.PROXY_EMPLOYEE_SEQ TO ${pa.proxyuser};
-                            </sqlCommand>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
             <!--Pack test classes due dependency to other modules (Oracle Spatial Test)-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -415,6 +212,216 @@
 
     <profiles>
         <!--Oracle Extension related profiles-->
+        <profile>
+            <id>oracle</id>
+            <build>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <configuration>
+                        <dependenciesToScan>
+                            <dependency>org.eclipse.persistence:org.eclipse.persistence.core.test.framework</dependency>
+                        </dependenciesToScan>
+                        <!--Set system properties required for tests-->
+                        <systemPropertiesFile>${test.properties.file}</systemPropertiesFile>
+                        <workingDirectory>${project.build.directory}/test-run</workingDirectory>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>clear-database</id>
+                            <phase>process-test-resources</phase>
+                            <goals>
+                                <goal>integration-test</goal>
+                            </goals>
+                            <configuration>
+                                <skipTests>${test-skip-oracle-extension}</skipTests>
+                                <reportNameSuffix>clear-database</reportNameSuffix>
+                                <includes>
+                                    <test>org.eclipse.persistence.testing.tests.ClearDatabaseSchemaTest</test>
+                                </includes>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>test-oracle-extension</id>
+                            <goals>
+                                <goal>integration-test</goal>
+                            </goals>
+                            <configuration>
+                                <skipTests>${test-skip-oracle-extension}</skipTests>
+                                <reportNameSuffix>test-oracle-extension</reportNameSuffix>
+                                <argLine>-Djava.naming.factory.initial=com.sun.jndi.cosnaming.CNCtxFactory</argLine>
+                                <systemPropertyVariables>
+                                    <pa.connection.user>${pa.connection.user}</pa.connection.user>
+                                    <pa.connection.password>${pa.connection.password}</pa.connection.password>
+                                    <pa.proxyuser>${pa.proxyuser}</pa.proxyuser>
+                                    <pa.proxyuser.password>${pa.proxyuser.password}</pa.proxyuser.password>
+                                    <pa.proxyuser2>${pa.proxyuser2}</pa.proxyuser2>
+                                    <pa.proxyuser2.password>${pa.proxyuser2.password}</pa.proxyuser2.password>
+                                    <!--Override db.platform system property loaded from file.
+                                    For Oracle DB Extension tests is required: org.eclipse.persistence.platform.database.oracle.Oracle12Platform
+                                    instead of: org.eclipse.persistence.platform.database.Oracle12Platform-->
+                                    <db.platform>${db.platform.oracle.ext}</db.platform>
+                                </systemPropertyVariables>
+                                <includes>
+                                    <include>org.eclipse.persistence.testing.tests.OracleTestModel</include>
+                                    <include>org.eclipse.persistence.testing.tests.xdb.XDBTestModel</include>
+                                    <include>org.eclipse.persistence.testing.tests.xdb.XDBTestModelMWIntegration</include>
+                                    <include>org.eclipse.persistence.testing.tests.unwrappedconnection.UnwrapConnectionXDBTestModel</include>
+                                </includes>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>verify-integration-tests</id>
+                            <goals>
+                                <goal>verify</goal>
+                            </goals>
+                            <configuration>
+                                <skip>${integration.test.skip.verify}</skip>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                <!--This plugin sql-maven-plugin must be after maven-surefire-plugin to call dbteardown*.sql scripts after tests-->
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>sql-maven-plugin</artifactId>
+                    <!-- common configuration shared by all executions -->
+                    <configuration>
+                        <username>${db.sys.user} as sysdba</username>
+                        <password>${db.sys.pwd}</password>
+                        <autocommit>true</autocommit>
+                        <onError>continue</onError>
+                        <!--all executions are ignored if -Dmaven.test.skip=true-->
+                        <skip>${test-skip-oracle-extension}</skip>
+                    </configuration>
+                    <executions>
+                        <!-- create proxy user and grant permissions -->
+                        <execution>
+                            <id>setup-connuser</id>
+                            <phase>process-test-resources</phase>
+                            <goals>
+                                <goal>execute</goal>
+                            </goals>
+                            <configuration>
+                                <sqlCommand>
+                                    DROP USER ${pa.connection.user} CASCADE;
+
+                                    CREATE USER ${pa.connection.user} IDENTIFIED BY ${pa.connection.password} ACCOUNT UNLOCK;
+                                    GRANT CONNECT TO ${pa.connection.user};
+                                    GRANT RESOURCE TO ${pa.connection.user};
+                                    GRANT CREATE SESSION TO ${pa.connection.user};
+                                    GRANT UNLIMITED TABLESPACE TO ${pa.connection.user};
+                                    GRANT CREATE ANY VIEW TO ${pa.connection.user};
+                                    GRANT CREATE ANY context TO ${pa.connection.user};
+                                    GRANT DROP ANY context TO ${pa.connection.user};
+                                    GRANT EXECUTE ON dbms_flashback TO ${pa.connection.user};
+                                    GRANT EXECUTE ON dbms_rls TO ${pa.connection.user};
+                                    GRANT EXECUTE ON dbms_session TO ${pa.connection.user};
+                                    GRANT change notification TO ${pa.connection.user};
+                                    GRANT CREATE ANY directory TO ${pa.connection.user};
+                                    GRANT DROP ANY directory TO ${pa.connection.user};
+                                </sqlCommand>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>setup-proxy-authentication</id>
+                            <phase>process-test-resources</phase>
+                            <goals>
+                                <goal>execute</goal>
+                            </goals>
+                            <configuration>
+                                <sqlCommand>
+                                    DROP USER ${pa.proxyuser} CASCADE;
+                                    DROP USER ${pa.proxyuser2} CASCADE;
+
+                                    CREATE USER ${pa.proxyuser} IDENTIFIED BY ${pa.proxyuser.password} ACCOUNT UNLOCK;
+                                    CREATE USER ${pa.proxyuser2} IDENTIFIED BY ${pa.proxyuser2.password} ACCOUNT UNLOCK;
+                                    GRANT UNLIMITED TABLESPACE TO ${pa.proxyuser};
+                                    GRANT UNLIMITED TABLESPACE TO ${pa.proxyuser2};
+                                    GRANT CONNECT TO ${pa.proxyuser};
+                                    GRANT CONNECT TO ${pa.proxyuser2};
+                                    GRANT RESOURCE TO ${pa.proxyuser};
+                                    GRANT CREATE SESSION TO ${pa.proxyuser};
+                                    ALTER USER ${pa.proxyuser} GRANT CONNECT THROUGH ${pa.connection.user};
+                                    ALTER USER ${pa.proxyuser2} GRANT CONNECT THROUGH ${pa.connection.user};
+                                </sqlCommand>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>setup-proxy-authentication-create-employee-table</id>
+                            <phase>process-test-resources</phase>
+                            <goals>
+                                <goal>execute</goal>
+                            </goals>
+                            <configuration>
+                                <username>${pa.connection.user}</username>
+                                <password>${pa.connection.password}</password>
+                                <sqlCommand>
+                                    CREATE TABLE JPA_PROXY_EMPLOYEE (
+                                                                        EMP_ID NUMBER (15) NOT NULL,
+                                                                        F_NAME VARCHAR2 (40) NULL,
+                                                                        L_NAME VARCHAR2 (40) NULL,
+                                                                        PRIMARY KEY (EMP_ID)
+                                    );
+                                    CREATE TABLE PROXY_EMPLOYEE_SEQ (
+                                                                        SEQ_NAME  VARCHAR2 (50) NOT NULL,
+                                                                        SEQ_COUNT NUMBER (38) NULL,
+                                                                        PRIMARY KEY (SEQ_NAME)
+                                    );
+                                    INSERT INTO PROXY_EMPLOYEE_SEQ (SEQ_NAME, SEQ_COUNT) VALUES ('PROXY_EMPLOYEE_SEQ', 1);
+                                </sqlCommand>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>setup-proxy-authentication-create-phonenumber-table</id>
+                            <phase>process-test-resources</phase>
+                            <goals>
+                                <goal>execute</goal>
+                            </goals>
+                            <configuration>
+                                <username>${pa.proxyuser}</username>
+                                <password>${pa.proxyuser.password}</password>
+                                <sqlCommand>
+                                    CREATE TABLE PROXY_PHONENUMBER (
+                                                                       OWNER_ID  NUMBER (15) NOT NULL,
+                                                                       TYPE      VARCHAR2 (15) NOT NULL,
+                                                                       AREA_CODE VARCHAR2 (3) NULL,
+                                                                       NUMB      VARCHAR2 (8) NULL,
+                                                                       PRIMARY KEY (OWNER_ID, TYPE)
+                                    );
+                                </sqlCommand>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>grant-permissions-to-proxyuser</id>
+                            <phase>process-test-resources</phase>
+                            <goals>
+                                <goal>execute</goal>
+                            </goals>
+                            <configuration>
+                                <sqlCommand>
+                                    GRANT ALTER ON ${pa.connection.user}.JPA_PROXY_EMPLOYEE TO ${pa.proxyuser};
+                                    GRANT DELETE ON ${pa.connection.user}.JPA_PROXY_EMPLOYEE TO ${pa.proxyuser};
+                                    GRANT INSERT ON ${pa.connection.user}.JPA_PROXY_EMPLOYEE TO ${pa.proxyuser};
+                                    GRANT SELECT ON ${pa.connection.user}.JPA_PROXY_EMPLOYEE TO ${pa.proxyuser};
+                                    GRANT UPDATE ON ${pa.connection.user}.JPA_PROXY_EMPLOYEE TO ${pa.proxyuser};
+                                    GRANT INDEX ON ${pa.connection.user}.JPA_PROXY_EMPLOYEE TO ${pa.proxyuser};
+
+                                    GRANT ALTER ON ${pa.connection.user}.PROXY_EMPLOYEE_SEQ TO ${pa.proxyuser};
+                                    GRANT DELETE ON ${pa.connection.user}.PROXY_EMPLOYEE_SEQ TO ${pa.proxyuser};
+                                    GRANT INSERT ON ${pa.connection.user}.PROXY_EMPLOYEE_SEQ TO ${pa.proxyuser};
+                                    GRANT SELECT ON ${pa.connection.user}.PROXY_EMPLOYEE_SEQ TO ${pa.proxyuser};
+                                    GRANT UPDATE ON ${pa.connection.user}.PROXY_EMPLOYEE_SEQ TO ${pa.proxyuser};
+                                    GRANT INDEX ON ${pa.connection.user}.PROXY_EMPLOYEE_SEQ TO ${pa.proxyuser};
+                                </sqlCommand>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+            </build>
+        </profile>
         <profile>
             <id>test-oracle-extension</id>
             <properties>

--- a/utils/eclipselink.dbws.builder.test.oracle.server/pom.xml
+++ b/utils/eclipselink.dbws.builder.test.oracle.server/pom.xml
@@ -87,78 +87,85 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <configuration>
-                    <!--Set system properties required for tests-->
-                    <systemPropertiesFile>${test.properties.file}</systemPropertiesFile>
-                    <systemPropertyVariables>
-                        <db.ddl.create>true</db.ddl.create>
-                        <db.ddl.drop>true</db.ddl.drop>
-                        <db.ddl.debug>false</db.ddl.debug>
-                    </systemPropertyVariables>
-                    <workingDirectory>${project.build.directory}/test-run</workingDirectory>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>test-dbws-builder-oracle-server_builder</id>
-                        <goals>
-                            <goal>integration-test</goal>
-                        </goals>
-                        <configuration>
-                            <!--<skipTests>true</skipTests>-->
-                            <skipTests>${test-skip-dbws-builder-oracle-server}</skipTests>
-                            <reportNameSuffix>test-dbws-builder-oracle-server_builder</reportNameSuffix>
-                            <includes>
-                                <include>dbws.testing.attachedbinary.AttachedBinaryBuilderTestSuite</include>
-                                <include>dbws.testing.inlinebinary.InlineBinaryBuilderTestSuite</include>
-                                <include>dbws.testing.mtom.MTOMBuilderTestSuite</include>
-                                <include>dbws.testing.simpleplsql.SimplePLSQLBuilderTestSuite</include>
-                                <include>dbws.testing.simplesp.SimpleSPBuilderTestSuite</include>
-                                <include>dbws.testing.simplesql.SimpleSQLBuilderTestSuite</include>
-                                <include>dbws.testing.simpletable.SimpleTableBuilderTestSuite</include>
-                            </includes>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>test-dbws-builder-oracle-server_service</id>
-                        <goals>
-                            <goal>integration-test</goal>
-                        </goals>
-                        <configuration>
-                            <!--TODO applications must be deployed to WLS before test-->
-                            <skipTests>true</skipTests>
-                            <!--<skipTests>${test-skip-dbws-builder-oracle}</skipTests>-->
-                            <reportNameSuffix>test-dbws-builder-oracle-server_service</reportNameSuffix>
-                            <includes>
-                                <include>dbws.testing.attachedbinary.AttachedBinaryServiceTestSuite</include>
-                                <include>dbws.testing.inlinebinary.InlineBinaryServiceTestSuite</include>
-                                <include>dbws.testing.legacysimpletable.LegacySimpleTableServiceTestSuite</include>
-                                <include>dbws.testing.mtom.MTOMServiceTestSuite</include>
-                                <include>dbws.testing.simpleplsql.SimplePLSQLServiceTestSuite</include>
-                                <include>dbws.testing.simplesp.SimpleSPServiceTestSuite</include>
-                                <include>dbws.testing.simplesql.SimpleSQLServiceTestSuite</include>
-                                <include>dbws.testing.simpletable.SimpleTableServiceTestSuite</include>
-                            </includes>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>verify-integration-tests</id>
-                        <goals>
-                            <goal>verify</goal>
-                        </goals>
-                        <configuration>
-                            <skip>${integration.test.skip.verify}</skip>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 
     <profiles>
         <!--DBWS Builder Test Oracle related profiles-->
+        <profile>
+            <id>oracle</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <!--Set system properties required for tests-->
+                            <systemPropertiesFile>${test.properties.file}</systemPropertiesFile>
+                            <systemPropertyVariables>
+                                <db.ddl.create>true</db.ddl.create>
+                                <db.ddl.drop>true</db.ddl.drop>
+                                <db.ddl.debug>false</db.ddl.debug>
+                            </systemPropertyVariables>
+                            <workingDirectory>${project.build.directory}/test-run</workingDirectory>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>test-dbws-builder-oracle-server_builder</id>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                </goals>
+                                <configuration>
+                                    <!--<skipTests>true</skipTests>-->
+                                    <skipTests>${test-skip-dbws-builder-oracle-server}</skipTests>
+                                    <reportNameSuffix>test-dbws-builder-oracle-server_builder</reportNameSuffix>
+                                    <includes>
+                                        <include>dbws.testing.attachedbinary.AttachedBinaryBuilderTestSuite</include>
+                                        <include>dbws.testing.inlinebinary.InlineBinaryBuilderTestSuite</include>
+                                        <include>dbws.testing.mtom.MTOMBuilderTestSuite</include>
+                                        <include>dbws.testing.simpleplsql.SimplePLSQLBuilderTestSuite</include>
+                                        <include>dbws.testing.simplesp.SimpleSPBuilderTestSuite</include>
+                                        <include>dbws.testing.simplesql.SimpleSQLBuilderTestSuite</include>
+                                        <include>dbws.testing.simpletable.SimpleTableBuilderTestSuite</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>test-dbws-builder-oracle-server_service</id>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                </goals>
+                                <configuration>
+                                    <!--TODO applications must be deployed to WLS before test-->
+                                    <skipTests>true</skipTests>
+                                    <!--<skipTests>${test-skip-dbws-builder-oracle}</skipTests>-->
+                                    <reportNameSuffix>test-dbws-builder-oracle-server_service</reportNameSuffix>
+                                    <includes>
+                                        <include>dbws.testing.attachedbinary.AttachedBinaryServiceTestSuite</include>
+                                        <include>dbws.testing.inlinebinary.InlineBinaryServiceTestSuite</include>
+                                        <include>dbws.testing.legacysimpletable.LegacySimpleTableServiceTestSuite</include>
+                                        <include>dbws.testing.mtom.MTOMServiceTestSuite</include>
+                                        <include>dbws.testing.simpleplsql.SimplePLSQLServiceTestSuite</include>
+                                        <include>dbws.testing.simplesp.SimpleSPServiceTestSuite</include>
+                                        <include>dbws.testing.simplesql.SimpleSQLServiceTestSuite</include>
+                                        <include>dbws.testing.simpletable.SimpleTableServiceTestSuite</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>verify-integration-tests</id>
+                                <goals>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${integration.test.skip.verify}</skip>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>test-dbws-builder-oracle-server</id>
             <properties>

--- a/utils/eclipselink.dbws.builder.test.oracle/pom.xml
+++ b/utils/eclipselink.dbws.builder.test.oracle/pom.xml
@@ -88,93 +88,100 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <configuration>
-                    <!--Set system properties required for tests-->
-                    <systemPropertiesFile>${test.properties.file}</systemPropertiesFile>
-                    <systemPropertyVariables>
-                        <db.ddl.create>true</db.ddl.create>
-                        <db.ddl.drop>true</db.ddl.drop>
-                        <db.ddl.debug>false</db.ddl.debug>
-                    </systemPropertyVariables>
-                    <workingDirectory>${project.build.directory}/test-run</workingDirectory>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>test-dbws-builder-oracle</id>
-                        <goals>
-                            <goal>integration-test</goal>
-                        </goals>
-                        <configuration>
-                            <skipTests>${test-skip-dbws-builder-oracle}</skipTests>
-                            <reportNameSuffix>test-dbws-builder-oracle</reportNameSuffix>
-                            <excludes>
-                                <exclude>**.DBWSTestSuite*</exclude>
-                            </excludes>
-                            <includes>
-                                <include>**.*TestSuite*</include>
-                            </includes>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>verify-integration-tests</id>
-                        <goals>
-                            <goal>verify</goal>
-                        </goals>
-                        <configuration>
-                            <skip>${integration.test.skip.verify}</skip>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <!--This plugin sql-maven-plugin must be after maven-surefire-plugin to call dbteardown*.sql scripts after tests-->
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>sql-maven-plugin</artifactId>
-                <configuration>
-                    <autocommit>true</autocommit>
-                    <delimiter>|</delimiter>
-                    <onError>continue</onError>
-                    <!--all executions are ignored if -DskipTests-->
-                    <skip>${test-skip-dbws-builder-oracle}</skip>
-                </configuration>
-                <executions>
-                    <!-- create db tables after test -->
-                    <execution>
-                        <id>create-tables-before-test</id>
-                        <phase>pre-integration-test</phase>
-                        <goals>
-                            <goal>execute</goal>
-                        </goals>
-                        <configuration>
-                            <srcFiles>
-                                <srcFile>${integration.test.resources.directory}/sql/dbteardown_alltests.sql</srcFile>
-                                <srcFile>${integration.test.resources.directory}/sql/dbsetup_alltests.sql</srcFile>
-                            </srcFiles>
-                        </configuration>
-                    </execution>
-                    <!-- drop db tables after test -->
-                    <execution>
-                        <id>drop-tables-after-test</id>
-                        <phase>post-integration-test</phase>
-                        <goals>
-                            <goal>execute</goal>
-                        </goals>
-                        <configuration>
-                            <srcFiles>
-                                <srcFile>${integration.test.resources.directory}/sql/dbteardown_alltests.sql</srcFile>
-                            </srcFiles>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 
     <profiles>
         <!--DBWS Builder Test Oracle related profiles-->
+        <profile>
+            <id>oracle</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <!--Set system properties required for tests-->
+                            <systemPropertiesFile>${test.properties.file}</systemPropertiesFile>
+                            <systemPropertyVariables>
+                                <db.ddl.create>true</db.ddl.create>
+                                <db.ddl.drop>true</db.ddl.drop>
+                                <db.ddl.debug>false</db.ddl.debug>
+                            </systemPropertyVariables>
+                            <workingDirectory>${project.build.directory}/test-run</workingDirectory>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>test-dbws-builder-oracle</id>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                </goals>
+                                <configuration>
+                                    <skipTests>${test-skip-dbws-builder-oracle}</skipTests>
+                                    <reportNameSuffix>test-dbws-builder-oracle</reportNameSuffix>
+                                    <excludes>
+                                        <exclude>**.DBWSTestSuite*</exclude>
+                                    </excludes>
+                                    <includes>
+                                        <include>**.*TestSuite*</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>verify-integration-tests</id>
+                                <goals>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${integration.test.skip.verify}</skip>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!--This plugin sql-maven-plugin must be after maven-surefire-plugin to call dbteardown*.sql scripts after tests-->
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>sql-maven-plugin</artifactId>
+                        <configuration>
+                            <autocommit>true</autocommit>
+                            <delimiter>|</delimiter>
+                            <onError>continue</onError>
+                            <!--all executions are ignored if -DskipTests-->
+                            <skip>${test-skip-dbws-builder-oracle}</skip>
+                        </configuration>
+                        <executions>
+                            <!-- create db tables after test -->
+                            <execution>
+                                <id>create-tables-before-test</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>execute</goal>
+                                </goals>
+                                <configuration>
+                                    <srcFiles>
+                                        <srcFile>${integration.test.resources.directory}/sql/dbteardown_alltests.sql</srcFile>
+                                        <srcFile>${integration.test.resources.directory}/sql/dbsetup_alltests.sql</srcFile>
+                                    </srcFiles>
+                                </configuration>
+                            </execution>
+                            <!-- drop db tables after test -->
+                            <execution>
+                                <id>drop-tables-after-test</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>execute</goal>
+                                </goals>
+                                <configuration>
+                                    <srcFiles>
+                                        <srcFile>${integration.test.resources.directory}/sql/dbteardown_alltests.sql</srcFile>
+                                    </srcFiles>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>test-dbws-builder-oracle</id>
             <properties>


### PR DESCRIPTION
Due a changes in PR #828 (pom_oracle.xml removal) some integration tests in *.oracle.test modules must be moved into Maven "oracle" profile.
Without this change `mvn verify` or `mvn verify -Pmysql,test-lrg` commands used by _eclipselink-cb-master_ and _eclipselink-nightly-master_ jobs will execute Oracle tests against Derby or MySQL databases.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>