### PR TITLE
[2.6] Bug 559307 - EclipseLink can Dead-lock forever

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/PersistenceUnitProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/PersistenceUnitProperties.java
@@ -3740,6 +3740,17 @@ public class PersistenceUnitProperties {
      */
     public static final Map<String, String> PROPERTY_LOG_OVERRIDES = new HashMap<String, String>(1);
 
+    /**
+     * The "<code>eclipselink.concurrency.manager.sleeptime</code>" in milliseconds can control thread management in
+     * org.eclipse.persistence.internal.helper.ConcurrencyManager.
+     * It control how long thread will wait for the another thread. If value is greater than zero thread will
+     * continue after specified amount of miliseconds.
+     * Default value is 0ms (wait until another thread is done). Allowed values are: long
+     * This property should be specified as system property or property in persistence.xml file (higher priority).
+     */
+    public static final String CONCURRENCY_MANAGER_SLEEP_TIME  = "eclipselink.concurrency.manager.sleeptime";
+
+
     static {
         PROPERTY_LOG_OVERRIDES.put(JDBC_PASSWORD, "xxxxxx");
     }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/SystemProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/SystemProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2016 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the 
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0 
  * which accompanies this distribution. 
@@ -96,5 +96,13 @@ public class SystemProperties {
      */
     @Deprecated
     public static final String JAVASE7_INDIRECT_COLLECTIONS = "eclipselink.indirection.javase7-indirect-collections";
-    
+
+    /**
+     * This system property in milliseconds can control thread management in org.eclipse.persistence.internal.helper.ConcurrencyManager.
+     * It control how long thread will wait for the another thread. If value is greater than zero thread will
+     * continue after specified amount of miliseconds.
+     * Default value is 0ms (wait until another thread is done). Allowed values are: long
+     * This property should be specified as system property or property in persistence.xml file (higher priority).
+     */
+    public static final String CONCURRENCY_MANAGER_SLEEP_TIME  = "eclipselink.concurrency.manager.sleeptime";
 }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/exceptions/ConcurrencyException.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/exceptions/ConcurrencyException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2013 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the 
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0 
  * which accompanies this distribution. 
@@ -28,6 +28,7 @@ public class ConcurrencyException extends EclipseLinkException {
     public final static int MAX_TRIES_EXCEDED_FOR_LOCK_ON_MERGE = 2008;
     public final static int MAX_TRIES_EXCEDED_FOR_LOCK_ON_BUILD_OBJECT = 2009;
     public final static int ACTIVE_LOCK_ALREADY_TRANSITIONED = 2010;
+    public final static int WAIT_TIME_EXCEEDED = 2011;
 
     /**
      * INTERNAL:
@@ -123,6 +124,14 @@ public class ConcurrencyException extends EclipseLinkException {
 
         ConcurrencyException concurrencyException = new ConcurrencyException(ExceptionMessageGenerator.buildMessage(ConcurrencyException.class, SEQUENCING_MULTITHREAD_THRU_CONNECTION, args));
         concurrencyException.setErrorCode(SEQUENCING_MULTITHREAD_THRU_CONNECTION);
+        return concurrencyException;
+    }
+
+    public static ConcurrencyException waitTimeExceeded(long sleepTime, InterruptedException exception) {
+        Object[] args = {sleepTime, exception.getMessage()};
+
+        ConcurrencyException concurrencyException = new ConcurrencyException(ExceptionMessageGenerator.buildMessage(ConcurrencyException.class, WAIT_TIME_EXCEEDED, args));
+        concurrencyException.setErrorCode(WAIT_TIME_EXCEEDED);
         return concurrencyException;
     }
 }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/exceptions/ConcurrencyException.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/exceptions/ConcurrencyException.java
@@ -127,8 +127,8 @@ public class ConcurrencyException extends EclipseLinkException {
         return concurrencyException;
     }
 
-    public static ConcurrencyException waitTimeExceeded(long sleepTime, InterruptedException exception) {
-        Object[] args = {sleepTime, exception.getMessage()};
+    public static ConcurrencyException waitTimeExceeded(long sleepTime, String message) {
+        Object[] args = {sleepTime, message};
 
         ConcurrencyException concurrencyException = new ConcurrencyException(ExceptionMessageGenerator.buildMessage(ConcurrencyException.class, WAIT_TIME_EXCEEDED, args));
         concurrencyException.setErrorCode(WAIT_TIME_EXCEEDED);

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/exceptions/i18n/ConcurrencyExceptionResource.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/exceptions/i18n/ConcurrencyExceptionResource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2014 Oracle, IBM Corporation and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle, IBM Corporation and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the 
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0 
  * which accompanies this distribution. 
@@ -34,8 +34,8 @@ public class ConcurrencyExceptionResource extends ListResourceBundle {
                                            { "2007", "Max number of attempts to lock object: {0} exceeded.  Failed to clone the object." },
                                            { "2008", "Max number of attempts to lock object: {0} exceeded.  Failed to merge the transaction." },
                                            { "2009", "Max number of attempts to lock object exceeded.  Failed to build the object. Thread: {0} has a lock on the object but thread: {1} is building the object"},
-                                           { "2010", "Lock has already been transitioned to a Deferred Lock.  A second attempt to transition the lock has been requested by thread: {0} during merge."}
-
+                                           { "2010", "Lock has already been transitioned to a Deferred Lock.  A second attempt to transition the lock has been requested by thread: {0} during merge."},
+                                           { "2011", "Wait exceeds configured Time. {0} Message: [{1}]"}
     };
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/helper/ConcurrencyManager.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/helper/ConcurrencyManager.java
@@ -43,7 +43,7 @@ public class ConcurrencyManager implements Serializable {
     protected volatile transient Thread activeThread;
     public static Map<Thread, DeferredLockManager> deferredLockManagers = initializeDeferredLockManagers();
     protected boolean lockedByMergeManager;
-    private long maxAllowedSleepTime = Long.parseLong(System.getProperty(SystemProperties.CONCURRENCY_MANAGER_SLEEP_TIME, "0"));
+    protected long maxAllowedSleepTime = Long.parseLong(System.getProperty(SystemProperties.CONCURRENCY_MANAGER_SLEEP_TIME, "0"));
 
     protected static boolean shouldTrackStack = System.getProperty(SystemProperties.RECORD_STACK_ON_LOCK) != null;
     protected Exception stack;

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/AbstractIdentityMap.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/AbstractIdentityMap.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2013 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the 
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0 
  * which accompanies this distribution. 
@@ -238,7 +238,7 @@ public abstract class AbstractIdentityMap implements IdentityMap, Serializable, 
      * Create the correct type of CacheKey for this map.
      */
     public CacheKey createCacheKey(Object primaryKey, Object object, Object writeLockValue, long readTime) {
-        return new CacheKey(primaryKey, object, writeLockValue, readTime, this.isIsolated);
+        return new CacheKey(primaryKey, object, writeLockValue, readTime, this.isIsolated, this.session.getProject().getConcurrencyManagerMaxAllowedSleepTime());
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/AbstractIdentityMap.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/AbstractIdentityMap.java
@@ -238,7 +238,7 @@ public abstract class AbstractIdentityMap implements IdentityMap, Serializable, 
      * Create the correct type of CacheKey for this map.
      */
     public CacheKey createCacheKey(Object primaryKey, Object object, Object writeLockValue, long readTime) {
-        return new CacheKey(primaryKey, object, writeLockValue, readTime, this.isIsolated, this.session.getProject().getConcurrencyManagerMaxAllowedSleepTime());
+        return new CacheKey(primaryKey, object, writeLockValue, readTime, this.isIsolated, (this.session == null) ? 0L : this.session.getProject().getConcurrencyManagerMaxAllowedSleepTime());
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/CacheIdentityMap.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/CacheIdentityMap.java
@@ -36,15 +36,15 @@ public class CacheIdentityMap extends FullIdentityMap {
 
     public CacheIdentityMap(int size, ClassDescriptor descriptor, AbstractSession session, boolean isolated) {
         super(size, descriptor, session, isolated);
-        this.first = new LinkedCacheKey(CacheId.EMPTY, null, null, 0, isIsolated, this.session.getProject().getConcurrencyManagerMaxAllowedSleepTime());
-        this.last = new LinkedCacheKey(CacheId.EMPTY, null, null, 0, isIsolated, this.session.getProject().getConcurrencyManagerMaxAllowedSleepTime());
+        this.first = new LinkedCacheKey(CacheId.EMPTY, null, null, 0, isIsolated, (session == null) ? 0L : session.getProject().getConcurrencyManagerMaxAllowedSleepTime());
+        this.last = new LinkedCacheKey(CacheId.EMPTY, null, null, 0, isIsolated, (session == null) ? 0L : session.getProject().getConcurrencyManagerMaxAllowedSleepTime());
         this.first.setNext(this.last);
         this.last.setPrevious(this.first);
     }
     
     @Override
     public CacheKey createCacheKey(Object primaryKey, Object object, Object writeLockValue, long readTime) {
-        return new LinkedCacheKey(primaryKey, object, writeLockValue, readTime, isIsolated, this.session.getProject().getConcurrencyManagerMaxAllowedSleepTime());
+        return new LinkedCacheKey(primaryKey, object, writeLockValue, readTime, isIsolated,  (this.session == null) ? 0L : this.session.getProject().getConcurrencyManagerMaxAllowedSleepTime());
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/CacheIdentityMap.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/CacheIdentityMap.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the 
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0 
  * which accompanies this distribution. 
@@ -36,15 +36,15 @@ public class CacheIdentityMap extends FullIdentityMap {
 
     public CacheIdentityMap(int size, ClassDescriptor descriptor, AbstractSession session, boolean isolated) {
         super(size, descriptor, session, isolated);
-        this.first = new LinkedCacheKey(CacheId.EMPTY, null, null, 0, isIsolated);
-        this.last = new LinkedCacheKey(CacheId.EMPTY, null, null, 0, isIsolated);
+        this.first = new LinkedCacheKey(CacheId.EMPTY, null, null, 0, isIsolated, this.session.getProject().getConcurrencyManagerMaxAllowedSleepTime());
+        this.last = new LinkedCacheKey(CacheId.EMPTY, null, null, 0, isIsolated, this.session.getProject().getConcurrencyManagerMaxAllowedSleepTime());
         this.first.setNext(this.last);
         this.last.setPrevious(this.first);
     }
     
     @Override
     public CacheKey createCacheKey(Object primaryKey, Object object, Object writeLockValue, long readTime) {
-        return new LinkedCacheKey(primaryKey, object, writeLockValue, readTime, isIsolated);
+        return new LinkedCacheKey(primaryKey, object, writeLockValue, readTime, isIsolated, this.session.getProject().getConcurrencyManagerMaxAllowedSleepTime());
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/CacheKey.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/CacheKey.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2016 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the 
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0 
  * which accompanies this distribution. 
@@ -110,7 +110,7 @@ public class CacheKey extends ConcurrencyManager implements Cloneable {
         }
     }
 
-    public CacheKey(Object primaryKey, Object object, Object lockValue, long readTime, boolean isIsolated) {
+    public CacheKey(Object primaryKey, Object object, Object lockValue, long readTime, boolean isIsolated, long maxAllowedSleepTime) {
         this.key = primaryKey;
         this.writeLockValue = lockValue;
         //bug4649617  use setter instead of this.object = object to avoid hard reference on object in subclasses
@@ -119,6 +119,7 @@ public class CacheKey extends ConcurrencyManager implements Cloneable {
         }
         this.readTime = readTime;
         this.isIsolated = isIsolated;
+        this.maxAllowedSleepTime = maxAllowedSleepTime;
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/HardCacheWeakIdentityMap.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/HardCacheWeakIdentityMap.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2013 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the 
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0 
  * which accompanies this distribution. 
@@ -119,7 +119,7 @@ public class HardCacheWeakIdentityMap extends WeakIdentityMap {
         protected LinkedNode referenceNode;
 
         public ReferenceCacheKey(Object primaryKey, Object object, Object writeLockValue, long readTime, boolean isIsolated) {
-            super(primaryKey, object, writeLockValue, readTime, isIsolated);
+            super(primaryKey, object, writeLockValue, readTime, isIsolated, session.getProject().getConcurrencyManagerMaxAllowedSleepTime());
         }
 
         public LinkedNode getReferenceCacheNode() {

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/HardCacheWeakIdentityMap.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/HardCacheWeakIdentityMap.java
@@ -119,7 +119,7 @@ public class HardCacheWeakIdentityMap extends WeakIdentityMap {
         protected LinkedNode referenceNode;
 
         public ReferenceCacheKey(Object primaryKey, Object object, Object writeLockValue, long readTime, boolean isIsolated) {
-            super(primaryKey, object, writeLockValue, readTime, isIsolated, session.getProject().getConcurrencyManagerMaxAllowedSleepTime());
+            super(primaryKey, object, writeLockValue, readTime, isIsolated,(session == null) ? 0L : session.getProject().getConcurrencyManagerMaxAllowedSleepTime());
         }
 
         public LinkedNode getReferenceCacheNode() {

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/LinkedCacheKey.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/LinkedCacheKey.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2013 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the 
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0 
  * which accompanies this distribution. 
@@ -34,8 +34,8 @@ public class LinkedCacheKey extends CacheKey {
      * @param object is the domain object.
      * @param writeLockValue is the write lock value number.
      */
-    public LinkedCacheKey(Object primaryKey, Object object, Object writeLockValue, long readTime, boolean isIsolated) {
-        super(primaryKey, object, writeLockValue, readTime, isIsolated);
+    public LinkedCacheKey(Object primaryKey, Object object, Object writeLockValue, long readTime, boolean isIsolated, long maxAllowedSleepTime) {
+        super(primaryKey, object, writeLockValue, readTime, isIsolated, maxAllowedSleepTime);
     }
 
     public LinkedCacheKey getNext() {

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/QueueableWeakCacheKey.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/QueueableWeakCacheKey.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     Oracle - initial API and implementation from Oracle TopLink
+ ******************************************************************************/
 package org.eclipse.persistence.internal.identitymaps;
 
 import java.lang.ref.ReferenceQueue;
@@ -9,8 +21,8 @@ public class QueueableWeakCacheKey extends WeakCacheKey {
     // makes for easy cleanup
     protected ReferenceQueue referenceQueue;
 
-    public QueueableWeakCacheKey(Object primaryKey, Object object, Object writeLockValue, long readTime, ReferenceQueue refQueue, boolean isIsolated) {
-        super(primaryKey, object, writeLockValue, readTime, isIsolated);
+    public QueueableWeakCacheKey(Object primaryKey, Object object, Object writeLockValue, long readTime, ReferenceQueue refQueue, boolean isIsolated, long maxAllowedSleepTime) {
+        super(primaryKey, object, writeLockValue, readTime, isIsolated, maxAllowedSleepTime);
         this.referenceQueue = refQueue;
     }
 

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/SoftCacheKey.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/SoftCacheKey.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2013 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the 
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0 
  * which accompanies this distribution. 
@@ -32,8 +32,8 @@ public class SoftCacheKey extends WeakCacheKey {
      * @param writeLockValue is the write lock value, null if optimistic locking not being used for this object.
      * @param readTime the time EclipseLInk read the cache key
      */
-    public SoftCacheKey(Object primaryKey, Object object, Object writeLockValue, long readTime, boolean isIsolated) {
-        super(primaryKey, object, writeLockValue, readTime, isIsolated);
+    public SoftCacheKey(Object primaryKey, Object object, Object writeLockValue, long readTime, boolean isIsolated, long maxAllowedSleepTime) {
+        super(primaryKey, object, writeLockValue, readTime, isIsolated, maxAllowedSleepTime);
     }
 
     public void setObject(Object object) {

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/SoftIdentityMap.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/SoftIdentityMap.java
@@ -36,6 +36,6 @@ public class SoftIdentityMap extends WeakIdentityMap {
     
     @Override
     public CacheKey createCacheKey(Object primaryKey, Object object, Object writeLockValue, long readTime) {
-        return new SoftCacheKey(primaryKey, object, writeLockValue, readTime, isIsolated, session.getProject().getConcurrencyManagerMaxAllowedSleepTime());
+        return new SoftCacheKey(primaryKey, object, writeLockValue, readTime, isIsolated, (session == null) ? 0L : session.getProject().getConcurrencyManagerMaxAllowedSleepTime());
     }
 }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/SoftIdentityMap.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/SoftIdentityMap.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2013 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the 
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0 
  * which accompanies this distribution. 
@@ -36,6 +36,6 @@ public class SoftIdentityMap extends WeakIdentityMap {
     
     @Override
     public CacheKey createCacheKey(Object primaryKey, Object object, Object writeLockValue, long readTime) {
-        return new SoftCacheKey(primaryKey, object, writeLockValue, readTime, isIsolated);
+        return new SoftCacheKey(primaryKey, object, writeLockValue, readTime, isIsolated, session.getProject().getConcurrencyManagerMaxAllowedSleepTime());
     }
 }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/UnitOfWorkIdentityMap.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/UnitOfWorkIdentityMap.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2013 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the 
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0 
  * which accompanies this distribution. 
@@ -40,7 +40,7 @@ public class UnitOfWorkIdentityMap extends FullIdentityMap {
     
     @Override
     public CacheKey createCacheKey(Object primaryKey, Object object, Object writeLockValue, long readTime) {
-        return new CacheKey(primaryKey, object, writeLockValue, readTime, true);
+        return new CacheKey(primaryKey, object, writeLockValue, readTime, true, this.session.getProject().getConcurrencyManagerMaxAllowedSleepTime());
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/WeakCacheKey.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/WeakCacheKey.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2013 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the 
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0 
  * which accompanies this distribution. 
@@ -35,8 +35,8 @@ public class WeakCacheKey extends CacheKey {
      * @param writeLockValue is the write lock value, null if optimistic locking not being used for this object.
      * @param readTime the time EclipseLInk read the cache key
      */
-    public WeakCacheKey(Object primaryKey, Object object, Object writeLockValue, long readTime, boolean isIsolated) {
-        super(primaryKey, object, writeLockValue, readTime, isIsolated);
+    public WeakCacheKey(Object primaryKey, Object object, Object writeLockValue, long readTime, boolean isIsolated, long maxAllowedSleepTime) {
+        super(primaryKey, object, writeLockValue, readTime, isIsolated, maxAllowedSleepTime);
     }
 
     public Object getObject() {

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/WeakIdentityMap.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/WeakIdentityMap.java
@@ -73,7 +73,7 @@ public class WeakIdentityMap extends FullIdentityMap {
 
     @Override
     public CacheKey createCacheKey(Object primaryKey, Object object, Object writeLockValue, long readTime) {
-        return new WeakCacheKey(primaryKey, object, writeLockValue, readTime, isIsolated, this.session.getProject().getConcurrencyManagerMaxAllowedSleepTime());
+        return new WeakCacheKey(primaryKey, object, writeLockValue, readTime, isIsolated, (this.session == null) ? 0L : this.session.getProject().getConcurrencyManagerMaxAllowedSleepTime());
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/WeakIdentityMap.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/WeakIdentityMap.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2013 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the 
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0 
  * which accompanies this distribution. 
@@ -73,7 +73,7 @@ public class WeakIdentityMap extends FullIdentityMap {
 
     @Override
     public CacheKey createCacheKey(Object primaryKey, Object object, Object writeLockValue, long readTime) {
-        return new WeakCacheKey(primaryKey, object, writeLockValue, readTime, isIsolated);
+        return new WeakCacheKey(primaryKey, object, writeLockValue, readTime, isIsolated, this.session.getProject().getConcurrencyManagerMaxAllowedSleepTime());
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/WeakUnitOfWorkIdentityMap.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/WeakUnitOfWorkIdentityMap.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     Oracle - initial API and implementation from Oracle TopLink
+ ******************************************************************************/
 package org.eclipse.persistence.internal.identitymaps;
 
 import java.lang.ref.ReferenceQueue;
@@ -39,7 +51,7 @@ public class WeakUnitOfWorkIdentityMap extends UnitOfWorkIdentityMap {
 
     @Override
     public CacheKey createCacheKey(Object primaryKey, Object object, Object writeLockValue, long readTime) {
-        return new QueueableWeakCacheKey(primaryKey, object, writeLockValue, readTime, referenceQueue, isIsolated);
+        return new QueueableWeakCacheKey(primaryKey, object, writeLockValue, readTime, referenceQueue, isIsolated, session.getProject().getConcurrencyManagerMaxAllowedSleepTime());
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/security/PrivilegedAccessHelper.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/security/PrivilegedAccessHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2016 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -65,7 +65,7 @@ public class PrivilegedAccessHelper {
             PersistenceUnitProperties.LOGGING_FILE, PersistenceUnitProperties.LOGGING_LEVEL,
             SystemProperties.ARCHIVE_FACTORY, SystemProperties.ENFORCE_TARGET_SERVER, SystemProperties.RECORD_STACK_ON_LOCK,
             SystemProperties.WEAVING_OUTPUT_PATH, SystemProperties.WEAVING_SHOULD_OVERWRITE, SystemProperties.WEAVING_REFLECTIVE_INTROSPECTION,
-            SystemProperties.DO_NOT_PROCESS_XTOMANY_FOR_QBE, SystemProperties.ONETOMANY_DEFER_INSERTS,
+            SystemProperties.DO_NOT_PROCESS_XTOMANY_FOR_QBE, SystemProperties.ONETOMANY_DEFER_INSERTS, SystemProperties.CONCURRENCY_MANAGER_SLEEP_TIME,
             ServerPlatformBase.JMX_REGISTER_RUN_MBEAN_PROPERTY, ServerPlatformBase.JMX_REGISTER_DEV_MBEAN_PROPERTY,
             XMLPlatformFactory.XML_PLATFORM_PROPERTY};
     private final static Set<String> legalPropertiesSet = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(legalProperties)));

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/sessions/AbstractSession.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/sessions/AbstractSession.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2015 Oracle and/or its affiliates, IBM Corporation. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates, IBM Corporation. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -3152,6 +3152,7 @@ public abstract class AbstractSession extends CoreAbstractSession<ClassDescripto
             synchronized (this) {
                 if (transactionMutex == null) {
                     transactionMutex = new ConcurrencyManager();
+                    transactionMutex.setMaxAllowedSleepTime(this.project.getConcurrencyManagerMaxAllowedSleepTime());
                 }
             }
         }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/sessions/PropertiesHandler.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/sessions/PropertiesHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2015 Oracle, IBM Corporation and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle, IBM Corporation and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the 
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0 
  * which accompanies this distribution. 
@@ -223,6 +223,7 @@ public class PropertiesHandler {
             //Enhancement
             addProp(new QueryTimeoutUnitProp());
             addProp(new BooleanProp(PersistenceUnitProperties.USE_LOCAL_TIMESTAMP, "false"));
+            addProp(new ConcurrencyManagerSleepTimeProp());
         }
         
         Prop(String name) {
@@ -685,6 +686,12 @@ public class PropertiesHandler {
                 TimeUnit.SECONDS.toString(),
                 TimeUnit.MINUTES.toString()
             };
+        }
+    }
+
+    protected static class ConcurrencyManagerSleepTimeProp extends Prop {
+        ConcurrencyManagerSleepTimeProp() {
+            super(PersistenceUnitProperties.CONCURRENCY_MANAGER_SLEEP_TIME, Integer.toString(0));
         }
     }
 }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/sessions/Project.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/sessions/Project.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2014 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the 
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0 
  * which accompanies this distribution. 
@@ -169,6 +169,14 @@ public class Project extends CoreProject<ClassDescriptor, Login, DatabaseSession
     /** used for Caching JPA projects */
     protected Collection<String> classNamesForWeaving;
     protected Collection<String> structConverters;
+
+    /**
+     * Can control thread management in org.eclipse.persistence.internal.helper.ConcurrencyManager.
+     * It control how long thread will wait for the another thread. If value is greater than zero thread will
+     * continue after specified amount of miliseconds.
+     * Default value is 0ms (wait until another thread is done). Allowed values are: long
+     */
+    protected long concurrencyManagerMaxAllowedSleepTime;
 
     /**
      * PUBLIC:
@@ -1486,6 +1494,26 @@ public class Project extends CoreProject<ClassDescriptor, Login, DatabaseSession
             return null;
         }
         return this.partitioningPolicies.get(name);
+    }
+
+    /**
+     * Can control thread management in org.eclipse.persistence.internal.helper.ConcurrencyManager.
+     * It control how long thread will wait for the another thread. If value is greater than zero thread will
+     * continue after specified amount of miliseconds.
+     * Default value is 0ms (wait until another thread is done). Allowed values are: long
+     */
+    public long getConcurrencyManagerMaxAllowedSleepTime() {
+        return concurrencyManagerMaxAllowedSleepTime;
+    }
+
+    /**
+     * Can control thread management in org.eclipse.persistence.internal.helper.ConcurrencyManager.
+     * It control how long thread will wait for the another thread. If value is greater than zero thread will
+     * continue after specified amount of miliseconds.
+     * Default value is 0ms (wait until another thread is done). Allowed values are: long
+     */
+    public void setConcurrencyManagerMaxAllowedSleepTime(long concurrencyManagerMaxAllowedSleepTime) {
+        this.concurrencyManagerMaxAllowedSleepTime = concurrencyManagerMaxAllowedSleepTime;
     }
 }
 

--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates, IBM Corporation. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates, IBM Corporation. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -2817,6 +2817,7 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
             updateQueryTimeout(m);
             updateQueryTimeoutUnit(m);
             updateLockingTimestampDefault(m);
+            updateConcurrencyManagerSleepTime(m);
             if (!session.hasBroker()) {
                 updateCacheCoordination(m, loader);
             }
@@ -3577,6 +3578,14 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
             }
         } catch (NumberFormatException exception) {
             this.session.handleException(ValidationException.invalidValueForProperty(local, PersistenceUnitProperties.USE_LOCAL_TIMESTAMP, exception));
+        }
+    }
+
+    private void updateConcurrencyManagerSleepTime(Map persistenceProperties) {
+        String sleepTimeProp = EntityManagerFactoryProvider.getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.CONCURRENCY_MANAGER_SLEEP_TIME, persistenceProperties, session);
+        if (sleepTimeProp != null) {
+            long sleepTime = Long.parseLong(sleepTimeProp);
+            this.session.getTransactionMutex().setMaxAllowedSleepTime(sleepTime);
         }
     }
 

--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
@@ -3585,7 +3585,10 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
         String sleepTimeProp = EntityManagerFactoryProvider.getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.CONCURRENCY_MANAGER_SLEEP_TIME, persistenceProperties, session);
         if (sleepTimeProp != null) {
             long sleepTime = Long.parseLong(sleepTimeProp);
+            this.session.getProject().setConcurrencyManagerMaxAllowedSleepTime(sleepTime);
             this.session.getTransactionMutex().setMaxAllowedSleepTime(sleepTime);
+            this.deployLock.setMaxAllowedSleepTime(sleepTime);
+            this.session.getIdentityMapAccessorInstance().getIdentityMapManager().getCacheMutex().setMaxAllowedSleepTime(sleepTime);
         }
     }
 


### PR DESCRIPTION
This is improved version of PR #675 .
Thread wait time should be passed as 

- System property e.g. `-Declipselink.concurrency.manager.sleeptime=60000`
- property from _persistence.xml_ file e.g. `<property name="eclipselink.concurrency.manager.sleeptime" value="40000"/>`

If value is not specified of equals zero origin code in `org.eclipse.persistence.internal.helper.ConcurrencyManager` with `wait()` is called.

In this implementation is `eclipselink.concurrency.manager.sleeptime` property applied to all `org.eclipse.persistence.internal.helper.ConcurrencyManager` usages like
`deployLock` in `org.eclipse.persistence.internal.jpa.EntityManagerSetupImpl`,
`transactionMutex` in `org.eclipse.persistence.internal.sessions.AbstractSession`
and thread management in L2 caching.