### PR TITLE
[2.7] Property: only add marshal methods - backport from master

### DIFF
--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/compiler/Property.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/compiler/Property.java
@@ -218,10 +218,10 @@ public class Property implements Cloneable {
                     setTypeFromAdapterClass(returnType, parameterTypes[0]);
                     return;
                 }
+                // Found a marshal method with an Object return type; add
+                // it to the list in case we need to process it later
+                marshalMethods.add(method);
             }
-            // Found a marshal method with an Object return type; add
-            // it to the list in case we need to process it later
-            marshalMethods.add(method);
         }
         // At this point we didn't find a marshal method with a non-Object return type
         for (JavaMethod method : marshalMethods) {


### PR DESCRIPTION
The issue is that on OpenJ9. Method adapterCls.getMethods() returns all the classes' methods. The current code add all the methods to "marshalMethods", so marshal methods but also getClass, equals and so on.
On openjdk the marshal method is the first one to pop, which is not the case on OpenJ9, the first one is getClass
So in the second loop:
JavaClass paramType = method.getParameterTypes()[0]; an ArrayIndexOutOfBoundsException is thrown.
The modification will only add to "marshalMethods" methods named marshal with one argument. Which seems to me the wanted behaviour from the start.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>