### PR TITLE
[2.6] Jenkins build resources change

### DIFF
--- a/etc/jenkins/build.groovy
+++ b/etc/jenkins/build.groovy
@@ -58,14 +58,23 @@ spec:
     
   containers:
 
+  - name: jnlp
+    resources:
+      limits:
+        memory: "1Gi"
+        cpu: "1"
+      requests:
+        memory: "1Gi"
+        cpu: "500m"
   - name: el-build
     resources:
       limits:
-        memory: "12Gi"
-        cpu: "6"
+        memory: "6Gi"
+        cpu: "4"
       requests:
-        memory: "12Gi"
-        cpu: "6"
+        memory: "6Gi"
+        cpu: "4"
+        cpu: "3.5"
     image: tkraus/el-build:1.1.8
     volumeMounts:
     - name: tools

--- a/etc/jenkins/promote.groovy
+++ b/etc/jenkins/promote.groovy
@@ -57,6 +57,15 @@ spec:
     
   containers:
 
+
+  - name: jnlp
+    resources:
+      limits:
+        memory: "1Gi"
+        cpu: "1"
+      requests:
+        memory: "1Gi"
+        cpu: "500m"
   - name: el-build
     resources:
       limits:


### PR DESCRIPTION
This is change based on recommendations from https://bugs.eclipse.org/bugs/show_bug.cgi?id=564240 .
It improves build time and stability at https://ci.eclipse.org/eclipselink .

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>