### PR TITLE
[master] JPA Criteria API: Empty IN Statement leads to SQL-Error

### DIFF
--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/expressions/ExpressionTestSuite.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/expressions/ExpressionTestSuite.java
@@ -742,6 +742,34 @@ public class ExpressionTestSuite extends TestSuite {
         addTest(test);
     }
 
+    private void addInCollectionEmptyTest() {
+        Employee employee = (Employee)getManager().getObject(new Employee().getClass(), "0003");
+        // Empty collection without any items
+        Set names = new HashSet();
+
+        ExpressionBuilder builder = new ExpressionBuilder();
+        Expression expression = builder.get("lastName").in(names);
+
+        ReadObjectExpressionTest test = new ReadObjectExpressionTest(employee, expression);
+        test.setName("InCollectionEmptyExpressionTest");
+        test.setDescription("Test IN expression with empty collection");
+        addTest(test);
+    }
+
+    private void addInCollectionNullTest() {
+        Employee employee = (Employee)getManager().getObject(new Employee().getClass(), "0003");
+        // Collection is not initialized
+        Set names = null;
+
+        ExpressionBuilder builder = new ExpressionBuilder();
+        Expression expression = builder.get("lastName").in(names);
+
+        ReadObjectExpressionTest test = new ReadObjectExpressionTest(employee, expression);
+        test.setName("InCollectionNullExpressionTest");
+        test.setDescription("Test IN expression with null collection");
+        addTest(test);
+    }
+
     private void addIsNotNullTest() {
         ExpressionBuilder builder = new ExpressionBuilder();
         Expression expression = builder.get("firstName").notEqual(null);
@@ -1692,6 +1720,8 @@ public class ExpressionTestSuite extends TestSuite {
         // ET. The test doesn't work with DB2 jcc driver(Bug 4563813)
         addAdvancedDB2ExpressionFunctionTest();
         addInCollectionTest();
+        addInCollectionEmptyTest();
+        addInCollectionNullTest();
         // Bug 247076 - LiteralExpression does not print SQL in statement
         addTest(new LiteralExpressionTest());
         // Bug 284884 - Quoted '?' symbol in expression literal causes ArrayIndexOutOfBoundsException

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/expressions/ExpressionTestSuite.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/expressions/ExpressionTestSuite.java
@@ -743,28 +743,26 @@ public class ExpressionTestSuite extends TestSuite {
     }
 
     private void addInCollectionEmptyTest() {
-        Employee employee = (Employee)getManager().getObject(new Employee().getClass(), "0003");
         // Empty collection without any items
         Set names = new HashSet();
 
         ExpressionBuilder builder = new ExpressionBuilder();
         Expression expression = builder.get("lastName").in(names);
 
-        ReadObjectExpressionTest test = new ReadObjectExpressionTest(employee, expression);
+        ReadObjectExpressionTest test = new ReadObjectExpressionTest(new Employee().getClass(), expression);
         test.setName("InCollectionEmptyExpressionTest");
         test.setDescription("Test IN expression with empty collection");
         addTest(test);
     }
 
     private void addInCollectionNullTest() {
-        Employee employee = (Employee)getManager().getObject(new Employee().getClass(), "0003");
         // Collection is not initialized
         Set names = null;
 
         ExpressionBuilder builder = new ExpressionBuilder();
         Expression expression = builder.get("lastName").in(names);
 
-        ReadObjectExpressionTest test = new ReadObjectExpressionTest(employee, expression);
+        ReadObjectExpressionTest test = new ReadObjectExpressionTest(new Employee().getClass(), expression);
         test.setName("InCollectionNullExpressionTest");
         test.setDescription("Test IN expression with null collection");
         addTest(test);

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/expressions/ReadObjectExpressionTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/expressions/ReadObjectExpressionTest.java
@@ -23,9 +23,19 @@ import org.eclipse.persistence.testing.framework.ReadObjectTest;
  */
 public class ReadObjectExpressionTest extends ReadObjectTest {
     Expression expression;
+    /** The class of the target objects to be read from the database. */
+    private Class referenceClass;
 
     public ReadObjectExpressionTest(Object theOriginalObject, Expression theExpression) {
         originalObject = theOriginalObject;
+        expression = theExpression;
+        if (theOriginalObject != null) {
+            referenceClass = theOriginalObject.getClass();
+        }
+    }
+
+    public ReadObjectExpressionTest(Class theReferenceClass, Expression theExpression) {
+        referenceClass = theReferenceClass;
         expression = theExpression;
     }
 
@@ -41,7 +51,7 @@ public class ReadObjectExpressionTest extends ReadObjectTest {
         // Access and DB2 do not support UPPER and LOWER
         if (getQuery() == null) {
             setQuery(new ReadObjectQuery());
-            getQuery().setReferenceClass(getOriginalObject().getClass());
+            getQuery().setReferenceClass(referenceClass);
             getQuery().setSelectionCriteria(getExpression());
         }
     }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/ExpressionSQLPrinter.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/ExpressionSQLPrinter.java
@@ -38,6 +38,8 @@ import org.eclipse.persistence.internal.sessions.AbstractRecord;
  */
 public class ExpressionSQLPrinter {
 
+    private static final String NULL_STRING = "NULL";
+
     /**
      * Stores the current session. The session accessor
      * is used to print all the primitive types.
@@ -215,8 +217,8 @@ public class ExpressionSQLPrinter {
     public void printValuelist(Collection values) {
         try {
             getWriter().write("(");
-            if (values.isEmpty()) {
-                getWriter().write("NULL");
+            if (values == null || values.isEmpty()) {
+                getWriter().write(NULL_STRING);
             } else {
                 Iterator valuesEnum = values.iterator();
                 while (valuesEnum.hasNext()) {
@@ -246,8 +248,8 @@ public class ExpressionSQLPrinter {
     public void printList(Collection values) {
         try {
             getWriter().write("(");
-            if (values.isEmpty()) {
-                getWriter().write("NULL");
+            if (values == null || values.isEmpty()) {
+                getWriter().write(NULL_STRING);
             } else {
                 Iterator valuesEnum = values.iterator();
                 while (valuesEnum.hasNext()) {

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/ExpressionSQLPrinter.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/ExpressionSQLPrinter.java
@@ -215,19 +215,23 @@ public class ExpressionSQLPrinter {
     public void printValuelist(Collection values) {
         try {
             getWriter().write("(");
-            Iterator valuesEnum = values.iterator();
-            while (valuesEnum.hasNext()) {
-                Object value = valuesEnum.next();
-                // Support nested arrays for IN.
-                if (value instanceof Collection) {
-                    printValuelist((Collection)value);
-                } else if (value instanceof Expression) {
-                    ((Expression)value).printSQL(this);
-                } else {
-                    session.getPlatform().appendLiteralToCall(getCall(), getWriter(), value);
-                }
-                if (valuesEnum.hasNext()) {
-                    getWriter().write(", ");
+            if (values.isEmpty()) {
+                getWriter().write("NULL");
+            } else {
+                Iterator valuesEnum = values.iterator();
+                while (valuesEnum.hasNext()) {
+                    Object value = valuesEnum.next();
+                    // Support nested arrays for IN.
+                    if (value instanceof Collection) {
+                        printValuelist((Collection) value);
+                    } else if (value instanceof Expression) {
+                        ((Expression) value).printSQL(this);
+                    } else {
+                        session.getPlatform().appendLiteralToCall(getCall(), getWriter(), value);
+                    }
+                    if (valuesEnum.hasNext()) {
+                        getWriter().write(", ");
+                    }
                 }
             }
             getWriter().write(")");
@@ -242,16 +246,20 @@ public class ExpressionSQLPrinter {
     public void printList(Collection values) {
         try {
             getWriter().write("(");
-            Iterator valuesEnum = values.iterator();
-            while (valuesEnum.hasNext()) {
-                Object value = valuesEnum.next();
-                if (value instanceof Expression){
-                    ((Expression)value).printSQL(this);
-                }else{
-                    session.getPlatform().appendLiteralToCall(getCall(), getWriter(), value);
-                }
-                if (valuesEnum.hasNext()) {
-                    getWriter().write(", ");
+            if (values.isEmpty()) {
+                getWriter().write("NULL");
+            } else {
+                Iterator valuesEnum = values.iterator();
+                while (valuesEnum.hasNext()) {
+                    Object value = valuesEnum.next();
+                    if (value instanceof Expression) {
+                        ((Expression) value).printSQL(this);
+                    } else {
+                        session.getPlatform().appendLiteralToCall(getCall(), getWriter(), value);
+                    }
+                    if (valuesEnum.hasNext()) {
+                        getWriter().write(", ");
+                    }
                 }
             }
             getWriter().write(")");

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/criteria/AdvancedCriteriaQueryTestSuite.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/criteria/AdvancedCriteriaQueryTestSuite.java
@@ -404,6 +404,7 @@ public class AdvancedCriteriaQueryTestSuite extends JUnitTestCase {
             closeEntityManager(em);
         }
     }
+
     public void testInCollectionPrimitives(){
         EntityManager em = createEntityManager();
         beginTransaction(em);
@@ -416,6 +417,43 @@ public class AdvancedCriteriaQueryTestSuite extends JUnitTestCase {
             Query query = em.createQuery(cq);
             List<Employee> result = query.getResultList();
             assertFalse("No Employees were returned", result.isEmpty());
+        } finally {
+            rollbackTransaction(em);
+            closeEntityManager(em);
+        }
+    }
+
+    public void testInCollectionEmpty(){
+        EntityManager em = createEntityManager();
+        beginTransaction(em);
+        try {
+            CriteriaBuilder qb = em.getCriteriaBuilder();
+            CriteriaQuery<Employee> cq = qb.createQuery(Employee.class);
+            Root<Employee> emp = cq.from(Employee.class);
+            Root<PhoneNumber> phone = cq.from(PhoneNumber.class);
+            cq.where(qb.literal("Bug fixes").in(new HashSet()));
+            Query query = em.createQuery(cq);
+            List<Employee> result = query.getResultList();
+            assertTrue("No any Employees was expected", result.isEmpty());
+        } finally {
+            rollbackTransaction(em);
+            closeEntityManager(em);
+        }
+    }
+
+    public void testInCollectionNull(){
+        EntityManager em = createEntityManager();
+        beginTransaction(em);
+        try {
+            CriteriaBuilder qb = em.getCriteriaBuilder();
+            CriteriaQuery<Employee> cq = qb.createQuery(Employee.class);
+            Root<Employee> emp = cq.from(Employee.class);
+            Root<PhoneNumber> phone = cq.from(PhoneNumber.class);
+            List list = null;
+            cq.where(qb.literal("Bug fixes").in(list));
+            Query query = em.createQuery(cq);
+            List<Employee> result = query.getResultList();
+            assertTrue("No any Employees was expected", result.isEmpty());
         } finally {
             rollbackTransaction(em);
             closeEntityManager(em);


### PR DESCRIPTION
Bug fix + unit test for #847 .

Before this fix EclipseLink for (assume the `inList` is empty or `null`)
`Predicate in = from.get("projektID").in(inList);`
produced invalid SQL query like
`SELECT ... FROM ... WHERE PROJEKTID IN ()`
After this fix generated SQL query for empty or null collection used in `.in(...)` method/expression is e.g.
`SELECT ... FROM ... WHERE PROJEKTID IN (NULL)`
Which is valid SQL query.