### PR TITLE
Jenkins/Ant build fix 2.7

### DIFF
--- a/antbuild.xml
+++ b/antbuild.xml
@@ -479,7 +479,7 @@
         <antcall target="clean-internal-compdeps"/>
     </target>
 
-    <target name="clean-runtime" depends="generate-local-compdeps, clean-runtime-checkedin, clean-runtime-built" description="Clean the runtime projects"/>
+    <target name="clean-runtime" depends="generate-local-compdeps, generate-oracle-p2, clean-runtime-checkedin, clean-runtime-built" description="Clean the runtime projects"/>
     <!--   This allows testing to call a specific target that won't remove the default
            (or dropped-in copy of) eclipselink and the persistence jar, while still
            allowing unchanged operation by developers and users to clean all built artifacts. -->

--- a/antbuild.xml
+++ b/antbuild.xml
@@ -564,7 +564,6 @@
                 <exclude name="**/org.eclipse.persistence.antlr**"/>
                 <exclude name="**/org.eclipse.persistence.asm**"/>
                 <exclude name="**/readme.for.distribution**"/>
-                <exclude name="**/org.eclipse.persistence.oracle*.jar"/>
                 <exclude name="**/javax.persistence_unsigned_for_testing_1.0.0.jar"/>
             </fileset>
             <fileset dir="${eclipselink.jpa.plugins}">

--- a/etc/jenkins/build.sh
+++ b/etc/jenkins/build.sh
@@ -24,6 +24,6 @@ fi
 
 export ANT_OPTS=-Xmx4G
 set -o pipefail
-ant -f autobuild.xml ${ANT_TARGET} -Denv.JAVA_HOME=${JAVA_HOME} -DM2_HOME=${HOME}/extension.lib.external/apache-maven-3.6.0 -Djdbc.driver.jar=${HOME}/extension.lib.external/mysql-connector-java-5.1.48.jar -Ddb.url=${TEST_DB_URL} -Ddb.user=${TEST_DB_USERNAME} -Ddb.pwd=${TEST_DB_PASSWORD} -Dextensions.depend.dir=${HOME}/extension.lib.external -Djunit.lib=${HOME}/extension.lib.external/junit-4.12.jar:${HOME}/extension.lib.external/hamcrest-core-1.3.jar:${HOME}/extension.lib.external/jmockit-1.35.jar -Dhudson.workspace=${WORKSPACE} -Dtest.logging.level=INFO -Dfail.on.error=true
+ant -f autobuild.xml ${ANT_TARGET} -Denv.JAVA_HOME=${JAVA_HOME} -DM2_HOME=${HOME}/extension.lib.external/apache-maven-3.6.0 -Djdbc.driver.jar=${HOME}/extension.lib.external/mysql-connector-java-5.1.48.jar -Ddb.url=${TEST_DB_URL} -Ddb.user=${TEST_DB_USERNAME} -Ddb.pwd=${TEST_DB_PASSWORD} -Dextensions.depend.dir=${HOME}/extension.lib.external -Declipse.install.dir=${HOME}/extension.lib.external/eclipse -Djunit.lib=${HOME}/extension.lib.external/junit-4.12.jar:${HOME}/extension.lib.external/hamcrest-core-1.3.jar:${HOME}/extension.lib.external/jmockit-1.35.jar -Dhudson.workspace=${WORKSPACE} -Dtest.logging.level=INFO -Dfail.on.error=true
 
 /opt/bin/mysql-stop.sh

--- a/etc/jenkins/init.sh
+++ b/etc/jenkins/init.sh
@@ -38,13 +38,13 @@ tar -x -z -C $HOME/extension.lib.external -f $HOME/extension.lib.external/apache
 #PREPARE build.properties FILE
 echo "extensions.depend.dir=$HOME/extension.lib.external" >> $HOME/build.properties
 echo "junit.lib=$HOME/extension.lib.external/junit-4.12.jar:$HOME/extension.lib.external/hamcrest-core-1.3.jar" >> $HOME/build.properties
-echo 'jdbc.driver.jar=$HOME/extension.lib.external/mysql-connector-java-5.1.48.jar' >> $HOME/build.properties
+echo "jdbc.driver.jar=$HOME/extension.lib.external/mysql-connector-java-5.1.48.jar" >> $HOME/build.properties
 echo 'db.driver=com.mysql.jdbc.Driver' >> $HOME/build.properties
 echo "db.url=$TEST_DB_URL" >> $HOME/build.properties
 echo "db.user=$TEST_DB_USERNAME" >> $HOME/build.properties
 echo "db.pwd=$TEST_DB_PASSWORD" >> $HOME/build.properties
 echo 'db.platform=org.eclipse.persistence.platform.database.MySQLPlatform' >> $HOME/build.properties
-echo 'eclipse.install.dir=$HOME/extension.lib.external/eclipse' >> $HOME/build.properties
+echo "eclipse.install.dir=$HOME/extension.lib.external/eclipse" >> $HOME/build.properties
 echo 'server.name=wildfly' >> $HOME/build.properties
 echo "wildfly.home=$HOME/extension.lib.external/wildfly-15.0.1.Final" >> $HOME/build.properties
 echo 'wildfly.config=standalone-full.xml' >> $HOME/build.properties

--- a/etc/jenkins/promote_init.sh
+++ b/etc/jenkins/promote_init.sh
@@ -48,11 +48,11 @@ tar -x -z -C $HOME/extension.lib.external -f $HOME/extension.lib.external/eclips
 #PREPARE build.properties FILE
 echo "extensions.depend.dir=$HOME/extension.lib.external" >> $HOME/build.properties
 echo "junit.lib=$HOME/extension.lib.external/junit-4.12.jar:$HOME/extension.lib.external/hamcrest-core-1.3.jar" >> $HOME/build.properties
-echo 'jdbc.driver.jar=$HOME/extension.lib.external/mysql-connector-java-5.1.48.jar' >> $HOME/build.properties
+echo "jdbc.driver.jar=$HOME/extension.lib.external/mysql-connector-java-5.1.48.jar" >> $HOME/build.properties
 echo 'db.driver=com.mysql.jdbc.Driver' >> $HOME/build.properties
 echo "db.url=$TEST_DB_URL" >> $HOME/build.properties
 echo "db.user=$TEST_DB_USERNAME" >> $HOME/build.properties
 echo "db.pwd=$TEST_DB_PASSWORD" >> $HOME/build.properties
 echo 'db.platform=org.eclipse.persistence.platform.database.MySQLPlatform' >> $HOME/build.properties
-echo 'eclipse.install.dir=$HOME/extension.lib.external/eclipse' >> $HOME/build.properties
+echo "eclipse.install.dir=$HOME/extension.lib.external/eclipse" >> $HOME/build.properties
 echo hudson.workspace=$WORKSPACE


### PR DESCRIPTION
This is fix for a Jenkins/Ant build by switch into Oracle public JDBC driver (see PR #839). 
There was some issue with `ant -f antbuild clean` command.
There is some fix for Jenkins build script too.
