### PR TITLE
BUG534065 - ECLIPSE GETOBJECTFROMRESULTSET ON APPS.XMLTYPE DATA CAUSE…

### DIFF
--- a/foundation/org.eclipse.persistence.oracle/src/org/eclipse/persistence/platform/database/oracle/Oracle9Platform.java
+++ b/foundation/org.eclipse.persistence.oracle/src/org/eclipse/persistence/platform/database/oracle/Oracle9Platform.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2016 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.

--- a/foundation/org.eclipse.persistence.oracle/src/org/eclipse/persistence/platform/database/oracle/Oracle9Platform.java
+++ b/foundation/org.eclipse.persistence.oracle/src/org/eclipse/persistence/platform/database/oracle/Oracle9Platform.java
@@ -209,10 +209,13 @@ public class Oracle9Platform extends Oracle8Platform {
             return resultSet.getString(columnNumber);
         } else if (type == Types.SQLXML) {
             SQLXML sqlXml = resultSet.getSQLXML(columnNumber);
-            String str = sqlXml.getString();
-            sqlXml.free();
+            String str = null;
+            if (sqlXml != null) {
+                str = sqlXml.getString();
+                sqlXml.free();
+            }
             // Oracle 12c appends a \n character to the xml string
-            return str.endsWith("\n") ? str.substring(0, str.length() - 1) : str;
+            return (str != null && str.endsWith("\n")) ? str.substring(0, str.length() - 1) : str; 
         } else if (type == OracleTypes.OPAQUE) {
             try {
                 Object result = resultSet.getObject(columnNumber);


### PR DESCRIPTION
ECLIPSE GETOBJECTFROMRESULTSET ON APPS.XMLTYPE DATA CAUSE NPE

Signed-off-by: Ravi Babu Tummuru <ravi.babu.tummuru@oracle.com>