### PR TITLE
[2.6] Fix for a bug 553439 - JAXB Unmarshaller with Schema does not show location of error. - backport from master

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/record/XMLStreamReaderReader.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/record/XMLStreamReaderReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 1998, 2013 Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
 * which accompanies this distribution.
@@ -132,7 +132,7 @@ public class XMLStreamReaderReader extends XMLReaderAdapter {
                         contentHandler.startElement(namespaceURI, localName, prefix + Constants.COLON + localName, indexedAttributeList.reset());
                     }
                 } else {
-                    contentHandler.startElement(namespaceURI, localName, null, indexedAttributeList.reset());
+                    contentHandler.startElement(namespaceURI, localName, localName, indexedAttributeList.reset());
                 }
                 break;
             }


### PR DESCRIPTION
Before this fix MOXy produced incomplete error message in case of XML Schema validation failure during unmarshall operation, if schema validation was enabled and non-valid XML document used at the input.
E.G. Error message before fix
`Internal Exception: org.xml.sax.SAXParseException; cvc-complex-type.2.4.a: Invalid content was found starting with element ''. One of '{"http://myschema.com":elementOne}' is expected.]`

Error message after fix
`Internal Exception: org.xml.sax.SAXParseException; cvc-complex-type.2.4.a: Invalid content was found starting with element 'elementTwo'. One of '{"http://myschema.com":elementOne}' is expected.]`

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>