### PR TITLE
Indentation disappears with custom escape handler

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/oxm/record/OutputStreamRecord.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/oxm/record/OutputStreamRecord.java
@@ -292,7 +292,7 @@ public class OutputStreamRecord extends MarshalRecord<XMLMarshaller> {
                     CharArrayWriter out = new CharArrayWriter();
                     escapeHandler.escape(value.toCharArray(), 0, value.length(), isAttribute, out);
                     byte[] bytes = out.toString().getBytes();
-                    outputStreamWrite(bytes);
+                    outputStreamWrite(bytes, os);
                     out.close();
                 } catch (IOException e) {
                     throw XMLMarshalException.marshalException(e);


### PR DESCRIPTION
If a custom escape handler is set in combination with the JAXB_FORMATTED_OUTPUT option, the tabs are not printed as the tab() call expects the escaped value in the os stream.

I haven't done any significant testing with this fix.

Duplicate of #874 for signing reasons