### PR TITLE
[2.7] Update ASM 8.0.1 change to enable Eclipselink to use ASM8

### DIFF
--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/metadata/accessors/objects/MetadataAsmFactory.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/metadata/accessors/objects/MetadataAsmFactory.java
@@ -246,7 +246,7 @@ public class MetadataAsmFactory extends MetadataFactory {
         private MetadataClass classMetadata;
 
         ClassMetadataVisitor(MetadataClass metadataClass, boolean isLazy) {
-            super(Opcodes.ASM7);
+            super(Opcodes.ASM8);
             this.isLazy = isLazy;
             this.classMetadata = metadataClass;
         }
@@ -342,7 +342,7 @@ public class MetadataAsmFactory extends MetadataFactory {
         }
 
         MetadataAnnotationVisitor(MetadataAnnotatedElement element, String name, boolean isRegular) {
-            super(Opcodes.ASM7);
+            super(Opcodes.ASM8);
             this.element = element;
             this.annotation = new MetadataAnnotation();
             this.annotation.setName(processDescription(name, false).get(0));
@@ -350,7 +350,7 @@ public class MetadataAsmFactory extends MetadataFactory {
         }
 
         public MetadataAnnotationVisitor(MetadataAnnotation annotation) {
-            super(Opcodes.ASM7);
+            super(Opcodes.ASM8);
             this.annotation = annotation;
         }
 
@@ -402,7 +402,7 @@ public class MetadataAsmFactory extends MetadataFactory {
         private List<Object> values;
 
         public MetadataAnnotationArrayVisitor(MetadataAnnotation annotation, String name) {
-            super(Opcodes.ASM7);
+            super(Opcodes.ASM8);
             this.annotation = annotation;
             this.attributeName = name;
             this.values = new ArrayList<Object>();
@@ -441,7 +441,7 @@ public class MetadataAsmFactory extends MetadataFactory {
         private MetadataField field;
 
         public MetadataFieldVisitor(MetadataClass classMetadata, int access, String name, String desc, String signature, Object value) {
-            super(Opcodes.ASM7);
+            super(Opcodes.ASM8);
             this.field = new MetadataField(classMetadata);
             this.field.setModifiers(access);
             this.field.setName(name);
@@ -475,7 +475,7 @@ public class MetadataAsmFactory extends MetadataFactory {
         private MetadataMethod method;
 
         public MetadataMethodVisitor(MetadataClass classMetadata, int access, String name, String desc, String signature, String[] exceptions) {
-            super(Opcodes.ASM7);
+            super(Opcodes.ASM8);
             this.method = new MetadataMethod(MetadataAsmFactory.this, classMetadata);
 
             this.method.setName(name);

--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/weaving/ClassWeaver.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/weaving/ClassWeaver.java
@@ -207,7 +207,7 @@ public class ClassWeaver extends ClassVisitor implements Opcodes {
     }
 
     public ClassWeaver(ClassVisitor classWriter, ClassDetails classDetails) {
-        super(ASM7, classWriter);
+        super(ASM8, classWriter);
         this.classDetails = classDetails;
     }
 

--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/weaving/MethodWeaver.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/weaving/MethodWeaver.java
@@ -44,7 +44,7 @@ public class MethodWeaver extends MethodVisitor implements Opcodes {
     protected boolean methodStarted = false;
 
     public MethodWeaver(ClassWeaver tcw, String methodName, String methodDescriptor, MethodVisitor mv) {
-        super(ASM7, mv);
+        super(ASM8, mv);
         this.tcw = tcw;
         this.methodName = methodName;
         this.methodDescriptor = methodDescriptor;


### PR DESCRIPTION
for #877

The ASM 8.0.1 update for 2.7 (#805) did not include updates to the jpa portion of the project to use the ASM8 opcode.  Thus Eclipselink is not gaining the full benefit of using ASM 8.