### PR TITLE
[master] Dependency jakarta.resource-api upgrade 2.0.0-RC3 -> 2.0.0

### DIFF
--- a/bundles/moxy-standalone/pom.xml
+++ b/bundles/moxy-standalone/pom.xml
@@ -18,7 +18,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
 
-    <name>MOXy standalone distribution</name>
+    <name>EclipseLink Bundles MOXy standalone</name>
     <groupId>org.eclipse.persistence</groupId>
     <artifactId>moxy-standalone</artifactId>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
         <mail.version>2.0.0</mail.version>
         <oracle.ddlparser.version>3.0.0-M1</oracle.ddlparser.version>
         <org.glassfish.corba.version>4.2.3-RC2</org.glassfish.corba.version>
-        <resource.version>2.0.0-RC3</resource.version>
+        <resource.version>2.0.0</resource.version>
         <servlet.version>5.0.0</servlet.version>
         <transaction.version>2.0.0</transaction.version>
         <validation.version>3.0.0</validation.version>


### PR DESCRIPTION
This is fix for broken build too because 2.0.0-RC3 was removed from staging repo.
See https://jakarta.oss.sonatype.org/content/repositories/staging/jakarta/resource/jakarta.resource-api/