### PR TITLE
[master] Maven build - performance test fix

### DIFF
--- a/performance/eclipselink.perf.test/pom.xml
+++ b/performance/eclipselink.perf.test/pom.xml
@@ -77,8 +77,8 @@
             <artifactId>jakarta.validation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.persistence</groupId>
-            <artifactId>jakarta.persistence</artifactId>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
             <scope>test</scope>
         </dependency>
         <!--Other dependencies-->
@@ -172,7 +172,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>1.6.0</version>
                 <configuration>
                     <classpathScope>test</classpathScope>
                     <!--Required for JMH framework-->

--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
         <hibernate.version>7.0.0.Alpha6</hibernate.version>
         <!-- CQ #21122 -->
         <jgroups.version>4.1.8.Final</jgroups.version>
-        <jmh.version>1.21</jmh.version>
+        <jmh.version>1.25.2</jmh.version>
         <jmockit.version>1.35</jmockit.version>
         <junit.version>4.13</junit.version>
         <!-- CQ #21138 -->
@@ -1115,7 +1115,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
-                    <version>1.6.0</version>
+                    <version>3.0.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
There is dependency fix for _jakarta.persistence_ and JMH + _exec-maven-plugin_ upgrade.
Performance test should be executed by `mvn test -pl :org.eclipse.persistence.performance.test -Ptest-performance` comand.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>