### PR TITLE
[Master] Bug 538296: Wrong month is returned if OffsetDateTime is used

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/SystemProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/SystemProperties.java
@@ -12,6 +12,8 @@
 
 // Contributors:
 //     tware - added to allow pluggage archive factory
+//     05/11/2020-2.7.0 Jody Grassel
+//       - 538296: Wrong month is returned if OffsetDateTime is used in JPA 2.2 code
 package org.eclipse.persistence.config;
 
 /**
@@ -75,6 +77,20 @@ public class SystemProperties {
      */
     public static final String ENFORCE_TARGET_SERVER = "eclipselink.target-server.enforce";
 
+    /**
+     * This system property can be set the specific time zone used by ConversionManager to convert
+     * LocalDateTime, OffsetDateTime, and OffsetTime types.
+     */
+    public static final String CONVERSION_USE_TIMEZONE = "org.eclipse.persistence.conversion.useTimeZone";
+    
+    /**
+     * This system property can be set to restore ConversionManager behavior with converting 
+     * LocalDateTime, OffsetDateTime, and OffsetTime types back to using the JVM's default time zone instead
+     * of UTC.  This restores behavior prior to fixing Bug 538296.  This property is ignored if the
+     * System Property CONVERSION_USE_TIMEZONE has been set.
+     */
+    public static final String CONVERSION_USE_DEFAULT_TIMEZONE = "org.eclipse.persistence.conversion.useDefaultTimeZoneForJavaTime";
+    
     /**
      * This property can be set to <code>false</code> to enable UPDATE call to set
      * foreign key value in the target row in unidirectional 1-Many mapping

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ConversionManager.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ConversionManager.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 1998, 2018 IBM Corporation and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 IBM Corporation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,6 +15,8 @@
 //     Oracle - initial API and implementation from Oracle TopLink
 //     09/30/2014-2.6.0 Dalia Abo Sheasha
 //       - 445546: NullPointerException thrown when an Array of Bytes contains null values
+//     05/11/2020-2.7.0 Jody Grassel
+//       - 538296: Wrong month is returned if OffsetDateTime is used in JPA 2.2 code
 package org.eclipse.persistence.internal.helper;
 
 import java.io.ByteArrayOutputStream;
@@ -31,18 +33,24 @@ import java.sql.Clob;
 import java.sql.SQLException;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Map;
 import java.util.Vector;
 
+
+import org.eclipse.persistence.config.SystemProperties;
 import org.eclipse.persistence.exceptions.ConversionException;
 import org.eclipse.persistence.exceptions.DatabaseException;
 import org.eclipse.persistence.internal.core.helper.CoreConversionManager;
 import org.eclipse.persistence.internal.security.PrivilegedAccessHelper;
 import org.eclipse.persistence.internal.security.PrivilegedGetClassLoaderForClass;
 import org.eclipse.persistence.internal.security.PrivilegedGetContextClassLoader;
+import org.eclipse.persistence.logging.AbstractSessionLog;
+import org.eclipse.persistence.logging.SessionLog;
 
 /**
  * <p>
@@ -57,6 +65,7 @@ import org.eclipse.persistence.internal.security.PrivilegedGetContextClassLoader
  */
 public class ConversionManager extends CoreConversionManager implements Serializable, Cloneable {
     protected Map defaultNullValues;
+    private static ZoneId defaultZoneOffset = null;
 
     /**
      * This flag is here if the Conversion Manager should use the class loader on the
@@ -75,6 +84,57 @@ public class ConversionManager extends CoreConversionManager implements Serializ
     /** Store the list of Classes that can be converted from to the key. */
     protected Hashtable dataTypesConvertedToAClass;
 
+    private static ZoneId getDefaultZoneOffset() {
+        if (defaultZoneOffset == null) {
+            ZoneId tzoneid = null;
+            String tzone = null;
+            try {
+                tzone = PrivilegedAccessHelper.getSystemProperty(SystemProperties.CONVERSION_USE_TIMEZONE);
+                if (tzone != null) {
+                    try {
+                        tzoneid = java.time.ZoneId.of(tzone);
+                    } catch (Throwable t) {
+                        // If an invalid time zone id is supplied, then fall back to checking for checking for using
+                        // either UTC or the system's default time zone.
+                        if (AbstractSessionLog.getLog().shouldLog(SessionLog.WARNING)) {
+                            AbstractSessionLog.getLog().log(SessionLog.WARNING, "invalid_tzone", 
+                                    SystemProperties.CONVERSION_USE_TIMEZONE, tzone);
+                        }
+                    }
+                } 
+            } catch (Exception e) {
+                // Error occurred attempting to access this system property.  Fall back to the next property.
+            }
+            
+            String propVal = null;
+            try {
+                if (tzoneid == null) {
+                    propVal = PrivilegedAccessHelper.getSystemProperty(SystemProperties.CONVERSION_USE_DEFAULT_TIMEZONE, "false");
+                    if (Boolean.parseBoolean(propVal)) {
+                        tzoneid = java.time.ZoneId.systemDefault();
+                    } else {
+                        tzoneid = ZoneOffset.UTC;
+                    }
+                }
+            } catch (Exception e) {
+                // Error occurred attempting to access this system property.  Fall back to UTC.
+                tzoneid = ZoneOffset.UTC;
+                if (AbstractSessionLog.getLog().shouldLog(SessionLog.WARNING)) {
+                    AbstractSessionLog.getLog().log(SessionLog.WARNING, "invalid_default_tzone", 
+                            SystemProperties.CONVERSION_USE_DEFAULT_TIMEZONE, propVal);
+                }
+            }           
+            
+            defaultZoneOffset = tzoneid;
+            
+            if (AbstractSessionLog.getLog().shouldLog(SessionLog.FINER)) {
+                AbstractSessionLog.getLog().log(SessionLog.FINER, "using_conversion_tzone", defaultZoneOffset);
+            }
+        }
+        
+        return defaultZoneOffset;        
+    }
+    
     public ConversionManager() {
         this.dataTypesConvertedFromAClass = new Hashtable();
         this.dataTypesConvertedToAClass = new Hashtable();
@@ -800,10 +860,10 @@ public class ConversionManager extends CoreConversionManager implements Serializ
         } else if (sourceObject instanceof java.util.Date) {
             // handles sql.Time
             java.util.Date date = (java.util.Date) sourceObject;
-            localDate = java.time.LocalDate.ofEpochDay(date.toInstant().getEpochSecond());
+            localDate = java.time.LocalDate.ofEpochDay(date.toInstant().getEpochSecond() / (60 * 60 * 24)); // Conv sec to day
         } else if (sourceObject instanceof Calendar) {
             Calendar cal = (Calendar) sourceObject;
-            localDate = java.time.LocalDate.of(cal.get(Calendar.YEAR), cal.get(Calendar.MONTH), cal.get(Calendar.DAY_OF_MONTH));
+            localDate = java.time.LocalDate.of(cal.get(Calendar.YEAR), cal.get(Calendar.MONTH) + 1, cal.get(Calendar.DAY_OF_MONTH));
         } else if (sourceObject instanceof Long) {
             localDate = java.time.LocalDate.ofEpochDay((Long) sourceObject);
         } else {
@@ -878,17 +938,17 @@ public class ConversionManager extends CoreConversionManager implements Serializ
             Calendar cal = Helper.allocateCalendar();
             cal.setTime((java.util.Date) sourceObject);
             localDateTime = java.time.LocalDateTime.of(
-                    cal.get(Calendar.YEAR), cal.get(Calendar.MONTH), cal.get(Calendar.DAY_OF_MONTH),
+                    cal.get(Calendar.YEAR), cal.get(Calendar.MONTH) + 1, cal.get(Calendar.DAY_OF_MONTH),
                     cal.get(Calendar.HOUR), cal.get(Calendar.MINUTE), cal.get(Calendar.SECOND), cal.get(Calendar.MILLISECOND));
             Helper.releaseCalendar(cal);
         } else if (sourceObject instanceof Calendar) {
             Calendar cal = (Calendar) sourceObject;
             localDateTime = java.time.LocalDateTime.of(
-                    cal.get(Calendar.YEAR), cal.get(Calendar.MONTH), cal.get(Calendar.DAY_OF_MONTH),
+                    cal.get(Calendar.YEAR), cal.get(Calendar.MONTH) + 1, cal.get(Calendar.DAY_OF_MONTH),
                     cal.get(Calendar.HOUR), cal.get(Calendar.MINUTE), cal.get(Calendar.SECOND), cal.get(Calendar.MILLISECOND));
         } else if (sourceObject instanceof Long) {
             localDateTime = java.time.LocalDateTime.ofInstant(
-                    java.time.Instant.ofEpochSecond((Long) sourceObject), java.time.ZoneId.systemDefault());
+                    java.time.Instant.ofEpochSecond((Long) sourceObject), getDefaultZoneOffset());
         } else {
             throw ConversionException.couldNotBeConverted(sourceObject, ClassConstants.TIME_LDATETIME);
         }
@@ -919,19 +979,19 @@ public class ConversionManager extends CoreConversionManager implements Serializ
             Calendar cal = Helper.allocateCalendar();
             cal.setTime((java.util.Date) sourceObject);
             offsetDateTime = java.time.OffsetDateTime.of(
-                    cal.get(Calendar.YEAR), cal.get(Calendar.MONTH), cal.get(Calendar.DAY_OF_MONTH),
+                    cal.get(Calendar.YEAR), cal.get(Calendar.MONTH) + 1, cal.get(Calendar.DAY_OF_MONTH),
                     cal.get(Calendar.HOUR), cal.get(Calendar.MINUTE), cal.get(Calendar.SECOND), cal.get(Calendar.MILLISECOND) * 1000000,
                     java.time.ZoneOffset.ofTotalSeconds((cal.get(Calendar.ZONE_OFFSET) + cal.get(Calendar.DST_OFFSET)) / 1000));
             Helper.releaseCalendar(cal);
         } else if (sourceObject instanceof Calendar) {
             Calendar cal = (Calendar) sourceObject;
             offsetDateTime = java.time.OffsetDateTime.of(
-                    cal.get(Calendar.YEAR), cal.get(Calendar.MONTH), cal.get(Calendar.DAY_OF_MONTH),
-                    cal.get(Calendar.HOUR), cal.get(Calendar.MINUTE), cal.get(Calendar.SECOND), cal.get(Calendar.MILLISECOND  * 1000000),
+                    cal.get(Calendar.YEAR), cal.get(Calendar.MONTH) + 1, cal.get(Calendar.DAY_OF_MONTH),
+                    cal.get(Calendar.HOUR), cal.get(Calendar.MINUTE), cal.get(Calendar.SECOND), cal.get(Calendar.MILLISECOND)  * 1000000,
                     java.time.ZoneOffset.ofTotalSeconds((cal.get(Calendar.ZONE_OFFSET) + cal.get(Calendar.DST_OFFSET)) / 1000));
         } else if (sourceObject instanceof Long) {
             offsetDateTime = java.time.OffsetDateTime.ofInstant(
-                    java.time.Instant.ofEpochSecond((Long) sourceObject), java.time.ZoneId.systemDefault());
+                    java.time.Instant.ofEpochSecond((Long) sourceObject), getDefaultZoneOffset());
         } else {
             throw ConversionException.couldNotBeConverted(sourceObject, ClassConstants.TIME_ODATETIME);
         }
@@ -976,7 +1036,7 @@ public class ConversionManager extends CoreConversionManager implements Serializ
                     java.time.ZoneOffset.ofTotalSeconds((cal.get(Calendar.ZONE_OFFSET) + cal.get(Calendar.DST_OFFSET)) / 1000));
         } else if (sourceObject instanceof Long) {
             offsetTime = java.time.OffsetTime.ofInstant(
-                    java.time.Instant.ofEpochSecond((Long) sourceObject), java.time.ZoneId.systemDefault());
+                    java.time.Instant.ofEpochSecond((Long) sourceObject), getDefaultZoneOffset());
         } else {
             throw ConversionException.couldNotBeConverted(sourceObject, ClassConstants.TIME_OTIME);
         }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/TraceLocalizationResource.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/TraceLocalizationResource.java
@@ -17,6 +17,8 @@
 //       - 350487: JPA 2.1 Specification defined support for Stored Procedure Calls
 //     11/07/2017 - Dalia Abo Sheasha
 //       - 526957 : Split the logging and trace messages
+//     05/11/2020-2.7.0 Jody Grassel
+//       - 538296: Wrong month is returned if OffsetDateTime is used in JPA 2.2 code
 package org.eclipse.persistence.internal.localization.i18n;
 
 import java.util.ListResourceBundle;
@@ -376,7 +378,10 @@ public class TraceLocalizationResource extends ListResourceBundle {
         { "moxy_write_to_moxy_json_provider", "MOXyJsonProvider.writeTo(...) is called."},
         { "moxy_set_marshaller_property", "Setting marshaller property (name/value): {0}/{1}"},
         { "moxy_set_unmarshaller_property", "Setting unmarshaller property (name/value): {0}/{1}"},
-        { "moxy_set_jaxb_context_property", "Setting JAXBContext property (name/value): {0}/{1}"}
+        { "moxy_set_jaxb_context_property", "Setting JAXBContext property (name/value): {0}/{1}"},
+        { "invalid_tzone", "Invalid timezone conversion property {0} value: {1}.  Will attempt to resolve default." },
+        { "invalid_default_tzone", "Invalid timezone conversion property {0} value: {1}.  Defaulting to UTC." },
+        { "using_conversion_tzone", "ConversionManager using default zone offset: {1}." }
     };
 
     /**

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/conversion/TestJavaTimeTypeConverter.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/conversion/TestJavaTimeTypeConverter.java
@@ -1,0 +1,486 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 IBM Corporation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     05/11/2020-2.7.0 Jody Grassel
+//       - 538296: Wrong month is returned if OffsetDateTime is used in JPA 2.2 code
+
+package org.eclipse.persistence.jpa.test.conversion;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Month;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+import java.util.Calendar;
+
+import jakarta.persistence.EntityManagerFactory;
+
+import org.eclipse.persistence.exceptions.ConversionException;
+import org.eclipse.persistence.internal.helper.ClassConstants;
+import org.eclipse.persistence.internal.helper.ConversionManager;
+import org.eclipse.persistence.jpa.test.framework.Emf;
+import org.eclipse.persistence.jpa.test.framework.EmfRunner;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(EmfRunner.class)
+public class TestJavaTimeTypeConverter { 
+    private ConversionManager cm = ConversionManager.getDefaultManager();
+    
+    // LocalDate
+    @Test
+    public void timeConvertLocalDateToLocalDate() {
+        LocalDate src = LocalDate.of(2020, 1, 1);
+        LocalDate ld = (LocalDate) cm.convertObject(src, ClassConstants.TIME_LDATE);
+        
+        Assert.assertNotNull(ld);
+        Assert.assertEquals(src,  ld);;
+        Assert.assertEquals(Month.JANUARY, ld.getMonth());
+        Assert.assertEquals(1, ld.getDayOfMonth());
+        Assert.assertEquals(2020,  ld.getYear());
+    }
+    
+    @Test
+    public void timeConvertCalendarToLocalDate() {
+        Calendar cal = Calendar.getInstance();
+        cal.set(2020, 0, 1, 0, 0, 0);
+        
+        LocalDate ld = (LocalDate) cm.convertObject(cal, ClassConstants.TIME_LDATE);
+        
+        Assert.assertNotNull(ld);
+        Assert.assertEquals(Month.JANUARY, ld.getMonth());
+        Assert.assertEquals(1, ld.getDayOfMonth());
+        Assert.assertEquals(2020,  ld.getYear());
+    }
+    
+    @Test
+    public void timeConvertUtilDateToLocalDate() {
+        Calendar cal = Calendar.getInstance();
+        java.util.Date date = null;
+        OffsetDateTime odt = null;
+        
+        cal.set(2020, 0, 1, 0, 0, 0);
+        date = cal.getTime();
+        Assert.assertEquals(2020 - 1900, date.getYear());
+        Assert.assertEquals(0, date.getMonth());
+        Assert.assertEquals(1, date.getDate());        
+        
+        LocalDate ld = (LocalDate) cm.convertObject(date, ClassConstants.TIME_LDATE);
+        
+        Assert.assertNotNull(ld);
+        Assert.assertEquals(Month.JANUARY, ld.getMonth());
+        Assert.assertEquals(1, ld.getDayOfMonth());
+        Assert.assertEquals(2020,  ld.getYear());
+    }
+    
+    @Test
+    public void timeConvertSqlDateToLocalDate() {
+        java.sql.Date date = java.sql.Date.valueOf("2020-01-01"); 
+        
+        LocalDate ld = (LocalDate) cm.convertObject(date, ClassConstants.TIME_LDATE);
+        
+        Assert.assertNotNull(ld);
+        Assert.assertEquals(Month.JANUARY, ld.getMonth());
+        Assert.assertEquals(1, ld.getDayOfMonth());
+        Assert.assertEquals(2020,  ld.getYear());
+    }
+    
+    @Test
+    public void timeConvertSqlTimestampToLocalDate() {
+        java.sql.Timestamp ts = java.sql.Timestamp.valueOf("2020-01-01 01:00:00");
+        
+        LocalDate ld = (LocalDate) cm.convertObject(ts, ClassConstants.TIME_LDATE);
+        
+        Assert.assertNotNull(ld);
+        Assert.assertEquals(Month.JANUARY, ld.getMonth());
+        Assert.assertEquals(1, ld.getDayOfMonth());
+        Assert.assertEquals(2020,  ld.getYear());
+    }
+    
+    @Test
+    public void timeConvertStringToLocalDate() {
+        String date = "2020-01-01T1:15:30";
+        LocalDate ld = (LocalDate) cm.convertObject(date, ClassConstants.TIME_LDATE);
+        
+        Assert.assertNotNull(ld);
+        Assert.assertEquals(Month.JANUARY, ld.getMonth());
+        Assert.assertEquals(1, ld.getDayOfMonth());
+        Assert.assertEquals(2020,  ld.getYear());
+    }
+    
+    @Test
+    public void timeConvertLongToLocalDate() {
+        long l = 18262; // 2020-01-01
+        LocalDate ld = (LocalDate) cm.convertObject(l, ClassConstants.TIME_LDATE);
+        
+        Assert.assertNotNull(ld);
+        Assert.assertEquals(Month.JANUARY, ld.getMonth());
+        Assert.assertEquals(1, ld.getDayOfMonth());
+        Assert.assertEquals(2020,  ld.getYear());
+    }
+    
+    @Test
+    public void timeConvertToLocalDateException() {
+        String date = "Bogus";
+        
+        try {
+            cm.convertObject(date, ClassConstants.TIME_LDATE);
+            Assert.fail("Expected Exception was not thrown.");
+        } catch (ConversionException ce) {
+            // Expected
+        }
+       
+    }
+    
+    // LocalDateTime
+    @Test
+    public void timeConvertLocalDateTimeToLocalDateTime() {
+        LocalDateTime src = LocalDateTime.of(2020, 1, 1, 1, 0, 0);
+        LocalDateTime ld = (LocalDateTime) cm.convertObject(src, ClassConstants.TIME_LDATETIME);
+        
+        Assert.assertNotNull(ld);
+        Assert.assertEquals(src,  ld);;
+        Assert.assertEquals(Month.JANUARY, ld.getMonth());
+        Assert.assertEquals(1, ld.getDayOfMonth());
+        Assert.assertEquals(2020,  ld.getYear());
+        Assert.assertEquals(1, ld.getHour());
+        Assert.assertEquals(0, ld.getMinute());
+        Assert.assertEquals(0, ld.getSecond());
+    }
+    
+    @Test
+    public void timeConvertStringToLocalDateTime() {
+        String date = "2020-01-01T1:15:30";
+        LocalDateTime ld = (LocalDateTime) cm.convertObject(date, ClassConstants.TIME_LDATETIME);
+        
+        Assert.assertNotNull(ld);
+        Assert.assertEquals(Month.JANUARY, ld.getMonth());
+        Assert.assertEquals(1, ld.getDayOfMonth());
+        Assert.assertEquals(2020,  ld.getYear());
+        Assert.assertEquals(1, ld.getHour());
+        Assert.assertEquals(15, ld.getMinute());
+        Assert.assertEquals(30, ld.getSecond());
+    }
+    
+    @Test
+    public void timeConvertUtilDateToLocalDateTime() {
+        Calendar cal = Calendar.getInstance();
+        java.util.Date date = null;
+        LocalDateTime ldt = null;
+        
+        cal.set(2020, 0, 1, 2, 15, 30);
+        date = cal.getTime();
+               
+        ldt = (LocalDateTime) cm.convertObject(date, ClassConstants.TIME_LDATETIME);
+        
+        Assert.assertNotNull(ldt);
+        Assert.assertEquals(Month.JANUARY, ldt.getMonth());
+        Assert.assertEquals(1, ldt.getDayOfMonth());
+        Assert.assertEquals(2020,  ldt.getYear());
+        Assert.assertEquals(2, ldt.getHour());
+        Assert.assertEquals(15, ldt.getMinute());
+        Assert.assertEquals(30, ldt.getSecond());
+    }
+    
+    @Test
+    public void timeConvertCalendarToLocalDateTime() {
+        Calendar cal = Calendar.getInstance();
+        cal.set(2020, 0, 1, 2, 15, 30);
+        
+        LocalDateTime ldt = (LocalDateTime) cm.convertObject(cal, ClassConstants.TIME_LDATETIME);
+        
+        Assert.assertNotNull(ldt);
+        Assert.assertEquals(Month.JANUARY, ldt.getMonth());
+        Assert.assertEquals(1, ldt.getDayOfMonth());
+        Assert.assertEquals(2020,  ldt.getYear());
+        Assert.assertEquals(2, ldt.getHour());
+        Assert.assertEquals(15, ldt.getMinute());
+        Assert.assertEquals(30, ldt.getSecond());
+    }
+    
+    @Test
+    public void timeConvertLongToLocalDateTime() {
+        long l = 18262 * (60 * 60 * 24); // 2020-01-01      
+        LocalDateTime ldt = (LocalDateTime) cm.convertObject(l, ClassConstants.TIME_LDATETIME);
+        
+        Assert.assertNotNull(ldt);
+        Assert.assertEquals(Month.JANUARY, ldt.getMonth());
+        Assert.assertEquals(1, ldt.getDayOfMonth());
+        Assert.assertEquals(2020,  ldt.getYear());
+    }
+    
+    @Test
+    public void timeConvertToLocalDateTimeException() {
+        String date = "Bogus";
+        
+        try {
+            cm.convertObject(date, ClassConstants.TIME_LDATETIME);
+            Assert.fail("Expected Exception was not thrown.");
+        } catch (ConversionException ce) {
+            // Expected
+        }
+    }
+    
+    // LocalTime
+    @Test
+    public void timeConvertLocalTimeToLocalTime() {
+        LocalTime src = LocalTime.of(1, 15, 30);
+        LocalTime ld = (LocalTime) cm.convertObject(src, ClassConstants.TIME_LTIME);
+        
+        Assert.assertNotNull(ld);
+        Assert.assertEquals(src,  ld);;
+        Assert.assertEquals(1, ld.getHour());
+        Assert.assertEquals(15, ld.getMinute());
+        Assert.assertEquals(30, ld.getSecond());
+    }
+    
+    @Test
+    public void timeConvertStringToLocalTime() {
+        String date = "T1:15:30";
+        LocalTime ld = (LocalTime) cm.convertObject(date, ClassConstants.TIME_LTIME);
+        
+        Assert.assertNotNull(ld);
+        Assert.assertEquals(1, ld.getHour());
+        Assert.assertEquals(15, ld.getMinute());
+        Assert.assertEquals(30, ld.getSecond());
+    }
+    
+    @Test
+    public void timeConvertTimestampToLocalTime() {
+        java.sql.Timestamp ts = java.sql.Timestamp.valueOf("2020-01-01 01:15:30");
+        
+        LocalTime ld = (LocalTime) cm.convertObject(ts, ClassConstants.TIME_LTIME);
+        
+        Assert.assertNotNull(ld);
+        Assert.assertEquals(1, ld.getHour());
+        Assert.assertEquals(15, ld.getMinute());
+        Assert.assertEquals(30, ld.getSecond());
+    }
+    
+    @Test
+    public void timeConvertTimeToLocalTime() {
+        java.sql.Time ts = java.sql.Time.valueOf("01:15:30");
+        
+        LocalTime ld = (LocalTime) cm.convertObject(ts, ClassConstants.TIME_LTIME);
+        
+        Assert.assertNotNull(ld);
+        Assert.assertEquals(1, ld.getHour());
+        Assert.assertEquals(15, ld.getMinute());
+        Assert.assertEquals(30, ld.getSecond());
+    }
+    
+    @Test
+    public void timeConvertUtilDateToLocalTime() {
+        Calendar cal = Calendar.getInstance();
+        java.util.Date date = null;
+        LocalTime ld = null;
+        
+        cal.set(2020, 0, 1, 2, 15, 30);
+        date = cal.getTime();
+               
+        ld = (LocalTime) cm.convertObject(date, ClassConstants.TIME_LTIME);
+        
+        Assert.assertNotNull(ld);
+        Assert.assertEquals(2, ld.getHour());
+        Assert.assertEquals(15, ld.getMinute());
+        Assert.assertEquals(30, ld.getSecond());
+    }
+    
+    @Test
+    public void convertLongToLocalTime() {
+        long sod = 60*60 + 60*15 + 30;
+        LocalTime ld = (LocalTime) cm.convertObject(sod, ClassConstants.TIME_LTIME);
+        
+        Assert.assertNotNull(ld);
+        Assert.assertEquals(1, ld.getHour());
+        Assert.assertEquals(15, ld.getMinute());
+        Assert.assertEquals(30, ld.getSecond());
+    }
+    
+    @Test
+    public void timeConvertToLocalTimeException() {
+        String date = "Bogus";
+        
+        try {
+            cm.convertObject(date, ClassConstants.TIME_LTIME);
+            Assert.fail("Expected Exception was not thrown.");
+        } catch (ConversionException ce) {
+            // Expected
+        }
+    }
+        
+    // OffsetDateTime
+    
+    @Test
+    public void timeConvertCalendarToOffsetDateTime() {
+        Calendar cal = Calendar.getInstance();
+        cal.set(2020, 0, 1, 0, 0, 0);
+        
+        OffsetDateTime odt = (OffsetDateTime) cm.convertObject(cal, ClassConstants.TIME_ODATETIME);
+        
+        Assert.assertNotNull(odt);
+        Assert.assertEquals(Month.JANUARY, odt.getMonth());
+        Assert.assertEquals(1, odt.getDayOfMonth());
+        Assert.assertEquals(2020,  odt.getYear());
+    }
+    
+    @Test
+    public void timeConvertUtilDateToOffsetDateTime() {
+        Calendar cal = Calendar.getInstance();
+        java.util.Date date = null;
+        OffsetDateTime odt = null;
+        
+        cal.set(2020, 0, 1, 0, 0, 0);
+        date = cal.getTime();
+               
+        odt = (OffsetDateTime) cm.convertObject(date, ClassConstants.TIME_ODATETIME);
+        
+        Assert.assertNotNull(odt);
+        Assert.assertEquals(Month.JANUARY, odt.getMonth());
+        Assert.assertEquals(1, odt.getDayOfMonth());
+        Assert.assertEquals(2020,  odt.getYear());
+    }
+    
+    @Test
+    public void timeConvertStringToOffsetDateTime() {
+        String date = "2020-01-01T1:15:30";
+        OffsetDateTime odt = null;
+               
+        odt = (OffsetDateTime) cm.convertObject(date, ClassConstants.TIME_ODATETIME);
+        
+        Assert.assertNotNull(odt);
+        Assert.assertEquals(Month.JANUARY, odt.getMonth());
+        Assert.assertEquals(1, odt.getDayOfMonth());
+        Assert.assertEquals(2020,  odt.getYear());
+        Assert.assertEquals(1, odt.getHour());
+        Assert.assertEquals(15,  odt.getMinute());
+        Assert.assertEquals(30, odt.getSecond());
+    }
+    
+    @Test
+    public void timeConvertOffsetDateTimeToOffsetDateTime() {
+        OffsetDateTime original = OffsetDateTime.of(2020, 1, 1, 1, 15, 30, 0, ZoneOffset.UTC);
+        OffsetDateTime odt = null;
+               
+        odt = (OffsetDateTime) cm.convertObject(original, ClassConstants.TIME_ODATETIME);
+        
+        Assert.assertNotNull(odt);
+        Assert.assertSame(original,  odt);
+        Assert.assertEquals(Month.JANUARY, odt.getMonth());
+        Assert.assertEquals(1, odt.getDayOfMonth());
+        Assert.assertEquals(2020,  odt.getYear());
+        Assert.assertEquals(1, odt.getHour());
+        Assert.assertEquals(15,  odt.getMinute());
+        Assert.assertEquals(30, odt.getSecond());
+    }
+    
+    @Test
+    public void timeConvertToOffsetDateTimeException() {
+        String date = "Bogus";
+        
+        try {
+            cm.convertObject(date, ClassConstants.TIME_ODATETIME);
+            Assert.fail("Expected Exception was not thrown.");
+        } catch (ConversionException ce) {
+            // Expected
+        }
+    }
+
+    // OffSetTime
+    
+    @Test
+    public void timeConvertOffsetTimeToOffsetTime() {
+        OffsetTime original = OffsetTime.of(1, 15, 30, 0, ZoneOffset.UTC);
+        OffsetTime odt = null;
+               
+        odt = (OffsetTime) cm.convertObject(original, ClassConstants.TIME_OTIME);
+        
+        Assert.assertNotNull(odt);
+        Assert.assertSame(original,  odt);
+        Assert.assertEquals(1, odt.getHour());
+        Assert.assertEquals(15,  odt.getMinute());
+        Assert.assertEquals(30, odt.getSecond());
+    }
+    
+    @Test
+    public void timeConvertStringToOffsetTime() {
+        String date = "T1:15:30";
+        OffsetTime odt = null;
+               
+        odt = (OffsetTime) cm.convertObject(date, ClassConstants.TIME_OTIME);
+        
+        Assert.assertNotNull(odt);
+        Assert.assertEquals(1, odt.getHour());
+        Assert.assertEquals(15,  odt.getMinute());
+        Assert.assertEquals(30, odt.getSecond());
+    }
+    
+    @Test
+    public void timeConvertUtilDateToOffsetTime() {
+        Calendar cal = Calendar.getInstance();
+        java.util.Date date = null;
+        OffsetTime odt = null;
+        
+        cal.set(2020, 0, 1, 1, 15, 30);
+        date = cal.getTime();
+               
+        odt = (OffsetTime) cm.convertObject(date, ClassConstants.TIME_OTIME);
+        
+        Assert.assertNotNull(odt);
+        Assert.assertEquals(1, odt.getHour());
+        Assert.assertEquals(15,  odt.getMinute());
+        Assert.assertEquals(30, odt.getSecond());
+    }
+    
+    @Test
+    public void timeConvertCalendarToOffsetTime() {
+        Calendar cal = Calendar.getInstance();
+        cal.set(2020, 0, 1, 1, 15, 30);
+        
+        OffsetTime odt = (OffsetTime) cm.convertObject(cal, ClassConstants.TIME_OTIME);
+        
+        Assert.assertNotNull(odt);
+        Assert.assertEquals(1, odt.getHour());
+        Assert.assertEquals(15,  odt.getMinute());
+        Assert.assertEquals(30, odt.getSecond());
+    }
+    
+    @Test
+    public void testConvertLongToOffsetTime() {
+        long l = 18262 * (60 * 60 * 24) + (60*60 + 60*15 + 30); // 2020-01-01  T01:15:30     
+        OffsetTime ldt = (OffsetTime) cm.convertObject(l, ClassConstants.TIME_OTIME);
+        
+        Assert.assertNotNull(ldt);
+        Assert.assertEquals(1, ldt.getHour());
+        Assert.assertEquals(15,  ldt.getMinute());
+        Assert.assertEquals(30, ldt.getSecond());
+    }
+    
+    @Test
+    public void timeConvertToOffsetTimeException() {
+        String date = "Bogus";
+        
+        try {
+            cm.convertObject(date, ClassConstants.TIME_OTIME);
+            Assert.fail("Expected Exception was not thrown.");
+        } catch (ConversionException ce) {
+            // Expected
+        }
+    }
+    
+}


### PR DESCRIPTION
for #893

Fix for https://bugs.eclipse.org/bugs/show_bug.cgi?id=538296

Corrected a number of issues in the java.time conversion logic, and added unit tests to verify conversion  operations.

Prior to this fix, the ConversionManager defaulted to the JVM's system default time zone instead of UTC.  This could lead to unexpected time zone changes, especially for an application system that  could be distributed over multiple timezones.  This fix changes the default time zone used in certain conversions* to UTC.

Applications which want to return to the prior behavior, or select a specific timezone may take advantage of one of two JVM system properties introduced by this fix:

- `org.eclipse.persistence.conversion.useTimeZone` - Set this to a value that is an acceptable input for `java.time.ZoneId.of()`.   This time zone will then be used for select conversions* with ConversionManager.
- `org.eclipse.persistence.conversion.useDefaultTimeZoneForJavaTime` - Set to true to use `ZoneId.systemDefault()` (the behavior before this fix) for select conversions with ConversionManager, or false to use `ZoneOffset.UTC`.

There is an order of precedence with these properties.  If `useTimeZone` is set, and has a valid value, then `useDefaultTimeZoneForJavaTime` will be ignored.  However, if `useTimeZone` is either not set or is set to an invalid value, then, if it is set, `org.eclipse.persistence.conversion.useDefaultTimeZoneForJavaTime` will be processed.  If this system property is set true, then the previous behavior of using the system's default time zone will be used; If set to false (or is unset), then ConversionManager will use UTC.

`* select conversions include conversions to LocalDateTime, OffsetDateTime, and OffsetTime)`