### PR TITLE
[master] Maven build - Nightly module fix.

### DIFF
--- a/bundles/nightly/pom.xml
+++ b/bundles/nightly/pom.xml
@@ -207,7 +207,7 @@
                         <configuration>
                             <fileSets>
                                 <fileSet>
-                                    <sourceFile>../eclipselink/target/eclipselink.zip</sourceFile>
+                                    <sourceFile>../eclipselink/target/eclipselink-${project.version}.zip</sourceFile>
                                     <destinationFile>
                                         ${project.build.directory}${nightlyDir}/eclipselink${nightlyVersion}.zip
                                     </destinationFile>

--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
         <apache.felix.framework.version>6.0.3</apache.felix.framework.version>
         <!-- CQ #21133 -->
         <ant.version>1.10.9</ant.version>
-        <!-- CQ #22146 -->
+        <!-- CQ #22750 -->
         <asm.version>9.0</asm.version>
         <commonj.sdo.version>2.1.1</commonj.sdo.version>
         <derby.version>10.14.2.0</derby.version>


### PR DESCRIPTION
This is fix of nightly Maven module. Due previous changes there is different _eclipselink.zip_ file name e.g. _eclipselink-3.0.0-SNAPSHOT.zip_. This fix reflect this change.
For bug details see https://ci.eclipse.org/eclipselink/view/Current%20Jobs/job/eclipselink-nightly-master/141/console
Signed-off-by: Radek Felcman <radek.felcman@oracle.com>