### PR TITLE
[2.7] JPA Criteria API: Empty IN Statement leads to SQL-Error - backport from master

### DIFF
--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/expressions/ExpressionTestSuite.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/expressions/ExpressionTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -739,6 +739,32 @@ public class ExpressionTestSuite extends TestSuite {
         ReadObjectExpressionTest test = new ReadObjectExpressionTest(employee, expression);
         test.setName("InCollectionExpressionTest");
         test.setDescription("Test IN expression");
+        addTest(test);
+    }
+
+    private void addInCollectionEmptyTest() {
+        // Empty collection without any items
+        Set names = new HashSet();
+
+        ExpressionBuilder builder = new ExpressionBuilder();
+        Expression expression = builder.get("lastName").in(names);
+
+        ReadObjectExpressionTest test = new ReadObjectExpressionTest(new Employee().getClass(), expression);
+        test.setName("InCollectionEmptyExpressionTest");
+        test.setDescription("Test IN expression with empty collection");
+        addTest(test);
+    }
+
+    private void addInCollectionNullTest() {
+        // Collection is not initialized
+        Set names = null;
+
+        ExpressionBuilder builder = new ExpressionBuilder();
+        Expression expression = builder.get("lastName").in(names);
+
+        ReadObjectExpressionTest test = new ReadObjectExpressionTest(new Employee().getClass(), expression);
+        test.setName("InCollectionNullExpressionTest");
+        test.setDescription("Test IN expression with null collection");
         addTest(test);
     }
 
@@ -1692,6 +1718,8 @@ public class ExpressionTestSuite extends TestSuite {
         // ET. The test doesn't work with DB2 jcc driver(Bug 4563813)
         addAdvancedDB2ExpressionFunctionTest();
         addInCollectionTest();
+        addInCollectionEmptyTest();
+        addInCollectionNullTest();
         // Bug 247076 - LiteralExpression does not print SQL in statement
         addTest(new LiteralExpressionTest());
         // Bug 284884 - Quoted '?' symbol in expression literal causes ArrayIndexOutOfBoundsException

--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/expressions/ReadObjectExpressionTest.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/expressions/ReadObjectExpressionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -23,9 +23,19 @@ import org.eclipse.persistence.testing.framework.ReadObjectTest;
  */
 public class ReadObjectExpressionTest extends ReadObjectTest {
     Expression expression;
+    /** The class of the target objects to be read from the database. */
+    private Class referenceClass;
 
     public ReadObjectExpressionTest(Object theOriginalObject, Expression theExpression) {
         originalObject = theOriginalObject;
+        expression = theExpression;
+        if (theOriginalObject != null) {
+            referenceClass = theOriginalObject.getClass();
+        }
+    }
+
+    public ReadObjectExpressionTest(Class theReferenceClass, Expression theExpression) {
+        referenceClass = theReferenceClass;
         expression = theExpression;
     }
 
@@ -41,7 +51,7 @@ public class ReadObjectExpressionTest extends ReadObjectTest {
         // Access and DB2 do not support UPPER and LOWER
         if (getQuery() == null) {
             setQuery(new ReadObjectQuery());
-            getQuery().setReferenceClass(getOriginalObject().getClass());
+            getQuery().setReferenceClass(referenceClass);
             getQuery().setSelectionCriteria(getExpression());
         }
     }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/expressions/ExpressionSQLPrinter.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/expressions/ExpressionSQLPrinter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -37,6 +37,8 @@ import org.eclipse.persistence.internal.sessions.AbstractRecord;
  *    @since TOPLink/Java 1.0
  */
 public class ExpressionSQLPrinter {
+
+    private static final String NULL_STRING = "NULL";
 
     /**
      * Stores the current session. The session accessor
@@ -215,19 +217,23 @@ public class ExpressionSQLPrinter {
     public void printValuelist(Collection values) {
         try {
             getWriter().write("(");
-            Iterator valuesEnum = values.iterator();
-            while (valuesEnum.hasNext()) {
-                Object value = valuesEnum.next();
-                // Support nested arrays for IN.
-                if (value instanceof Collection) {
-                    printValuelist((Collection)value);
-                } else if (value instanceof Expression) {
-                    ((Expression)value).printSQL(this);
-                } else {
-                    session.getPlatform().appendLiteralToCall(getCall(), getWriter(), value);
-                }
-                if (valuesEnum.hasNext()) {
-                    getWriter().write(", ");
+            if (values == null || values.isEmpty()) {
+                getWriter().write(NULL_STRING);
+            } else {
+                Iterator valuesEnum = values.iterator();
+                while (valuesEnum.hasNext()) {
+                    Object value = valuesEnum.next();
+                    // Support nested arrays for IN.
+                    if (value instanceof Collection) {
+                        printValuelist((Collection) value);
+                    } else if (value instanceof Expression) {
+                        ((Expression) value).printSQL(this);
+                    } else {
+                        session.getPlatform().appendLiteralToCall(getCall(), getWriter(), value);
+                    }
+                    if (valuesEnum.hasNext()) {
+                        getWriter().write(", ");
+                    }
                 }
             }
             getWriter().write(")");
@@ -242,16 +248,20 @@ public class ExpressionSQLPrinter {
     public void printList(Collection values) {
         try {
             getWriter().write("(");
-            Iterator valuesEnum = values.iterator();
-            while (valuesEnum.hasNext()) {
-                Object value = valuesEnum.next();
-                if (value instanceof Expression){
-                    ((Expression)value).printSQL(this);
-                }else{
-                    session.getPlatform().appendLiteralToCall(getCall(), getWriter(), value);
-                }
-                if (valuesEnum.hasNext()) {
-                    getWriter().write(", ");
+            if (values == null || values.isEmpty()) {
+                getWriter().write(NULL_STRING);
+            } else {
+                Iterator valuesEnum = values.iterator();
+                while (valuesEnum.hasNext()) {
+                    Object value = valuesEnum.next();
+                    if (value instanceof Expression) {
+                        ((Expression) value).printSQL(this);
+                    } else {
+                        session.getPlatform().appendLiteralToCall(getCall(), getWriter(), value);
+                    }
+                    if (valuesEnum.hasNext()) {
+                        getWriter().write(", ");
+                    }
                 }
             }
             getWriter().write(")");

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/criteria/AdvancedCriteriaQueryTestSuite.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/criteria/AdvancedCriteriaQueryTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2018 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -404,6 +404,7 @@ public class AdvancedCriteriaQueryTestSuite extends JUnitTestCase {
             closeEntityManager(em);
         }
     }
+
     public void testInCollectionPrimitives(){
         EntityManager em = createEntityManager();
         beginTransaction(em);
@@ -416,6 +417,43 @@ public class AdvancedCriteriaQueryTestSuite extends JUnitTestCase {
             Query query = em.createQuery(cq);
             List<Employee> result = query.getResultList();
             assertFalse("No Employees were returned", result.isEmpty());
+        } finally {
+            rollbackTransaction(em);
+            closeEntityManager(em);
+        }
+    }
+
+    public void testInCollectionEmpty(){
+        EntityManager em = createEntityManager();
+        beginTransaction(em);
+        try {
+            CriteriaBuilder qb = em.getCriteriaBuilder();
+            CriteriaQuery<Employee> cq = qb.createQuery(Employee.class);
+            Root<Employee> emp = cq.from(Employee.class);
+            Root<PhoneNumber> phone = cq.from(PhoneNumber.class);
+            cq.where(qb.literal("Bug fixes").in(new HashSet()));
+            Query query = em.createQuery(cq);
+            List<Employee> result = query.getResultList();
+            assertTrue("No any Employees was expected", result.isEmpty());
+        } finally {
+            rollbackTransaction(em);
+            closeEntityManager(em);
+        }
+    }
+
+    public void testInCollectionNull(){
+        EntityManager em = createEntityManager();
+        beginTransaction(em);
+        try {
+            CriteriaBuilder qb = em.getCriteriaBuilder();
+            CriteriaQuery<Employee> cq = qb.createQuery(Employee.class);
+            Root<Employee> emp = cq.from(Employee.class);
+            Root<PhoneNumber> phone = cq.from(PhoneNumber.class);
+            List list = null;
+            cq.where(qb.literal("Bug fixes").in(list));
+            Query query = em.createQuery(cq);
+            List<Employee> result = query.getResultList();
+            assertTrue("No any Employees was expected", result.isEmpty());
         } finally {
             rollbackTransaction(em);
             closeEntityManager(em);


### PR DESCRIPTION
Bug fix + unit test for #847 .

Before this fix EclipseLink for (assume the `inList` is empty or `null`)
`Predicate in = from.get("projektID").in(inList);`
produced invalid SQL query like
`SELECT ... FROM ... WHERE PROJEKTID IN ()`
After this fix generated SQL query for empty or null collection used in `.in(...)` method/expression is e.g.
`SELECT ... FROM ... WHERE PROJEKTID IN (NULL)`
Which is valid SQL query.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>