### PR TITLE
[2.7] Fix for a bug 553439 v2.0 - JAXB Unmarshaller with Schema does not show location of error - backport from master

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/record/XMLStreamReaderReader.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/record/XMLStreamReaderReader.java
@@ -154,7 +154,7 @@ public class XMLStreamReaderReader extends XMLReaderAdapter {
                         contentHandler.endElement(namespaceURI, localName, prefix + Constants.COLON + localName);
                     }
                 } else {
-                    contentHandler.endElement(namespaceURI, localName, null);
+                    contentHandler.endElement(namespaceURI, localName, localName);
                 }
                 int namespaceCount = xmlStreamReader.getNamespaceCount();
                 if(namespaceCount > 0) {


### PR DESCRIPTION
This is additional bug fix for reopened bug https://bugs.eclipse.org/bugs/show_bug.cgi?id=553439 .