### PR TITLE
[2.6] Fix for a bug 553439 2.0 - JAXB Unmarshaller with Schema does not show location of error - backport from master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ install:
   - wget -nc https://repo1.maven.org/maven2/org/jboss/logging/jboss-logging/3.3.0.Final/jboss-logging-3.3.0.Final.jar -O $HOME/extension.lib.external/jboss-logging-3.3.0.Final.jar || true
   - wget -nc https://repo1.maven.org/maven2/org/glassfish/javax.el/3.0.1-b08/javax.el-3.0.1-b08.jar -O $HOME/extension.lib.external/javax.el-3.0.1-b08.jar || true
   - wget -nc https://repo1.maven.org/maven2/com/fasterxml/classmate/1.3.1/classmate-1.3.1.jar -O $HOME/extension.lib.external/classmate-1.3.1.jar || true
-  - wget -nc https://apache.redkiwi.nl//ant/binaries/apache-ant-1.9.15-bin.tar.gz -O $HOME/extension.lib.external/apache-ant-1.9.15-bin.tar.gz || true
+  - wget -nc https://archive.apache.org/dist/ant/binaries/apache-ant-1.9.15-bin.tar.gz -O $HOME/extension.lib.external/apache-ant-1.9.15-bin.tar.gz || true
   - wget -nc https://download.eclipse.org/eclipse/downloads/drops4/R-4.5.2-201602121500/eclipse-SDK-4.5.2-linux-gtk-x86_64.tar.gz -O $HOME/extension.lib.external/eclipse-SDK-4.5.2-linux-gtk-x86_64.tar.gz || true
   - tar -x -z -C $HOME -f $HOME/extension.lib.external/apache-ant-1.9.15-bin.tar.gz
   - tar -x -z -C $HOME/extension.lib.external -f $HOME/extension.lib.external/eclipse-SDK-4.5.2-linux-gtk-x86_64.tar.gz

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/record/XMLStreamReaderReader.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/record/XMLStreamReaderReader.java
@@ -151,7 +151,7 @@ public class XMLStreamReaderReader extends XMLReaderAdapter {
                         contentHandler.endElement(namespaceURI, localName, prefix + Constants.COLON + localName);
                     }
                 } else {
-                    contentHandler.endElement(namespaceURI, localName, null);
+                    contentHandler.endElement(namespaceURI, localName, localName);
                 }
                 int namespaceCount = xmlStreamReader.getNamespaceCount();
                 if(namespaceCount > 0) {


### PR DESCRIPTION
This is additional bug fix for reopened bug https://bugs.eclipse.org/bugs/show_bug.cgi?id=553439 .

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>