### PR TITLE
Jenkins build - Snapshots promotion during Nightly build

### DIFF
--- a/etc/jenkins/build.groovy
+++ b/etc/jenkins/build.groovy
@@ -175,6 +175,18 @@ spec:
                 }
             }
         }
+        // Publish to snapshots
+        stage('Publish to snapshots') {
+            steps {
+                container('el-build') {
+                    sshagent([SSH_CREDENTIALS_ID]) {
+                        sh """
+                            etc/jenkins/publish_snapshots.sh
+                            """
+                    }
+                }
+            }
+        }
         stage('Proceed test results') {
             steps {
                 script {

--- a/etc/jenkins/publish_snapshots.sh
+++ b/etc/jenkins/publish_snapshots.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -e
+#
+# Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Distribution License v. 1.0, which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+#
+# Arguments:
+#  N/A
+
+echo '-[ EclipseLink Publish to Jakarta Snapshots ]-----------------------------------------------------------'
+. /etc/profile
+mvn --no-transfer-progress -U -C -B -V \
+      -Psnapshots -DskipTests \
+      -DskipTests -Ddoclint=none \
+      -Ddeploy \
+      clean deploy

--- a/etc/jenkins/publish_snapshots.sh
+++ b/etc/jenkins/publish_snapshots.sh
@@ -16,6 +16,5 @@ echo '-[ EclipseLink Publish to Jakarta Snapshots ]-----------------------------
 . /etc/profile
 mvn --no-transfer-progress -U -C -B -V \
       -Psnapshots -DskipTests \
-      -DskipTests -Ddoclint=none \
-      -Ddeploy \
+      -Ddoclint=none -Ddeploy \
       clean deploy

--- a/pom.xml
+++ b/pom.xml
@@ -95,9 +95,6 @@
     </repositories>
 
     <properties>
-        <sonatypeOssDistMgmtNexusUrl>https://jakarta.oss.sonatype.org</sonatypeOssDistMgmtNexusUrl>
-        <sonatypeOssDistMgmtStagingUrl>${sonatypeOssDistMgmtNexusUrl}/content/repositories/staging/</sonatypeOssDistMgmtStagingUrl>
-
         <!-- TOOL Properties -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- PROJECT Properties -->


### PR DESCRIPTION
This PR extends Jenkins build with new stage **Publish to snapshots**. Output from Nightly build job after successful tests will be published to https://jakarta.oss.sonatype.org/content/repositories/snapshots/ too. Other outputs (Nightly download page at https://www.eclipse.org/eclipselink/downloads/nightly.php) remains untouched.
There is minor cleanup in project pom. Maven properties `sonatypeOssDistMgmtNexusUrl` and `sonatypeOssDistMgmtStagingUrl` were removed due duplication with parent pom `org.eclipse.ee4j:project:1.0.6` .

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>