### PR TITLE
[master] Bug/New Feature 559307: EclipseLink on all versions can dead-lock forever 2.0

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ExplainDeadLockUtil.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ExplainDeadLockUtil.java
@@ -959,8 +959,7 @@ public class ExplainDeadLockUtil {
                             IsBuildObjectCompleteOutcome recursiveOutcome = isBuildObjectOnThreadComplete(
                                     concurrencyManagerStateDto, activeThread, recursiveSet);
                             if (recursiveOutcome != null) {
-                                // return false
-                                return recursiveOutcome;
+                                return new IsBuildObjectCompleteOutcome(activeThread, deferedLock);
                             }
                         }
                     } else {


### PR DESCRIPTION
There is small fix to improve readability of massive dump Page 7 of Concurrency manager state.