### PR TITLE
Fix SQL Server error code 145 for select distinct with result limited queries.

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/SQLServerPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/SQLServerPlatform.java
@@ -813,11 +813,11 @@ public class SQLServerPlatform extends org.eclipse.persistence.platform.database
             return;
         }
         
-        // OFFSET + FETCH NEXT requires ORDER BY, so add an ordering if there are none
-        // this SQL will satisfy the query parser without actually changing the ordering of the rows
+        // OFFSET + FETCH NEXT requires ORDER BY
         List<Expression> orderBy = statement.getOrderByExpressions();
         if (orderBy.isEmpty()) {
-            orderBy.add(statement.getBuilder().literal("ROW_NUMBER() OVER (ORDER BY (SELECT null))"));
+            super.printSQLSelectStatement(call, printer, statement);
+            return;
         }
         
         // decide exact syntax to use, depending on whether a limit is specified (could just have an offset)


### PR DESCRIPTION
Fixes #963 with the proposed solution to step out.


I did not create a dedicated test as the current test suite finds this one already when run against SQL Server, e.g.:

```
org.eclipse.persistence.testing.tests.jpa.jpql.JUnitJPQLSimpleTestSuite.selectPhoneUsingALLTest  Time elapsed: 0.023 s  <<< ERROR!
jakarta.persistence.PersistenceException: 
Exception [EclipseLink-4002] (Eclipse Persistence Services - 3.0.0.v202011171834): org.eclipse.persistence.exceptions.DatabaseException
Internal Exception: com.microsoft.sqlserver.jdbc.SQLServerException: ORDER BY items must appear in the select list if SELECT DISTINCT is specified.
Error Code: 145
Call: SELECT DISTINCT t1.EMP_ID, t2.EMP_ID, t1.F_NAME, t1.GENDER, t1.L_NAME, t1.PAY_SCALE, t1.ROOM_NUM, t2.SALARY, t1.STATUS, t1.VERSION, t1.START_TIME, t1.END_TIME, t1.START_OVERTIME, t1.END_OVERTIME, t1.FORMER_COMPANY, t1.FORMER_END_DATE, t1.FORMER_START_DATE, t1.FORMER_COMPANY_ADDRESS_ID, t1.END_DATE, t1.START_DATE, t1.COMPANYADDRESS_ADDRESS_ID, t1.ADDR_ID, t1.DEPT_ID, t1.MANAGER_EMP_ID, t1.HUGE_PROJ_ID, t0.ID, t0.NAME, t0.DEPT_HEAD FROM CMP3_EMPLOYEE t1 LEFT OUTER JOIN CMP3_DEPT t0 ON (t0.ID = t1.DEPT_ID), CMP3_PHONENUMBER t3, CMP3_SALARY t2 WHERE (((t3.NUMB = ALL(SELECT MIN(t4.NUMB) FROM CMP3_PHONENUMBER t4)) AND (t2.EMP_ID = t1.EMP_ID)) AND (t3.OWNER_ID = t1.EMP_ID)) ORDER BY ROW_NUMBER() OVER (ORDER BY (SELECT null)) OFFSET ? ROWS FETCH NEXT ? ROWS ONLY
	bind => [2 parameters bound]
Query: ReadAllQuery(referenceClass=Employee sql="SELECT DISTINCT t1.EMP_ID, t2.EMP_ID, t1.F_NAME, t1.GENDER, t1.L_NAME, t1.PAY_SCALE, t1.ROOM_NUM, t2.SALARY, t1.STATUS, t1.VERSION, t1.START_TIME, t1.END_TIME, t1.START_OVERTIME, t1.END_OVERTIME, t1.FORMER_COMPANY, t1.FORMER_END_DATE, t1.FORMER_START_DATE, t1.FORMER_COMPANY_ADDRESS_ID, t1.END_DATE, t1.START_DATE, t1.COMPANYADDRESS_ADDRESS_ID, t1.ADDR_ID, t1.DEPT_ID, t1.MANAGER_EMP_ID, t1.HUGE_PROJ_ID, t0.ID, t0.NAME, t0.DEPT_HEAD FROM CMP3_EMPLOYEE t1 LEFT OUTER JOIN CMP3_DEPT t0 ON (t0.ID = t1.DEPT_ID), CMP3_PHONENUMBER t3, CMP3_SALARY t2 WHERE (((t3.NUMB = ALL(SELECT MIN(t4.NUMB) FROM CMP3_PHONENUMBER t4)) AND (t2.EMP_ID = t1.EMP_ID)) AND (t3.OWNER_ID = t1.EMP_ID)) ORDER BY ROW_NUMBER() OVER (ORDER BY (SELECT null)) OFFSET ? ROWS FETCH NEXT ? ROWS ONLY")
	at org.eclipse.persistence.testing.tests.jpa.jpql.JUnitJPQLSimpleTestSuite.selectPhoneUsingALLTest(JUnitJPQLSimpleTestSuite.java:1946)
Caused by: org.eclipse.persistence.exceptions.DatabaseException: 

Internal Exception: com.microsoft.sqlserver.jdbc.SQLServerException: ORDER BY items must appear in the select list if SELECT DISTINCT is specified.
Error Code: 145
Call: SELECT DISTINCT t1.EMP_ID, t2.EMP_ID, t1.F_NAME, t1.GENDER, t1.L_NAME, t1.PAY_SCALE, t1.ROOM_NUM, t2.SALARY, t1.STATUS, t1.VERSION, t1.START_TIME, t1.END_TIME, t1.START_OVERTIME, t1.END_OVERTIME, t1.FORMER_COMPANY, t1.FORMER_END_DATE, t1.FORMER_START_DATE, t1.FORMER_COMPANY_ADDRESS_ID, t1.END_DATE, t1.START_DATE, t1.COMPANYADDRESS_ADDRESS_ID, t1.ADDR_ID, t1.DEPT_ID, t1.MANAGER_EMP_ID, t1.HUGE_PROJ_ID, t0.ID, t0.NAME, t0.DEPT_HEAD FROM CMP3_EMPLOYEE t1 LEFT OUTER JOIN CMP3_DEPT t0 ON (t0.ID = t1.DEPT_ID), CMP3_PHONENUMBER t3, CMP3_SALARY t2 WHERE (((t3.NUMB = ALL(SELECT MIN(t4.NUMB) FROM CMP3_PHONENUMBER t4)) AND (t2.EMP_ID = t1.EMP_ID)) AND (t3.OWNER_ID = t1.EMP_ID)) ORDER BY ROW_NUMBER() OVER (ORDER BY (SELECT null)) OFFSET ? ROWS FETCH NEXT ? ROWS ONLY
	bind => [2 parameters bound]
Query: ReadAllQuery(referenceClass=Employee sql="SELECT DISTINCT t1.EMP_ID, t2.EMP_ID, t1.F_NAME, t1.GENDER, t1.L_NAME, t1.PAY_SCALE, t1.ROOM_NUM, t2.SALARY, t1.STATUS, t1.VERSION, t1.START_TIME, t1.END_TIME, t1.START_OVERTIME, t1.END_OVERTIME, t1.FORMER_COMPANY, t1.FORMER_END_DATE, t1.FORMER_START_DATE, t1.FORMER_COMPANY_ADDRESS_ID, t1.END_DATE, t1.START_DATE, t1.COMPANYADDRESS_ADDRESS_ID, t1.ADDR_ID, t1.DEPT_ID, t1.MANAGER_EMP_ID, t1.HUGE_PROJ_ID, t0.ID, t0.NAME, t0.DEPT_HEAD FROM CMP3_EMPLOYEE t1 LEFT OUTER JOIN CMP3_DEPT t0 ON (t0.ID = t1.DEPT_ID), CMP3_PHONENUMBER t3, CMP3_SALARY t2 WHERE (((t3.NUMB = ALL(SELECT MIN(t4.NUMB) FROM CMP3_PHONENUMBER t4)) AND (t2.EMP_ID = t1.EMP_ID)) AND (t3.OWNER_ID = t1.EMP_ID)) ORDER BY ROW_NUMBER() OVER (ORDER BY (SELECT null)) OFFSET ? ROWS FETCH NEXT ? ROWS ONLY")
	at org.eclipse.persistence.testing.tests.jpa.jpql.JUnitJPQLSimpleTestSuite.selectPhoneUsingALLTest(JUnitJPQLSimpleTestSuite.java:1946)
Caused by: com.microsoft.sqlserver.jdbc.SQLServerException: ORDER BY items must appear in the select list if SELECT DISTINCT is specified.
	at org.eclipse.persistence.testing.tests.jpa.jpql.JUnitJPQLSimpleTestSuite.selectPhoneUsingALLTest(JUnitJPQLSimpleTestSuite.java:1946)
```