### PR TITLE
[2.6] Ant build - clean task fix

### DIFF
--- a/antbuild.xml
+++ b/antbuild.xml
@@ -455,7 +455,9 @@
     </target>
 
     <!-- Cleans all build generated files. -->
-    <target name="clean" depends="clean-runtime,clean-testing" description="Clean the build"/>
+    <target name="clean" depends="clean-runtime,clean-testing" description="Clean the build">
+        <ant antfile="antbuild.xml" dir="${eclipselink.compdeps}"               target="clean"/>
+    </target>
 
     <target name="clean-runtime" depends="generate-local-compdeps, clean-runtime-checkedin, clean-runtime-built" description="Clean the runtime projects"/>
     <!--   This allows testing to call a specific target that won't remove the default
@@ -475,6 +477,7 @@
         <delete failonerror="false">
             <fileset dir="${eclipselink.util.rename}" includes="${package-rename.jar}*"/>
         </delete>
+        <delete failonerror="false" dir="${build.dir}"/>
     </target>
 
     <target name="clean-runtime-built" description="Clean the runtime projects" depends="clean-core">
@@ -513,11 +516,15 @@
     </target>
 
     <target name="clean-testing" description="Clean the testing projects">
+        <ant antfile="antbuild.xml" dir="${eclipselink.jpa.wdf.test}"        target="clean"/>
+        <ant antfile="antbuild.xml" dir="${eclipselink.jpars.test}"          target="clean"/>
         <ant antfile="antbuild.xml" dir="${eclipselink.core.test}"           target="clean"/>
         <ant antfile="antbuild.xml" dir="${eclipselink.jpa.test}"            target="clean"/>
         <ant antfile="antbuild.xml" dir="${eclipselink.moxy.test}"           target="clean"/>
         <ant antfile="antbuild.xml" dir="${eclipselink.sdo.test}"            target="clean"/>
+        <ant antfile="antbuild.xml" dir="${eclipselink.dbws.test}"           target="clean"/>
         <ant antfile="build.xml"    dir="${eclipselink.util.workbench.test}" target="clean"/>
+        <ant antfile="antbuild.xml" dir="${eclipselink.dbws.builder.test}"   target="clean"/>
         <delete file="${eclipselink.tst.src.prefix}${eclipselink.zip.suffix}" failonerror="false"/>
         <antcall target="clean-oracle-if-dependencies"/>
     </target>

--- a/dbws/eclipselink.dbws.test/antbuild.xml
+++ b/dbws/eclipselink.dbws.test/antbuild.xml
@@ -352,6 +352,7 @@
         <delete includeEmptyDirs="true" failonerror="false">
             <fileset dir="${classes.dir}"/>
             <fileset dir="." includes="${dbws_util.jar}"/>
+            <fileset file="${dbws_test.build.location}/${eclipselink.dbws.test.common.jar}"/>
         </delete>
     </target>
 

--- a/jpa/eclipselink.jpa.test/antbuild.xml
+++ b/jpa/eclipselink.jpa.test/antbuild.xml
@@ -535,7 +535,7 @@
             <fileset dir="${jpatest.basedir}/${build.dir}"/>
             <fileset file="${jpatest.basedir}/${jpa.test.jar}"/>
             <fileset file="${jpatest.basedir}/${jpa21.test.jar}"/>
-            <fileset file="${jpatest.basedir}/${jpatest.framework}.jar"/>
+            <fileset file="${jpatest.basedir}/${jpatest.framework.jar}"/>
             <fileset file="${jpatest.basedir}/*-model.jar"/>
             <fileset file="${jpatest.basedir}/${eclipselink.jpa21.model}.jar"/>
             <fileset file="${jpatest.basedir}/${eclipselink.annotation.model}.jar"/>

--- a/moxy/eclipselink.moxy.test/antbuild.xml
+++ b/moxy/eclipselink.moxy.test/antbuild.xml
@@ -487,8 +487,8 @@
     <target name="clean" description="clean the build">
         <delete includeEmptyDirs="true" failonerror="false">
             <fileset dir="${classes.dir}"/>
+            <fileset dir="${report.dir}"/>
         </delete>
-        <mkdir dir="${classes.dir}"/>
     </target>
 
     <!-- Test run macros -->

--- a/utils/eclipselink.utils.workbench.test/build.xml
+++ b/utils/eclipselink.utils.workbench.test/build.xml
@@ -100,6 +100,7 @@
         <ant antfile="build.xml" dir="${mappingspluginDir}"  target="clean"/>
         <ant antfile="build.xml" dir="${scpluginDir}"        target="clean"/>
         <delete file="${libDir}/${workbench.jarfile}"/>
+        <delete failonerror="false" dir="${_buildLogDir}"/>
     </target>
 
     <!-- =================================================================== -->

--- a/utils/eclipselink.utils.workbench/build.xml
+++ b/utils/eclipselink.utils.workbench/build.xml
@@ -104,6 +104,7 @@
         <delete file="${libDir}/${workbench.jarfile}"/>
         <delete file="${libDir}/${mwcore.src.jarfile}"/>
         <delete file="${libDir}/${workbench.src.jarfile}"/>
+        <delete failonerror="false" dir="${_buildLogDir}"/>
     </target>
 
     <!-- =================================================================== -->


### PR DESCRIPTION
This is fix for Ant build - clean task. Before this fix command `ant -f antbuild.xml clean` didn't deleted all working (build temporary) files and directories from all projects.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>