### PR TITLE
[master] Jenkins build fix - Snapshots publishing

### DIFF
--- a/etc/jenkins/publish_snapshots.sh
+++ b/etc/jenkins/publish_snapshots.sh
@@ -12,9 +12,13 @@
 # Arguments:
 #  N/A
 
-echo '-[ EclipseLink Publish to Jakarta Snapshots ]-----------------------------------------------------------'
-. /etc/profile
-mvn --no-transfer-progress -U -C -B -V \
+if [ ${CONTINUOUS_BUILD} = "true" ]; then
+    echo '-[ EclipseLink Publish to Jakarta Snapshots -> No publishing any artifacts]-----------------------------------------------------------'
+else
+    echo '-[ EclipseLink Publish to Jakarta Snapshots ]-----------------------------------------------------------'
+    . /etc/profile
+    mvn --no-transfer-progress -U -C -B -V \
       -Psnapshots -DskipTests \
       -Ddoclint=none -Ddeploy \
-      clean deploy
+      deploy
+fi


### PR DESCRIPTION
This fix has two parts:
1. Bash condition `if [ ${CONTINUOUS_BUILD} = "true" ]; then` ensure, that snapshots publishing will be active only during "Nightly build".
2. Maven target change from `... clean deploy` to `... deploy` ensure, that tests results from previous Jenkins stages will remain there for last Jenkins pipeline stage "Proceed test results"

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>