### PR TITLE
[Master] Add doPriv blocks to use of protected ThreadMXBean methods in ConcurrencyUtil

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ConcurrencyUtil.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ConcurrencyUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Oracle, IBM and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -12,6 +12,7 @@
 
 // Contributors:
 //     Oracle - initial API and implementation from Oracle TopLink
+//     IBM - ConcurrencyUtil call of ThreadMXBean.getThreadInfo() needs doPriv
 package org.eclipse.persistence.internal.helper;
 
 import org.eclipse.persistence.config.SystemProperties;
@@ -23,6 +24,7 @@ import org.eclipse.persistence.internal.identitymaps.CacheKey;
 import org.eclipse.persistence.internal.localization.TraceLocalization;
 import org.eclipse.persistence.internal.security.PrivilegedAccessHelper;
 import org.eclipse.persistence.internal.security.PrivilegedGetSystemProperty;
+import org.eclipse.persistence.internal.security.PrivilegedGetThreadInfo;
 import org.eclipse.persistence.logging.AbstractSessionLog;
 import org.eclipse.persistence.logging.SessionLog;
 
@@ -793,8 +795,14 @@ public class ConcurrencyUtil {
         try {
             // (a) search for the stack trace of the current
             final StringWriter writer = new StringWriter();
-            final ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
-            final ThreadInfo[] threadInfos = threadMXBean.getThreadInfo(new long[] { currentThreadId }, 700);
+            ThreadInfo[] threadInfos = null;
+            if (PrivilegedAccessHelper.shouldUsePrivilegedAccess()) {
+                threadInfos = AccessController.doPrivileged(new PrivilegedGetThreadInfo(new long[] { currentThreadId }, 700));
+            } else {
+                final ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+                threadInfos = threadMXBean.getThreadInfo(new long[] { currentThreadId }, 700);
+            }
+            
             for (ThreadInfo threadInfo : threadInfos) {
                 enrichGenerateThreadDumpForThreadInfo(writer, threadInfo);
             }
@@ -819,8 +827,15 @@ public class ConcurrencyUtil {
     private String enrichGenerateThreadDump() {
         try {
             final StringWriter writer = new StringWriter();
-            final ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
-            final ThreadInfo[] threadInfos = threadMXBean.getThreadInfo(threadMXBean.getAllThreadIds(), 700);
+            
+            ThreadInfo[] threadInfos = null;
+            if (PrivilegedAccessHelper.shouldUsePrivilegedAccess()) {
+                threadInfos = AccessController.doPrivileged(new PrivilegedGetThreadInfo(700));
+            } else {
+                final ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+                threadInfos = threadMXBean.getThreadInfo(threadMXBean.getAllThreadIds(), 700);
+            }
+            
             for (ThreadInfo threadInfo : threadInfos) {
                 enrichGenerateThreadDumpForThreadInfo(writer, threadInfo);
             }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/security/PrivilegedGetThreadInfo.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/security/PrivilegedGetThreadInfo.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2020 IBM and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     IBM - ConcurrencyUtil call of ThreadMXBean.getThreadInfo() needs doPriv
+package org.eclipse.persistence.internal.security;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.security.PrivilegedExceptionAction;
+
+public class PrivilegedGetThreadInfo implements PrivilegedExceptionAction<ThreadInfo[]> {
+    private final long[] ids;
+    private final int maxDepth;
+    
+    public PrivilegedGetThreadInfo(long[] ids, int maxDepth) {
+        this.ids = ids;
+        this.maxDepth = maxDepth;
+    }
+    
+    public PrivilegedGetThreadInfo(int maxDepth) {
+        this.ids = null;
+        this.maxDepth = maxDepth;
+    }
+    
+    @Override
+    public ThreadInfo[] run() throws Exception {
+        final ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+        
+        if (ids != null) {
+            return threadMXBean.getThreadInfo(ids, maxDepth);
+        } else {
+            return threadMXBean.getThreadInfo(threadMXBean.getAllThreadIds(), maxDepth);
+        }
+    }
+
+}


### PR DESCRIPTION
Addresses the doPriv() issues as commented in #972.