### PR TITLE
#567891: improving fix to pass TCKs

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabaseAccessor.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabaseAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2018 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -1383,6 +1383,8 @@ public class DatabaseAccessor extends DatasourceAccessor {
         } else if ((fieldType == ClassConstants.SHORT) || (fieldType == ClassConstants.PSHORT)) {
             value = Short.valueOf(resultSet.getShort(columnNumber));
             isPrimitive = ((Short)value).shortValue() == 0;
+        } else if (fieldType == ClassConstants.BOOLEAN) {
+            value = resultSet.getBoolean(columnNumber);
         } else if ((type == Types.TIME) || (type == Types.DATE) || (type == Types.TIMESTAMP)) {
             if (Helper.shouldOptimizeDates) {
                 // Optimize dates by avoid conversion to timestamp then back to date or time or util.date.
@@ -1424,7 +1426,7 @@ public class DatabaseAccessor extends DatasourceAccessor {
             if (value != null) return ((BigDecimal)value).toBigInteger();
         } else if (fieldType == ClassConstants.BIGDECIMAL) {
             value = resultSet.getBigDecimal(columnNumber);
-         }
+        }
 
         // PERF: Only check for null for primitives.
         if (isPrimitive && resultSet.wasNull()) {

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/ReportQueryResult.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/ReportQueryResult.java
@@ -34,7 +34,6 @@ import java.util.Set;
 import java.util.Vector;
 
 import org.eclipse.persistence.descriptors.ClassDescriptor;
-import org.eclipse.persistence.exceptions.ConversionException;
 import org.eclipse.persistence.exceptions.QueryException;
 import org.eclipse.persistence.expressions.ExpressionOperator;
 import org.eclipse.persistence.internal.expressions.FunctionExpression;
@@ -289,21 +288,6 @@ public class ReportQueryResult implements Serializable, Map {
                 }
             } else {
                 value = row.getValues().get(itemIndex);
-
-                // Verify that the expected result type matches the actual value type
-                if(value != null) {
-                    Class valueType = value.getClass();
-                    Class resultType = item.getResultType();
-                    if(!valueType.isInstance(resultType)) {
-                        try {
-                            value = query.getSession().getPlatform().convertObject(value, resultType);
-                        } catch (ConversionException e) {
-                            // If an Exception is thrown while attempting to 
-                            // convert, ignore and return the original value
-                        }
-                    }
-                }
-
                 // GF_ISSUE_395
                 if (this.key != null) {
                     this.key.append(value);


### PR DESCRIPTION
@dazey3 fix in #925 for bug 567891 caused TCK failure, in particular com/sun/ts/tests/jpa/core/criteriaapi/CriteriaBuilder/Client.java#toStringTest_from_standalone test fails with:

```
[javatest.batch] 12-07-2020 14:29:09:  ERROR: java.lang.ClassCastException: java.lang.Character cannot be cast to java.lang.String
[javatest.batch] 	at com.sun.ts.tests.jpa.core.criteriaapi.CriteriaBuilder.Client.toStringTest(Client.java:6345)
[javatest.batch] 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[javatest.batch] 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[javatest.batch] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[javatest.batch] 	at java.lang.reflect.Method.invoke(Method.java:498)
[javatest.batch] 	at com.sun.ts.lib.harness.EETest.run(EETest.java:596)
[javatest.batch] 	at com.sun.ts.lib.harness.ServiceEETest.run(ServiceEETest.java:115)
[javatest.batch] 	at com.sun.ts.tests.common.vehicle.EmptyVehicleRunner.run(EmptyVehicleRunner.java:40)
[javatest.batch] 	at com.sun.ts.lib.harness.ServiceEETest.run(ServiceEETest.java:105)
[javatest.batch] 	at com.sun.ts.lib.harness.EETest.getPropsReady(EETest.java:486)
[javatest.batch] 	at com.sun.ts.lib.harness.ServiceEETest.run(ServiceEETest.java:209)
[javatest.batch] 	at com.sun.ts.lib.harness.EETest.run(EETest.java:285)
[javatest.batch] 	at com.sun.ts.tests.common.vehicle.VehicleClient.main(VehicleClient.java:38)
[javatest.batch] 
```

The problem in #925 is, IMHO, that it is altering the object to meet user expectations too late - after all processing has been done and right before returning the value to the caller. Apparently, there are cases where customized type is used during result processing but newly introduced code is changing that to some unexpected type and thus causes the failure as seen ie in the TCK test. What should have been done is to follow the path properly - on the way to the DB, boolean literals are being converted to values being understood by the DB (ie `true` -> `1`), on the way back from the DB, these values should be translated back to types eclipselink uses internally (ie `1` -> `true`). I believe this last step is what was missing, since eclipselink knows that the type retrieved from the DB is `Boolean`, it should have been just using proper method to "decode" returned value properly - this PR does exactly that.

@rfelcman as to why the TCK test is failing - the code introduced by @dazey3 explicitly tries to convert the value returned by the DB (which is expected `String`) to the initial type (which is `Character`) ignoring the fact that `CriteriaBuilder.toString()` has been called on that `Character`. The conversion unfortunately succeeds - conversion manager converts `String` to `Character` as `someString.charAt(0)` and the test fails with ClassCastEx because expected type is  `Character` while `String` should have been returned.