### PR TITLE
CriteriaBuilderImpl fix revert and code improvement in DatabaseAccessor to fix JPA.WDF tests.

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabaseAccessor.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabaseAccessor.java
@@ -1383,8 +1383,9 @@ public class DatabaseAccessor extends DatasourceAccessor {
         } else if ((fieldType == ClassConstants.SHORT) || (fieldType == ClassConstants.PSHORT)) {
             value = Short.valueOf(resultSet.getShort(columnNumber));
             isPrimitive = ((Short)value).shortValue() == 0;
-        } else if (fieldType == ClassConstants.BOOLEAN) {
-            value = resultSet.getBoolean(columnNumber);
+        } else if ((fieldType == ClassConstants.BOOLEAN) || (fieldType == ClassConstants.PBOOLEAN))  {
+            value = Boolean.valueOf(resultSet.getBoolean(columnNumber));
+            isPrimitive = ((Boolean)value).booleanValue() == false;
         } else if ((type == Types.TIME) || (type == Types.DATE) || (type == Types.TIMESTAMP)) {
             if (Helper.shouldOptimizeDates) {
                 // Optimize dates by avoid conversion to timestamp then back to date or time or util.date.

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/CriteriaBuilderImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/CriteriaBuilderImpl.java
@@ -1407,7 +1407,6 @@ public class CriteriaBuilderImpl implements JpaCriteriaBuilder, Serializable {
     @Override
     public Expression<String> toString(Expression<Character> character){
         ExpressionImpl impl = (ExpressionImpl) character;
-        impl.javaType = ClassConstants.STRING;
         return impl;
     }
 


### PR DESCRIPTION
Fix #983 broken JPA.WDF tests see https://ci.eclipse.org/eclipselink/view/Current%20Jobs/job/eclipselink-nightly-master/153/console . This PR removes unnecessary change in CriteriaBuilderImpl and extends fix in DatabaseAccessor.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>