### PR TITLE
Ant build - catchup ASM upgrade

### DIFF
--- a/features/antbuild.xml
+++ b/features/antbuild.xml
@@ -270,7 +270,7 @@
         <property name="antlr.prefix" value="org.eclipse.persistence.antlr"/>
         <property name="antlr.criteria" value="[3.0,9.0)"/>
         <property name="asm.prefix" value="org.eclipse.persistence.asm"/>
-        <property name="asm.criteria" value="[3.0,9.0)"/>
+        <property name="asm.criteria" value="[3.0,15.0)"/>
         <property name="hermes.prefix" value="org.eclipse.persistence.jpa.jpql"/>
         <property name="hermes.criteria" value="[1.0,9.0)"/>
         <property name="oracleddl.prefix" value="org.eclipse.persistence.oracleddlparser"/>

--- a/uploadToMaven.xml
+++ b/uploadToMaven.xml
@@ -171,7 +171,7 @@
         <property name="antlr.criteria"       value="[3.0.0,4.0.0)"/>
         <property name="antlr.name"           value="EclipseLink ANTLR"/>
         <property name="asm.prefix"           value="org.eclipse.persistence.asm"/>
-        <property name="asm.criteria"         value="[3.0.0,4.0.0)"/>
+        <property name="asm.criteria"         value="[3.0.0,15.0.0)"/>
         <property name="asm.name"             value="EclipseLink ASM"/>
         <property name="oracleddl.prefix"     value="org.eclipse.persistence.oracleddlparser"/>
         <property name="oracleddl.criteria"   value="[1.0.0,9.0.0)"/>

--- a/uploadToNexus.xml
+++ b/uploadToNexus.xml
@@ -177,7 +177,7 @@
         <property name="antlr.criteria"       value="[3.0.0,4.0.0)"/>
         <property name="antlr.name"           value="EclipseLink ANTLR"/>
         <property name="asm.prefix"           value="org.eclipse.persistence.asm"/>
-        <property name="asm.criteria"         value="[5.0.0,9.0.0)"/>
+        <property name="asm.criteria"         value="[5.0.0,15.0.0)"/>
         <property name="asm.name"             value="EclipseLink ASM"/>
         <property name="oracleddl.prefix"     value="org.eclipse.persistence.oracleddlparser"/>
         <property name="oracleddl.criteria"   value="[1.0.0,9.0.0)"/>


### PR DESCRIPTION
This is fix for the promotion. Ant scripts don't reflect current ASM version. There was a limit into < 9.0 version. It leads into not initialized `asm.version` property in build scripts.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>