### PR TITLE
[2.6_WAS] Fix TCK failure for java.lang.Character type

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/PersistenceUnitProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/PersistenceUnitProperties.java
@@ -2551,7 +2551,7 @@ public class PersistenceUnitProperties {
      * The "<code>eclipselink.allow-result-type-conversion</code>" property configures eclipselink
      * should convert resultset values to the expected value based on the query expression.
      *
-     * Default: "<code>false</code>".
+     * Default: "<code>true</code>".
      */
     public static final String ALLOW_RESULT_TYPE_CONVERSION = "eclipselink.allow-result-type-conversion";
 

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatabaseAccessor.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatabaseAccessor.java
@@ -1377,6 +1377,11 @@ public class DatabaseAccessor extends DatasourceAccessor {
         } else if ((fieldType == ClassConstants.SHORT) || (fieldType == ClassConstants.PSHORT)) {
             value = Short.valueOf(resultSet.getShort(columnNumber));
             isPrimitive = ((Short)value).shortValue() == 0;
+        } else if ((fieldType == ClassConstants.BOOLEAN) || (fieldType == ClassConstants.PBOOLEAN)) {
+            if(session.getProject().allowResultTypeConversion()) {
+                value = Boolean.valueOf(resultSet.getBoolean(columnNumber));
+                isPrimitive = ((Boolean)value).booleanValue() == false;
+            }
         } else if (Helper.shouldOptimizeDates && (fieldType != null) && ((type == Types.TIME) || (type == Types.DATE) || (type == Types.TIMESTAMP))) {
             // Optimize dates by avoid conversion to timestamp then back to date or time or util.date.
             String dateString = resultSet.getString(columnNumber);

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/ReportQueryResult.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/ReportQueryResult.java
@@ -279,20 +279,6 @@ public class ReportQueryResult implements Serializable, Map {
             } else {
                 value = row.getValues().get(itemIndex);
 
-                // Verify that the expected result type matches the actual value type
-                if(value != null && query.getSession().getProject().allowResultTypeConversion()) {
-                    Class valueType = value.getClass();
-                    Class resultType = item.getResultType();
-                    if(!valueType.isInstance(resultType)) {
-                        try {
-                            value = query.getSession().getPlatform().convertObject(value, resultType);
-                        } catch (ConversionException e) {
-                            // If an Exception is thrown while attempting to 
-                            // convert, ignore and return the original value
-                        }
-                    }
-                }
-
                 // GF_ISSUE_395
                 if (this.key != null) {
                     this.key.append(value);

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/sessions/Project.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/sessions/Project.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the 
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0 
  * which accompanies this distribution. 
@@ -176,7 +176,7 @@ public class Project extends CoreProject<ClassDescriptor, Login, DatabaseSession
     protected Collection<String> structConverters;
 
     protected boolean allowNullResultMaxMin = true;
-    protected boolean allowResultTypeConversion = false;
+    protected boolean allowResultTypeConversion = true;
 
     /**
      * PUBLIC:

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/property/TestConvertResultToBoolean.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/property/TestConvertResultToBoolean.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Oracle, IBM Corporation and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ ******************************************************************************/
+package org.eclipse.persistence.jpa.test.property;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.List;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Query;
+
+import org.eclipse.persistence.config.PersistenceUnitProperties;
+import org.eclipse.persistence.jpa.test.framework.DDLGen;
+import org.eclipse.persistence.jpa.test.framework.Emf;
+import org.eclipse.persistence.jpa.test.framework.EmfRunner;
+import org.eclipse.persistence.jpa.test.framework.Property;
+import org.eclipse.persistence.jpa.test.property.model.GenericEntity;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(EmfRunner.class)
+/**
+ * Tests the 'eclipselink.sql.allow-result-type-conversion' persistence property. 
+ * By enabling this property, the result type of a case select with Booleans should be an integer
+ */
+public class TestConvertResultToBoolean {
+
+    @Emf(createTables = DDLGen.DROP_CREATE, classes = { GenericEntity.class }, 
+            properties = { @Property(name="eclipselink.logging.level", value="FINE"), 
+                    @Property(name=PersistenceUnitProperties.ALLOW_RESULT_TYPE_CONVERSION, value="false")})
+    private EntityManagerFactory emf;
+
+    private static boolean POPULATED = false;
+
+    @Test
+    public void testCASE_DisableConvertResultToBoolean() {
+        if (emf == null)
+            return;
+
+        if(!POPULATED) 
+            populate();
+
+        EntityManager em = emf.createEntityManager();
+        try {
+            em.getTransaction().begin();
+
+            Query query = em.createQuery(""
+                    + "SELECT ("
+                       + "CASE "
+                       + "WHEN g.itemInteger1 = 1 THEN TRUE "
+                       + "ELSE FALSE "
+                       + "END "
+                    + ") "
+                    + "FROM GenericEntity g ORDER BY g.itemInteger1 ASC");
+
+            List<?> intList = query.getResultList();
+            assertNotNull(intList);
+            assertEquals(2, intList.size());
+            assertEquals(new Long(1), intList.get(0));
+            assertEquals(new Long(0), intList.get(1));
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if(em.isOpen()) {
+                em.close();
+            }
+        }
+    }
+
+    private void populate() {
+        EntityManager em = emf.createEntityManager();
+        try {
+
+            GenericEntity tbl1 = new GenericEntity();
+            tbl1.setKeyString("Key01");
+            tbl1.setItemString1("A");
+            tbl1.setItemInteger1(1);
+
+            GenericEntity tbl2 = new GenericEntity();
+            tbl2.setKeyString("Key02");
+            tbl2.setItemString1("B");
+            tbl2.setItemInteger1(2);
+
+            em.getTransaction().begin();
+            em.persist(tbl1);
+            em.persist(tbl2);
+            em.getTransaction().commit();
+
+            POPULATED = true;
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if(em.isOpen()) {
+                em.close();
+            }
+        }
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQueryCase.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQueryCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 IBM Corporation, Oracle, and/or affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 IBM Corporation, Oracle, and/or affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -21,7 +21,6 @@ import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.TypedQuery;
 
-import org.eclipse.persistence.config.PersistenceUnitProperties;
 import org.eclipse.persistence.jpa.test.framework.DDLGen;
 import org.eclipse.persistence.jpa.test.framework.Emf;
 import org.eclipse.persistence.jpa.test.framework.EmfRunner;
@@ -34,8 +33,7 @@ import org.junit.runner.RunWith;
 @RunWith(EmfRunner.class)
 public class TestQueryCase {
     @Emf(createTables = DDLGen.DROP_CREATE, classes = { EntityTbl01.class }, 
-            properties = { @Property(name="eclipselink.logging.level", value="FINE"), 
-                    @Property(name=PersistenceUnitProperties.ALLOW_RESULT_TYPE_CONVERSION, value="true")})
+            properties = { @Property(name="eclipselink.logging.level", value="FINE")})
     private EntityManagerFactory emf;
 
     private static boolean POPULATED = false;


### PR DESCRIPTION
You may notice that I did not alter the name of the persistence property for this port. This was intentional as the current property name was already released for WebSphere and is now supported. Rather than change the property name and break customers, the property will remain named the same for the 2.6_WAS release.

for #922

Signed-off-by: Will Dazey <dazeydev.3@gmail.com>