### PR TITLE
[2.7] Fix TCK failure for Character type

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/PersistenceUnitProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/PersistenceUnitProperties.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 1998, 2020 IBM Corporation. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -2598,6 +2598,14 @@ public class PersistenceUnitProperties {
      * Default: "<code>true</code>".
      */
     public static final String ALLOW_NULL_MAX_MIN = "eclipselink.allow-null-max-min";
+
+    /**
+     * The "<code>eclipselink.sql.allow-convert-result-to-boolean</code>" property allows
+     * eclipselink to convert resultset values to boolean types.
+     *
+     * Default: "<code>true</code>".
+     */
+    public static final String ALLOW_CONVERT_RESULT_TO_BOOLEAN = "eclipselink.sql.allow-convert-result-to-boolean";
 
     /**
      * The "<code>eclipselink.id-validation</code>" property defines

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatabaseAccessor.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatabaseAccessor.java
@@ -1384,8 +1384,10 @@ public class DatabaseAccessor extends DatasourceAccessor {
             value = Short.valueOf(resultSet.getShort(columnNumber));
             isPrimitive = ((Short)value).shortValue() == 0;
         } else if ((fieldType == ClassConstants.BOOLEAN) || (fieldType == ClassConstants.PBOOLEAN))  {
-            value = Boolean.valueOf(resultSet.getBoolean(columnNumber));
-            isPrimitive = ((Boolean)value).booleanValue() == false;
+            if(session.getProject().allowConvertResultToBoolean()) {
+                value = Boolean.valueOf(resultSet.getBoolean(columnNumber));
+                isPrimitive = ((Boolean)value).booleanValue() == false;
+            }
         } else if ((type == Types.TIME) || (type == Types.DATE) || (type == Types.TIMESTAMP)) {
             if (Helper.shouldOptimizeDates) {
                 // Optimize dates by avoid conversion to timestamp then back to date or time or util.date.

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/sessions/Project.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/sessions/Project.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020 IBM Corporation. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -192,6 +192,7 @@ public class Project extends CoreProject<ClassDescriptor, Login, DatabaseSession
     protected Collection<String> structConverters;
 
     protected boolean allowNullResultMaxMin = true;
+    protected boolean allowConvertResultToBoolean = true;
 
     /**
      * PUBLIC:
@@ -1316,6 +1317,14 @@ public class Project extends CoreProject<ClassDescriptor, Login, DatabaseSession
 
     /**
      * INTERNAL:
+     * Return true if ResultSet values should be converted for this project.
+     */
+    public boolean allowConvertResultToBoolean() {
+        return this.allowConvertResultToBoolean;
+    }
+
+    /**
+     * INTERNAL:
      * Return true if SQL calls can defer to EOT on this project.
      */
     public boolean allowSQLDeferral() {
@@ -1375,6 +1384,14 @@ public class Project extends CoreProject<ClassDescriptor, Login, DatabaseSession
      */
     public void setAllowNullResultMaxMin(boolean allowNullResultMaxMin) {
         this.allowNullResultMaxMin = allowNullResultMaxMin;
+    }
+
+    /**
+     * INTERNAL:
+     * Set whether ResultSet values should be converted for this project.
+     */
+    public void setAllowConvertResultToBoolean(boolean allowConvertResultToBoolean) {
+        this.allowConvertResultToBoolean = allowConvertResultToBoolean;
     }
 
     /**

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/property/TestConvertResultToBoolean.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/property/TestConvertResultToBoolean.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2021 IBM Corporation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.persistence.jpa.test.property;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.List;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Query;
+
+import org.eclipse.persistence.config.PersistenceUnitProperties;
+import org.eclipse.persistence.jpa.test.framework.DDLGen;
+import org.eclipse.persistence.jpa.test.framework.Emf;
+import org.eclipse.persistence.jpa.test.framework.EmfRunner;
+import org.eclipse.persistence.jpa.test.framework.Property;
+import org.eclipse.persistence.jpa.test.property.model.GenericEntity;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(EmfRunner.class)
+/**
+ * Tests the 'eclipselink.sql.allow-convert-result-to-boolean' persistence property. 
+ * By enabling this property, the result type of a case select with Booleans should be an integer
+ */
+public class TestConvertResultToBoolean {
+
+    @Emf(createTables = DDLGen.DROP_CREATE, classes = { GenericEntity.class }, 
+            properties = { @Property(name="eclipselink.logging.level", value="FINE"), 
+                    @Property(name=PersistenceUnitProperties.ALLOW_CONVERT_RESULT_TO_BOOLEAN, value="false")})
+    private EntityManagerFactory emf;
+
+    private static boolean POPULATED = false;
+
+    @Test
+    public void testCASE_DisableConvertResultToBoolean() {
+        if (emf == null)
+            return;
+
+        if(!POPULATED) 
+            populate();
+
+        EntityManager em = emf.createEntityManager();
+        try {
+            em.getTransaction().begin();
+
+            Query query = em.createQuery(""
+                    + "SELECT ("
+                       + "CASE "
+                       + "WHEN g.itemInteger1 = 1 THEN TRUE "
+                       + "ELSE FALSE "
+                       + "END "
+                    + ") "
+                    + "FROM GenericEntity g ORDER BY g.itemInteger1 ASC");
+
+            List<?> intList = query.getResultList();
+            assertNotNull(intList);
+            assertEquals(2, intList.size());
+            assertEquals(new Long(1), intList.get(0));
+            assertEquals(new Long(0), intList.get(1));
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if(em.isOpen()) {
+                em.close();
+            }
+        }
+    }
+
+    private void populate() {
+        EntityManager em = emf.createEntityManager();
+        try {
+
+            GenericEntity tbl1 = new GenericEntity();
+            tbl1.setKeyString("Key01");
+            tbl1.setItemString1("A");
+            tbl1.setItemInteger1(1);
+
+            GenericEntity tbl2 = new GenericEntity();
+            tbl2.setKeyString("Key02");
+            tbl2.setItemString1("B");
+            tbl2.setItemInteger1(2);
+
+            em.getTransaction().begin();
+            em.persist(tbl1);
+            em.persist(tbl2);
+            em.getTransaction().commit();
+
+            POPULATED = true;
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if(em.isOpen()) {
+                em.close();
+            }
+        }
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQueryCase.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQueryCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 IBM Corporation, Oracle, and/or affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 IBM Corporation, Oracle, and/or affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -21,7 +21,6 @@ import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.TypedQuery;
 
-import org.eclipse.persistence.config.PersistenceUnitProperties;
 import org.eclipse.persistence.jpa.test.framework.DDLGen;
 import org.eclipse.persistence.jpa.test.framework.Emf;
 import org.eclipse.persistence.jpa.test.framework.EmfRunner;

--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
@@ -2848,6 +2848,7 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
                 updateAllowZeroIdSetting(m);
             }
             updateAllowNULLMAXMINSetting(m);
+            updateAllowConvertResultToBoolean(m);
             updateIdValidation(m);
             updatePessimisticLockTimeout(m);
             updatePessimisticLockTimeoutUnit(m);
@@ -3558,6 +3559,22 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
                 session.getProject().setAllowNullResultMaxMin(false);
             } else {
                 session.handleException(ValidationException.invalidBooleanValueForProperty(allowNull, PersistenceUnitProperties.ALLOW_NULL_MAX_MIN));
+            }
+        }
+    }
+
+    /**
+     * Enable or disable default allowing conversion of ResultSet values type to boolean type
+     */
+    protected void updateAllowConvertResultToBoolean(Map m) {
+        String allowNull = EntityManagerFactoryProvider.getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.ALLOW_CONVERT_RESULT_TO_BOOLEAN, m, this.session);
+        if (allowNull != null) {
+            if (allowNull.equalsIgnoreCase("true")) {
+                session.getProject().setAllowConvertResultToBoolean(true);
+            } else if (allowNull.equalsIgnoreCase("false")) {
+                session.getProject().setAllowConvertResultToBoolean(false);
+            } else {
+                session.handleException(ValidationException.invalidBooleanValueForProperty(allowNull, PersistenceUnitProperties.ALLOW_CONVERT_RESULT_TO_BOOLEAN));
             }
         }
     }


### PR DESCRIPTION
I changed the name of the persistence property for this fix to more accurately describe what it is gating. Since the old property was not released in a 2.7 release, I think renaming the property is fine.

for #922

Signed-off-by: Will Dazey <dazeydev.3@gmail.com>