### PR TITLE
[2.6] Concurrency manager logging - extension (backport from master)

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/helper/ConcurrencyUtil.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/helper/ConcurrencyUtil.java
@@ -283,17 +283,19 @@ public class ConcurrencyUtil {
             Object cacheKeyObject = cacheKey.getObject();
             String canonicalName = cacheKeyObject != null ? cacheKeyObject.getClass().getCanonicalName()
                     : LoggingLocalization.buildMessage("concurrency_util_owned_cache_key_null");
-            return LoggingLocalization.buildMessage("concurrency_util_owned_cache_key_is_cache_key", new Object[] {canonicalName, primaryKey, cacheKeyObject, cacheKeyClass, activeThread,
-                    concurrencyManager.getNumberOfReaders(), concurrencyManagerId,
-                    concurrencyManagerCreationDate
+            return LoggingLocalization.buildMessage("concurrency_util_owned_cache_key_is_cache_key", new Object[] {canonicalName, primaryKey,
+                    cacheKeyObject, String.valueOf(System.identityHashCode(cacheKeyObject)),
+                    cacheKeyClass, String.valueOf(System.identityHashCode(cacheKey)),
+                    activeThread, concurrencyManager.getNumberOfReaders(), concurrencyManagerId,
+                    ConversionManager.getDefaultManager().convertObject(concurrencyManagerCreationDate, String.class).toString(),
                     // metadata of number of times the cache key suffered increases in number readers
-                    , cacheKey.getTotalNumberOfKeysAcquiredForReading(),
+                    cacheKey.getTotalNumberOfKeysAcquiredForReading(),
                     cacheKey.getTotalNumberOfKeysReleasedForReading(),
                     cacheKey.getTotalNumberOfKeysReleasedForReadingBlewUpExceptionDueToCacheKeyHavingReachedCounterZero()});
 
         } else {
             return LoggingLocalization.buildMessage("concurrency_util_owned_cache_key_is_not_cache_key", new Object[] {cacheKeyClass, concurrencyManager, activeThread,
-                    concurrencyManagerId, concurrencyManagerCreationDate,
+                    concurrencyManagerId, ConversionManager.getDefaultManager().convertObject(concurrencyManagerCreationDate, String.class).toString(),
                     concurrencyManager.getTotalNumberOfKeysAcquiredForReading(),
                     concurrencyManager.getTotalNumberOfKeysReleasedForReading(), concurrencyManager
                     .getTotalNumberOfKeysReleasedForReadingBlewUpExceptionDueToCacheKeyHavingReachedCounterZero()});
@@ -744,7 +746,7 @@ public class ConcurrencyUtil {
                 readLockNumber++;
                 writer.write(LoggingLocalization.buildMessage("concurrency_util_summary_read_locks_on_thread_step002_3", new Object[] {readLockNumber,
                         SINGLETON.createToStringExplainingOwnedCacheKey(currentReadLockAcquiredAndNeverReleased.getCacheKeyWhoseNumberOfReadersThreadIsIncrementing()),
-                        currentReadLockAcquiredAndNeverReleased.getDateOfReadLockAcquisition(),
+                        ConversionManager.getDefaultManager().convertObject(currentReadLockAcquiredAndNeverReleased.getDateOfReadLockAcquisition(), String.class).toString(),
                         currentReadLockAcquiredAndNeverReleased.getNumberOfReadersOnCacheKeyBeforeIncrementingByOne(),
                         currentReadLockAcquiredAndNeverReleased.getCurrentThreadStackTraceInformationCpuTimeCostMs()}));
                 String stackTraceInformation = currentReadLockAcquiredAndNeverReleased.getCurrentThreadStackTraceInformation();
@@ -929,7 +931,7 @@ public class ConcurrencyUtil {
         int currentThreadNumber = 0;
         for (Thread currentEntry : setThreadWaitingToReleaseDeferredLocksClone) {
             currentThreadNumber++;
-            writer.write(LoggingLocalization.buildMessage("concurrency_util_create_information_all_threads_release_deferred_locks_1", new Object[] {currentThreadNumber, currentEntry.getName()}));
+            writer.write(LoggingLocalization.buildMessage("concurrency_util_create_information_all_threads_release_deferred_locks_2", new Object[] {currentThreadNumber, currentEntry.getName()}));
         }
         writer.write(LoggingLocalization.buildMessage("concurrency_util_create_information_all_threads_release_deferred_locks_3"));
         return writer.toString();
@@ -1442,7 +1444,7 @@ public class ConcurrencyUtil {
         Thread currentThread = Thread.currentThread();
         StringWriter writer = new StringWriter();
         writer.write(LoggingLocalization.buildMessage("concurrency_util_read_lock_manager_problem02", new Object[] {currentThread.getName(), SINGLETON.createToStringExplainingOwnedCacheKey(cacheKey),
-                threadId, enrichGenerateThreadDumpForCurrentThread(), new Date()}));
+                threadId, enrichGenerateThreadDumpForCurrentThread(), ConversionManager.getDefaultManager().convertObject(new Date(), String.class).toString()}));
         // We do log immediately the error as we spot it
         AbstractSessionLog.getLog().log(SessionLog.SEVERE, SessionLog.CACHE, writer.toString(), new Object[] {}, false);
         // we also return the error message we just logged to added it to our tracing permanently
@@ -1453,7 +1455,7 @@ public class ConcurrencyUtil {
         Thread currentThread = Thread.currentThread();
         StringWriter writer = new StringWriter();
         writer.write(LoggingLocalization.buildMessage("concurrency_util_read_lock_manager_problem03", new Object[] {currentThread.getName(), SINGLETON.createToStringExplainingOwnedCacheKey(cacheKey),
-                threadId, enrichGenerateThreadDumpForCurrentThread(), new Date()}));
+                threadId, enrichGenerateThreadDumpForCurrentThread(), ConversionManager.getDefaultManager().convertObject(new Date(), String.class).toString()}));
         // We do log immediately the error as we spot it
         AbstractSessionLog.getLog().log(SessionLog.SEVERE, SessionLog.CACHE, writer.toString(), new Object[] {}, false);
         // we also return the error message we just logged to added it to our tracing permanently

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/helper/ConcurrencyUtil.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/helper/ConcurrencyUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Oracle, IBM and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021 Oracle, IBM and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/localization/i18n/LoggingLocalizationResource.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/localization/i18n/LoggingLocalizationResource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2020 Oracle, IBM Corporation and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle, IBM Corporation and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the 
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0 
  * which accompanies this distribution. 

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/localization/i18n/LoggingLocalizationResource.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/localization/i18n/LoggingLocalizationResource.java
@@ -569,11 +569,11 @@ public class LoggingLocalizationResource extends ListResourceBundle {
                 + " The thread has been stuck for: ({3} ms) \n "
                 + " Bellow we will describe the ActiveLocks, DeferredLocks and ReadLocks for this thread. " },
         { "concurrency_util_owned_cache_key_null", "ObjectNull. Most likely not yet in server session cache and in the process of being created."},
-        { "concurrency_util_owned_cache_key_is_cache_key", "--- CacheKey  ({0}):  (primaryKey: {1}) (object: {2}) (cacheKeyClass: {3}) (current cache key owner/activeThread: {4}) (getNumberOfReaders: {5}) "
-                + " (concurrencyManagerId: {6}) (concurrencyManagerCreationDate: {7})"
-                + "  (totalNumberOfTimeCacheKeyAcquiredForReading:  {8}) "
-                + " (totalNumberOfTimeCacheKeyReleasedForReading:  {9}) "
-                + " (totalNumberOfTimeCacheKeyReleasedForReadingBlewUpExceptionDueToCacheKeyHavingReachedCounterZero:  {10})  ---"},
+        { "concurrency_util_owned_cache_key_is_cache_key", "--- CacheKey  ({0}):  (primaryKey: {1}) (object: {2}) (object hash code: {3}) (cacheKeyClass: {4}) (cacheKey hash code: {5}) (current cache key owner/activeThread: {6}) (getNumberOfReaders: {7}) "
+                + " (concurrencyManagerId: {8}) (concurrencyManagerCreationDate: {9})"
+                + "  (totalNumberOfTimeCacheKeyAcquiredForReading:  {10}) "
+                + " (totalNumberOfTimeCacheKeyReleasedForReading:  {11}) "
+                + " (totalNumberOfTimeCacheKeyReleasedForReadingBlewUpExceptionDueToCacheKeyHavingReachedCounterZero:  {12})  ---"},
         { "concurrency_util_owned_cache_key_is_not_cache_key", "--- ConcurrencyManager: (ConcurrencyManagerClass: {0} ) (ConcurrencyManagerToString: {1}) (current cache key owner/activeThread: {2}) (concurrencyManagerId: {3}) (concurrencyManagerCreationDate: {4}) "
                 + "  (totalNumberOfTimeCacheKeyAcquiredForReading:  {5}) "
                 + " (totalNumberOfTimeCacheKeyReleasedForReading:  {6}) "
@@ -631,7 +631,7 @@ public class LoggingLocalizationResource extends ListResourceBundle {
         { "concurrency_util_create_information_all_threads_release_deferred_locks_3", "Concurrency manager - Page 04 end - information about threads waiting on release deferred locks (waiting for other thread to finish building the objects deferred)\n"},
         { "concurrency_util_create_information_all_resources_acquired_deferred_1", "Concurrency manager - Page 05 start (currentThreadNumber: {0} of totalNumberOfThreads: {1})  - detailed information about specific thread "
                 + "\nThread: {2}"
-                + "\nThreadWaitingToReleaseDeferredLocks: {3}"},
+                + "\nThreadWaitingToReleaseDeferredLocks: {3}\n"},
         { "concurrency_util_create_information_all_resources_acquired_deferred_2", " waitingOnAcquireWritingCacheKey: true  waiting to acquire writing: {0}\n"},
         { "concurrency_util_create_information_all_resources_acquired_deferred_3", " waitingOnAcquireWritingCacheKey: false\n"},
         { "concurrency_util_create_information_all_resources_acquired_deferred_4", " waitingOnAcquireReadCacheKey: true   waiting to acquire reading: {0}\n"},


### PR DESCRIPTION
There is some minor change is log output produced by cache dead-lock diagnostic. concurrencyManagerCreationDate format is changed to display time with milliseconds and cache key and cached object hash code is added. There are some formatting changes too.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>