### PR TITLE
[2.7] Ant/Jenkins build - Nightly build extension to publish output to Jakarta snapshots

### DIFF
--- a/autobuild.xml
+++ b/autobuild.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -73,6 +73,8 @@
             depends="clean, build-no-javadoc, build-utils, test-srg"
     />
     <target name="build-milestone" depends="promote-init, sign-and-wait, regen-archives, publish-milestone, create-tag" description="Promote a build: nightly to milestone or milestone to release ('release' is a special milestone in this case)"
+    />
+    <target name="build-snapshot" depends="snapshot-init, promote-init, extract-signed-artifacts, regen-installer-archive, regen-plugin-archive, regen-nosql-archive, gen-build-for-maven, publish-milestone-artifacts, publish-milestone-nexus" description="Promote build to snapshot repository)"
     />
     <target name="build-ora-extension" description="Trigger the automated oracle extension build"
             depends="init, build-oracle-extension"
@@ -605,6 +607,21 @@
         <property name="temp.rebuild.dir" value="/tmp/EL${run.date}.${run.time}-${version.string}"/>
         <delete dir="${temp.rebuild.dir}" failonerror="false"/>
         <mkdir dir="${temp.rebuild.dir}"/>
+    </target>
+
+    <!--  =====     Snapshot Init     =====  -->
+    <target name="snapshot-init" depends="init">
+        <property name="build.extract.dir" value="${extract.root.dir}/build/bundles/${release.version}/${build.date}"/>
+
+        <echo message="build.extract.dir='${build.extract.dir}'"/>
+
+        <delete dir="${eclipselink.root.download.dir}/nightly/${release.version}/${build.date}" failonerror="false"/>
+        <mkdir dir="${eclipselink.root.download.dir}/nightly/${release.version}/${build.date}"/>
+        <copy todir="${eclipselink.root.download.dir}/nightly/${release.version}/${build.date}">
+            <fileset dir="${build.extract.dir}"/>
+        </copy>
+        <copy file="${eclipselink.root.download.dir}/nightly/${release.version}/${build.date}/${p2.archive.presigned.zip}" tofile="${eclipselink.root.download.dir}/nightly/${release.version}/${build.date}/${p2.archive.signed.zip}"/>
+        <copy file="${custom.tasks.lib}" tofile="${releng.repo.dir}/ant_customizations.jar"/>
     </target>
 
     <!--  =====     Milestone Signing     =====  -->

--- a/autobuild.xml
+++ b/autobuild.xml
@@ -74,7 +74,7 @@
     />
     <target name="build-milestone" depends="promote-init, sign-and-wait, regen-archives, publish-milestone, create-tag" description="Promote a build: nightly to milestone or milestone to release ('release' is a special milestone in this case)"
     />
-    <target name="build-snapshot" depends="snapshot-init, promote-init, extract-signed-artifacts, regen-installer-archive, regen-plugin-archive, regen-nosql-archive, gen-build-for-maven, publish-milestone-artifacts, publish-milestone-nexus" description="Promote build to snapshot repository)"
+    <target name="build-snapshot" depends="snapshot-init, promote-init, extract-signed-artifacts, regen-installer-archive, regen-plugin-archive, regen-nosql-archive, gen-build-for-maven, publish-milestone-artifacts, publish-milestone-nexus" description="Promote build to snapshot repository"
     />
     <target name="build-ora-extension" description="Trigger the automated oracle extension build"
             depends="init, build-oracle-extension"

--- a/etc/jenkins/build.groovy
+++ b/etc/jenkins/build.groovy
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -131,6 +131,18 @@ spec:
                         sh """
                             etc/jenkins/build.sh
                         """
+                    }
+                }
+            }
+        }
+        // Publish to snapshots
+        stage('Publish to snapshots') {
+            steps {
+                container('el-build') {
+                    sshagent([SSH_CREDENTIALS_ID]) {
+                        sh """
+                            etc/jenkins/publish_snapshots.sh
+                            """
                     }
                 }
             }

--- a/etc/jenkins/publish_snapshots.sh
+++ b/etc/jenkins/publish_snapshots.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -e
+#
+# Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Distribution License v. 1.0, which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+#
+# Arguments:
+#  N/A
+#==========================
+#   Basic Env Setup
+#
+#Directories
+RELENG_REPO=${HOME}/etc/jenkins
+DNLD_DIR=${HOME}/etc/jenkins/download
+
+echo '-[ EclipseLink Publish to Jakarta Snapshots ]-----------------------------------------------------------'
+. /etc/profile
+
+if [ ${CONTINUOUS_BUILD} = "true" ]; then
+    echo '-[ EclipseLink Continuous Build -> No publishing any artifacts to Jakarta Snapshots]-------------------------------'
+else
+    echo '-[ EclipseLink Publish to Nightly -> Publishing artifacts to Jakarta Snapshots]-----------------------------------------------------------'
+    export ANT_OPTS=-Xmx4G
+    set -o pipefail
+    ant -f autobuild.xml build-snapshot -Denv.JAVA_HOME=${JAVA_HOME} -DM2_HOME=${HOME}/extension.lib.external/apache-maven-3.6.0 -Djdbc.driver.jar=${HOME}/extension.lib.external/mysql-connector-java-5.1.48.jar -Ddb.url=${TEST_DB_URL} -Ddb.user=${TEST_DB_USERNAME} -Ddb.pwd=${TEST_DB_PASSWORD} -Dextensions.depend.dir=${HOME}/extension.lib.external -Declipse.install.dir=${HOME}/extension.lib.external/eclipse -Djunit.lib=${HOME}/extension.lib.external/junit-4.12.jar:${HOME}/extension.lib.external/hamcrest-core-1.3.jar:${HOME}/extension.lib.external/jmockit-1.35.jar -Dhudson.workspace=${WORKSPACE} -Dtest.logging.level=INFO -Dfail.on.error=true -Dreleng.repo.dir=${RELENG_REPO} -Declipselink.root.download.dir=${DNLD_DIR}
+fi

--- a/pom.xml.template
+++ b/pom.xml.template
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.eclipse.ee4j</groupId>
     <artifactId>project</artifactId>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
   </parent>
 
   <groupId>@groupId@</groupId>

--- a/uploadToNexus.xml
+++ b/uploadToNexus.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -80,8 +80,8 @@
     <!--    Override value to change defaults                          -->
     <property name="stagingId"   value="ossrh"/>
     <property name="stagingURL"  value="https://jakarta.oss.sonatype.org/service/local/staging/deploy/maven2"/>
-    <property name="snapshotId"  value="sonatype-nexus-snapshots"/>
-    <property name="snapshotURL" value="https://oss.sonatype.org/content/repositories/snapshots"/>
+    <property name="snapshotId"  value="ossrh"/>
+    <property name="snapshotURL" value="https://jakarta.oss.sonatype.org/content/repositories/snapshots/"/>
 
     <target name="upload-maven-all" depends="upload-eclipselink"/>
 
@@ -160,6 +160,11 @@
         <condition property="sign">
             <not> <equals arg1="${build.type}" arg2="SNAPSHOT"/> </not>
         </condition>
+
+        <condition property="is.snapshot.build">
+            <equals arg1="${build.type}" arg2="SNAPSHOT"/>
+        </condition>
+        <echo message="is.snapshot.build:   ${is.snapshot.build}"/>
 
         <condition property="target.repo.message" value="Target repository ID: '${stagingId}' URL:'${stagingURL}'"
                    else="Target repository ID: '${snapshotId}' URL:'${snapshotURL}'">
@@ -593,33 +598,32 @@
         <!-- cleanup -->
         <delete file="pom.xml"/>
     </target>
-    <target name="ua-snapshot" unless="sign">
-        <!-- Install provider for https protocol -->
-        <artifact:install-provider artifactId="wagon-http" version="${wagon.http.version}"/>
-        <!-- Deploy Artifact to repote repo, attach source -->
-        <artifact:deploy file="${artifact}">
-          <artifact:remoteRepository id="${snapshotId}" url="${snapshotURL}" />
-          <artifact:pom id="maven.project" file="pom.xml" />
-          <artifact:attach file="${artifactSrc}"     type="jar" classifier="sources"/>
-          <artifact:attach file="${artifactJavadoc}" type="jar" classifier="javadoc"/>
-        </artifact:deploy>
-    </target>
 
     <!-- Uploads a single artifact, source & javadoc to maven repository -->
     <target name="upload-artifact-with-javadoc" depends="prepare-pom, uawj-snapshot, ua-staging, us-staging, uj-staging">
         <!-- cleanup -->
         <delete file="pom.xml"/>
     </target>
-    <target name="uawj-snapshot" unless="sign">
-        <!-- Install provider for https protocol -->
-        <artifact:install-provider artifactId="wagon-http" version="${wagon.http.version}"/>
-        <!-- Deploy Artifact to repote repo, attach source and javadoc -->
-        <artifact:deploy file="${artifact}">
-          <artifact:remoteRepository id="${snapshotId}" url="${snapshotURL}"/>
-          <artifact:pom id="maven.project" file="pom.xml" />
-          <artifact:attach file="${artifactSrc}"     type="jar" classifier="sources"/>
-          <artifact:attach file="${artifactJavadoc}" type="zip" classifier="javadoc"/>
-        </artifact:deploy>
+
+    <target name="uawj-snapshot" if="is.snapshot.build" depends="ua-snapshot, us-snapshot, uj-snapshot" />
+
+    <!-- Snapshot targets -->
+    <target name="ua-snapshot" if="is.snapshot.build">
+        <exec dir="${maven.build.location}" executable="sh">
+            <arg line="-c '${M2_HOME}/bin/mvn clean deploy:deploy-file -Dfile=${artifact} -DpomFile=${maven.build.location}/pom.xml -Durl=${snapshotURL} -DrepositoryId=${snapshotId} -Psnapshots'" />
+        </exec>
+    </target>
+    <target name="us-snapshot" if="is.snapshot.build">
+        <!-- sign and deploy the sources artifact -->
+        <exec dir="${maven.build.location}" executable="sh">
+            <arg line="-c '${M2_HOME}/bin/mvn clean deploy:deploy-file -Dfile=${artifactSrc} -DpomFile=${maven.build.location}/pom.xml -Durl=${snapshotURL} -DrepositoryId=${snapshotId} -Dclassifier=sources -Psnapshots'" />
+        </exec>
+    </target>
+    <target name="uj-snapshot" if="is.snapshot.build">
+        <!-- sign and deploy the javadoc artifact -->
+        <exec dir="${maven.build.location}" executable="sh">
+            <arg line="-c '${M2_HOME}/bin/mvn clean deploy:deploy-file -Dfile=${artifactJavadoc} -DpomFile=${maven.build.location}/pom.xml -Durl=${snapshotURL} -DrepositoryId=${snapshotId} -Dclassifier=javadoc -Psnapshots'" />
+        </exec>
     </target>
 
     <!-- Staging targets -->


### PR DESCRIPTION
There are changes in build scripts called in Jenkins environment to publish build outputs/artifacts to Jakarta snapshots repository.
It's useful for tests (TCKs or use nightly build output in Maven environment).
There is parent pom (org.eclipse.ee4j:project) upgrade from 1.0.5 to 1.0.6 in pom files attached to published artifacts.