### PR TITLE
[2.6] Force deferred locks persistence query property - backport from master

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/PersistenceUnitProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/PersistenceUnitProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates, IBM Corporation. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates, IBM Corporation. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -1401,6 +1401,19 @@ public class PersistenceUnitProperties {
      * @see org.eclipse.persistence.platform.database.oracle.dcn.OracleChangeNotificationListener
      */
     public static final String DATABASE_EVENT_LISTENER = "eclipselink.cache.database-event-listener";
+
+    /**
+     * The "<code>eclipselink.cache.query-force-deferred-locks</code>" property force all queries and relationships
+     * to use deferred lock strategy during object building and L2 cache population.
+     * <p>
+     * <b>Allowed Values</b> (String)<b>:</b>
+     * <ul>
+     * <li>"<code>false</code>" (DEFAULT) - use use mixed object cache locking strategy
+     * <li>"<code>true</code>" - use deferred locking strategy all queries and relationships
+     * </ul>
+     */
+
+    public static final String CACHE_QUERY_FORCE_DEFERRED_LOCKS = "eclipselink.cache.query-force-deferred-locks";
 
     // Customizations properties
 

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/ObjectBuildingQuery.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/ObjectBuildingQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the 
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0 
  * which accompanies this distribution. 
@@ -598,7 +598,11 @@ public abstract class ObjectBuildingQuery extends ReadQuery {
      * with an object the acquires deferred locks behaves the same as its owner
      */
     public void setRequiresDeferredLocks(boolean cascadeDeferredLocks) {
-        this.requiresDeferredLocks = Boolean.valueOf(cascadeDeferredLocks);
+        if (session.getProject().isQueryCacheForceDeferredLocks()) {
+            this.requiresDeferredLocks = true;
+        } else {
+            this.requiresDeferredLocks = Boolean.valueOf(cascadeDeferredLocks);
+        }
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/ObjectBuildingQuery.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/ObjectBuildingQuery.java
@@ -598,7 +598,7 @@ public abstract class ObjectBuildingQuery extends ReadQuery {
      * with an object the acquires deferred locks behaves the same as its owner
      */
     public void setRequiresDeferredLocks(boolean cascadeDeferredLocks) {
-        if (session.getProject().isQueryCacheForceDeferredLocks()) {
+        if (session != null && session.getProject().isQueryCacheForceDeferredLocks()) {
             this.requiresDeferredLocks = true;
         } else {
             this.requiresDeferredLocks = Boolean.valueOf(cascadeDeferredLocks);

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/sessions/Project.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/sessions/Project.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2014 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the 
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0 
  * which accompanies this distribution. 
@@ -170,6 +170,9 @@ public class Project extends CoreProject<ClassDescriptor, Login, DatabaseSession
     protected Collection<String> classNamesForWeaving;
     protected Collection<String> structConverters;
 
+    /** Force all queries and relationships to use deferred lock strategy during object building and L2 cache population. */
+    protected boolean queryCacheForceDeferredLocks = false;
+
     /**
      * PUBLIC:
      * Create a new project.
@@ -225,7 +228,23 @@ public class Project extends CoreProject<ClassDescriptor, Login, DatabaseSession
     public void setDefaultQueryResultsCachePolicy(QueryResultsCachePolicy defaultQueryResultsCachePolicy) {
         this.defaultQueryResultsCachePolicy = defaultQueryResultsCachePolicy;
     }
-    
+
+    /**
+     * PUBLIC:
+     * Get property to Force all queries and relationships to use deferred lock strategy during object building and L2 cache population.
+     */
+    public boolean isQueryCacheForceDeferredLocks() {
+        return queryCacheForceDeferredLocks;
+    }
+
+    /**
+     * PUBLIC:
+     * Set property to Force all queries and relationships to use deferred lock strategy during object building and L2 cache population.
+     * By default there is false value - use use mixed object cache locking strategy (depends on relationship and fetch type) */
+    public void setQueryCacheForceDeferredLocks(boolean queryCacheForceDeferredLocks) {
+        this.queryCacheForceDeferredLocks = queryCacheForceDeferredLocks;
+    }
+
     /**
      * PUBLIC:
      * Return the default setting for configuring if dates and calendars are mutable.

--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates, IBM Corporation. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates, IBM Corporation. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -1430,7 +1430,13 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
         if ((queryCache != null) && queryCache.equalsIgnoreCase("true")) {
             session.getProject().setDefaultQueryResultsCachePolicy(new QueryResultsCachePolicy());
         }
-        
+        String queryCacheForceDeferredLocks = getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.CACHE_QUERY_FORCE_DEFERRED_LOCKS, m, session);
+        if ((queryCacheForceDeferredLocks != null) && queryCacheForceDeferredLocks.equalsIgnoreCase("true")) {
+            session.getProject().setQueryCacheForceDeferredLocks(true);
+        } else {
+            session.getProject().setQueryCacheForceDeferredLocks(false);
+        }
+
         Map typeMap = PropertiesHandler.getPrefixValuesLogDebug(PersistenceUnitProperties.CACHE_TYPE_, m, session);
         Map sizeMap = PropertiesHandler.getPrefixValuesLogDebug(PersistenceUnitProperties.CACHE_SIZE_, m, session);
         Map sharedMap = PropertiesHandler.getPrefixValuesLogDebug(PersistenceUnitProperties.CACHE_SHARED_, m, session);


### PR DESCRIPTION
New `eclipselink.cache.query-force-deferred-locks` property force all queries and relationships
 to use deferred lock strategy during object building and L2 cache population.
 It helps to solve dead lock issues in multithreaded environments where one L2 cache is accessed/populated
 by multiple threads.
 Threads create objects from the same object graph but from different starting point.
 Dead lock issue should happens in large object graphs and entities connected with relationships with EAGER fetch strategy.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>