### PR TITLE
[master] Bug/New Feature 559307: EclipseLink on all versions can dead-lock forever - performance fix

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/PersistenceUnitProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/PersistenceUnitProperties.java
@@ -3948,33 +3948,49 @@ public class PersistenceUnitProperties {
     public static final String CONCURRENCY_MANAGER_MAX_FREQUENCY_DUMP_MASSIVE_MESSAGE  = "eclipselink.concurrency.manager.maxfrequencytodumpmassivemessage";
 
     /**
-     * true - if we want the to fire up an exception to try to get the current thread to release all of its acquired locks and allow other
-     * threads to progress.
-     * false - if aborting frozen thread is not effective it is preferable to not fire the interrupted exception let the system
+     * <p>
+     * This property control (enable/disable) if <code>InterruptedException</code> fired when dead-lock diagnostic is enabled.
+     * <p>
+     * <b>Allowed Values</b> (case sensitive String)<b>:</b>
+     * <ul>
+     * <li>"<code>false</code>" - if aborting frozen thread is not effective it is preferable to not fire the interrupted exception let the system
      * In the places where use this property normally if a thread is stuck it is because it is doing object building.
      * Blowing the threads ups is not that dangerous. It can be very dangerous for production if the dead lock ends up
      * not being resolved because the productive business transactions will become cancelled if the application has a
      * limited number of retries to for example process an MDB. However, the code spots where we use this constant are
      * not as sensible as when the write lock manager is starving to run commit.
+     * <li>"<code>true</code>" (DEFAULT) - if we want the to fire up an exception to try to get the current thread to release all of its acquired locks and allow other
+     * threads to progress.
+     * </ul>
      */
     public static final String CONCURRENCY_MANAGER_ALLOW_INTERRUPTED_EXCEPTION  = "eclipselink.concurrency.manager.allow.interruptedexception";
 
     /**
-     * true - if we want the to fire up an exception to try to get the current thread to realease all of its acquired locks and allow other
-     * threads to progress.
-     * false - if aborting frozen thread is not effective it is preferable to not fire the concurrency exception let the system
+     * <p>
+     * This property control (enable/disable) if <code>ConcurrencyException</code> fired when dead-lock diagnostic is enabled.
+     * <p>
+     * <b>Allowed Values</b> (case sensitive String)<b>:</b>
+     * <ul>
+     * <li>"<code>false</code>" - if aborting frozen thread is not effective it is preferable to not fire the concurrency exception let the system
      * freeze and die and force the administration to kill the server. This is preferable to aborting the transactions
      * multiple times without success in resolving the dead lock and having business critical messages that after 3 JMS
      * retries are discarded out. Failing to resolve a dead lock can have terrible impact in system recovery unless we
      * have infinite retries for the business transactions.
-     * Allowed values are: true/false.
+     * <li>"<code>true</code>" (DEFAULT) - if we want the to fire up an exception to try to get the current thread to release all of its acquired
+     * locks and allow other threads to progress.
+     * </ul>
      */
     public static final String CONCURRENCY_MANAGER_ALLOW_CONCURRENCY_EXCEPTION  = "eclipselink.concurrency.manager.allow.concurrencyexception";
 
     /**
-     * true - collect debug/trace information during ReadLock acquisition. Has negative impact to the performance.
-     * false - (Default) don't collect debug/trace information during ReadLock acquisition
-     * Allowed values are: true/false.
+     * <p>
+     * This property control (enable/disable) collection debug/trace information during ReadLock acquisition, when dead-lock diagnostic is enabled.
+     * <p>
+     * <b>Allowed Values</b> (case sensitive String)<b>:</b>
+     * <ul>
+     * <li>"<code>false</code>" (DEFAULT) - don't collect debug/trace information during ReadLock acquisition
+     * <li>"<code>true</code>" - collect debug/trace information during ReadLock acquisition. Has negative impact to the performance.
+     * </ul>
      */
     public static final String CONCURRENCY_MANAGER_ALLOW_STACK_TRACE_READ_LOCK = "eclipselink.concurrency.manager.allow.readlockstacktrace";
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/PersistenceUnitProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/PersistenceUnitProperties.java
@@ -3972,8 +3972,8 @@ public class PersistenceUnitProperties {
     public static final String CONCURRENCY_MANAGER_ALLOW_CONCURRENCY_EXCEPTION  = "eclipselink.concurrency.manager.allow.concurrencyexception";
 
     /**
-     * true - collect debug/trace information during ReadLock acquisition
-     * false - don't collect debug/trace information during ReadLock acquisition
+     * true - collect debug/trace information during ReadLock acquisition. Has negative impact to the performance.
+     * false - (Default) don't collect debug/trace information during ReadLock acquisition
      * Allowed values are: true/false.
      */
     public static final String CONCURRENCY_MANAGER_ALLOW_STACK_TRACE_READ_LOCK = "eclipselink.concurrency.manager.allow.readlockstacktrace";

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/SystemProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/SystemProperties.java
@@ -130,33 +130,49 @@ public class SystemProperties {
     public static final String CONCURRENCY_MANAGER_MAX_FREQUENCY_DUMP_MASSIVE_MESSAGE  = "eclipselink.concurrency.manager.maxfrequencytodumpmassivemessage";
 
     /**
-     * true - if we want the to fire up an exception to try to get the current thread to release all of its acquired locks and allow other
-     * threads to progress.
-     * false - if aborting frozen thread is not effective it is preferable to not fire the interrupted exception let the system
+     * <p>
+     * This property control (enable/disable) if <code>InterruptedException</code> fired when dead-lock diagnostic is enabled.
+     * <p>
+     * <b>Allowed Values</b> (case sensitive String)<b>:</b>
+     * <ul>
+     * <li>"<code>false</code>" - if aborting frozen thread is not effective it is preferable to not fire the interrupted exception let the system
      * In the places where use this property normally if a thread is stuck it is because it is doing object building.
      * Blowing the threads ups is not that dangerous. It can be very dangerous for production if the dead lock ends up
      * not being resolved because the productive business transactions will become cancelled if the application has a
      * limited number of retries to for example process an MDB. However, the code spots where we use this constant are
      * not as sensible as when the write lock manager is starving to run commit.
+     * <li>"<code>true</code>" (DEFAULT) - if we want the to fire up an exception to try to get the current thread to release all of its acquired locks and allow other
+     * threads to progress.
+     * </ul>
      */
     public static final String CONCURRENCY_MANAGER_ALLOW_INTERRUPTED_EXCEPTION  = "eclipselink.concurrency.manager.allow.interruptedexception";
 
     /**
-     * true - if we want the to fire up an exception to try to get the current thread to realease all of its acquired locks and allow other
-     * threads to progress.
-     * false - if aborting frozen thread is not effective it is preferable to not fire the concurrency exception let the system
+     * <p>
+     * This property control (enable/disable) if <code>ConcurrencyException</code> fired when dead-lock diagnostic is enabled.
+     * <p>
+     * <b>Allowed Values</b> (case sensitive String)<b>:</b>
+     * <ul>
+     * <li>"<code>false</code>" - if aborting frozen thread is not effective it is preferable to not fire the concurrency exception let the system
      * freeze and die and force the administration to kill the server. This is preferable to aborting the transactions
      * multiple times without success in resolving the dead lock and having business critical messages that after 3 JMS
      * retries are discarded out. Failing to resolve a dead lock can have terrible impact in system recovery unless we
      * have infinite retries for the business transactions.
-     * Allowed values are: true/false.
+     * <li>"<code>true</code>" (DEFAULT) - if we want the to fire up an exception to try to get the current thread to release all of its acquired
+     * locks and allow other threads to progress.
+     * </ul>
      */
     public static final String CONCURRENCY_MANAGER_ALLOW_CONCURRENCY_EXCEPTION  = "eclipselink.concurrency.manager.allow.concurrency.exception";
 
     /**
-     * true - collect debug/trace information during ReadLock acquisition. Has negative impact to the performance.
-     * false - (Default) don't collect debug/trace information during ReadLock acquisition
-     * Allowed values are: true/false.
+     * <p>
+     * This property control (enable/disable) collection debug/trace information during ReadLock acquisition, when dead-lock diagnostic is enabled.
+     * <p>
+     * <b>Allowed Values</b> (case sensitive String)<b>:</b>
+     * <ul>
+     * <li>"<code>false</code>" (DEFAULT) - don't collect debug/trace information during ReadLock acquisition
+     * <li>"<code>true</code>" - collect debug/trace information during ReadLock acquisition. Has negative impact to the performance.
+     * </ul>
      */
     public static final String CONCURRENCY_MANAGER_ALLOW_STACK_TRACE_READ_LOCK = "eclipselink.concurrency.manager.allow.readlockstacktrace";
 }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/SystemProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/SystemProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -154,8 +154,8 @@ public class SystemProperties {
     public static final String CONCURRENCY_MANAGER_ALLOW_CONCURRENCY_EXCEPTION  = "eclipselink.concurrency.manager.allow.concurrency.exception";
 
     /**
-     * true - collect debug/trace information during ReadLock acquisition
-     * false - don't collect debug/trace information during ReadLock acquisition
+     * true - collect debug/trace information during ReadLock acquisition. Has negative impact to the performance.
+     * false - (Default) don't collect debug/trace information during ReadLock acquisition
      * Allowed values are: true/false.
      */
     public static final String CONCURRENCY_MANAGER_ALLOW_STACK_TRACE_READ_LOCK = "eclipselink.concurrency.manager.allow.readlockstacktrace";

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ConcurrencyUtil.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ConcurrencyUtil.java
@@ -46,7 +46,7 @@ public class ConcurrencyUtil {
     private static final long DEFAULT_MAX_ALLOWED_FREQUENCY_MASSIVE_DUMP_LOG_MESSAGE = 60000L;
     private static final boolean DEFAULT_INTERRUPTED_EXCEPTION_FIRED = true;
     private static final boolean DEFAULT_CONCURRENCY_EXCEPTION_FIRED = true;
-    private static final boolean DEFAULT_TAKING_STACKTRACE_DURING_READ_LOCK_ACQUISITION = true;
+    private static final boolean DEFAULT_TAKING_STACKTRACE_DURING_READ_LOCK_ACQUISITION = false;
 
     private long acquireWaitTime = getLongProperty(SystemProperties.CONCURRENCY_MANAGER_ACQUIRE_WAIT_TIME, DEFAULT_ACQUIRE_WAIT_TIME);
     private long maxAllowedSleepTime = getLongProperty(SystemProperties.CONCURRENCY_MANAGER_MAX_SLEEP_TIME, DEFAULT_MAX_ALLOWED_SLEEP_TIME_MS);


### PR DESCRIPTION
There is small fix for performance improvement when dead-lock detection/logging is enabled.
`eclipselink.concurrency.manager.allow.readlockstacktrace` default value will be false.
Stack trace collection for read locks consumes so much resources.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>