### PR TITLE
EclipseLink doesn't generate SQL UPDATE correctly if @ReturnUpdate is used in InheritanceType.JOINED

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/queries/ExpressionQueryMechanism.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/queries/ExpressionQueryMechanism.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2019 IBM and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -835,7 +835,16 @@ public class ExpressionQueryMechanism extends StatementQueryMechanism {
         updateStatement.setModifyRow(getModifyRow());
         updateStatement.setTranslationRow(getTranslationRow());
         if (getDescriptor().hasReturningPolicies() && getDescriptor().getReturnFieldsToGenerateUpdate() != null) {
-            updateStatement.setReturnFields(getDescriptor().getReturnFieldsToGenerateUpdate());
+            // In case of RelationalDescriptor only return fields for current table must be used.
+            Vector<DatabaseField> returnFieldsForTable = new NonSynchronizedVector();
+            for (DatabaseField item: getDescriptor().getReturnFieldsToGenerateInsert()) {
+                if (table.equals(item.getTable())) {
+                    returnFieldsForTable.add(item);
+                }
+                if (!returnFieldsForTable.isEmpty()) {
+                    updateStatement.setReturnFields(getDescriptor().getReturnFieldsToGenerateInsert());
+                }
+            }
         }
         updateStatement.setTable(table);
         updateStatement.setWhereClause(getDescriptor().getObjectBuilder().buildUpdateExpression(table, getTranslationRow(), getModifyRow()));

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/queries/ExpressionQueryMechanism.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/queries/ExpressionQueryMechanism.java
@@ -836,7 +836,7 @@ public class ExpressionQueryMechanism extends StatementQueryMechanism {
         updateStatement.setTranslationRow(getTranslationRow());
         if (getDescriptor().hasReturningPolicies() && getDescriptor().getReturnFieldsToGenerateUpdate() != null) {
             // In case of RelationalDescriptor only return fields for current table must be used.
-            Vector<DatabaseField> returnFieldsForTable = new NonSynchronizedVector();
+            List<DatabaseField> returnFieldsForTable = new ArrayList<>();
             for (DatabaseField item: getDescriptor().getReturnFieldsToGenerateInsert()) {
                 if (table.equals(item.getTable())) {
                     returnFieldsForTable.add(item);

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/returninsert/model/ReturnInsertDetailJoined.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/returninsert/model/ReturnInsertDetailJoined.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,9 +14,10 @@
 //     Oracle - initial API and implementation
 package org.eclipse.persistence.jpa.returninsert.model;
 
-import org.eclipse.persistence.annotations.ReturnInsert;
-
 import jakarta.persistence.*;
+
+import org.eclipse.persistence.annotations.ReturnUpdate;
+import org.eclipse.persistence.annotations.ReturnInsert;
 
 /**
  * The parent persistent class for the JPA22_RETURNINSERT_DETAIL_JOINED database table.
@@ -28,15 +29,20 @@ import jakarta.persistence.*;
 @DiscriminatorValue("A")
 public class ReturnInsertDetailJoined extends ReturnInsertMasterJoined {
 
-	@Column(name = "detail_nr", nullable = false, unique = true, updatable = false)
-	@ReturnInsert(returnOnly = true)
+	@Column(name = "detail_nr")
 	Long detailNumber = null;
+
+	@Column(name = "detail_nr_virtual", nullable = false, unique = true, updatable = false)
+	@ReturnInsert(returnOnly = true)
+	@ReturnUpdate
+	Long detailNumberVirtual = null;
 
 	public ReturnInsertDetailJoined() {
 	}
 
-	public ReturnInsertDetailJoined(Long id, String type) {
+	public ReturnInsertDetailJoined(Long id, Long detailNumber, String type) {
 		super(id, type);
+		this.detailNumber = detailNumber;
 	}
 
 	public Long getDetailNumber() {
@@ -45,5 +51,13 @@ public class ReturnInsertDetailJoined extends ReturnInsertMasterJoined {
 
 	public void setDetailNumber(Long detailNumber) {
 		this.detailNumber = detailNumber;
+	}
+
+	public Long getDetailNumberVirtual() {
+		return detailNumberVirtual;
+	}
+
+	public void setDetailNumberVirtual(Long detailNumber) {
+		this.detailNumberVirtual = detailNumber;
 	}
 }


### PR DESCRIPTION
Bugfix for #1016 + unit test

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>