### PR TITLE
[2.7] EclipseLink doesn't generate SQL UPDATE correctly if @ReturnUpdate is used in InheritanceType.JOINED - backport from master

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/ExpressionQueryMechanism.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/ExpressionQueryMechanism.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2020 IBM and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -778,8 +778,8 @@ public class ExpressionQueryMechanism extends StatementQueryMechanism {
     }
 
     /**
-     * Return the appropriate update statement
-     * @return SQLInsertStatement
+     * Return the appropriate update statement with return update columns (if any)
+     * @return SQLUpdateStatement
      */
     protected SQLUpdateStatement buildUpdateStatement(DatabaseTable table) {
         SQLUpdateStatement updateStatement = new SQLUpdateStatement();
@@ -787,7 +787,15 @@ public class ExpressionQueryMechanism extends StatementQueryMechanism {
         updateStatement.setModifyRow(getModifyRow());
         updateStatement.setTranslationRow(getTranslationRow());
         if (getDescriptor().hasReturningPolicies() && getDescriptor().getReturnFieldsToGenerateUpdate() != null) {
-            updateStatement.setReturnFields(getDescriptor().getReturnFieldsToGenerateUpdate());
+            List<DatabaseField> returnFieldsForTable = new ArrayList<>();
+            for (DatabaseField item: getDescriptor().getReturnFieldsToGenerateInsert()) {
+                if (table.equals(item.getTable())) {
+                    returnFieldsForTable.add(item);
+                }
+                if (!returnFieldsForTable.isEmpty()) {
+                    updateStatement.setReturnFields(getDescriptor().getReturnFieldsToGenerateInsert());
+                }
+            }
         }
         updateStatement.setTable(table);
         updateStatement.setWhereClause(getDescriptor().getObjectBuilder().buildUpdateExpression(table, getTranslationRow(), getModifyRow()));

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/returninsert/TestReturnInsert.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/returninsert/TestReturnInsert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -61,6 +61,8 @@ public class TestReturnInsert {
         testFindUpdate();
         testQuery();
         testCreateJoined();
+        testUpdateMasterDetailJoined();
+        testUpdateDetailJoined();
         emf.close();
     }
 
@@ -111,7 +113,8 @@ public class TestReturnInsert {
                         "    TYPE   VARCHAR2(50) NOT NULL)");
                 session.executeNonSelectingSQL("CREATE TABLE JPA22_RETURNINSERT_DETAIL_JOINED  (" +
                         "    ID          NUMBER(15) PRIMARY KEY ," +
-                        "    DETAIL_NR   NUMBER(15) AS ( ID * 10 ) VIRTUAL)");
+                        "    DETAIL_NR           NUMBER(15)," +
+                        "    DETAIL_NR_VIRTUAL   NUMBER(15) AS ( DETAIL_NR * 10 ) VIRTUAL)");
             } catch (Exception ignore) {
             }
         } finally {
@@ -162,7 +165,7 @@ public class TestReturnInsert {
         EntityManager em = emf.createEntityManager();
         try {
             em.getTransaction().begin();
-            returnInsertDetailJoined = new ReturnInsertDetailJoined(1L, "TYPE_A");
+            returnInsertDetailJoined = new ReturnInsertDetailJoined(1L, 1L, "TYPE_A");
             returnInsertDetailJoined = em.merge(returnInsertDetailJoined);
 
             em.getTransaction().commit();
@@ -176,7 +179,56 @@ public class TestReturnInsert {
         }
         assertEquals(Long.valueOf(1L), returnInsertDetailJoined.getId());
         assertEquals("TYPE_A", returnInsertDetailJoined.getType());
-        assertEquals(Long.valueOf(10L), returnInsertDetailJoined.getDetailNumber());
+        assertEquals(Long.valueOf(10L), returnInsertDetailJoined.getDetailNumberVirtual());
+    }
+
+    private void testUpdateMasterDetailJoined() {
+        ReturnInsertDetailJoined returnInsertDetailJoined = null;
+
+        EntityManager em = emf.createEntityManager();
+        try {
+            em.getTransaction().begin();
+            returnInsertDetailJoined = em.find(ReturnInsertDetailJoined.class, 1L);
+            returnInsertDetailJoined.setType("TYPE_B");
+            returnInsertDetailJoined.setDetailNumber(22L);
+            returnInsertDetailJoined = em.merge(returnInsertDetailJoined);
+
+            em.getTransaction().commit();
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if (em.isOpen()) {
+                em.close();
+            }
+        }
+        assertEquals(Long.valueOf(1L), returnInsertDetailJoined.getId());
+        assertEquals("TYPE_B", returnInsertDetailJoined.getType());
+        assertEquals(Long.valueOf(220L), returnInsertDetailJoined.getDetailNumberVirtual());
+    }
+
+    private void testUpdateDetailJoined() {
+        ReturnInsertDetailJoined returnInsertDetailJoined = null;
+
+        EntityManager em = emf.createEntityManager();
+        try {
+            em.getTransaction().begin();
+            returnInsertDetailJoined = em.find(ReturnInsertDetailJoined.class, 1L);
+            returnInsertDetailJoined.setDetailNumber(33L);
+            returnInsertDetailJoined = em.merge(returnInsertDetailJoined);
+
+            em.getTransaction().commit();
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if (em.isOpen()) {
+                em.close();
+            }
+        }
+        assertEquals(Long.valueOf(1L), returnInsertDetailJoined.getId());
+        assertEquals("TYPE_B", returnInsertDetailJoined.getType());
+        assertEquals(Long.valueOf(330L), returnInsertDetailJoined.getDetailNumberVirtual());
     }
 
     private void testFindUpdate() {

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/returninsert/model/ReturnInsertDetailJoined.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/returninsert/model/ReturnInsertDetailJoined.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,13 +14,14 @@
 //     Oracle - initial API and implementation
 package org.eclipse.persistence.jpa.returninsert.model;
 
-import org.eclipse.persistence.annotations.ReturnInsert;
-
 import javax.persistence.*;
+
+import org.eclipse.persistence.annotations.ReturnUpdate;
+import org.eclipse.persistence.annotations.ReturnInsert;
 
 /**
  * The parent persistent class for the JPA22_RETURNINSERT_DETAIL_JOINED database table.
- * 
+ *
  */
 @Entity
 @Table(name = "JPA22_RETURNINSERT_DETAIL_JOINED")
@@ -28,15 +29,20 @@ import javax.persistence.*;
 @DiscriminatorValue("A")
 public class ReturnInsertDetailJoined extends ReturnInsertMasterJoined {
 
-	@Column(name = "detail_nr", nullable = false, unique = true, updatable = false)
-	@ReturnInsert(returnOnly = true)
+	@Column(name = "detail_nr")
 	Long detailNumber = null;
+
+	@Column(name = "detail_nr_virtual", nullable = false, unique = true, updatable = false)
+	@ReturnInsert(returnOnly = true)
+	@ReturnUpdate
+	Long detailNumberVirtual = null;
 
 	public ReturnInsertDetailJoined() {
 	}
 
-	public ReturnInsertDetailJoined(Long id, String type) {
+	public ReturnInsertDetailJoined(Long id, Long detailNumber, String type) {
 		super(id, type);
+		this.detailNumber = detailNumber;
 	}
 
 	public Long getDetailNumber() {
@@ -45,5 +51,13 @@ public class ReturnInsertDetailJoined extends ReturnInsertMasterJoined {
 
 	public void setDetailNumber(Long detailNumber) {
 		this.detailNumber = detailNumber;
+	}
+
+	public Long getDetailNumberVirtual() {
+		return detailNumberVirtual;
+	}
+
+	public void setDetailNumberVirtual(Long detailNumber) {
+		this.detailNumberVirtual = detailNumber;
 	}
 }


### PR DESCRIPTION
Bugfix for #1016 + unit test

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>