### PR TITLE
[2.6] EclipseLink doesn't generate SQL UPDATE correctly if @ReturnUpdate is used in InheritanceType.JOINED - backport from master

### DIFF
--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/returninsert/TestReturnInsert.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/returninsert/TestReturnInsert.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -59,6 +59,8 @@ public class TestReturnInsert {
         testFindUpdate();
         testQuery();
         testCreateJoined();
+        testUpdateMasterDetailJoined();
+        testUpdateDetailJoined();
         emf.close();
     }
 
@@ -109,7 +111,8 @@ public class TestReturnInsert {
                         "    TYPE   VARCHAR2(50) NOT NULL)");
                 session.executeNonSelectingSQL("CREATE TABLE JPA22_RETURNINSERT_DETAIL_JOINED  (" +
                         "    ID          NUMBER(15) PRIMARY KEY ," +
-                        "    DETAIL_NR   NUMBER(15) AS ( ID * 10 ) VIRTUAL)");
+                        "    DETAIL_NR           NUMBER(15)," +
+                        "    DETAIL_NR_VIRTUAL   NUMBER(15) AS ( DETAIL_NR * 10 ) VIRTUAL)");
             } catch (Exception ignore) {
             }
         } finally {
@@ -160,7 +163,7 @@ public class TestReturnInsert {
         EntityManager em = emf.createEntityManager();
         try {
             em.getTransaction().begin();
-            returnInsertDetailJoined = new ReturnInsertDetailJoined(1L, "TYPE_A");
+            returnInsertDetailJoined = new ReturnInsertDetailJoined(1L, 1L, "TYPE_A");
             returnInsertDetailJoined = em.merge(returnInsertDetailJoined);
 
             em.getTransaction().commit();
@@ -174,7 +177,56 @@ public class TestReturnInsert {
         }
         assertEquals(Long.valueOf(1L), returnInsertDetailJoined.getId());
         assertEquals("TYPE_A", returnInsertDetailJoined.getType());
-        assertEquals(Long.valueOf(10L), returnInsertDetailJoined.getDetailNumber());
+        assertEquals(Long.valueOf(10L), returnInsertDetailJoined.getDetailNumberVirtual());
+    }
+
+    private void testUpdateMasterDetailJoined() {
+        ReturnInsertDetailJoined returnInsertDetailJoined = null;
+
+        EntityManager em = emf.createEntityManager();
+        try {
+            em.getTransaction().begin();
+            returnInsertDetailJoined = em.find(ReturnInsertDetailJoined.class, 1L);
+            returnInsertDetailJoined.setType("TYPE_B");
+            returnInsertDetailJoined.setDetailNumber(22L);
+            returnInsertDetailJoined = em.merge(returnInsertDetailJoined);
+
+            em.getTransaction().commit();
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if (em.isOpen()) {
+                em.close();
+            }
+        }
+        assertEquals(Long.valueOf(1L), returnInsertDetailJoined.getId());
+        assertEquals("TYPE_B", returnInsertDetailJoined.getType());
+        assertEquals(Long.valueOf(220L), returnInsertDetailJoined.getDetailNumberVirtual());
+    }
+
+    private void testUpdateDetailJoined() {
+        ReturnInsertDetailJoined returnInsertDetailJoined = null;
+
+        EntityManager em = emf.createEntityManager();
+        try {
+            em.getTransaction().begin();
+            returnInsertDetailJoined = em.find(ReturnInsertDetailJoined.class, 1L);
+            returnInsertDetailJoined.setDetailNumber(33L);
+            returnInsertDetailJoined = em.merge(returnInsertDetailJoined);
+
+            em.getTransaction().commit();
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if (em.isOpen()) {
+                em.close();
+            }
+        }
+        assertEquals(Long.valueOf(1L), returnInsertDetailJoined.getId());
+        assertEquals("TYPE_B", returnInsertDetailJoined.getType());
+        assertEquals(Long.valueOf(330L), returnInsertDetailJoined.getDetailNumberVirtual());
     }
 
     private void testFindUpdate() {

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/returninsert/model/ReturnInsertDetailJoined.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/returninsert/model/ReturnInsertDetailJoined.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -12,13 +12,13 @@
  ******************************************************************************/
 package org.eclipse.persistence.jpa.test.returninsert.model;
 
-import org.eclipse.persistence.annotations.ReturnInsert;
-
 import javax.persistence.*;
+
+import org.eclipse.persistence.annotations.ReturnInsert;
+import org.eclipse.persistence.annotations.ReturnUpdate;
 
 /**
  * The parent persistent class for the JPA22_RETURNINSERT_DETAIL_JOINED database table.
- * 
  */
 @Entity
 @Table(name = "JPA22_RETURNINSERT_DETAIL_JOINED")
@@ -26,15 +26,20 @@ import javax.persistence.*;
 @DiscriminatorValue("A")
 public class ReturnInsertDetailJoined extends ReturnInsertMasterJoined {
 
-	@Column(name = "detail_nr", nullable = false, unique = true, updatable = false)
-	@ReturnInsert(returnOnly = true)
+	@Column(name = "detail_nr")
 	Long detailNumber = null;
+
+	@Column(name = "detail_nr_virtual", nullable = false, unique = true, updatable = false)
+	@ReturnInsert(returnOnly = true)
+	@ReturnUpdate
+	Long detailNumberVirtual = null;
 
 	public ReturnInsertDetailJoined() {
 	}
 
-	public ReturnInsertDetailJoined(Long id, String type) {
+	public ReturnInsertDetailJoined(Long id, Long detailNumber, String type) {
 		super(id, type);
+		this.detailNumber = detailNumber;
 	}
 
 	public Long getDetailNumber() {
@@ -43,5 +48,13 @@ public class ReturnInsertDetailJoined extends ReturnInsertMasterJoined {
 
 	public void setDetailNumber(Long detailNumber) {
 		this.detailNumber = detailNumber;
+	}
+
+	public Long getDetailNumberVirtual() {
+		return detailNumberVirtual;
+	}
+
+	public void setDetailNumberVirtual(Long detailNumber) {
+		this.detailNumberVirtual = detailNumber;
 	}
 }


### PR DESCRIPTION
Bugfix for #1016 + unit test