### PR TITLE
[2.6] Bug 535088 - [test] SubSelectFromClauseTest2 failing randomly on public infra 2.0 - backport

### DIFF
--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/expressions/ExpressionSubSelectTestSuite.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/expressions/ExpressionSubSelectTestSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -859,15 +859,12 @@ public class ExpressionSubSelectTestSuite extends TestSuite {
         query.addItem("e", builder);
         Expression alias = builder.getAlias(builder.subQuery(subQuery));
         query.addNonFetchJoin(alias);
-        query.setSelectionCriteria(builder.get("id").equal(alias.get("id")).and(builder.get("id").notEqual(alias.get("id2"))));
+        query.setSelectionCriteria(builder.get("id").equal(alias.get("id")).and(builder.get("id").notEqual(alias.get("id2"))).and(builder.get("id").equal("0")));
 
         ReadAllExpressionTest test = new ReadAllExpressionTest(Employee.class, 0);
         test.setQuery(query);
         test.setName("SubSelectFromClauseTest2");
         test.setDescription("Test subselects in the from clause");
-        //bug 535088: this test fails randomly on public infra
-        //TODO: investigate why; hardly reproducible locally
-        test.addUnsupportedPlatform(MySQLPlatform.class);
         addTest(test);
     }
 


### PR DESCRIPTION
I think, that behind this test failure is some race condition with another test. It seems, that due a parallel test execution there are values in the DB tables which leads, that query in the test returns at least one row. But this test is focused on `ExpressionBuilder` syntax and doesn't expect any rows from DB. Additional condition/criteria ensures, that nothing is selected.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>