### PR TITLE
 ConcurrencyManager dead-lock detection diagnostic improvement 2.0 - semaphores

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/PersistenceUnitProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/PersistenceUnitProperties.java
@@ -60,6 +60,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
@@ -4001,6 +4002,78 @@ public class PersistenceUnitProperties {
      * </ul>
      */
     public static final String CONCURRENCY_MANAGER_ALLOW_STACK_TRACE_READ_LOCK = "eclipselink.concurrency.manager.allow.readlockstacktrace";
+
+    /**
+     * <p>
+     * This property control (enable/disable) semaphore in {@link org.eclipse.persistence.internal.descriptors.ObjectBuilder}
+     * </p>
+     * Object building see {@link org.eclipse.persistence.internal.descriptors.ObjectBuilder} could be one of the
+     * primary sources pressure on concurrency manager. Most of the cache key acquisition and releasing is taking place during object building.
+     * Enable <code>true</code> this property to try reduce the likelihood of having dead locks is to allow less threads to start object
+     * building in parallel. In this case there should be negative impact to the performance.
+     * Note: Parallel access to the same entity/entity tree from different threads is not recommended technique in EclipseLink.
+     * <ul>
+     * <li>"<code>true</code>" - means we want to override vanilla behavior and use a semaphore to not allow too many
+     * threads in parallel to do object building
+     * <li>"<code>false</code>" (DEFAULT) - means just go ahead and try to build the object without any semaphore (false is
+     * vanilla behavior).
+     * </ul>
+     */
+    public static final String CONCURRENCY_MANAGER_USE_SEMAPHORE_TO_SLOW_DOWN_OBJECT_BUILDING = "eclipselink.concurrency.manager.object.building.semaphore";
+
+    /**
+     * <p>
+     * This property control (enable/disable) semaphore in {@link org.eclipse.persistence.internal.helper.WriteLockManager#acquireRequiredLocks}
+     * </p>
+     * This algorithm
+     * {@link org.eclipse.persistence.internal.helper.WriteLockManager#acquireRequiredLocks}
+     * is being used when a transaction is committing and it is acquire locks to merge the change set.
+     * It should happen if algorithm has trouble when multiple threads report change sets on the same entity (e.g.
+     * one-to-many relations of master detail being enriched with more details on this master).
+     * Note: Parallel access to the same entity/entity tree from different threads is not recommended technique in EclipseLink.
+     * <ul>
+     * <li>"<code>true</code>" - means we want to override vanilla behavior and use a semaphore to not allow too many
+     * threads. In this case there should be negative impact to the performance.
+     * <li>"<code>false</code>" (DEFAULT) - means just go ahead and try to build the object without any semaphore (false is
+     * vanilla behavior).
+     * </ul>
+     */
+    public static final String CONCURRENCY_MANAGER_USE_SEMAPHORE_TO_SLOW_DOWN_WRITE_LOCK_MANAGER_ACQUIRE_REQUIRED_LOCKS = "eclipselink.concurrency.manager.write.lock.manager.semaphore";
+
+    /**
+     * <p>
+     * This property control number of threads in semaphore in {@link org.eclipse.persistence.internal.descriptors.ObjectBuilder}
+     * If "eclipselink.concurrency.manager.object.building.semaphore" property is <code>true</code> default value is 10. Allowed values are: int
+     * If "eclipselink.concurrency.manager.object.building.semaphore" property is <code>false</code> (DEFAULT) number of threads is unlimited.
+     * </p>
+     */
+    public static final String CONCURRENCY_MANAGER_OBJECT_BUILDING_NO_THREADS = "eclipselink.concurrency.manager.object.building.no.threads";
+
+    /**
+     * <p>
+     * This property control number of threads in semaphore in {@link org.eclipse.persistence.internal.helper.WriteLockManager#acquireRequiredLocks}
+     * If "eclipselink.concurrency.manager.write.lock.manager.semaphore" property is <code>true</code> default value is 2. Allowed values are: int
+     * If "eclipselink.concurrency.manager.write.lock.manager.semaphore" property is <code>false</code> (DEFAULT) number of threads is unlimited.
+     * </p>
+     */
+    public static final String CONCURRENCY_MANAGER_WRITE_LOCK_MANAGER_ACQUIRE_REQUIRED_LOCKS_NO_THREADS = "eclipselink.concurrency.manager.write.lock.manager.no.threads";
+
+    /**
+     * <p>
+     * This property control semaphore the maximum time to wait for a permit in {@link org.eclipse.persistence.internal.helper.ConcurrencySemaphore#acquireSemaphoreIfAppropriate(boolean)}
+     * It's passed to {@link java.util.concurrent.Semaphore#tryAcquire(long, TimeUnit)}
+     * Default value is 2000 (unit is ms). Allowed values are: long
+     * </p>
+     */
+    public static final String CONCURRENCY_SEMAPHORE_MAX_TIME_PERMIT = "eclipselink.concurrency.semaphore.max.time.permit";
+
+    /**
+     * <p>
+     * This property control timeout between log messages in {@link org.eclipse.persistence.internal.helper.ConcurrencySemaphore#acquireSemaphoreIfAppropriate(boolean)} when method/thread tries to get permit for the execution.
+     * Default value is 10000 (unit is ms). Allowed values are: long
+     * </p>
+     */
+    public static final String CONCURRENCY_SEMAPHORE_LOG_TIMEOUT = "eclipselink.concurrency.semaphore.log.timeout";
 
     /**
      * INTERNAL: The following properties will not be displayed through logging

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/SystemProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/SystemProperties.java
@@ -16,6 +16,8 @@
 //       - 538296: Wrong month is returned if OffsetDateTime is used in JPA 2.2 code
 package org.eclipse.persistence.config;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * This class provides the list of System properties that are recognized by EclipseLink.
  * @author tware
@@ -183,4 +185,76 @@ public class SystemProperties {
      * </ul>
      */
     public static final String CONCURRENCY_MANAGER_ALLOW_STACK_TRACE_READ_LOCK = "eclipselink.concurrency.manager.allow.readlockstacktrace";
+
+    /**
+     * <p>
+     * This property control (enable/disable) semaphore in {@link org.eclipse.persistence.internal.descriptors.ObjectBuilder}
+     * </p>
+     * Object building see {@link org.eclipse.persistence.internal.descriptors.ObjectBuilder} could be one of the
+     * primary sources pressure on concurrency manager. Most of the cache key acquisition and releasing is taking place during object building.
+     * Enable <code>true</code> this property to try reduce the likelihood of having dead locks is to allow less threads to start object
+     * building in parallel. In this case there should be negative impact to the performance.
+     * Note: Parallel access to the same entity/entity tree from different threads is not recommended technique in EclipseLink.
+     * <ul>
+     * <li>"<code>true</code>" - means we want to override vanilla behavior and use a semaphore to not allow too many
+     * threads in parallel to do object building
+     * <li>"<code>false</code>" (DEFAULT) - means just go ahead and try to build the object without any semaphore (false is
+     * vanilla behavior).
+     * </ul>
+     */
+    public static final String CONCURRENCY_MANAGER_USE_SEMAPHORE_TO_SLOW_DOWN_OBJECT_BUILDING = "eclipselink.concurrency.manager.object.building.semaphore";
+
+    /**
+     * <p>
+     * This property control (enable/disable) semaphore in {@link org.eclipse.persistence.internal.helper.WriteLockManager#acquireRequiredLocks}
+     * </p>
+     * This algorithm
+     * {@link org.eclipse.persistence.internal.helper.WriteLockManager#acquireRequiredLocks}
+     * is being used when a transaction is committing and it is acquire locks to merge the change set.
+     * It should happen if algorithm has trouble when multiple threads report change sets on the same entity (e.g.
+     * one-to-many relations of master detail being enriched with more details on this master).
+     * Note: Parallel access to the same entity/entity tree from different threads is not recommended technique in EclipseLink.
+     * <ul>
+     * <li>"<code>true</code>" - means we want to override vanilla behavior and use a semaphore to not allow too many
+     * threads. In this case there should be negative impact to the performance.
+     * <li>"<code>false</code>" (DEFAULT) - means just go ahead and try to build the object without any semaphore (false is
+     * vanilla behavior).
+     * </ul>
+     */
+    public static final String CONCURRENCY_MANAGER_USE_SEMAPHORE_TO_SLOW_DOWN_WRITE_LOCK_MANAGER_ACQUIRE_REQUIRED_LOCKS = "eclipselink.concurrency.manager.write.lock.manager.semaphore";
+
+    /**
+     * <p>
+     * This property control number of threads in semaphore in {@link org.eclipse.persistence.internal.descriptors.ObjectBuilder}
+     * If "eclipselink.concurrency.manager.object.building.semaphore" property is <code>true</code> default value is 10. Allowed values are: int
+     * If "eclipselink.concurrency.manager.object.building.semaphore" property is <code>false</code> (DEFAULT) number of threads is unlimited.
+     * </p>
+     */
+    public static final String CONCURRENCY_MANAGER_OBJECT_BUILDING_NO_THREADS = "eclipselink.concurrency.manager.object.building.no.threads";
+
+    /**
+     * <p>
+     * This property control number of threads in semaphore in {@link org.eclipse.persistence.internal.helper.WriteLockManager#acquireRequiredLocks}
+     * If "eclipselink.concurrency.manager.write.lock.manager.semaphore" property is <code>true</code> default value is 2. Allowed values are: int
+     * If "eclipselink.concurrency.manager.write.lock.manager.semaphore" property is <code>false</code> (DEFAULT) number of threads is unlimited.
+     * </p>
+     */
+    public static final String CONCURRENCY_MANAGER_WRITE_LOCK_MANAGER_ACQUIRE_REQUIRED_LOCKS_NO_THREADS = "eclipselink.concurrency.manager.write.lock.manager.no.threads";
+
+    /**
+     * <p>
+     * This property control semaphore the maximum time to wait for a permit in {@link org.eclipse.persistence.internal.helper.ConcurrencySemaphore#acquireSemaphoreIfAppropriate(boolean)}
+     * It's passed to {@link java.util.concurrent.Semaphore#tryAcquire(long, TimeUnit)}
+     * Default value is 2000 (unit is ms). Allowed values are: long
+     * </p>
+     */
+    public static final String CONCURRENCY_SEMAPHORE_MAX_TIME_PERMIT = "eclipselink.concurrency.semaphore.max.time.permit";
+
+    /**
+     * <p>
+     * This property control timeout between log messages in {@link org.eclipse.persistence.internal.helper.ConcurrencySemaphore#acquireSemaphoreIfAppropriate(boolean)} when method/thread tries to get permit for the execution.
+     * Default value is 10000 (unit is ms). Allowed values are: long
+     * </p>
+     */
+    public static final String CONCURRENCY_SEMAPHORE_LOG_TIMEOUT = "eclipselink.concurrency.semaphore.log.timeout";
 }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/descriptors/ObjectBuilder.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/descriptors/ObjectBuilder.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Vector;
+import java.util.concurrent.Semaphore;
 
 import org.eclipse.persistence.annotations.BatchFetchType;
 import org.eclipse.persistence.annotations.CacheKeyType;
@@ -71,6 +72,8 @@ import org.eclipse.persistence.internal.databaseaccess.Platform;
 import org.eclipse.persistence.internal.expressions.ObjectExpression;
 import org.eclipse.persistence.internal.expressions.QueryKeyExpression;
 import org.eclipse.persistence.internal.expressions.SQLSelectStatement;
+import org.eclipse.persistence.internal.helper.ConcurrencySemaphore;
+import org.eclipse.persistence.internal.helper.ConcurrencyUtil;
 import org.eclipse.persistence.internal.helper.DatabaseField;
 import org.eclipse.persistence.internal.helper.DatabaseTable;
 import org.eclipse.persistence.internal.helper.Helper;
@@ -181,6 +184,11 @@ public class ObjectBuilder extends CoreObjectBuilder<AbstractRecord, AbstractSes
     protected boolean shouldKeepRow = false;
     /** PERF: is there an cache index field that's would not be selected by SOP query. Ignored unless descriptor uses SOP and CachePolicy has cache indexes. */
     protected boolean hasCacheIndexesInSopObject = false;
+    /** Semaphore related properties. Transient to avoid serialization in clustered/replicated environments see CORBA tests*/
+    private static final transient ThreadLocal<Boolean> SEMAPHORE_THREAD_LOCAL_VAR = new ThreadLocal<>();
+    private static final transient int SEMAPHORE_MAX_NUMBER_THREADS = ConcurrencyUtil.SINGLETON.getNoOfThreadsAllowedToObjectBuildInParallel();
+    private static final transient Semaphore SEMAPHORE_LIMIT_MAX_NUMBER_OF_THREADS_OBJECT_BUILDING = new Semaphore(SEMAPHORE_MAX_NUMBER_THREADS);
+    private transient ConcurrencySemaphore objectBuilderSemaphore = new ConcurrencySemaphore(SEMAPHORE_THREAD_LOCAL_VAR, SEMAPHORE_MAX_NUMBER_THREADS, SEMAPHORE_LIMIT_MAX_NUMBER_OF_THREADS_OBJECT_BUILDING, this, "object_builder_semaphore_acquired_01");
 
     public ObjectBuilder(ClassDescriptor descriptor) {
         this.descriptor = descriptor;
@@ -761,8 +769,29 @@ public class ObjectBuilder extends CoreObjectBuilder<AbstractRecord, AbstractSes
     /**
      * Return an instance of the receivers javaClass. Set the attributes of an instance
      * from the values stored in the database row.
+     * This is wrapper method with semaphore logic.
      */
     public Object buildObject(ObjectBuildingQuery query, AbstractRecord databaseRow, JoinedAttributeManager joinManager,
+                              AbstractSession session, ClassDescriptor concreteDescriptor, InheritancePolicy inheritancePolicy, boolean isUnitOfWork,
+                              boolean shouldCacheQueryResults, boolean shouldUseWrapperPolicy) {
+        boolean semaphoreWasAcquired = false;
+        boolean useSemaphore = ConcurrencyUtil.SINGLETON.isUseSemaphoreInObjectBuilder();
+        if (objectBuilderSemaphore == null) {
+            objectBuilderSemaphore = new ConcurrencySemaphore(SEMAPHORE_THREAD_LOCAL_VAR, SEMAPHORE_MAX_NUMBER_THREADS, SEMAPHORE_LIMIT_MAX_NUMBER_OF_THREADS_OBJECT_BUILDING, this, "object_builder_semaphore_acquired_01");
+        }
+        try {
+            semaphoreWasAcquired = objectBuilderSemaphore.acquireSemaphoreIfAppropriate(useSemaphore);
+            return buildObjectInternal(query, databaseRow, joinManager, session, concreteDescriptor, inheritancePolicy, isUnitOfWork, shouldCacheQueryResults, shouldUseWrapperPolicy);
+        } finally {
+            objectBuilderSemaphore.releaseSemaphoreAllowOtherThreadsToStartDoingObjectBuilding(semaphoreWasAcquired);
+        }
+    }
+
+    /**
+     * Return an instance of the receivers javaClass. Set the attributes of an instance
+     * from the values stored in the database row.
+     */
+    private Object buildObjectInternal(ObjectBuildingQuery query, AbstractRecord databaseRow, JoinedAttributeManager joinManager,
             AbstractSession session, ClassDescriptor concreteDescriptor, InheritancePolicy inheritancePolicy, boolean isUnitOfWork,
             boolean shouldCacheQueryResults, boolean shouldUseWrapperPolicy) {
         Object domainObject = null;
@@ -2350,8 +2379,30 @@ public class ObjectBuilder extends CoreObjectBuilder<AbstractRecord, AbstractSes
      * PERF: This method is optimized for a specific case of building objects
      * so can avoid many of the normal checks, only queries that have this criteria
      * can use this method of building objects.
+     * This is wrapper method with semaphore logic.
      */
     public Object buildObjectFromResultSet(ObjectBuildingQuery query, JoinedAttributeManager joinManager, ResultSet resultSet, AbstractSession executionSession, DatabaseAccessor accessor, ResultSetMetaData metaData, DatabasePlatform platform, Vector fieldsList, DatabaseField[] fieldsArray) throws SQLException {
+        boolean semaphoreWasAcquired = false;
+        boolean useSemaphore = ConcurrencyUtil.SINGLETON.isUseSemaphoreInObjectBuilder();
+        if (objectBuilderSemaphore == null) {
+            objectBuilderSemaphore = new ConcurrencySemaphore(SEMAPHORE_THREAD_LOCAL_VAR, SEMAPHORE_MAX_NUMBER_THREADS, SEMAPHORE_LIMIT_MAX_NUMBER_OF_THREADS_OBJECT_BUILDING, this, "object_builder_semaphore_acquired_01");
+        }
+        try {
+            semaphoreWasAcquired = objectBuilderSemaphore.acquireSemaphoreIfAppropriate(useSemaphore);
+            return buildObjectFromResultSetInternal(query, joinManager, resultSet, executionSession, accessor, metaData, platform, fieldsList, fieldsArray);
+        } finally {
+            objectBuilderSemaphore.releaseSemaphoreAllowOtherThreadsToStartDoingObjectBuilding(semaphoreWasAcquired);
+        }
+    }
+
+    /**
+     * INTERNAL:
+     * Builds a working copy clone directly from a result set.
+     * PERF: This method is optimized for a specific case of building objects
+     * so can avoid many of the normal checks, only queries that have this criteria
+     * can use this method of building objects.
+     */
+    private Object buildObjectFromResultSetInternal(ObjectBuildingQuery query, JoinedAttributeManager joinManager, ResultSet resultSet, AbstractSession executionSession, DatabaseAccessor accessor, ResultSetMetaData metaData, DatabasePlatform platform, Vector fieldsList, DatabaseField[] fieldsArray) throws SQLException {
         ClassDescriptor descriptor = this.descriptor;
         int pkFieldsSize = descriptor.getPrimaryKeyFields().size();
         DatabaseMapping primaryKeyMapping = null;

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ConcurrencyManager.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ConcurrencyManager.java
@@ -15,6 +15,7 @@
 package org.eclipse.persistence.internal.helper;
 
 import java.io.Serializable;
+import java.io.StringWriter;
 import java.security.AccessController;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -771,12 +772,14 @@ public class ConcurrencyManager implements Serializable {
         //When this method is invoked during an acquire lock sometimes there is no lock manager
         if (lockManager == null) {
             String cacheKeyToString = ConcurrencyUtil.SINGLETON.createToStringExplainingOwnedCacheKey(this);
-            AbstractSessionLog.getLog().log(SessionLog.SEVERE, SessionLog.CACHE,"concurrency_manager_release_locks_acquired_by_thread_1", currentThread.getName(), cacheKeyToString);
+            StringWriter writer = new StringWriter();
+            writer.write(TraceLocalization.buildMessage("concurrency_manager_release_locks_acquired_by_thread_1", new Object[] {currentThread.getName(), cacheKeyToString}));
+            AbstractSessionLog.getLog().log(SessionLog.SEVERE, SessionLog.CACHE, writer.toString(), new Object[] {}, false);
             return;
         }
-
-        //Release the active locks on the thread
-        AbstractSessionLog.getLog().log(SessionLog.SEVERE, SessionLog.CACHE,"concurrency_manager_release_locks_acquired_by_thread_2", currentThread.toString());
+        StringWriter writer = new StringWriter();
+        writer.write(TraceLocalization.buildMessage("concurrency_manager_release_locks_acquired_by_thread_2", new Object[] {currentThread.toString()}));
+        AbstractSessionLog.getLog().log(SessionLog.SEVERE, SessionLog.CACHE, writer.toString(), new Object[] {}, false);
         lockManager.releaseActiveLocksOnThread();
         removeDeferredLockManager(currentThread);
     }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ConcurrencySemaphore.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ConcurrencySemaphore.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.internal.helper;
+
+import org.eclipse.persistence.exceptions.ConcurrencyException;
+import org.eclipse.persistence.internal.localization.TraceLocalization;
+import org.eclipse.persistence.logging.AbstractSessionLog;
+import org.eclipse.persistence.logging.SessionLog;
+
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+public class ConcurrencySemaphore {
+
+    private final long MAX_TIME_PERMIT = ConcurrencyUtil.SINGLETON.getConcurrencySemaphoreMaxTimePermit();
+    private final long TIMEOUT_BETWEEN_LOG_MESSAGES = ConcurrencyUtil.SINGLETON.getConcurrencySemaphoreLogTimeout();
+
+    private ThreadLocal<Boolean> threadLocal;
+    private int noOfThreads;
+    private Semaphore semaphore;
+    private String logMessageKey;
+    private Object outerObject;
+
+    /**
+     * Constructor to create {@link #ConcurrencySemaphore}
+     * @param threadLocalVarControlIfCurrentThreadHasAcquiredSemaphore
+     *          Thread local variable that the code to acquire a semaphore can check to make sure it does not try to acquire
+     *          twice the same semaphore (e.g. in case the object building algorithm is recursive).
+     * @param noOfThreadsAllowedToExecuteInParallel
+     *          Max number of threads to acquire semaphore.
+     * @param semaphoreOfThreadsAllowedToExecuteInParallel
+     *          Semaphore used to control.
+     * @param outerObject
+     *          Reference to outer object where is this semaphore used.
+     * @param logMessageKey
+     *          Log message key from {@link org.eclipse.persistence.internal.localization.TraceLocalization}
+     */
+    public ConcurrencySemaphore(ThreadLocal<Boolean> threadLocalVarControlIfCurrentThreadHasAcquiredSemaphore, int noOfThreadsAllowedToExecuteInParallel, Semaphore semaphoreOfThreadsAllowedToExecuteInParallel, Object outerObject, String logMessageKey) {
+        this.threadLocal = threadLocalVarControlIfCurrentThreadHasAcquiredSemaphore;
+        this.noOfThreads = noOfThreadsAllowedToExecuteInParallel;
+        this.semaphore = semaphoreOfThreadsAllowedToExecuteInParallel;
+        this.outerObject = outerObject;
+        this.logMessageKey = logMessageKey;
+    }
+
+    /**
+     * Do nothing if the semaphore has already been acquired by this thread in a higher recursive call or if the
+     * configuration to acquire the slow down semaphore is not active. Otherwise, try to acquire the semaphore
+     * @param useSemaphore
+     *         TRUE to use semaphore, FALSE don't use it.
+     * @return FALSE is returned if we do not want to be using the semaphore. FALSE is also returned if the current
+     *         thread has acquire the semaphore in an upper level recursive stack call. TRUE is returned if and only
+     *         using the semaphore is desired and we succeed acquiring the semaphore.
+     *
+     */
+    public boolean acquireSemaphoreIfAppropriate(boolean useSemaphore) {
+        // (a) If configuration is saying to not use semaphore and go vanilla there is nothing for us to do
+        boolean useSemaphoreToSlowDown = useSemaphore;
+        if (!useSemaphoreToSlowDown) {
+            return false;
+        }
+
+        // (b) The project is afraid of dead locks and does not allow acquire semaphore at the same time
+        // bottleneck slow down thread execution
+        // scenario 1:
+        // check if this thread has already acquired the semaphore in this call
+        Boolean currentThreadHasAcquiredSemaphoreAlready = threadLocal.get();
+        if (Boolean.TRUE.equals(currentThreadHasAcquiredSemaphoreAlready)) {
+            // don't allow this thread to acquire a second time the same semaphore it has done it already
+            return false;
+        }
+        // try to acquire the semaphore being careful with possible blow ups of thread interrupted
+        // Scenario 2:
+        // In this possibly recursive call stack this is the first time the current thread tries to acquire the semaphore to go build an object
+        boolean successAcquiringSemaphore = false;
+        // this thread will go nowhere until it manages to acquire semaphore that allows to continue with execution
+        // this should not only reduce the risk of dead locks but also if dead locks occur in the concurrency manager layer we will have a lot fewer threads making noise (easier to analyze locks)
+        // being part of the same dead lock
+        final long startTimeAttemptingToAcquireSemaphoreMillis = System.currentTimeMillis();
+        long dateWhenWeLastSpammedServerLogAboutNotBeingAbleToAcquireOurSemaphore = startTimeAttemptingToAcquireSemaphoreMillis;
+        try {
+            successAcquiringSemaphore = semaphore.tryAcquire(MAX_TIME_PERMIT, TimeUnit.MILLISECONDS);
+            while (!successAcquiringSemaphore) {
+                // (i) check if ten seconds or more have passed
+                long whileCurrentTimeMillis = System.currentTimeMillis();
+                long elapsedTime = whileCurrentTimeMillis - dateWhenWeLastSpammedServerLogAboutNotBeingAbleToAcquireOurSemaphore;
+                if (elapsedTime > TIMEOUT_BETWEEN_LOG_MESSAGES) {
+                    String outerObjectString = outerObject.toString();
+                    String threadName = Thread.currentThread().getName();
+                    // spam a message into the server log this will be helpful
+                    String logMessage = TraceLocalization.buildMessage(logMessageKey, new Object[] {threadName, startTimeAttemptingToAcquireSemaphoreMillis, noOfThreads, outerObjectString});
+                    AbstractSessionLog.getLog().log(SessionLog.SEVERE, SessionLog.CACHE, logMessage, threadName);
+                    dateWhenWeLastSpammedServerLogAboutNotBeingAbleToAcquireOurSemaphore = whileCurrentTimeMillis;
+                }
+                // (ii) To avoid spamming the log every time lets update the data of when we last spammed the log
+                successAcquiringSemaphore = semaphore.tryAcquire(MAX_TIME_PERMIT, TimeUnit.MILLISECONDS);
+            }
+        } catch (InterruptedException interrupted) {
+            // If we are interrupted while trying to do object building log that we have been interrupted here
+            AbstractSessionLog.getLog().logThrowable(SessionLog.SEVERE, SessionLog.CACHE, interrupted);
+            throw ConcurrencyException.waitWasInterrupted(interrupted.getMessage());
+        } finally {
+            // (d) Before we leave this method regardless of a blow up or not always store in the thread local variable the accurate state of the successAcquiringSemaphore
+            threadLocal.set(successAcquiringSemaphore);
+        }
+        // (d) the final result
+        return successAcquiringSemaphore;
+    }
+
+    /**
+     * If the call to
+     * {@link #acquireSemaphoreIfAppropriate(boolean)}
+     * returned true implying the current thread acquire the semaphore, the same thread on the same method is mandated
+     * to release the semaphore.
+     * @param semaphoreWasAcquired
+     *            flag that tells us if the current thread had successfully acquired semaphore if the flag is true then
+     *            the semaphore will be released and given resources again.
+     */
+    public void releaseSemaphoreAllowOtherThreadsToStartDoingObjectBuilding(boolean semaphoreWasAcquired) {
+        if (semaphoreWasAcquired) {
+            // release the semaphore resource for the current thread
+            semaphore.release();
+            // ensure the thread local variable is cleaned up to indicate that the thread was not yet acquired
+            // the semaphore and would need to do so
+            threadLocal.set(Boolean.FALSE);
+        }
+    }
+}

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ExplainDeadLockUtil.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ExplainDeadLockUtil.java
@@ -16,9 +16,11 @@ import org.eclipse.persistence.internal.helper.type.CacheKeyToThreadRelationship
 import org.eclipse.persistence.internal.helper.type.ConcurrencyManagerState;
 import org.eclipse.persistence.internal.helper.type.DeadLockComponent;
 import org.eclipse.persistence.internal.helper.type.IsBuildObjectCompleteOutcome;
+import org.eclipse.persistence.internal.localization.TraceLocalization;
 import org.eclipse.persistence.logging.AbstractSessionLog;
 import org.eclipse.persistence.logging.SessionLog;
 
+import java.io.StringWriter;
 import java.util.*;
 
 import static java.lang.String.format;
@@ -735,11 +737,13 @@ public class ExplainDeadLockUtil {
                 // this cache key has an active thread that seems to not be tracked by our
                 // ConcurrencyManagerState
                 //
-                AbstractSessionLog.getLog().log(SessionLog.WARNING, SessionLog.CACHE, "explain_dead_lock_util_current_thread_blocked_active_thread_warning",
+                StringWriter writer = new StringWriter();
+                writer.write(TraceLocalization.buildMessage("explain_dead_lock_util_current_thread_blocked_active_thread_warning",
                         new Object[] {nextCandidateThreadPartOfTheDeadLock.getName(),
                         currentCandidateThreadPartOfTheDeadLock.getName(),
                         ConcurrencyUtil.SINGLETON.createToStringExplainingOwnedCacheKey(
-                        cacheKeyThreadWantsToAcquireButCannotGet)});
+                        cacheKeyThreadWantsToAcquireButCannotGet)}));
+                AbstractSessionLog.getLog().log(SessionLog.WARNING, SessionLog.CACHE, writer.toString(), new Object[] {}, false);
                 return DEAD_LOCK_NOT_FOUND;
             } else {
                 // The active thread on the cache key is needing some resources we are tracing
@@ -805,8 +809,9 @@ public class ExplainDeadLockUtil {
         // the only case where it would make sense for this to be null is if the current candidate is actually making progress and
         // was stuck for only a short period
         if(result == null) {
-            AbstractSessionLog.getLog().log(SessionLog.WARNING, SessionLog.CACHE, "explain_dead_lock_util_thread_stuck_deferred_locks",
-                    new Object[] {currentCandidateThreadPartOfTheDeadLock.getName()});
+            StringWriter writer = new StringWriter();
+            writer.write(TraceLocalization.buildMessage("explain_dead_lock_util_thread_stuck_deferred_locks", new Object[] {currentCandidateThreadPartOfTheDeadLock.getName()}));
+            AbstractSessionLog.getLog().log(SessionLog.WARNING, SessionLog.CACHE, writer.toString(), new Object[] {}, false);
             return DEAD_LOCK_NOT_FOUND;
         }
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/TraceLocalizationResource.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/TraceLocalizationResource.java
@@ -106,8 +106,8 @@ public class TraceLocalizationResource extends ListResourceBundle {
         { "acquiring_deferred_lock", "Thread \"{1}\" has acquired a deferred lock on object : {0} in order to avoid deadlock." },
         { "dead_lock_encountered_on_write", "Thread \"{1}\" encountered deadlock when attempting to lock : {0}.  Entering deadlock avoidance algorithm." },
         { "dead_lock_encountered_on_write_no_cache_key", "Thread \"{2}\" encountered deadlock when attempting to lock object of class: {0} with PK {1}.  Entering deadlock avoidance algorithm." },
-        { "concurrency_manager_release_locks_acquired_by_thread_1", "releaseAllLocksAcquiredByThread: Thread \"{1}\"  .The Lock manager is null. This might be an acquire operation. So not possible to lockManager.releaseActiveLocksOnThread(). Cache Key:  \"{2}\"" },
-        { "concurrency_manager_release_locks_acquired_by_thread_2", "releaseAllLocksAcquiredByThread: Release active locks on Thread \"{1}\"" },
+        { "concurrency_manager_release_locks_acquired_by_thread_1", "releaseAllLocksAcquiredByThread: Thread \"{0}\"  .The Lock manager is null. This might be an acquire operation. So not possible to lockManager.releaseActiveLocksOnThread(). Cache Key:  \"{1}\"" },
+        { "concurrency_manager_release_locks_acquired_by_thread_2", "releaseAllLocksAcquiredByThread: Release active locks on Thread \"{0}\"" },
         { "concurrency_manager_build_object_thread_complete_1", "isBuildObjectComplete ExpandedThread NR  {0}: {1} \n" },
         { "concurrency_manager_build_object_thread_complete_2", "\nAll threads in this stack are doing object building and needed to defer on one or more cache keys.\n"
                 + "The last thread has deferred lock on ac cache key that is acquired by thread that is not yet finished with its work. \n\n"},

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/cachedeadlock/CacheDeadLockDetectionTest.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/cachedeadlock/CacheDeadLockDetectionTest.java
@@ -26,6 +26,7 @@ import org.eclipse.persistence.jpa.test.cachedeadlock.model.CacheDeadLockDetecti
 import org.eclipse.persistence.jpa.test.cachedeadlock.cdi.event.EventProducer;
 
 import org.eclipse.persistence.sessions.DatabaseSession;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
@@ -33,6 +34,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 public class CacheDeadLockDetectionTest {
 
@@ -40,6 +42,7 @@ public class CacheDeadLockDetectionTest {
     public static final int NO_OF_THREADS = 100;
 
     public static EntityManagerFactory emf = Persistence.createEntityManagerFactory("cachedeadlockdetection-pu");
+    public static EntityManagerFactory emfSemaphore = Persistence.createEntityManagerFactory("cachedeadlocksemaphore-pu");
 
     SeContainer container;
 
@@ -62,12 +65,33 @@ public class CacheDeadLockDetectionTest {
                 em.getTransaction().rollback();
             }
         }
+        threadExecution(em);
+        try {
+            Thread.currentThread().sleep(7000L);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        System.out.println("##########################Test with semaphores - begin###########################");
+        EntityManager emSemaphore = emfSemaphore.createEntityManager();
+        verifySemaphoreProperties();
+        threadExecution(emSemaphore);
+        System.out.println("##########################Test with semaphores - end###########################");
+    }
 
+    private void threadExecution(EntityManager em) {
         ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(NO_OF_THREADS);
         for (int i = 1; i <= NO_OF_THREADS; i++) {
             Thread thread = new Thread(new MainThread(container, emf, em));
             thread.setName("MainThread: " + i);
             executor.execute(thread);
+        }
+        executor.shutdown();
+        // Wait for everything to finish.
+        try {
+            executor.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+            Assert.fail();
         }
     }
 
@@ -122,11 +146,27 @@ public class CacheDeadLockDetectionTest {
     private void verifyPersistenceProperties() {
         assertEquals(1L, ConcurrencyUtil.SINGLETON.getAcquireWaitTime());
         assertEquals(2L, ConcurrencyUtil.SINGLETON.getMaxAllowedSleepTime());
-        assertEquals(3L, ConcurrencyUtil.SINGLETON.getMaxAllowedFrequencyToProduceTinyDumpLogMessage());
-        assertEquals(4L, ConcurrencyUtil.SINGLETON.getMaxAllowedFrequencyToProduceMassiveDumpLogMessage());
+        assertEquals(800L, ConcurrencyUtil.SINGLETON.getMaxAllowedFrequencyToProduceTinyDumpLogMessage());
+        assertEquals(1000L, ConcurrencyUtil.SINGLETON.getMaxAllowedFrequencyToProduceMassiveDumpLogMessage());
         assertEquals(5L, ConcurrencyUtil.SINGLETON.getBuildObjectCompleteWaitTime());
         assertTrue(ConcurrencyUtil.SINGLETON.isAllowTakingStackTraceDuringReadLockAcquisition());
         assertTrue(ConcurrencyUtil.SINGLETON.isAllowConcurrencyExceptionToBeFiredUp());
         assertTrue(ConcurrencyUtil.SINGLETON.isAllowInterruptedExceptionFired());
+    }
+
+    private void verifySemaphoreProperties() {
+        assertEquals(1L, ConcurrencyUtil.SINGLETON.getAcquireWaitTime());
+        assertEquals(2L, ConcurrencyUtil.SINGLETON.getMaxAllowedSleepTime());
+        assertEquals(1000L, ConcurrencyUtil.SINGLETON.getMaxAllowedFrequencyToProduceTinyDumpLogMessage());
+        assertEquals(2000L, ConcurrencyUtil.SINGLETON.getMaxAllowedFrequencyToProduceMassiveDumpLogMessage());
+        assertTrue(ConcurrencyUtil.SINGLETON.isAllowTakingStackTraceDuringReadLockAcquisition());
+        assertTrue(ConcurrencyUtil.SINGLETON.isAllowConcurrencyExceptionToBeFiredUp());
+        assertTrue(ConcurrencyUtil.SINGLETON.isAllowInterruptedExceptionFired());
+        assertTrue(ConcurrencyUtil.SINGLETON.isUseSemaphoreInObjectBuilder());
+        assertEquals(5L, ConcurrencyUtil.SINGLETON.getNoOfThreadsAllowedToObjectBuildInParallel());
+        assertTrue(ConcurrencyUtil.SINGLETON.isUseSemaphoreToLimitConcurrencyOnWriteLockManagerAcquireRequiredLocks());
+        assertEquals(6L, ConcurrencyUtil.SINGLETON.getNoOfThreadsAllowedToDoWriteLockManagerAcquireRequiredLocksInParallel());
+        assertEquals(7L, ConcurrencyUtil.SINGLETON.getConcurrencySemaphoreMaxTimePermit());
+        assertEquals(8L, ConcurrencyUtil.SINGLETON.getConcurrencySemaphoreLogTimeout());
     }
 }

--- a/jpa/eclipselink.jpa.test.jse/src/it/resources/META-INF/persistence.xml
+++ b/jpa/eclipselink.jpa.test.jse/src/it/resources/META-INF/persistence.xml
@@ -69,12 +69,34 @@
           <properties>
                <property name="eclipselink.concurrency.manager.waittime" value="1"/>
                <property name="eclipselink.concurrency.manager.maxsleeptime" value="2"/>
-               <property name="eclipselink.concurrency.manager.maxfrequencytodumptinymessage" value="3"/>
-               <property name="eclipselink.concurrency.manager.maxfrequencytodumpmassivemessage" value="4"/>
+               <property name="eclipselink.concurrency.manager.maxfrequencytodumptinymessage" value="800"/>
+               <property name="eclipselink.concurrency.manager.maxfrequencytodumpmassivemessage" value="1000"/>
                <property name="eclipselink.concurrency.manager.build.object.complete.waittime" value="5"/>
                <property name="eclipselink.concurrency.manager.allow.readlockstacktrace" value="true"/>
                <property name="eclipselink.concurrency.manager.allow.concurrencyexception" value="true"/>
                <property name="eclipselink.concurrency.manager.allow.interruptedexception" value="true"/>
+          </properties>
+     </persistence-unit>
+
+     <persistence-unit name="cachedeadlocksemaphore-pu" transaction-type="RESOURCE_LOCAL">
+          <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+          <exclude-unlisted-classes>true</exclude-unlisted-classes>
+          <class>org.eclipse.persistence.jpa.test.cachedeadlock.model.CacheDeadLockDetectionMaster</class>
+          <class>org.eclipse.persistence.jpa.test.cachedeadlock.model.CacheDeadLockDetectionDetail</class>
+          <properties>
+               <property name="eclipselink.concurrency.manager.waittime" value="1"/>
+               <property name="eclipselink.concurrency.manager.maxsleeptime" value="2"/>
+               <property name="eclipselink.concurrency.manager.maxfrequencytodumptinymessage" value="1000"/>
+               <property name="eclipselink.concurrency.manager.maxfrequencytodumpmassivemessage" value="2000"/>
+               <property name="eclipselink.concurrency.manager.allow.readlockstacktrace" value="true"/>
+               <property name="eclipselink.concurrency.manager.allow.concurrencyexception" value="true"/>
+               <property name="eclipselink.concurrency.manager.allow.interruptedexception" value="true"/>
+               <property name="eclipselink.concurrency.manager.object.building.semaphore" value="true"/>
+               <property name="eclipselink.concurrency.manager.object.building.no.threads" value="5"/>
+               <property name="eclipselink.concurrency.manager.write.lock.manager.semaphore" value="true"/>
+               <property name="eclipselink.concurrency.manager.write.lock.manager.no.threads" value="6"/>
+               <property name="eclipselink.concurrency.semaphore.max.time.permit" value="7"/>
+               <property name="eclipselink.concurrency.semaphore.log.timeout" value="8"/>
           </properties>
      </persistence-unit>
 

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
@@ -2919,6 +2919,12 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
             updateConcurrencyManagerAllowInterruptedExceptionFired(m);
             updateConcurrencyManagerAllowConcurrencyExceptionToBeFiredUp(m);
             updateConcurrencyManagerAllowTakingStackTraceDuringReadLockAcquisition(m);
+            updateConcurrencyManagerUseObjectBuildingSemaphore(m);
+            updateConcurrencyManagerUseWriteLockManagerSemaphore(m);
+            updateConcurrencyManagerNoOfThreadsAllowedToObjectBuildInParallel(m);
+            updateConcurrencyManagerNoOfThreadsAllowedToDoWriteLockManagerAcquireRequiredLocksInParallel(m);
+            updateConcurrencySemaphoreMaxTimePermit(m);
+            updateConcurrencySemaphoreLogTimeout(m);
             // Customizers should be processed last
             processDescriptorCustomizers(m, loader);
             processSessionCustomizer(m, loader);
@@ -3836,6 +3842,72 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
             }
         } catch (NumberFormatException exception) {
             this.session.handleException(ValidationException.invalidValueForProperty(allowTakingStackTraceDuringReadLockAcquisition, PersistenceUnitProperties.CONCURRENCY_MANAGER_ALLOW_STACK_TRACE_READ_LOCK, exception));
+        }
+    }
+
+    private void updateConcurrencyManagerUseObjectBuildingSemaphore(Map persistenceProperties) {
+        String useObjectBuildingSemaphore = EntityManagerFactoryProvider.getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.CONCURRENCY_MANAGER_USE_SEMAPHORE_TO_SLOW_DOWN_OBJECT_BUILDING, persistenceProperties, session);
+        try {
+            if (useObjectBuildingSemaphore != null) {
+                ConcurrencyUtil.SINGLETON.setUseSemaphoreInObjectBuilder(Boolean.parseBoolean(useObjectBuildingSemaphore));
+            }
+        } catch (NumberFormatException exception) {
+            this.session.handleException(ValidationException.invalidValueForProperty(useObjectBuildingSemaphore, PersistenceUnitProperties.CONCURRENCY_MANAGER_USE_SEMAPHORE_TO_SLOW_DOWN_OBJECT_BUILDING, exception));
+        }
+    }
+
+    private void updateConcurrencyManagerUseWriteLockManagerSemaphore(Map persistenceProperties) {
+        String useWriteLockManagerSemaphore = EntityManagerFactoryProvider.getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.CONCURRENCY_MANAGER_USE_SEMAPHORE_TO_SLOW_DOWN_WRITE_LOCK_MANAGER_ACQUIRE_REQUIRED_LOCKS, persistenceProperties, session);
+        try {
+            if (useWriteLockManagerSemaphore != null) {
+                ConcurrencyUtil.SINGLETON.setUseSemaphoreToLimitConcurrencyOnWriteLockManagerAcquireRequiredLocks(Boolean.parseBoolean(useWriteLockManagerSemaphore));
+            }
+        } catch (NumberFormatException exception) {
+            this.session.handleException(ValidationException.invalidValueForProperty(useWriteLockManagerSemaphore, PersistenceUnitProperties.CONCURRENCY_MANAGER_USE_SEMAPHORE_TO_SLOW_DOWN_WRITE_LOCK_MANAGER_ACQUIRE_REQUIRED_LOCKS, exception));
+        }
+    }
+
+    private void updateConcurrencyManagerNoOfThreadsAllowedToObjectBuildInParallel(Map persistenceProperties) {
+        String noOfThreadsAllowedToObjectBuildInParallel = EntityManagerFactoryProvider.getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.CONCURRENCY_MANAGER_OBJECT_BUILDING_NO_THREADS, persistenceProperties, session);
+        try {
+            if (noOfThreadsAllowedToObjectBuildInParallel != null) {
+                ConcurrencyUtil.SINGLETON.setNoOfThreadsAllowedToObjectBuildInParallel(Integer.parseInt(noOfThreadsAllowedToObjectBuildInParallel));
+            }
+        } catch (NumberFormatException exception) {
+            this.session.handleException(ValidationException.invalidValueForProperty(noOfThreadsAllowedToObjectBuildInParallel, PersistenceUnitProperties.CONCURRENCY_MANAGER_OBJECT_BUILDING_NO_THREADS, exception));
+        }
+    }
+
+    private void updateConcurrencyManagerNoOfThreadsAllowedToDoWriteLockManagerAcquireRequiredLocksInParallel(Map persistenceProperties) {
+        String noOfThreadsAllowedToDoWriteLockManagerAcquireRequiredLocksInParallel = EntityManagerFactoryProvider.getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.CONCURRENCY_MANAGER_WRITE_LOCK_MANAGER_ACQUIRE_REQUIRED_LOCKS_NO_THREADS, persistenceProperties, session);
+        try {
+            if (noOfThreadsAllowedToDoWriteLockManagerAcquireRequiredLocksInParallel != null) {
+                ConcurrencyUtil.SINGLETON.setNoOfThreadsAllowedToDoWriteLockManagerAcquireRequiredLocksInParallel(Integer.parseInt(noOfThreadsAllowedToDoWriteLockManagerAcquireRequiredLocksInParallel));
+            }
+        } catch (NumberFormatException exception) {
+            this.session.handleException(ValidationException.invalidValueForProperty(noOfThreadsAllowedToDoWriteLockManagerAcquireRequiredLocksInParallel, PersistenceUnitProperties.CONCURRENCY_MANAGER_WRITE_LOCK_MANAGER_ACQUIRE_REQUIRED_LOCKS_NO_THREADS, exception));
+        }
+    }
+
+    private void updateConcurrencySemaphoreMaxTimePermit(Map persistenceProperties) {
+        String concurrencySemaphoreMaxTimePermit = EntityManagerFactoryProvider.getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.CONCURRENCY_SEMAPHORE_MAX_TIME_PERMIT, persistenceProperties, session);
+        try {
+            if (concurrencySemaphoreMaxTimePermit != null) {
+                ConcurrencyUtil.SINGLETON.setConcurrencySemaphoreMaxTimePermit(Long.parseLong(concurrencySemaphoreMaxTimePermit));
+            }
+        } catch (NumberFormatException exception) {
+            this.session.handleException(ValidationException.invalidValueForProperty(concurrencySemaphoreMaxTimePermit, PersistenceUnitProperties.CONCURRENCY_SEMAPHORE_MAX_TIME_PERMIT, exception));
+        }
+    }
+
+    private void updateConcurrencySemaphoreLogTimeout(Map persistenceProperties) {
+        String concurrencySemaphoreLogTimeout = EntityManagerFactoryProvider.getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.CONCURRENCY_SEMAPHORE_LOG_TIMEOUT, persistenceProperties, session);
+        try {
+            if (concurrencySemaphoreLogTimeout != null) {
+                ConcurrencyUtil.SINGLETON.setConcurrencySemaphoreLogTimeout(Long.parseLong(concurrencySemaphoreLogTimeout));
+            }
+        } catch (NumberFormatException exception) {
+            this.session.handleException(ValidationException.invalidValueForProperty(concurrencySemaphoreLogTimeout, PersistenceUnitProperties.CONCURRENCY_SEMAPHORE_LOG_TIMEOUT, exception));
         }
     }
 


### PR DESCRIPTION
This is second part of dead-lock detection diagnostic improvement 2.0 related with previous PR #1038 .
Previous PR content was passive from point of the view of the EclipseLink code execution.
This PR has has active component `org.eclipse.persistence.internal.helper.ConcurrencySemaphore` which should be used to control/limit how many threads should execute selected code.
In this case is `ConcurrencySemaphore` used to limit parallel access to `org.eclipse.persistence.internal.descriptors.ObjectBuilder` and `org.eclipse.persistence.internal.helper.WriteLockManager` to prevent possible dead-lock issues there.
If `ConcurrencySemaphore` will be active, there should be negative impact to the performance.
By default `ConcurrencySemaphore` is disabled and must be enabled by persistence or system properties.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>