### PR TITLE
[2.7] Jenkins build/tests fix - resources increase

### DIFF
--- a/etc/jenkins/build.groovy
+++ b/etc/jenkins/build.groovy
@@ -61,18 +61,18 @@ spec:
   - name: jnlp
     resources:
       limits:
-        memory: "2Gi"
+        memory: "4Gi"
         cpu: "2"
       requests:
-        memory: "2Gi"
+        memory: "4Gi"
         cpu: "1"
   - name: el-build
     resources:
       limits:
-        memory: "10Gi"
+        memory: "12Gi"
         cpu: "6"
       requests:
-        memory: "10Gi"
+        memory: "12Gi"
         cpu: "6"
         cpu: "5.5"
     image: tkraus/el-build:1.1.9

--- a/etc/jenkins/build.groovy
+++ b/etc/jenkins/build.groovy
@@ -69,10 +69,10 @@ spec:
   - name: el-build
     resources:
       limits:
-        memory: "8Gi"
+        memory: "10Gi"
         cpu: "6"
       requests:
-        memory: "8Gi"
+        memory: "10Gi"
         cpu: "6"
         cpu: "5.5"
     image: tkraus/el-build:1.1.9

--- a/etc/jenkins/build.groovy
+++ b/etc/jenkins/build.groovy
@@ -61,11 +61,11 @@ spec:
   - name: jnlp
     resources:
       limits:
-        memory: "1Gi"
-        cpu: "1"
+        memory: "2Gi"
+        cpu: "2"
       requests:
-        memory: "1Gi"
-        cpu: "500m"
+        memory: "2Gi"
+        cpu: "1"
   - name: el-build
     resources:
       limits:

--- a/etc/jenkins/build.groovy
+++ b/etc/jenkins/build.groovy
@@ -69,12 +69,12 @@ spec:
   - name: el-build
     resources:
       limits:
-        memory: "6Gi"
-        cpu: "4"
+        memory: "8Gi"
+        cpu: "6"
       requests:
-        memory: "6Gi"
-        cpu: "4"
-        cpu: "3.5"
+        memory: "8Gi"
+        cpu: "6"
+        cpu: "5.5"
     image: tkraus/el-build:1.1.9
     volumeMounts:
     - name: tools


### PR DESCRIPTION
This is change to prevent SQL timeout errors during build and test execution. It reflects some environment changes done by Eclipse.org admins.