### PR TITLE
[master] Jenkins build/tests fix - resources increase

### DIFF
--- a/etc/jenkins/build.groovy
+++ b/etc/jenkins/build.groovy
@@ -1,5 +1,5 @@
 //
-//  Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+//  Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
 //
 //  This program and the accompanying materials are made available under the
 //  terms of the Eclipse Public License v. 2.0 which is available at
@@ -60,19 +60,19 @@ spec:
   - name: jnlp
     resources:
       limits:
-        memory: "1Gi"
-        cpu: "1"
+        memory: "4Gi"
+        cpu: "2"
       requests:
-        memory: "1Gi"
-        cpu: "500m"
+        memory: "4Gi"
+        cpu: "1"
   - name: el-build
     resources:
       limits:
-        memory: "6Gi"
-        cpu: "4"
+        memory: "12Gi"
+        cpu: "6"
       requests:
-        memory: "6Gi"
-        cpu: "3.5"
+        memory: "12Gi"
+        cpu: "5.5"
     image: tkraus/el-build:1.1.9
     volumeMounts:
     - name: tools


### PR DESCRIPTION
This is change to prevent SQL timeout errors during build and test execution. It reflects some environment changes done by Eclipse.org admins.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>