### PR TITLE
[2.6] ConcurrencyManager dead-lock detection diagnostic improvement (+ Semaphores) 2.0 - backport from master

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/PersistenceUnitProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/PersistenceUnitProperties.java
@@ -51,6 +51,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
@@ -3830,6 +3831,78 @@ public class PersistenceUnitProperties {
      * </ul>
      */
     public static final String CONCURRENCY_MANAGER_ALLOW_STACK_TRACE_READ_LOCK = "eclipselink.concurrency.manager.allow.readlockstacktrace";
+
+    /**
+     * <p>
+     * This property control (enable/disable) semaphore in {@link org.eclipse.persistence.internal.descriptors.ObjectBuilder}
+     * </p>
+     * Object building see {@link org.eclipse.persistence.internal.descriptors.ObjectBuilder} could be one of the
+     * primary sources pressure on concurrency manager. Most of the cache key acquisition and releasing is taking place during object building.
+     * Enable <code>true</code> this property to try reduce the likelihood of having dead locks is to allow less threads to start object
+     * building in parallel. In this case there should be negative impact to the performance.
+     * Note: Parallel access to the same entity/entity tree from different threads is not recommended technique in EclipseLink.
+     * <ul>
+     * <li>"<code>true</code>" - means we want to override vanilla behavior and use a semaphore to not allow too many
+     * threads in parallel to do object building
+     * <li>"<code>false</code>" (DEFAULT) - means just go ahead and try to build the object without any semaphore (false is
+     * vanilla behavior).
+     * </ul>
+     */
+    public static final String CONCURRENCY_MANAGER_USE_SEMAPHORE_TO_SLOW_DOWN_OBJECT_BUILDING = "eclipselink.concurrency.manager.object.building.semaphore";
+
+    /**
+     * <p>
+     * This property control (enable/disable) semaphore in {@link org.eclipse.persistence.internal.helper.WriteLockManager#acquireRequiredLocks}
+     * </p>
+     * This algorithm
+     * {@link org.eclipse.persistence.internal.helper.WriteLockManager#acquireRequiredLocks}
+     * is being used when a transaction is committing and it is acquire locks to merge the change set.
+     * It should happen if algorithm has trouble when multiple threads report change sets on the same entity (e.g.
+     * one-to-many relations of master detail being enriched with more details on this master).
+     * Note: Parallel access to the same entity/entity tree from different threads is not recommended technique in EclipseLink.
+     * <ul>
+     * <li>"<code>true</code>" - means we want to override vanilla behavior and use a semaphore to not allow too many
+     * threads. In this case there should be negative impact to the performance.
+     * <li>"<code>false</code>" (DEFAULT) - means just go ahead and try to build the object without any semaphore (false is
+     * vanilla behavior).
+     * </ul>
+     */
+    public static final String CONCURRENCY_MANAGER_USE_SEMAPHORE_TO_SLOW_DOWN_WRITE_LOCK_MANAGER_ACQUIRE_REQUIRED_LOCKS = "eclipselink.concurrency.manager.write.lock.manager.semaphore";
+
+    /**
+     * <p>
+     * This property control number of threads in semaphore in {@link org.eclipse.persistence.internal.descriptors.ObjectBuilder}
+     * If "eclipselink.concurrency.manager.object.building.semaphore" property is <code>true</code> default value is 10. Allowed values are: int
+     * If "eclipselink.concurrency.manager.object.building.semaphore" property is <code>false</code> (DEFAULT) number of threads is unlimited.
+     * </p>
+     */
+    public static final String CONCURRENCY_MANAGER_OBJECT_BUILDING_NO_THREADS = "eclipselink.concurrency.manager.object.building.no.threads";
+
+    /**
+     * <p>
+     * This property control number of threads in semaphore in {@link org.eclipse.persistence.internal.helper.WriteLockManager#acquireRequiredLocks}
+     * If "eclipselink.concurrency.manager.write.lock.manager.semaphore" property is <code>true</code> default value is 2. Allowed values are: int
+     * If "eclipselink.concurrency.manager.write.lock.manager.semaphore" property is <code>false</code> (DEFAULT) number of threads is unlimited.
+     * </p>
+     */
+    public static final String CONCURRENCY_MANAGER_WRITE_LOCK_MANAGER_ACQUIRE_REQUIRED_LOCKS_NO_THREADS = "eclipselink.concurrency.manager.write.lock.manager.no.threads";
+
+    /**
+     * <p>
+     * This property control semaphore the maximum time to wait for a permit in {@link org.eclipse.persistence.internal.helper.ConcurrencySemaphore#acquireSemaphoreIfAppropriate(boolean)}
+     * It's passed to {@link java.util.concurrent.Semaphore#tryAcquire(long, TimeUnit)}
+     * Default value is 2000 (unit is ms). Allowed values are: long
+     * </p>
+     */
+    public static final String CONCURRENCY_SEMAPHORE_MAX_TIME_PERMIT = "eclipselink.concurrency.semaphore.max.time.permit";
+
+    /**
+     * <p>
+     * This property control timeout between log messages in {@link org.eclipse.persistence.internal.helper.ConcurrencySemaphore#acquireSemaphoreIfAppropriate(boolean)} when method/thread tries to get permit for the execution.
+     * Default value is 10000 (unit is ms). Allowed values are: long
+     * </p>
+     */
+    public static final String CONCURRENCY_SEMAPHORE_LOG_TIMEOUT = "eclipselink.concurrency.semaphore.log.timeout";
 
     /**
      * INTERNAL: The following properties will not be displayed through logging

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/PersistenceUnitProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/PersistenceUnitProperties.java
@@ -3757,6 +3757,14 @@ public class PersistenceUnitProperties {
 
     /**
      * This system property in milliseconds can control thread management in org.eclipse.persistence.internal.helper.ConcurrencyManager.
+     * It control how much time ConcurrencyManager will wait before it will identify, that thread which builds new object/entity instance
+     * should be identified as a potential dead lock source. It leads into some additional log messages.
+     * Default value is 0 (unit is ms). In this case extended logging is not active. Allowed values are: long
+     */
+    public static final String CONCURRENCY_MANAGER_BUILD_OBJECT_COMPLETE_WAIT_TIME = "eclipselink.concurrency.manager.build.object.complete.waittime";
+
+    /**
+     * This system property in milliseconds can control thread management in org.eclipse.persistence.internal.helper.ConcurrencyManager.
      * It control how long we are willing to wait before firing up an exception
      * Default value is 40000 (unit is ms). Allowed values are: long
      */

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/SystemProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/SystemProperties.java
@@ -107,6 +107,14 @@ public class SystemProperties {
 
     /**
      * This system property in milliseconds can control thread management in org.eclipse.persistence.internal.helper.ConcurrencyManager.
+     * It control how much time ConcurrencyManager will wait before it will identify, that thread which builds new object/entity instance
+     * should be identified as a potential dead lock source. It leads into some additional log messages.
+     * Default value is 0 (unit is ms). In this case extended logging is not active. Allowed values are: long
+     */
+    public static final String CONCURRENCY_MANAGER_BUILD_OBJECT_COMPLETE_WAIT_TIME = "eclipselink.concurrency.manager.build.object.complete.waittime";
+
+    /**
+     * This system property in milliseconds can control thread management in org.eclipse.persistence.internal.helper.ConcurrencyManager.
      * It control how long we are willing to wait before firing up an exception
      * Default value is 40000 (unit is ms). Allowed values are: long
      */

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/SystemProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/SystemProperties.java
@@ -12,6 +12,8 @@
  ******************************************************************************/  
 package org.eclipse.persistence.config;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * This class provides the list of System properties that are recognized by EclipseLink.
  * @author tware
@@ -180,4 +182,76 @@ public class SystemProperties {
      * </ul>
      */
     public static final String CONCURRENCY_MANAGER_ALLOW_STACK_TRACE_READ_LOCK = "eclipselink.concurrency.manager.allow.readlockstacktrace";
+
+    /**
+     * <p>
+     * This property control (enable/disable) semaphore in {@link org.eclipse.persistence.internal.descriptors.ObjectBuilder}
+     * </p>
+     * Object building see {@link org.eclipse.persistence.internal.descriptors.ObjectBuilder} could be one of the
+     * primary sources pressure on concurrency manager. Most of the cache key acquisition and releasing is taking place during object building.
+     * Enable <code>true</code> this property to try reduce the likelihood of having dead locks is to allow less threads to start object
+     * building in parallel. In this case there should be negative impact to the performance.
+     * Note: Parallel access to the same entity/entity tree from different threads is not recommended technique in EclipseLink.
+     * <ul>
+     * <li>"<code>true</code>" - means we want to override vanilla behavior and use a semaphore to not allow too many
+     * threads in parallel to do object building
+     * <li>"<code>false</code>" (DEFAULT) - means just go ahead and try to build the object without any semaphore (false is
+     * vanilla behavior).
+     * </ul>
+     */
+    public static final String CONCURRENCY_MANAGER_USE_SEMAPHORE_TO_SLOW_DOWN_OBJECT_BUILDING = "eclipselink.concurrency.manager.object.building.semaphore";
+
+    /**
+     * <p>
+     * This property control (enable/disable) semaphore in {@link org.eclipse.persistence.internal.helper.WriteLockManager#acquireRequiredLocks}
+     * </p>
+     * This algorithm
+     * {@link org.eclipse.persistence.internal.helper.WriteLockManager#acquireRequiredLocks}
+     * is being used when a transaction is committing and it is acquire locks to merge the change set.
+     * It should happen if algorithm has trouble when multiple threads report change sets on the same entity (e.g.
+     * one-to-many relations of master detail being enriched with more details on this master).
+     * Note: Parallel access to the same entity/entity tree from different threads is not recommended technique in EclipseLink.
+     * <ul>
+     * <li>"<code>true</code>" - means we want to override vanilla behavior and use a semaphore to not allow too many
+     * threads. In this case there should be negative impact to the performance.
+     * <li>"<code>false</code>" (DEFAULT) - means just go ahead and try to build the object without any semaphore (false is
+     * vanilla behavior).
+     * </ul>
+     */
+    public static final String CONCURRENCY_MANAGER_USE_SEMAPHORE_TO_SLOW_DOWN_WRITE_LOCK_MANAGER_ACQUIRE_REQUIRED_LOCKS = "eclipselink.concurrency.manager.write.lock.manager.semaphore";
+
+    /**
+     * <p>
+     * This property control number of threads in semaphore in {@link org.eclipse.persistence.internal.descriptors.ObjectBuilder}
+     * If "eclipselink.concurrency.manager.object.building.semaphore" property is <code>true</code> default value is 10. Allowed values are: int
+     * If "eclipselink.concurrency.manager.object.building.semaphore" property is <code>false</code> (DEFAULT) number of threads is unlimited.
+     * </p>
+     */
+    public static final String CONCURRENCY_MANAGER_OBJECT_BUILDING_NO_THREADS = "eclipselink.concurrency.manager.object.building.no.threads";
+
+    /**
+     * <p>
+     * This property control number of threads in semaphore in {@link org.eclipse.persistence.internal.helper.WriteLockManager#acquireRequiredLocks}
+     * If "eclipselink.concurrency.manager.write.lock.manager.semaphore" property is <code>true</code> default value is 2. Allowed values are: int
+     * If "eclipselink.concurrency.manager.write.lock.manager.semaphore" property is <code>false</code> (DEFAULT) number of threads is unlimited.
+     * </p>
+     */
+    public static final String CONCURRENCY_MANAGER_WRITE_LOCK_MANAGER_ACQUIRE_REQUIRED_LOCKS_NO_THREADS = "eclipselink.concurrency.manager.write.lock.manager.no.threads";
+
+    /**
+     * <p>
+     * This property control semaphore the maximum time to wait for a permit in {@link org.eclipse.persistence.internal.helper.ConcurrencySemaphore#acquireSemaphoreIfAppropriate(boolean)}
+     * It's passed to {@link java.util.concurrent.Semaphore#tryAcquire(long, TimeUnit)}
+     * Default value is 2000 (unit is ms). Allowed values are: long
+     * </p>
+     */
+    public static final String CONCURRENCY_SEMAPHORE_MAX_TIME_PERMIT = "eclipselink.concurrency.semaphore.max.time.permit";
+
+    /**
+     * <p>
+     * This property control timeout between log messages in {@link org.eclipse.persistence.internal.helper.ConcurrencySemaphore#acquireSemaphoreIfAppropriate(boolean)} when method/thread tries to get permit for the execution.
+     * Default value is 10000 (unit is ms). Allowed values are: long
+     * </p>
+     */
+    public static final String CONCURRENCY_SEMAPHORE_LOG_TIMEOUT = "eclipselink.concurrency.semaphore.log.timeout";
 }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/descriptors/ObjectBuilder.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/descriptors/ObjectBuilder.java
@@ -22,6 +22,7 @@ package org.eclipse.persistence.internal.descriptors;
 
 import java.io.*;
 import java.util.*;
+import java.util.concurrent.Semaphore;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
@@ -118,6 +119,11 @@ public class ObjectBuilder extends CoreObjectBuilder<AbstractRecord, AbstractSes
     protected boolean shouldKeepRow = false;
     /** PERF: is there an cache index field that's would not be selected by SOP query. Ignored unless descriptor uses SOP and CachePolicy has cache indexes. */ 
     protected boolean hasCacheIndexesInSopObject = false;
+    /** Semaphore related properties. Transient to avoid serialization in clustered/replicated environments see CORBA tests*/
+    private static final transient ThreadLocal<Boolean> SEMAPHORE_THREAD_LOCAL_VAR = new ThreadLocal<>();
+    private static final transient int SEMAPHORE_MAX_NUMBER_THREADS = ConcurrencyUtil.SINGLETON.getNoOfThreadsAllowedToObjectBuildInParallel();
+    private static final transient Semaphore SEMAPHORE_LIMIT_MAX_NUMBER_OF_THREADS_OBJECT_BUILDING = new Semaphore(SEMAPHORE_MAX_NUMBER_THREADS);
+    private transient ConcurrencySemaphore objectBuilderSemaphore = new ConcurrencySemaphore(SEMAPHORE_THREAD_LOCAL_VAR, SEMAPHORE_MAX_NUMBER_THREADS, SEMAPHORE_LIMIT_MAX_NUMBER_OF_THREADS_OBJECT_BUILDING, this, "object_builder_semaphore_acquired_01");
 
     public ObjectBuilder(ClassDescriptor descriptor) {
         this.descriptor = descriptor;
@@ -696,8 +702,29 @@ public class ObjectBuilder extends CoreObjectBuilder<AbstractRecord, AbstractSes
     /**
      * Return an instance of the receivers javaClass. Set the attributes of an instance
      * from the values stored in the database row.
+     * This is wrapper method with semaphore logic.
      */
     public Object buildObject(ObjectBuildingQuery query, AbstractRecord databaseRow, JoinedAttributeManager joinManager,
+                              AbstractSession session, ClassDescriptor concreteDescriptor, InheritancePolicy inheritancePolicy, boolean isUnitOfWork,
+                              boolean shouldCacheQueryResults, boolean shouldUseWrapperPolicy) {
+        boolean semaphoreWasAcquired = false;
+        boolean useSemaphore = ConcurrencyUtil.SINGLETON.isUseSemaphoreInObjectBuilder();
+        if (objectBuilderSemaphore == null) {
+            objectBuilderSemaphore = new ConcurrencySemaphore(SEMAPHORE_THREAD_LOCAL_VAR, SEMAPHORE_MAX_NUMBER_THREADS, SEMAPHORE_LIMIT_MAX_NUMBER_OF_THREADS_OBJECT_BUILDING, this, "object_builder_semaphore_acquired_01");
+        }
+        try {
+            semaphoreWasAcquired = objectBuilderSemaphore.acquireSemaphoreIfAppropriate(useSemaphore);
+            return buildObjectInternal(query, databaseRow, joinManager, session, concreteDescriptor, inheritancePolicy, isUnitOfWork, shouldCacheQueryResults, shouldUseWrapperPolicy);
+        } finally {
+            objectBuilderSemaphore.releaseSemaphoreAllowOtherThreadsToStartDoingObjectBuilding(semaphoreWasAcquired);
+        }
+    }
+
+    /**
+     * Return an instance of the receivers javaClass. Set the attributes of an instance
+     * from the values stored in the database row.
+     */
+    private Object buildObjectInternal(ObjectBuildingQuery query, AbstractRecord databaseRow, JoinedAttributeManager joinManager,
             AbstractSession session, ClassDescriptor concreteDescriptor, InheritancePolicy inheritancePolicy, boolean isUnitOfWork,
             boolean shouldCacheQueryResults, boolean shouldUseWrapperPolicy) {
         Object domainObject = null;
@@ -2279,8 +2306,30 @@ public class ObjectBuilder extends CoreObjectBuilder<AbstractRecord, AbstractSes
      * PERF: This method is optimized for a specific case of building objects
      * so can avoid many of the normal checks, only queries that have this criteria
      * can use this method of building objects.
+     * This is wrapper method with semaphore logic.
      */
     public Object buildObjectFromResultSet(ObjectBuildingQuery query, JoinedAttributeManager joinManager, ResultSet resultSet, AbstractSession executionSession, DatabaseAccessor accessor, ResultSetMetaData metaData, DatabasePlatform platform, Vector fieldsList, DatabaseField[] fieldsArray) throws SQLException {
+        boolean semaphoreWasAcquired = false;
+        boolean useSemaphore = ConcurrencyUtil.SINGLETON.isUseSemaphoreInObjectBuilder();
+        if (objectBuilderSemaphore == null) {
+            objectBuilderSemaphore = new ConcurrencySemaphore(SEMAPHORE_THREAD_LOCAL_VAR, SEMAPHORE_MAX_NUMBER_THREADS, SEMAPHORE_LIMIT_MAX_NUMBER_OF_THREADS_OBJECT_BUILDING, this, "object_builder_semaphore_acquired_01");
+        }
+        try {
+            semaphoreWasAcquired = objectBuilderSemaphore.acquireSemaphoreIfAppropriate(useSemaphore);
+            return buildObjectFromResultSetInternal(query, joinManager, resultSet, executionSession, accessor, metaData, platform, fieldsList, fieldsArray);
+        } finally {
+            objectBuilderSemaphore.releaseSemaphoreAllowOtherThreadsToStartDoingObjectBuilding(semaphoreWasAcquired);
+        }
+    }
+
+    /**
+     * INTERNAL:
+     * Builds a working copy clone directly from a result set.
+     * PERF: This method is optimized for a specific case of building objects
+     * so can avoid many of the normal checks, only queries that have this criteria
+     * can use this method of building objects.
+     */
+    private Object buildObjectFromResultSetInternal(ObjectBuildingQuery query, JoinedAttributeManager joinManager, ResultSet resultSet, AbstractSession executionSession, DatabaseAccessor accessor, ResultSetMetaData metaData, DatabasePlatform platform, Vector fieldsList, DatabaseField[] fieldsArray) throws SQLException {
         ClassDescriptor descriptor = this.descriptor;
         int pkFieldsSize = descriptor.getPrimaryKeyFields().size();
         DatabaseMapping primaryKeyMapping = null;

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/helper/ConcurrencyManager.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/helper/ConcurrencyManager.java
@@ -761,12 +761,16 @@ public class ConcurrencyManager implements Serializable {
         //When this method is invoked during an acquire lock sometimes there is no lock manager
         if (lockManager == null) {
             String cacheKeyToString = ConcurrencyUtil.SINGLETON.createToStringExplainingOwnedCacheKey(this);
-            AbstractSessionLog.getLog().log(SessionLog.SEVERE, SessionLog.CACHE,"concurrency_manager_release_locks_acquired_by_thread_1", currentThread.getName(), cacheKeyToString);
+            StringWriter writer = new StringWriter();
+            writer.write(LoggingLocalization.buildMessage("concurrency_manager_release_locks_acquired_by_thread_1", new Object[] {currentThread.getName(), cacheKeyToString}));
+            AbstractSessionLog.getLog().log(SessionLog.SEVERE, SessionLog.CACHE, writer.toString(), new Object[] {}, false);
             return;
         }
 
         //Release the active locks on the thread
-        AbstractSessionLog.getLog().log(SessionLog.SEVERE, SessionLog.CACHE,"concurrency_manager_release_locks_acquired_by_thread_2", currentThread.toString());
+        StringWriter writer = new StringWriter();
+        writer.write(LoggingLocalization.buildMessage("concurrency_manager_release_locks_acquired_by_thread_2", new Object[] {currentThread.toString()}));
+        AbstractSessionLog.getLog().log(SessionLog.SEVERE, SessionLog.CACHE, writer.toString(), new Object[] {}, false);
         lockManager.releaseActiveLocksOnThread();
         removeDeferredLockManager(currentThread);
     }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/helper/ConcurrencySemaphore.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/helper/ConcurrencySemaphore.java
@@ -1,0 +1,138 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     Oracle - initial API and implementation
+ ******************************************************************************/
+package org.eclipse.persistence.internal.helper;
+
+import org.eclipse.persistence.exceptions.ConcurrencyException;
+import org.eclipse.persistence.internal.localization.LoggingLocalization;
+import org.eclipse.persistence.logging.AbstractSessionLog;
+import org.eclipse.persistence.logging.SessionLog;
+
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+public class ConcurrencySemaphore {
+
+    private final long MAX_TIME_PERMIT = ConcurrencyUtil.SINGLETON.getConcurrencySemaphoreMaxTimePermit();
+    private final long TIMEOUT_BETWEEN_LOG_MESSAGES = ConcurrencyUtil.SINGLETON.getConcurrencySemaphoreLogTimeout();
+
+    private ThreadLocal<Boolean> threadLocal;
+    private int noOfThreads;
+    private Semaphore semaphore;
+    private String logMessageKey;
+    private Object outerObject;
+
+    /**
+     * Constructor to create {@link #ConcurrencySemaphore}
+     * @param threadLocalVarControlIfCurrentThreadHasAcquiredSemaphore
+     *          Thread local variable that the code to acquire a semaphore can check to make sure it does not try to acquire
+     *          twice the same semaphore (e.g. in case the object building algorithm is recursive).
+     * @param noOfThreadsAllowedToExecuteInParallel
+     *          Max number of threads to acquire semaphore.
+     * @param semaphoreOfThreadsAllowedToExecuteInParallel
+     *          Semaphore used to control.
+     * @param outerObject
+     *          Reference to outer object where is this semaphore used.
+     * @param logMessageKey
+     *          Log message key from {@link org.eclipse.persistence.internal.localization.LoggingLocalization}
+     */
+    public ConcurrencySemaphore(ThreadLocal<Boolean> threadLocalVarControlIfCurrentThreadHasAcquiredSemaphore, int noOfThreadsAllowedToExecuteInParallel, Semaphore semaphoreOfThreadsAllowedToExecuteInParallel, Object outerObject, String logMessageKey) {
+        this.threadLocal = threadLocalVarControlIfCurrentThreadHasAcquiredSemaphore;
+        this.noOfThreads = noOfThreadsAllowedToExecuteInParallel;
+        this.semaphore = semaphoreOfThreadsAllowedToExecuteInParallel;
+        this.outerObject = outerObject;
+        this.logMessageKey = logMessageKey;
+    }
+
+    /**
+     * Do nothing if the semaphore has already been acquired by this thread in a higher recursive call or if the
+     * configuration to acquire the slow down semaphore is not active. Otherwise, try to acquire the semaphore
+     * @param useSemaphore
+     *         TRUE to use semaphore, FALSE don't use it.
+     * @return FALSE is returned if we do not want to be using the semaphore. FALSE is also returned if the current
+     *         thread has acquire the semaphore in an upper level recursive stack call. TRUE is returned if and only
+     *         using the semaphore is desired and we succeed acquiring the semaphore.
+     *
+     */
+    public boolean acquireSemaphoreIfAppropriate(boolean useSemaphore) {
+        // (a) If configuration is saying to not use semaphore and go vanilla there is nothing for us to do
+        boolean useSemaphoreToSlowDown = useSemaphore;
+        if (!useSemaphoreToSlowDown) {
+            return false;
+        }
+
+        // (b) The project is afraid of dead locks and does not allow acquire semaphore at the same time
+        // bottleneck slow down thread execution
+        // scenario 1:
+        // check if this thread has already acquired the semaphore in this call
+        Boolean currentThreadHasAcquiredSemaphoreAlready = threadLocal.get();
+        if (Boolean.TRUE.equals(currentThreadHasAcquiredSemaphoreAlready)) {
+            // don't allow this thread to acquire a second time the same semaphore it has done it already
+            return false;
+        }
+        // try to acquire the semaphore being careful with possible blow ups of thread interrupted
+        // Scenario 2:
+        // In this possibly recursive call stack this is the first time the current thread tries to acquire the semaphore to go build an object
+        boolean successAcquiringSemaphore = false;
+        // this thread will go nowhere until it manages to acquire semaphore that allows to continue with execution
+        // this should not only reduce the risk of dead locks but also if dead locks occur in the concurrency manager layer we will have a lot fewer threads making noise (easier to analyze locks)
+        // being part of the same dead lock
+        final long startTimeAttemptingToAcquireSemaphoreMillis = System.currentTimeMillis();
+        long dateWhenWeLastSpammedServerLogAboutNotBeingAbleToAcquireOurSemaphore = startTimeAttemptingToAcquireSemaphoreMillis;
+        try {
+            successAcquiringSemaphore = semaphore.tryAcquire(MAX_TIME_PERMIT, TimeUnit.MILLISECONDS);
+            while (!successAcquiringSemaphore) {
+                // (i) check if ten seconds or more have passed
+                long whileCurrentTimeMillis = System.currentTimeMillis();
+                long elapsedTime = whileCurrentTimeMillis - dateWhenWeLastSpammedServerLogAboutNotBeingAbleToAcquireOurSemaphore;
+                if (elapsedTime > TIMEOUT_BETWEEN_LOG_MESSAGES) {
+                    String outerObjectString = outerObject.toString();
+                    String threadName = Thread.currentThread().getName();
+                    // spam a message into the server log this will be helpful
+                    String logMessage = LoggingLocalization.buildMessage(logMessageKey, new Object[] {threadName, startTimeAttemptingToAcquireSemaphoreMillis, noOfThreads, outerObjectString});
+                    AbstractSessionLog.getLog().log(SessionLog.SEVERE, SessionLog.CACHE, logMessage, threadName);
+                    dateWhenWeLastSpammedServerLogAboutNotBeingAbleToAcquireOurSemaphore = whileCurrentTimeMillis;
+                }
+                // (ii) To avoid spamming the log every time lets update the data of when we last spammed the log
+                successAcquiringSemaphore = semaphore.tryAcquire(MAX_TIME_PERMIT, TimeUnit.MILLISECONDS);
+            }
+        } catch (InterruptedException interrupted) {
+            // If we are interrupted while trying to do object building log that we have been interrupted here
+            AbstractSessionLog.getLog().logThrowable(SessionLog.SEVERE, SessionLog.CACHE, interrupted);
+            throw ConcurrencyException.waitWasInterrupted(interrupted.getMessage());
+        } finally {
+            // (d) Before we leave this method regardless of a blow up or not always store in the thread local variable the accurate state of the successAcquiringSemaphore
+            threadLocal.set(successAcquiringSemaphore);
+        }
+        // (d) the final result
+        return successAcquiringSemaphore;
+    }
+
+    /**
+     * If the call to
+     * {@link #acquireSemaphoreIfAppropriate(boolean)}
+     * returned true implying the current thread acquire the semaphore, the same thread on the same method is mandated
+     * to release the semaphore.
+     * @param semaphoreWasAcquired
+     *            flag that tells us if the current thread had successfully acquired semaphore if the flag is true then
+     *            the semaphore will be released and given resources again.
+     */
+    public void releaseSemaphoreAllowOtherThreadsToStartDoingObjectBuilding(boolean semaphoreWasAcquired) {
+        if (semaphoreWasAcquired) {
+            // release the semaphore resource for the current thread
+            semaphore.release();
+            // ensure the thread local variable is cleaned up to indicate that the thread was not yet acquired
+            // the semaphore and would need to do so
+            threadLocal.set(Boolean.FALSE);
+        }
+    }
+}

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/helper/ConcurrencyUtil.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/helper/ConcurrencyUtil.java
@@ -46,6 +46,12 @@ public class ConcurrencyUtil {
     private static final boolean DEFAULT_INTERRUPTED_EXCEPTION_FIRED = true;
     private static final boolean DEFAULT_CONCURRENCY_EXCEPTION_FIRED = true;
     private static final boolean DEFAULT_TAKING_STACKTRACE_DURING_READ_LOCK_ACQUISITION = false;
+    public static final boolean DEFAULT_USE_SEMAPHORE_TO_SLOW_DOWN_OBJECT_BUILDING_CONCURRENCY = false;
+    public static final boolean DEFAULT_USE_SEMAPHORE_TO_SLOW_DOWN_WRITE_LOCK_MANAGER_ACQUIRE_REQUIRED_LOCKS = false;
+    public static final int DEFAULT_CONCURRENCY_MANAGER_OBJECT_BUILDING_NO_THREADS = 10;
+    public static final int DEFAULT_CONCURRENCY_MANAGER_WRITE_LOCK_MANAGER_ACQUIRE_REQUIRED_LOCKS_NO_THREADS = 2;
+    public static final long DEFAULT_CONCURRENCY_SEMAPHORE_MAX_TIME_PERMIT = 2000L;
+    public static final long DEFAULT_CONCURRENCY_SEMAPHORE_LOG_TIMEOUT = 10000L;
 
     private long acquireWaitTime = getLongProperty(SystemProperties.CONCURRENCY_MANAGER_ACQUIRE_WAIT_TIME, DEFAULT_ACQUIRE_WAIT_TIME);
     private long buildObjectCompleteWaitTime = getLongProperty(SystemProperties.CONCURRENCY_MANAGER_BUILD_OBJECT_COMPLETE_WAIT_TIME, DEFAULT_BUILD_OBJECT_COMPLETE_WAIT_TIME);
@@ -55,6 +61,13 @@ public class ConcurrencyUtil {
     private boolean allowInterruptedExceptionFired = getBooleanProperty(SystemProperties.CONCURRENCY_MANAGER_ALLOW_INTERRUPTED_EXCEPTION, DEFAULT_INTERRUPTED_EXCEPTION_FIRED);
     private boolean allowConcurrencyExceptionToBeFiredUp = getBooleanProperty(SystemProperties.CONCURRENCY_MANAGER_ALLOW_CONCURRENCY_EXCEPTION, DEFAULT_CONCURRENCY_EXCEPTION_FIRED);
     private boolean allowTakingStackTraceDuringReadLockAcquisition = getBooleanProperty(SystemProperties.CONCURRENCY_MANAGER_ALLOW_STACK_TRACE_READ_LOCK, DEFAULT_TAKING_STACKTRACE_DURING_READ_LOCK_ACQUISITION);
+
+    private boolean useSemaphoreInObjectBuilder  = getBooleanProperty(SystemProperties.CONCURRENCY_MANAGER_USE_SEMAPHORE_TO_SLOW_DOWN_OBJECT_BUILDING, DEFAULT_USE_SEMAPHORE_TO_SLOW_DOWN_OBJECT_BUILDING_CONCURRENCY);
+    private boolean useSemaphoreToLimitConcurrencyOnWriteLockManagerAcquireRequiredLocks  = getBooleanProperty(SystemProperties.CONCURRENCY_MANAGER_USE_SEMAPHORE_TO_SLOW_DOWN_WRITE_LOCK_MANAGER_ACQUIRE_REQUIRED_LOCKS, DEFAULT_USE_SEMAPHORE_TO_SLOW_DOWN_WRITE_LOCK_MANAGER_ACQUIRE_REQUIRED_LOCKS);
+    private int noOfThreadsAllowedToObjectBuildInParallel = getIntProperty(SystemProperties.CONCURRENCY_MANAGER_OBJECT_BUILDING_NO_THREADS, DEFAULT_CONCURRENCY_MANAGER_OBJECT_BUILDING_NO_THREADS);
+    private int noOfThreadsAllowedToDoWriteLockManagerAcquireRequiredLocksInParallel = getIntProperty(SystemProperties.CONCURRENCY_MANAGER_WRITE_LOCK_MANAGER_ACQUIRE_REQUIRED_LOCKS_NO_THREADS, DEFAULT_CONCURRENCY_MANAGER_WRITE_LOCK_MANAGER_ACQUIRE_REQUIRED_LOCKS_NO_THREADS);
+    private long concurrencySemaphoreMaxTimePermit = getLongProperty(SystemProperties.CONCURRENCY_SEMAPHORE_MAX_TIME_PERMIT, DEFAULT_CONCURRENCY_SEMAPHORE_MAX_TIME_PERMIT);
+    private long concurrencySemaphoreLogTimeout = getLongProperty(SystemProperties.CONCURRENCY_SEMAPHORE_LOG_TIMEOUT, DEFAULT_CONCURRENCY_SEMAPHORE_LOG_TIMEOUT);
 
     /**
      * Thread local variable that allows the current thread to know when was the last time that this specific thread
@@ -278,6 +291,54 @@ public class ConcurrencyUtil {
 
     public void setAllowTakingStackTraceDuringReadLockAcquisition(boolean allowTakingStackTraceDuringReadLockAcquisition) {
         this.allowTakingStackTraceDuringReadLockAcquisition = allowTakingStackTraceDuringReadLockAcquisition;
+    }
+
+    public boolean isUseSemaphoreInObjectBuilder() {
+        return useSemaphoreInObjectBuilder;
+    }
+
+    public void setUseSemaphoreInObjectBuilder(boolean useSemaphoreInObjectBuilder) {
+        this.useSemaphoreInObjectBuilder = useSemaphoreInObjectBuilder;
+    }
+
+    public boolean isUseSemaphoreToLimitConcurrencyOnWriteLockManagerAcquireRequiredLocks() {
+        return useSemaphoreToLimitConcurrencyOnWriteLockManagerAcquireRequiredLocks;
+    }
+
+    public void setUseSemaphoreToLimitConcurrencyOnWriteLockManagerAcquireRequiredLocks(boolean useSemaphoreToLimitConcurrencyOnWriteLockManagerAcquireRequiredLocks) {
+        this.useSemaphoreToLimitConcurrencyOnWriteLockManagerAcquireRequiredLocks = useSemaphoreToLimitConcurrencyOnWriteLockManagerAcquireRequiredLocks;
+    }
+
+    public int getNoOfThreadsAllowedToObjectBuildInParallel() {
+        return noOfThreadsAllowedToObjectBuildInParallel;
+    }
+
+    public void setNoOfThreadsAllowedToObjectBuildInParallel(int noOfThreadsAllowedToObjectBuildInParallel) {
+        this.noOfThreadsAllowedToObjectBuildInParallel = noOfThreadsAllowedToObjectBuildInParallel;
+    }
+
+    public int getNoOfThreadsAllowedToDoWriteLockManagerAcquireRequiredLocksInParallel() {
+        return noOfThreadsAllowedToDoWriteLockManagerAcquireRequiredLocksInParallel;
+    }
+
+    public void setNoOfThreadsAllowedToDoWriteLockManagerAcquireRequiredLocksInParallel(int noOfThreadsAllowedToDoWriteLockManagerAcquireRequiredLocksInParallel) {
+        this.noOfThreadsAllowedToDoWriteLockManagerAcquireRequiredLocksInParallel = noOfThreadsAllowedToDoWriteLockManagerAcquireRequiredLocksInParallel;
+    }
+
+    public long getConcurrencySemaphoreMaxTimePermit() {
+        return concurrencySemaphoreMaxTimePermit;
+    }
+
+    public void setConcurrencySemaphoreMaxTimePermit(long concurrencySemaphoreMaxTimePermit) {
+        this.concurrencySemaphoreMaxTimePermit = concurrencySemaphoreMaxTimePermit;
+    }
+
+    public long getConcurrencySemaphoreLogTimeout() {
+        return concurrencySemaphoreLogTimeout;
+    }
+
+    public void setConcurrencySemaphoreLogTimeout(long concurrencySemaphoreLogTimeout) {
+        this.concurrencySemaphoreLogTimeout = concurrencySemaphoreLogTimeout;
     }
 
     /**
@@ -1580,6 +1641,20 @@ public class ConcurrencyUtil {
         // data in ReadLockAcquisitionMetadata are immutable it reflects an accurate snapshot of the time of acquisition
         return new ReadLockAcquisitionMetadata(concurrencyManager, numberOfReadersOnCacheKeyBeforeIncrementingByOne,
                 currentThreadStackTraceInformation, currentThreadStackTraceInformationCpuTimeCostMs);
+    }
+
+    private int getIntProperty(final String key, final int defaultValue) {
+        String value = (PrivilegedAccessHelper.shouldUsePrivilegedAccess()) ?
+                AccessController.doPrivileged(new PrivilegedGetSystemProperty(key, String.valueOf(defaultValue)))
+                : System.getProperty(key, String.valueOf(defaultValue));
+        if (value != null) {
+            try {
+                return Integer.parseInt(value.trim());
+            } catch (Exception ignoreE) {
+                return defaultValue;
+            }
+        }
+        return defaultValue;
     }
 
     private long getLongProperty(final String key, final long defaultValue) {

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/helper/ExplainDeadLockUtil.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/helper/ExplainDeadLockUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -899,7 +899,7 @@ public class ExplainDeadLockUtil {
     /**
      * This method is nothing more than copy paste code from the algorithm
      *
-     * {@link ConcurrencyManager#isBuildObjectOnThreadComplete(Thread, Map)}
+     * {@link ConcurrencyManager#isBuildObjectOnThreadComplete(Thread, Map, List, boolean)}
      *
      * We re-write this code to instead of returning true/false return an actual DTO object that can allow our dead lock
      * explanation algorithm to identify the next thread to expand to explain the dead lock.

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/helper/ExplainDeadLockUtil.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/helper/ExplainDeadLockUtil.java
@@ -16,9 +16,11 @@ import org.eclipse.persistence.internal.helper.type.CacheKeyToThreadRelationship
 import org.eclipse.persistence.internal.helper.type.ConcurrencyManagerState;
 import org.eclipse.persistence.internal.helper.type.DeadLockComponent;
 import org.eclipse.persistence.internal.helper.type.IsBuildObjectCompleteOutcome;
+import org.eclipse.persistence.internal.localization.LoggingLocalization;
 import org.eclipse.persistence.logging.AbstractSessionLog;
 import org.eclipse.persistence.logging.SessionLog;
 
+import java.io.StringWriter;
 import java.util.*;
 
 import static java.lang.String.format;
@@ -735,11 +737,13 @@ public class ExplainDeadLockUtil {
                 // this cache key has an active thread that seems to not be tracked by our
                 // ConcurrencyManagerState
                 //
-                AbstractSessionLog.getLog().log(SessionLog.WARNING, SessionLog.CACHE, "explain_dead_lock_util_current_thread_blocked_active_thread_warning",
+                StringWriter writer = new StringWriter();
+                writer.write(LoggingLocalization.buildMessage("explain_dead_lock_util_current_thread_blocked_active_thread_warning",
                         new Object[] {nextCandidateThreadPartOfTheDeadLock.getName(),
                         currentCandidateThreadPartOfTheDeadLock.getName(),
                         ConcurrencyUtil.SINGLETON.createToStringExplainingOwnedCacheKey(
-                        cacheKeyThreadWantsToAcquireButCannotGet)});
+                                cacheKeyThreadWantsToAcquireButCannotGet)}));
+                AbstractSessionLog.getLog().log(SessionLog.WARNING, SessionLog.CACHE, writer.toString(), new Object[] {}, false);
                 return DEAD_LOCK_NOT_FOUND;
             } else {
                 // The active thread on the cache key is needing some resources we are tracing
@@ -805,8 +809,9 @@ public class ExplainDeadLockUtil {
         // the only case where it would make sense for this to be null is if the current candidate is actually making progress and
         // was stuck for only a short period
         if(result == null) {
-            AbstractSessionLog.getLog().log(SessionLog.WARNING, SessionLog.CACHE, "explain_dead_lock_util_thread_stuck_deferred_locks",
-                    new Object[] {currentCandidateThreadPartOfTheDeadLock.getName()});
+            StringWriter writer = new StringWriter();
+            writer.write(LoggingLocalization.buildMessage("explain_dead_lock_util_thread_stuck_deferred_locks", new Object[] {currentCandidateThreadPartOfTheDeadLock.getName()}));
+            AbstractSessionLog.getLog().log(SessionLog.WARNING, SessionLog.CACHE, writer.toString(), new Object[] {}, false);
             return DEAD_LOCK_NOT_FOUND;
         }
 

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/helper/WriteLockManager.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/helper/WriteLockManager.java
@@ -19,6 +19,7 @@ package org.eclipse.persistence.internal.helper;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Semaphore;
 
 import org.eclipse.persistence.descriptors.ClassDescriptor;
 import org.eclipse.persistence.descriptors.FetchGroupManager;
@@ -99,6 +100,12 @@ public class WriteLockManager {
      *
      */
     private static final Map<Thread, Set<Object>> MAP_WRITE_LOCK_MANAGER_THREAD_TO_OBJECT_IDS_WITH_CHANGE_SET = new ConcurrentHashMap<>();
+
+    /** Semaphore related properties */
+    private static final transient ThreadLocal<Boolean> SEMAPHORE_THREAD_LOCAL_VAR = new ThreadLocal<>();
+    private static final transient int SEMAPHORE_MAX_NUMBER_THREADS = ConcurrencyUtil.SINGLETON.getNoOfThreadsAllowedToDoWriteLockManagerAcquireRequiredLocksInParallel();
+    private static final transient Semaphore SEMAPHORE_LIMIT_MAX_NUMBER_OF_THREADS_WRITE_LOCK_MANAGER = new Semaphore(SEMAPHORE_MAX_NUMBER_THREADS);
+    private transient ConcurrencySemaphore writeLockManagerSemaphore = new ConcurrencySemaphore(SEMAPHORE_THREAD_LOCAL_VAR, SEMAPHORE_MAX_NUMBER_THREADS, SEMAPHORE_LIMIT_MAX_NUMBER_OF_THREADS_WRITE_LOCK_MANAGER, this,"write_lock_manager_semaphore_acquired_01");
 
     // this will allow us to prevent a readlock thread from looping forever.
     public static int MAXTRIES = 10000;
@@ -309,8 +316,27 @@ public class WriteLockManager {
      * a changeset.  This method will hand off the processing of the deadlock algorithm to other member
      * methods.  The mergeManager must be the active mergemanager for the calling thread.
      * Returns true if all required locks were acquired
+     * This is wrapper method with semaphore logic.
      */
     public void acquireRequiredLocks(MergeManager mergeManager, UnitOfWorkChangeSet changeSet) {
+        boolean semaphoreWasAcquired = false;
+        boolean useSemaphore = ConcurrencyUtil.SINGLETON.isUseSemaphoreToLimitConcurrencyOnWriteLockManagerAcquireRequiredLocks();
+        try {
+            semaphoreWasAcquired = writeLockManagerSemaphore.acquireSemaphoreIfAppropriate(useSemaphore);
+            acquireRequiredLocksInternal(mergeManager, changeSet);
+        } finally {
+            writeLockManagerSemaphore.releaseSemaphoreAllowOtherThreadsToStartDoingObjectBuilding(semaphoreWasAcquired);
+        }
+    }
+
+    /**
+     * INTERNAL:
+     * This method will be the entry point for threads attempting to acquire locks for all objects that have
+     * a changeset.  This method will hand off the processing of the deadlock algorithm to other member
+     * methods.  The mergeManager must be the active mergemanager for the calling thread.
+     * Returns true if all required locks were acquired
+     */
+    private void acquireRequiredLocksInternal(MergeManager mergeManager, UnitOfWorkChangeSet changeSet) {
         if (!MergeManager.LOCK_ON_MERGE) {//lockOnMerge is a backdoor and not public
             return;
         }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/helper/WriteLockManager.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/helper/WriteLockManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the 
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0 
  * which accompanies this distribution. 
@@ -144,8 +144,9 @@ public class WriteLockManager {
                 // of the concurrency manager that we use for creating the massive log dump
                 // to indicate that the current thread is now stuck trying to acquire some arbitrary
                 // cache key for writing
+                StackTraceElement stackTraceElement = Thread.currentThread().getStackTrace()[1];
                 lastCacheKeyWeNeededToWaitToAcquire = toWaitOn;
-                lastCacheKeyWeNeededToWaitToAcquire.putThreadAsWaitingToAcquireLockForWriting(currentThread);
+                lastCacheKeyWeNeededToWaitToAcquire.putThreadAsWaitingToAcquireLockForWriting(currentThread, stackTraceElement.getClassName() + "." + stackTraceElement.getMethodName() + "(...)");
 
                 // Since we know this one of those methods that can appear in the dead locks
                 // we threads frozen here forever inside of the wait that used to have no timeout
@@ -179,7 +180,7 @@ public class WriteLockManager {
             throw ConcurrencyException.maxTriesLockOnCloneExceded(objectForClone);
         } finally {
             if (lastCacheKeyWeNeededToWaitToAcquire != null) {
-                cacheKey.removeThreadNoLongerWaitingToAcquireLockForWriting(currentThread);
+                lastCacheKeyWeNeededToWaitToAcquire.removeThreadNoLongerWaitingToAcquireLockForWriting(currentThread);
             }
             if (!successful) {//did not acquire locks but we are exiting
                 for (Iterator lockedList = lockedObjects.values().iterator(); lockedList.hasNext();) {

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/helper/type/ConcurrencyManagerState.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/helper/type/ConcurrencyManagerState.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -42,14 +42,30 @@ public class ConcurrencyManagerState {
     private final Map<Thread, Set<ConcurrencyManager>> unifiedMapOfThreadsStuckTryingToAcquireWriteLock;
 
     /**
+     * Name of the method that go stuck waiting to acquire resource and created the trace.
+     */
+    private final Map<Thread, String> unifiedMapOfThreadsStuckTryingToAcquireWriteLockMethodName;
+
+    /**
      * information about threads that are waiting to acquire READ locks
      */
     private final Map<Thread, ConcurrencyManager> mapThreadToWaitOnAcquireReadLockClone;
 
     /**
+     * Name of the method that go stuck waiting to acquire resource and created the trace.
+     */
+    private final Map<Thread, String> mapThreadToWaitOnAcquireReadLockCloneMethodName;
+
+    /**
      * information about threads that are waiting for object building to finish that have acquired deferred locks
      */
     private final Set<Thread> setThreadWaitingToReleaseDeferredLocksClone;
+
+    /**
+     * Stores an explanation created by the isBuildObjectComplete from the currency manager to be returning false, that
+     * build object is not yet complete.
+     */
+    private final Map<Thread, String> mapThreadsThatAreCurrentlyWaitingToReleaseDeferredLocksJustificationClone;
 
     /**
      * information about cache keys and their relationship to threads.
@@ -72,8 +88,11 @@ public class ConcurrencyManagerState {
      * @param readLockManagerMapClone
      * @param deferredLockManagerMapClone
      * @param unifiedMapOfThreadsStuckTryingToAcquireWriteLock
+     * @param unifiedMapOfThreadsStuckTryingToAcquireWriteLockMethodName
      * @param mapThreadToWaitOnAcquireReadLockClone
+     * @param mapThreadToWaitOnAcquireReadLockCloneMethodName
      * @param setThreadWaitingToReleaseDeferredLocksClone
+     * @param mapThreadsThatAreCurrentlyWaitingToReleaseDeferredLocksJustificationClone
      * @param mapOfCacheKeyToDtosExplainingThreadExpectationsOnCacheKey
      * @param mapThreadToObjectIdWithWriteLockManagerChangesClone
      */
@@ -81,16 +100,22 @@ public class ConcurrencyManagerState {
             Map<Thread, ReadLockManager> readLockManagerMapClone,
             Map<Thread, DeferredLockManager> deferredLockManagerMapClone,
             Map<Thread, Set<ConcurrencyManager>> unifiedMapOfThreadsStuckTryingToAcquireWriteLock,
+            Map<Thread, String> unifiedMapOfThreadsStuckTryingToAcquireWriteLockMethodName,
             Map<Thread, ConcurrencyManager> mapThreadToWaitOnAcquireReadLockClone,
+            Map<Thread, String> mapThreadToWaitOnAcquireReadLockCloneMethodName,
             Set<Thread> setThreadWaitingToReleaseDeferredLocksClone,
+            Map<Thread, String> mapThreadsThatAreCurrentlyWaitingToReleaseDeferredLocksJustificationClone,
             Map<ConcurrencyManager, CacheKeyToThreadRelationships> mapOfCacheKeyToDtosExplainingThreadExpectationsOnCacheKey,
             Map<Thread, Set<Object>> mapThreadToObjectIdWithWriteLockManagerChangesClone) {
         super();
         this.readLockManagerMapClone = readLockManagerMapClone;
         this.deferredLockManagerMapClone = deferredLockManagerMapClone;
         this.unifiedMapOfThreadsStuckTryingToAcquireWriteLock = unifiedMapOfThreadsStuckTryingToAcquireWriteLock;
+        this.unifiedMapOfThreadsStuckTryingToAcquireWriteLockMethodName = unifiedMapOfThreadsStuckTryingToAcquireWriteLockMethodName;
         this.mapThreadToWaitOnAcquireReadLockClone = mapThreadToWaitOnAcquireReadLockClone;
+        this.mapThreadToWaitOnAcquireReadLockCloneMethodName = mapThreadToWaitOnAcquireReadLockCloneMethodName;
         this.setThreadWaitingToReleaseDeferredLocksClone = setThreadWaitingToReleaseDeferredLocksClone;
+        this.mapThreadsThatAreCurrentlyWaitingToReleaseDeferredLocksJustificationClone = mapThreadsThatAreCurrentlyWaitingToReleaseDeferredLocksJustificationClone;
         this.mapOfCacheKeyToDtosExplainingThreadExpectationsOnCacheKey = mapOfCacheKeyToDtosExplainingThreadExpectationsOnCacheKey;
         this.mapThreadToObjectIdWithWriteLockManagerChangesClone = mapThreadToObjectIdWithWriteLockManagerChangesClone;
     }
@@ -120,6 +145,11 @@ public class ConcurrencyManagerState {
         return unmodifiableSet(setThreadWaitingToReleaseDeferredLocksClone);
     }
 
+    /** Getter for {@link #mapThreadsThatAreCurrentlyWaitingToReleaseDeferredLocksJustificationClone} */
+    public Map<Thread, String> getMapThreadsThatAreCurrentlyWaitingToReleaseDeferredLocksJustificationClone() {
+        return unmodifiableMap(mapThreadsThatAreCurrentlyWaitingToReleaseDeferredLocksJustificationClone);
+    }
+
     /** Getter for {@link #mapOfCacheKeyToDtosExplainingThreadExpectationsOnCacheKey} */
     public Map<ConcurrencyManager, CacheKeyToThreadRelationships> getMapOfCacheKeyToDtosExplainingThreadExpectationsOnCacheKey() {
         return unmodifiableMap(mapOfCacheKeyToDtosExplainingThreadExpectationsOnCacheKey);
@@ -128,5 +158,15 @@ public class ConcurrencyManagerState {
     /** Getter for {@link #mapThreadToObjectIdWithWriteLockManagerChangesClone} */
     public Map<Thread, Set<Object>> getMapThreadToObjectIdWithWriteLockManagerChangesClone() {
         return unmodifiableMap(mapThreadToObjectIdWithWriteLockManagerChangesClone);
+    }
+
+    /** Getter for {@link #unifiedMapOfThreadsStuckTryingToAcquireWriteLockMethodName} */
+    public Map<Thread, String> getUnifiedMapOfThreadsStuckTryingToAcquireWriteLockMethodName() {
+        return unmodifiableMap(unifiedMapOfThreadsStuckTryingToAcquireWriteLockMethodName);
+    }
+
+    /** Getter for {@link #mapThreadToWaitOnAcquireReadLockCloneMethodName} */
+    public Map<Thread, String> getMapThreadToWaitOnAcquireReadLockCloneMethodName() {
+        return unmodifiableMap(mapThreadToWaitOnAcquireReadLockCloneMethodName);
     }
 }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/localization/i18n/LoggingLocalizationResource.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/localization/i18n/LoggingLocalizationResource.java
@@ -557,8 +557,8 @@ public class LoggingLocalizationResource extends ListResourceBundle {
         { "acquiring_deferred_lock", "Thread \"{1}\" has acquired a deferred lock on object : {0} in order to avoid deadlock." },
         { "dead_lock_encountered_on_write", "Thread \"{1}\" encountered deadlock when attempting to lock : {0}.  Entering deadlock avoidance algorithm." },
         { "dead_lock_encountered_on_write_no_cache_key", "Thread \"{2}\" encountered deadlock when attempting to lock object of class: {0} with PK {1}.  Entering deadlock avoidance algorithm." },
-        { "concurrency_manager_release_locks_acquired_by_thread_1", "releaseAllLocksAcquiredByThread: Thread \"{1}\"  .The Lock manager is null. This might be an acquire operation. So not possible to lockManager.releaseActiveLocksOnThread(). Cache Key:  \"{2}\"" },
-        { "concurrency_manager_release_locks_acquired_by_thread_2", "releaseAllLocksAcquiredByThread: Release active locks on Thread \"{1}\"" },
+        { "concurrency_manager_release_locks_acquired_by_thread_1", "releaseAllLocksAcquiredByThread: Thread \"{0}\"  .The Lock manager is null. This might be an acquire operation. So not possible to lockManager.releaseActiveLocksOnThread(). Cache Key:  \"{1}\"" },
+        { "concurrency_manager_release_locks_acquired_by_thread_2", "releaseAllLocksAcquiredByThread: Release active locks on Thread \"{0}\"" },
         { "concurrency_manager_build_object_thread_complete_1", "isBuildObjectComplete ExpandedThread NR  {0}: {1} \n" },
         { "concurrency_manager_build_object_thread_complete_2", "\nAll threads in this stack are doing object building and needed to defer on one or more cache keys.\n"
                 + "The last thread has deferred lock on ac cache key that is acquired by thread that is not yet finished with its work. \n\n"},

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/localization/i18n/LoggingLocalizationResource.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/localization/i18n/LoggingLocalizationResource.java
@@ -559,6 +559,16 @@ public class LoggingLocalizationResource extends ListResourceBundle {
         { "dead_lock_encountered_on_write_no_cache_key", "Thread \"{2}\" encountered deadlock when attempting to lock object of class: {0} with PK {1}.  Entering deadlock avoidance algorithm." },
         { "concurrency_manager_release_locks_acquired_by_thread_1", "releaseAllLocksAcquiredByThread: Thread \"{1}\"  .The Lock manager is null. This might be an acquire operation. So not possible to lockManager.releaseActiveLocksOnThread(). Cache Key:  \"{2}\"" },
         { "concurrency_manager_release_locks_acquired_by_thread_2", "releaseAllLocksAcquiredByThread: Release active locks on Thread \"{1}\"" },
+        { "concurrency_manager_build_object_thread_complete_1", "isBuildObjectComplete ExpandedThread NR  {0}: {1} \n" },
+        { "concurrency_manager_build_object_thread_complete_2", "\nAll threads in this stack are doing object building and needed to defer on one or more cache keys.\n"
+                + "The last thread has deferred lock on ac cache key that is acquired by thread that is not yet finished with its work. \n\n"},
+        { "concurrency_manager_build_object_thread_complete_3", "finalDeferredLockCausingTrouble:  {0} \n"
+                + " This cache key had to be deferred by the last thread on the recursive stack. The thread was ACQUIRED. \n"},
+        { "concurrency_manager_build_object_thread_complete_4", "activeThreadOnTheCacheKey: {0}  \n"
+                + " hasDeferredLockManager: {1} \n "
+                + " This is the thread that has acquired the cache key and has been considered to not yet be finished with its business. \n"
+                + " When hasDeferredLockManager is true it typically means this thread is doing object building. \n"
+                + " When hasDeferredLockManager is false it might an object building thread or it could be a thread doing a commit and acquiring final locks to merge its objects with changesets look at the stack trace to understand. \n"},
         { "concurrency_manager_allow_concurrency_exception_fired_up", "allowConcurrencyExceptionToBeFiredUp: is set to FALSE."
                 + " No any exception be fired to avoid the risk of aborting the current thread not being sufficient to resolve any dead lock."
                 + " and leaving the system in a worth shape where aver 3 retries the business transaction is not re-attempted and the recovery of the system becomes complicated. "
@@ -571,13 +581,15 @@ public class LoggingLocalizationResource extends ListResourceBundle {
         { "concurrency_util_owned_cache_key_null", "ObjectNull. Most likely not yet in server session cache and in the process of being created."},
         { "concurrency_util_owned_cache_key_is_cache_key", "--- CacheKey  ({0}):  (primaryKey: {1}) (object: {2}) (object hash code: {3}) (cacheKeyClass: {4}) (cacheKey hash code: {5}) (current cache key owner/activeThread: {6}) (getNumberOfReaders: {7}) "
                 + " (concurrencyManagerId: {8}) (concurrencyManagerCreationDate: {9})"
-                + "  (totalNumberOfTimeCacheKeyAcquiredForReading:  {10}) "
+                + " (totalNumberOfTimeCacheKeyAcquiredForReading:  {10}) "
                 + " (totalNumberOfTimeCacheKeyReleasedForReading:  {11}) "
-                + " (totalNumberOfTimeCacheKeyReleasedForReadingBlewUpExceptionDueToCacheKeyHavingReachedCounterZero:  {12})  ---"},
+                + " (totalNumberOfTimeCacheKeyReleasedForReadingBlewUpExceptionDueToCacheKeyHavingReachedCounterZero:  {12}) "
+                + " (depth: {13}) ---"},
         { "concurrency_util_owned_cache_key_is_not_cache_key", "--- ConcurrencyManager: (ConcurrencyManagerClass: {0} ) (ConcurrencyManagerToString: {1}) (current cache key owner/activeThread: {2}) (concurrencyManagerId: {3}) (concurrencyManagerCreationDate: {4}) "
                 + "  (totalNumberOfTimeCacheKeyAcquiredForReading:  {5}) "
                 + " (totalNumberOfTimeCacheKeyReleasedForReading:  {6}) "
-                + " (totalNumberOfTimeCacheKeyReleasedForReadingBlewUpExceptionDueToCacheKeyHavingReachedCounterZero:  {7})  ---"},
+                + " (totalNumberOfTimeCacheKeyReleasedForReadingBlewUpExceptionDueToCacheKeyHavingReachedCounterZero:  {7}) "
+                + "(depth: {8}) ---"},
         { "concurrency_util_header_current_cache_key", "Summary current cache key of thread {0} "},
         { "concurrency_util_header_active_locks_owned_by_thread", "Summary of active locks owned by thread {0} "},
         { "concurrency_util_header_deferred_locks_owned_by_thread", "Summary of deferred locks (could not be acquired and cause thread to wait for object building to complete) of thread {0} "},
@@ -620,11 +632,14 @@ public class LoggingLocalizationResource extends ListResourceBundle {
         { "concurrency_util_create_information_all_threads_acquire_cache_keys_1", "Concurrency manager - Page 02 start - information about threads waiting to acquire (write/deferred) cache keys "
                 + "\nTotal number of threads waiting to acquire lock: {0}\n\n"},
         { "concurrency_util_create_information_all_threads_acquire_cache_keys_2", "[currentThreadNumber: {0}] [ThreadName: {1}]: Waiting to acquire (write/deferred): {2}\n"},
-        { "concurrency_util_create_information_all_threads_acquire_cache_keys_3", "Concurrency manager - Page 02 end - information about threads waiting to acquire (write/deferred) cache keys\n"},
+        { "concurrency_util_create_information_all_threads_acquire_cache_keys_3", "It seems, that trace was produced by the THREADS_TO_FAIL_TO_ACQUIRE_CACHE_KEYS - - org.eclipse.persistence.internal.helper.WriteLockManager.acquireRequiredLocks(MergeManager, UnitOfWorkChangeSet)"},
+        { "concurrency_util_create_information_all_threads_acquire_cache_keys_4", "[methodNameThatGotStuckWaitingToAcquire: {0}] \n"},
+        { "concurrency_util_create_information_all_threads_acquire_cache_keys_5", "Concurrency manager - Page 02 end - information about threads waiting to acquire (write/deferred) cache keys\n"},
         { "concurrency_util_create_information_all_threads_acquire_read_cache_keys_1", "Concurrency manager - Page 03 start - information about threads waiting to acquire read cache keys "
                 + "\nTotal number of threads waiting to acquire read locks: {0} \n\n"},
         { "concurrency_util_create_information_all_threads_acquire_read_cache_keys_2", "[currentThreadNumber: {0}] [ThreadName: {1} ]: Waiting to acquire (read lock): {2}\n"},
-        { "concurrency_util_create_information_all_threads_acquire_read_cache_keys_3", "Concurrency manager - Page 03 end - information about threads waiting to acquire read cache keys\n"},
+        { "concurrency_util_create_information_all_threads_acquire_read_cache_keys_3", "[methodNameThatGotStuckWaitingToAcquire: {0}]  \n"},
+        { "concurrency_util_create_information_all_threads_acquire_read_cache_keys_4", "Concurrency manager - Page 03 end - information about threads waiting to acquire read cache keys\n"},
         { "concurrency_util_create_information_all_threads_release_deferred_locks_1", "Concurrency manager - Page 04 start - information about threads waiting on release deferred locks (waiting for other thread to finish building the objects deferred) "
                 + "\nTotal number of threads waiting to acquire lock: {0} \n\n"},
         { "concurrency_util_create_information_all_threads_release_deferred_locks_2", "[currentThreadNumber: {0}] [ThreadName: {1} ]\n"},
@@ -639,7 +654,9 @@ public class LoggingLocalizationResource extends ListResourceBundle {
         { "concurrency_util_create_information_all_resources_acquired_deferred_6", " writeManagerThreadPrimaryKeysWithChangesToBeMerged: true"
                 + "\n writeManagerThreadPrimaryKeysWithChangesToBeMerged list: {0}\n"},
         { "concurrency_util_create_information_all_resources_acquired_deferred_7", " writeManagerThreadPrimaryKeysWithChangesToBeMerged: false\n"},
-        { "concurrency_util_create_information_all_resources_acquired_deferred_8", "Concurrency manager - Page 05 end (currentThreadNumber: {0} of totalNumberOfThreads: {1})  - detailed information about specific thread\n"},
+        { "concurrency_util_create_information_all_resources_acquired_deferred_8", " waitingToReleaseDeferredLocksJustification: \n {0} \n"},
+        { "concurrency_util_create_information_all_resources_acquired_deferred_9", " waitingToReleaseDeferredLocksJustification: information not available. \n"},
+        { "concurrency_util_create_information_all_resources_acquired_deferred_10", "Concurrency manager - Page 05 end (currentThreadNumber: {0} of totalNumberOfThreads: {1})  - detailed information about specific thread\n"},
         { "concurrency_util_read_lock_manager_problem01", "Remove cache key from read lock manager problem 01:"
                 + "\n The current thread: {0} is about to decrement the currentNumberOfReaders from: {1}  to decrementedNumberOfReaders {2} "
                 + "\n  on the cache key: {3}"

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/security/PrivilegedAccessHelper.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/security/PrivilegedAccessHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -66,7 +66,7 @@ public class PrivilegedAccessHelper {
             SystemProperties.ARCHIVE_FACTORY, SystemProperties.ENFORCE_TARGET_SERVER, SystemProperties.RECORD_STACK_ON_LOCK,
             SystemProperties.WEAVING_OUTPUT_PATH, SystemProperties.WEAVING_SHOULD_OVERWRITE, SystemProperties.WEAVING_REFLECTIVE_INTROSPECTION,
             SystemProperties.DO_NOT_PROCESS_XTOMANY_FOR_QBE, SystemProperties.ONETOMANY_DEFER_INSERTS,
-            SystemProperties.CONCURRENCY_MANAGER_ACQUIRE_WAIT_TIME, SystemProperties.CONCURRENCY_MANAGER_MAX_SLEEP_TIME,
+            SystemProperties.CONCURRENCY_MANAGER_ACQUIRE_WAIT_TIME, SystemProperties.CONCURRENCY_MANAGER_BUILD_OBJECT_COMPLETE_WAIT_TIME, SystemProperties.CONCURRENCY_MANAGER_MAX_SLEEP_TIME,
             SystemProperties.CONCURRENCY_MANAGER_MAX_FREQUENCY_DUMP_TINY_MESSAGE, SystemProperties.CONCURRENCY_MANAGER_MAX_FREQUENCY_DUMP_MASSIVE_MESSAGE,
             SystemProperties.CONCURRENCY_MANAGER_ALLOW_INTERRUPTED_EXCEPTION, SystemProperties.CONCURRENCY_MANAGER_ALLOW_CONCURRENCY_EXCEPTION, SystemProperties.CONCURRENCY_MANAGER_ALLOW_STACK_TRACE_READ_LOCK,
             ServerPlatformBase.JMX_REGISTER_RUN_MBEAN_PROPERTY, ServerPlatformBase.JMX_REGISTER_DEV_MBEAN_PROPERTY,

--- a/jpa/eclipselink.jpa.test.jse/src/META-INF/persistence.xml
+++ b/jpa/eclipselink.jpa.test.jse/src/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <!--/*******************************************************************************
-* Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
-* Copyright (c) 2020 IBM Corporation. All rights reserved.
+* Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 2020, 2021 IBM Corporation. All rights reserved.
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
 * which accompanies this distribution.
@@ -60,6 +60,7 @@
                <property name="eclipselink.concurrency.manager.maxsleeptime" value="2"/>
                <property name="eclipselink.concurrency.manager.maxfrequencytodumptinymessage" value="3"/>
                <property name="eclipselink.concurrency.manager.maxfrequencytodumpmassivemessage" value="4"/>
+               <property name="eclipselink.concurrency.manager.build.object.complete.waittime" value="5"/>
                <property name="eclipselink.concurrency.manager.allow.readlockstacktrace" value="true"/>
                <property name="eclipselink.concurrency.manager.allow.concurrencyexception" value="true"/>
                <property name="eclipselink.concurrency.manager.allow.interruptedexception" value="true"/>

--- a/jpa/eclipselink.jpa.test.jse/src/META-INF/persistence.xml
+++ b/jpa/eclipselink.jpa.test.jse/src/META-INF/persistence.xml
@@ -58,12 +58,34 @@
           <properties>
                <property name="eclipselink.concurrency.manager.waittime" value="1"/>
                <property name="eclipselink.concurrency.manager.maxsleeptime" value="2"/>
-               <property name="eclipselink.concurrency.manager.maxfrequencytodumptinymessage" value="3"/>
-               <property name="eclipselink.concurrency.manager.maxfrequencytodumpmassivemessage" value="4"/>
+               <property name="eclipselink.concurrency.manager.maxfrequencytodumptinymessage" value="800"/>
+               <property name="eclipselink.concurrency.manager.maxfrequencytodumpmassivemessage" value="1000"/>
                <property name="eclipselink.concurrency.manager.build.object.complete.waittime" value="5"/>
                <property name="eclipselink.concurrency.manager.allow.readlockstacktrace" value="true"/>
                <property name="eclipselink.concurrency.manager.allow.concurrencyexception" value="true"/>
                <property name="eclipselink.concurrency.manager.allow.interruptedexception" value="true"/>
+          </properties>
+     </persistence-unit>
+
+     <persistence-unit name="cachedeadlocksemaphore-pu" transaction-type="RESOURCE_LOCAL">
+          <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+          <exclude-unlisted-classes>true</exclude-unlisted-classes>
+          <class>org.eclipse.persistence.jpa.test.cachedeadlock.model.CacheDeadLockDetectionMaster</class>
+          <class>org.eclipse.persistence.jpa.test.cachedeadlock.model.CacheDeadLockDetectionDetail</class>
+          <properties>
+               <property name="eclipselink.concurrency.manager.waittime" value="1"/>
+               <property name="eclipselink.concurrency.manager.maxsleeptime" value="2"/>
+               <property name="eclipselink.concurrency.manager.maxfrequencytodumptinymessage" value="1000"/>
+               <property name="eclipselink.concurrency.manager.maxfrequencytodumpmassivemessage" value="2000"/>
+               <property name="eclipselink.concurrency.manager.allow.readlockstacktrace" value="true"/>
+               <property name="eclipselink.concurrency.manager.allow.concurrencyexception" value="true"/>
+               <property name="eclipselink.concurrency.manager.allow.interruptedexception" value="true"/>
+               <property name="eclipselink.concurrency.manager.object.building.semaphore" value="true"/>
+               <property name="eclipselink.concurrency.manager.object.building.no.threads" value="5"/>
+               <property name="eclipselink.concurrency.manager.write.lock.manager.semaphore" value="true"/>
+               <property name="eclipselink.concurrency.manager.write.lock.manager.no.threads" value="6"/>
+               <property name="eclipselink.concurrency.semaphore.max.time.permit" value="7"/>
+               <property name="eclipselink.concurrency.semaphore.log.timeout" value="8"/>
           </properties>
      </persistence-unit>
 

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/cachedeadlock/CacheDeadLockDetectionTest.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/cachedeadlock/CacheDeadLockDetectionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -122,6 +122,7 @@ public class CacheDeadLockDetectionTest {
         assertEquals(2L, ConcurrencyUtil.SINGLETON.getMaxAllowedSleepTime());
         assertEquals(3L, ConcurrencyUtil.SINGLETON.getMaxAllowedFrequencyToProduceTinyDumpLogMessage());
         assertEquals(4L, ConcurrencyUtil.SINGLETON.getMaxAllowedFrequencyToProduceMassiveDumpLogMessage());
+        assertEquals(5L, ConcurrencyUtil.SINGLETON.getBuildObjectCompleteWaitTime());
         assertTrue(ConcurrencyUtil.SINGLETON.isAllowTakingStackTraceDuringReadLockAcquisition());
         assertTrue(ConcurrencyUtil.SINGLETON.isAllowConcurrencyExceptionToBeFiredUp());
         assertTrue(ConcurrencyUtil.SINGLETON.isAllowInterruptedExceptionFired());

--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
@@ -2842,6 +2842,12 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
             updateConcurrencyManagerAllowInterruptedExceptionFired(m);
             updateConcurrencyManagerAllowConcurrencyExceptionToBeFiredUp(m);
             updateConcurrencyManagerAllowTakingStackTraceDuringReadLockAcquisition(m);
+            updateConcurrencyManagerUseObjectBuildingSemaphore(m);
+            updateConcurrencyManagerUseWriteLockManagerSemaphore(m);
+            updateConcurrencyManagerNoOfThreadsAllowedToObjectBuildInParallel(m);
+            updateConcurrencyManagerNoOfThreadsAllowedToDoWriteLockManagerAcquireRequiredLocksInParallel(m);
+            updateConcurrencySemaphoreMaxTimePermit(m);
+            updateConcurrencySemaphoreLogTimeout(m);
             // Customizers should be processed last
             processDescriptorCustomizers(m, loader);
             processSessionCustomizer(m, loader);
@@ -3680,6 +3686,72 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
             }
         } catch (NumberFormatException exception) {
             this.session.handleException(ValidationException.invalidValueForProperty(allowTakingStackTraceDuringReadLockAcquisition, PersistenceUnitProperties.CONCURRENCY_MANAGER_ALLOW_STACK_TRACE_READ_LOCK, exception));
+        }
+    }
+
+    private void updateConcurrencyManagerUseObjectBuildingSemaphore(Map persistenceProperties) {
+        String useObjectBuildingSemaphore = EntityManagerFactoryProvider.getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.CONCURRENCY_MANAGER_USE_SEMAPHORE_TO_SLOW_DOWN_OBJECT_BUILDING, persistenceProperties, session);
+        try {
+            if (useObjectBuildingSemaphore != null) {
+                ConcurrencyUtil.SINGLETON.setUseSemaphoreInObjectBuilder(Boolean.parseBoolean(useObjectBuildingSemaphore));
+            }
+        } catch (NumberFormatException exception) {
+            this.session.handleException(ValidationException.invalidValueForProperty(useObjectBuildingSemaphore, PersistenceUnitProperties.CONCURRENCY_MANAGER_USE_SEMAPHORE_TO_SLOW_DOWN_OBJECT_BUILDING, exception));
+        }
+    }
+
+    private void updateConcurrencyManagerUseWriteLockManagerSemaphore(Map persistenceProperties) {
+        String useWriteLockManagerSemaphore = EntityManagerFactoryProvider.getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.CONCURRENCY_MANAGER_USE_SEMAPHORE_TO_SLOW_DOWN_WRITE_LOCK_MANAGER_ACQUIRE_REQUIRED_LOCKS, persistenceProperties, session);
+        try {
+            if (useWriteLockManagerSemaphore != null) {
+                ConcurrencyUtil.SINGLETON.setUseSemaphoreToLimitConcurrencyOnWriteLockManagerAcquireRequiredLocks(Boolean.parseBoolean(useWriteLockManagerSemaphore));
+            }
+        } catch (NumberFormatException exception) {
+            this.session.handleException(ValidationException.invalidValueForProperty(useWriteLockManagerSemaphore, PersistenceUnitProperties.CONCURRENCY_MANAGER_USE_SEMAPHORE_TO_SLOW_DOWN_WRITE_LOCK_MANAGER_ACQUIRE_REQUIRED_LOCKS, exception));
+        }
+    }
+
+    private void updateConcurrencyManagerNoOfThreadsAllowedToObjectBuildInParallel(Map persistenceProperties) {
+        String noOfThreadsAllowedToObjectBuildInParallel = EntityManagerFactoryProvider.getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.CONCURRENCY_MANAGER_OBJECT_BUILDING_NO_THREADS, persistenceProperties, session);
+        try {
+            if (noOfThreadsAllowedToObjectBuildInParallel != null) {
+                ConcurrencyUtil.SINGLETON.setNoOfThreadsAllowedToObjectBuildInParallel(Integer.parseInt(noOfThreadsAllowedToObjectBuildInParallel));
+            }
+        } catch (NumberFormatException exception) {
+            this.session.handleException(ValidationException.invalidValueForProperty(noOfThreadsAllowedToObjectBuildInParallel, PersistenceUnitProperties.CONCURRENCY_MANAGER_OBJECT_BUILDING_NO_THREADS, exception));
+        }
+    }
+
+    private void updateConcurrencyManagerNoOfThreadsAllowedToDoWriteLockManagerAcquireRequiredLocksInParallel(Map persistenceProperties) {
+        String noOfThreadsAllowedToDoWriteLockManagerAcquireRequiredLocksInParallel = EntityManagerFactoryProvider.getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.CONCURRENCY_MANAGER_WRITE_LOCK_MANAGER_ACQUIRE_REQUIRED_LOCKS_NO_THREADS, persistenceProperties, session);
+        try {
+            if (noOfThreadsAllowedToDoWriteLockManagerAcquireRequiredLocksInParallel != null) {
+                ConcurrencyUtil.SINGLETON.setNoOfThreadsAllowedToDoWriteLockManagerAcquireRequiredLocksInParallel(Integer.parseInt(noOfThreadsAllowedToDoWriteLockManagerAcquireRequiredLocksInParallel));
+            }
+        } catch (NumberFormatException exception) {
+            this.session.handleException(ValidationException.invalidValueForProperty(noOfThreadsAllowedToDoWriteLockManagerAcquireRequiredLocksInParallel, PersistenceUnitProperties.CONCURRENCY_MANAGER_WRITE_LOCK_MANAGER_ACQUIRE_REQUIRED_LOCKS_NO_THREADS, exception));
+        }
+    }
+
+    private void updateConcurrencySemaphoreMaxTimePermit(Map persistenceProperties) {
+        String concurrencySemaphoreMaxTimePermit = EntityManagerFactoryProvider.getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.CONCURRENCY_SEMAPHORE_MAX_TIME_PERMIT, persistenceProperties, session);
+        try {
+            if (concurrencySemaphoreMaxTimePermit != null) {
+                ConcurrencyUtil.SINGLETON.setConcurrencySemaphoreMaxTimePermit(Long.parseLong(concurrencySemaphoreMaxTimePermit));
+            }
+        } catch (NumberFormatException exception) {
+            this.session.handleException(ValidationException.invalidValueForProperty(concurrencySemaphoreMaxTimePermit, PersistenceUnitProperties.CONCURRENCY_SEMAPHORE_MAX_TIME_PERMIT, exception));
+        }
+    }
+
+    private void updateConcurrencySemaphoreLogTimeout(Map persistenceProperties) {
+        String concurrencySemaphoreLogTimeout = EntityManagerFactoryProvider.getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.CONCURRENCY_SEMAPHORE_LOG_TIMEOUT, persistenceProperties, session);
+        try {
+            if (concurrencySemaphoreLogTimeout != null) {
+                ConcurrencyUtil.SINGLETON.setConcurrencySemaphoreLogTimeout(Long.parseLong(concurrencySemaphoreLogTimeout));
+            }
+        } catch (NumberFormatException exception) {
+            this.session.handleException(ValidationException.invalidValueForProperty(concurrencySemaphoreLogTimeout, PersistenceUnitProperties.CONCURRENCY_SEMAPHORE_LOG_TIMEOUT, exception));
         }
     }
 
@@ -4567,4 +4639,3 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
         }
     }
 }
-

--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
@@ -189,6 +189,7 @@ import org.eclipse.persistence.internal.descriptors.OptimisticLockingPolicy;
 import org.eclipse.persistence.internal.descriptors.OptimisticLockingPolicy.LockOnChange;
 import org.eclipse.persistence.internal.helper.ClassConstants;
 import org.eclipse.persistence.internal.helper.ConcurrencyManager;
+import org.eclipse.persistence.internal.helper.ConcurrencyUtil;
 import org.eclipse.persistence.internal.helper.Helper;
 import org.eclipse.persistence.internal.helper.JPAClassLoaderHolder;
 import org.eclipse.persistence.internal.helper.JPAConversionManager;
@@ -2832,7 +2833,15 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
             updateShouldOptimizeResultSetAccess(m);
             updateTolerateInvalidJPQL(m);
             updateTenancy(m, loader);
-            
+            // ConcurrencyManager properties
+            updateConcurrencyManagerWaitTime(m);
+            updateConcurrencyManagerBuildObjectCompleteWaitTime(m);
+            updateConcurrencyManagerMaxAllowedSleepTime(m);
+            updateConcurrencyManagerMaxAllowedFrequencyToProduceTinyDumpLogMessage(m);
+            updateConcurrencyManagerMaxAllowedFrequencyToProduceMassiveDumpLogMessage(m);
+            updateConcurrencyManagerAllowInterruptedExceptionFired(m);
+            updateConcurrencyManagerAllowConcurrencyExceptionToBeFiredUp(m);
+            updateConcurrencyManagerAllowTakingStackTraceDuringReadLockAcquisition(m);
             // Customizers should be processed last
             processDescriptorCustomizers(m, loader);
             processSessionCustomizer(m, loader);
@@ -3583,6 +3592,94 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
             }
         } catch (NumberFormatException exception) {
             this.session.handleException(ValidationException.invalidValueForProperty(local, PersistenceUnitProperties.USE_LOCAL_TIMESTAMP, exception));
+        }
+    }
+
+    private void updateConcurrencyManagerWaitTime(Map persistenceProperties) {
+        String acquireWaitTime = EntityManagerFactoryProvider.getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.CONCURRENCY_MANAGER_ACQUIRE_WAIT_TIME, persistenceProperties, session);
+        try {
+            if (acquireWaitTime != null) {
+                ConcurrencyUtil.SINGLETON.setAcquireWaitTime(Long.parseLong(acquireWaitTime));
+            }
+        } catch (NumberFormatException exception) {
+            this.session.handleException(ValidationException.invalidValueForProperty(acquireWaitTime, PersistenceUnitProperties.CONCURRENCY_MANAGER_ACQUIRE_WAIT_TIME, exception));
+        }
+    }
+
+    private void updateConcurrencyManagerBuildObjectCompleteWaitTime(Map persistenceProperties) {
+        String buildObjectCompleteWaitTime = EntityManagerFactoryProvider.getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.CONCURRENCY_MANAGER_BUILD_OBJECT_COMPLETE_WAIT_TIME, persistenceProperties, session);
+        try {
+            if (buildObjectCompleteWaitTime != null) {
+                ConcurrencyUtil.SINGLETON.setBuildObjectCompleteWaitTime(Long.parseLong(buildObjectCompleteWaitTime));
+            }
+        } catch (NumberFormatException exception) {
+            this.session.handleException(ValidationException.invalidValueForProperty(buildObjectCompleteWaitTime, PersistenceUnitProperties.CONCURRENCY_MANAGER_BUILD_OBJECT_COMPLETE_WAIT_TIME, exception));
+        }
+    }
+
+    private void updateConcurrencyManagerMaxAllowedSleepTime(Map persistenceProperties) {
+        String maxAllowedSleepTime = EntityManagerFactoryProvider.getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.CONCURRENCY_MANAGER_MAX_SLEEP_TIME, persistenceProperties, session);
+        try {
+            if (maxAllowedSleepTime != null) {
+                ConcurrencyUtil.SINGLETON.setMaxAllowedSleepTime(Long.parseLong(maxAllowedSleepTime));
+            }
+        } catch (NumberFormatException exception) {
+            this.session.handleException(ValidationException.invalidValueForProperty(maxAllowedSleepTime, PersistenceUnitProperties.CONCURRENCY_MANAGER_MAX_SLEEP_TIME, exception));
+        }
+    }
+
+    private void updateConcurrencyManagerMaxAllowedFrequencyToProduceTinyDumpLogMessage(Map persistenceProperties) {
+        String maxAllowedSleepTime = EntityManagerFactoryProvider.getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.CONCURRENCY_MANAGER_MAX_FREQUENCY_DUMP_TINY_MESSAGE, persistenceProperties, session);
+        try {
+            if (maxAllowedSleepTime != null) {
+                ConcurrencyUtil.SINGLETON.setMaxAllowedFrequencyToProduceTinyDumpLogMessage(Long.parseLong(maxAllowedSleepTime));
+            }
+        } catch (NumberFormatException exception) {
+            this.session.handleException(ValidationException.invalidValueForProperty(maxAllowedSleepTime, PersistenceUnitProperties.CONCURRENCY_MANAGER_MAX_FREQUENCY_DUMP_TINY_MESSAGE, exception));
+        }
+    }
+
+    private void updateConcurrencyManagerMaxAllowedFrequencyToProduceMassiveDumpLogMessage(Map persistenceProperties) {
+        String maxAllowedSleepTime = EntityManagerFactoryProvider.getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.CONCURRENCY_MANAGER_MAX_FREQUENCY_DUMP_MASSIVE_MESSAGE, persistenceProperties, session);
+        try {
+            if (maxAllowedSleepTime != null) {
+                ConcurrencyUtil.SINGLETON.setMaxAllowedFrequencyToProduceMassiveDumpLogMessage(Long.parseLong(maxAllowedSleepTime));
+            }
+        } catch (NumberFormatException exception) {
+            this.session.handleException(ValidationException.invalidValueForProperty(maxAllowedSleepTime, PersistenceUnitProperties.CONCURRENCY_MANAGER_MAX_FREQUENCY_DUMP_MASSIVE_MESSAGE, exception));
+        }
+    }
+
+    private void updateConcurrencyManagerAllowInterruptedExceptionFired(Map persistenceProperties) {
+        String allowInterruptedExceptionFired = EntityManagerFactoryProvider.getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.CONCURRENCY_MANAGER_ALLOW_INTERRUPTED_EXCEPTION, persistenceProperties, session);
+        try {
+            if (allowInterruptedExceptionFired != null) {
+                ConcurrencyUtil.SINGLETON.setAllowInterruptedExceptionFired(Boolean.parseBoolean(allowInterruptedExceptionFired));
+            }
+        } catch (NumberFormatException exception) {
+            this.session.handleException(ValidationException.invalidValueForProperty(allowInterruptedExceptionFired, PersistenceUnitProperties.CONCURRENCY_MANAGER_ALLOW_INTERRUPTED_EXCEPTION, exception));
+        }
+    }
+
+    private void updateConcurrencyManagerAllowConcurrencyExceptionToBeFiredUp(Map persistenceProperties) {
+        String allowConcurrencyExceptionToBeFiredUp = EntityManagerFactoryProvider.getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.CONCURRENCY_MANAGER_ALLOW_CONCURRENCY_EXCEPTION, persistenceProperties, session);
+        try {
+            if (allowConcurrencyExceptionToBeFiredUp != null) {
+                ConcurrencyUtil.SINGLETON.setAllowConcurrencyExceptionToBeFiredUp(Boolean.parseBoolean(allowConcurrencyExceptionToBeFiredUp));
+            }
+        } catch (NumberFormatException exception) {
+            this.session.handleException(ValidationException.invalidValueForProperty(allowConcurrencyExceptionToBeFiredUp, PersistenceUnitProperties.CONCURRENCY_MANAGER_ALLOW_CONCURRENCY_EXCEPTION, exception));
+        }
+    }
+
+    private void updateConcurrencyManagerAllowTakingStackTraceDuringReadLockAcquisition(Map persistenceProperties) {
+        String allowTakingStackTraceDuringReadLockAcquisition = EntityManagerFactoryProvider.getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.CONCURRENCY_MANAGER_ALLOW_STACK_TRACE_READ_LOCK, persistenceProperties, session);
+        try {
+            if (allowTakingStackTraceDuringReadLockAcquisition != null) {
+                ConcurrencyUtil.SINGLETON.setAllowTakingStackTraceDuringReadLockAcquisition(Boolean.parseBoolean(allowTakingStackTraceDuringReadLockAcquisition));
+            }
+        } catch (NumberFormatException exception) {
+            this.session.handleException(ValidationException.invalidValueForProperty(allowTakingStackTraceDuringReadLockAcquisition, PersistenceUnitProperties.CONCURRENCY_MANAGER_ALLOW_STACK_TRACE_READ_LOCK, exception));
         }
     }
 


### PR DESCRIPTION
This backport of PRs #1038,  #1041 and #1048

This is extension to current dead-lock detection diagnostic.
Major updates are:

- New system/persistence property `eclipselink.concurrency.manager.build.object.complete.waittime` to control how much time ConcurrencyManager will wait before it will identify, that thread which builds new object/entity instance should be identified as a potential dead lock source and log info.
- Addition to current dead-lock detection log output with method name (from ConcurrencyManager) where dead-lock should happen
- `org.eclipse.persistence.internal.helper.ConcurrencyManager#isBuildObjectOnThreadComplete` minor changes to log some dead-lock diagnostic output
- Implementation of  `org.eclipse.persistence.internal.helper.ConcurrencySemaphore` which should be used to control/limit how many threads should execute selected code.
In this case is `ConcurrencySemaphore` used to limit parallel access to `org.eclipse.persistence.internal.descriptors.ObjectBuilder` and `org.eclipse.persistence.internal.helper.WriteLockManager` to prevent possible dead-lock issues there.
If ConcurrencySemaphore will be active, there should be negative impact to the performance.
By default ConcurrencySemaphore is disabled and must be enabled by persistence or system properties.
