### PR TITLE
[master] ConcurrencySemaphore unit test

### DIFF
--- a/foundation/eclipselink.core.test/src/test/java/org/eclipse/persistence/testing/tests/junit/helper/ConcurrencySemaphoreTest.java
+++ b/foundation/eclipselink.core.test/src/test/java/org/eclipse/persistence/testing/tests/junit/helper/ConcurrencySemaphoreTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.testing.tests.junit.helper;
+
+import org.eclipse.persistence.internal.helper.ConcurrencyUtil;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class ConcurrencySemaphoreTest {
+
+    private static final int INITIAL_NO_OF_THREADS = 100;
+    private static final long MAX_TIME_PERMIT = 500L;
+    private static final long TIMEOUT_BETWEEN_LOG_MESSAGES = 20000L;
+
+    @Before
+    public void setup() {
+        //This kind of setup is for test purpose only. Standard way is via persistence.xml properties or system properties.
+        ConcurrencyUtil.SINGLETON.setConcurrencySemaphoreMaxTimePermit(MAX_TIME_PERMIT);
+        ConcurrencyUtil.SINGLETON.setConcurrencySemaphoreLogTimeout(TIMEOUT_BETWEEN_LOG_MESSAGES);
+    }
+
+    @Test
+    public void testConcurrencySemaphore() throws Exception {
+        //Verify setup
+        assertEquals(MAX_TIME_PERMIT, ConcurrencyUtil.SINGLETON.getConcurrencySemaphoreMaxTimePermit());
+        assertEquals(TIMEOUT_BETWEEN_LOG_MESSAGES, ConcurrencyUtil.SINGLETON.getConcurrencySemaphoreLogTimeout());
+        //Prepare executor and start threads
+        ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(INITIAL_NO_OF_THREADS);
+        for (int i = 1; i <= INITIAL_NO_OF_THREADS; i++) {
+            Thread thread = new Thread(new ConcurrencySemaphoreThread());
+            executor.execute(thread);
+        }
+        executor.shutdown();
+        // Wait for everything to finish.
+        while (!executor.awaitTermination(20, TimeUnit.SECONDS)) {
+            System.out.println("Awaiting completion of threads.");
+        }
+    }
+}

--- a/foundation/eclipselink.core.test/src/test/java/org/eclipse/persistence/testing/tests/junit/helper/ConcurrencySemaphoreTest.java
+++ b/foundation/eclipselink.core.test/src/test/java/org/eclipse/persistence/testing/tests/junit/helper/ConcurrencySemaphoreTest.java
@@ -16,7 +16,6 @@ package org.eclipse.persistence.testing.tests.junit.helper;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.persistence.internal.helper.ConcurrencyUtil;

--- a/foundation/eclipselink.core.test/src/test/java/org/eclipse/persistence/testing/tests/junit/helper/ConcurrencySemaphoreTest.java
+++ b/foundation/eclipselink.core.test/src/test/java/org/eclipse/persistence/testing/tests/junit/helper/ConcurrencySemaphoreTest.java
@@ -14,6 +14,7 @@
 //     Oracle - initial API and implementation
 package org.eclipse.persistence.testing.tests.junit.helper;
 
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -44,14 +45,14 @@ public class ConcurrencySemaphoreTest {
         assertEquals(MAX_TIME_PERMIT, ConcurrencyUtil.SINGLETON.getConcurrencySemaphoreMaxTimePermit());
         assertEquals(TIMEOUT_BETWEEN_LOG_MESSAGES, ConcurrencyUtil.SINGLETON.getConcurrencySemaphoreLogTimeout());
         //Prepare executor and start threads
-        ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(INITIAL_NO_OF_THREADS);
+        ExecutorService executorService = Executors.newFixedThreadPool(INITIAL_NO_OF_THREADS);
         for (int i = 1; i <= INITIAL_NO_OF_THREADS; i++) {
-            Thread thread = new Thread(new ConcurrencySemaphoreThread());
-            executor.execute(thread);
+            Runnable thread = new ConcurrencySemaphoreThread();
+            executorService.execute(thread);
         }
-        executor.shutdown();
+        executorService.shutdown();
         // Wait for everything to finish.
-        while (!executor.awaitTermination(20, TimeUnit.SECONDS)) {
+        while (!executorService.awaitTermination(20, TimeUnit.SECONDS)) {
             System.out.println("Awaiting completion of threads.");
         }
     }

--- a/foundation/eclipselink.core.test/src/test/java/org/eclipse/persistence/testing/tests/junit/helper/ConcurrencySemaphoreTest.java
+++ b/foundation/eclipselink.core.test/src/test/java/org/eclipse/persistence/testing/tests/junit/helper/ConcurrencySemaphoreTest.java
@@ -14,13 +14,13 @@
 //     Oracle - initial API and implementation
 package org.eclipse.persistence.testing.tests.junit.helper;
 
-import org.eclipse.persistence.internal.helper.ConcurrencyUtil;
-import org.junit.Before;
-import org.junit.Test;
-
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+
+import org.eclipse.persistence.internal.helper.ConcurrencyUtil;
+import org.junit.Before;
+import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 

--- a/foundation/eclipselink.core.test/src/test/java/org/eclipse/persistence/testing/tests/junit/helper/ConcurrencySemaphoreThread.java
+++ b/foundation/eclipselink.core.test/src/test/java/org/eclipse/persistence/testing/tests/junit/helper/ConcurrencySemaphoreThread.java
@@ -18,6 +18,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.persistence.internal.helper.ConcurrencySemaphore;
+import org.junit.Assert;
 
 import static org.junit.Assert.assertTrue;
 
@@ -43,7 +44,7 @@ public class ConcurrencySemaphoreThread implements Runnable {
             //Instead or some code which should take some time is there sleep.
             Thread.currentThread().sleep(300);
         } catch (InterruptedException ex) {
-            throw new RuntimeException("Semaphore Test thread was interrupted.  Test failed to run properly");
+            Assert.fail("Semaphore Test thread was interrupted.  Test failed to run properly");
         } finally {
             currentNoOfThreads.decrementAndGet();
             testSemaphore.releaseSemaphoreAllowOtherThreadsToStartDoingObjectBuilding(semaphoreWasAcquired);

--- a/foundation/eclipselink.core.test/src/test/java/org/eclipse/persistence/testing/tests/junit/helper/ConcurrencySemaphoreThread.java
+++ b/foundation/eclipselink.core.test/src/test/java/org/eclipse/persistence/testing/tests/junit/helper/ConcurrencySemaphoreThread.java
@@ -41,7 +41,7 @@ public class ConcurrencySemaphoreThread implements Runnable {
             semaphoreWasAcquired = testSemaphore.acquireSemaphoreIfAppropriate(true);
             //Current No of threads there can't be more than SEMAPHORE_MAX_NUMBER_THREADS
             assertTrue(currentNoOfThreads.incrementAndGet() <= SEMAPHORE_MAX_NUMBER_THREADS);
-            //Instead or some code which should take some time is there sleep.
+            //Instead of some code which should take some time is there sleep.
             Thread.currentThread().sleep(300);
         } catch (InterruptedException ex) {
             Assert.fail("Semaphore Test thread was interrupted.  Test failed to run properly");

--- a/foundation/eclipselink.core.test/src/test/java/org/eclipse/persistence/testing/tests/junit/helper/ConcurrencySemaphoreThread.java
+++ b/foundation/eclipselink.core.test/src/test/java/org/eclipse/persistence/testing/tests/junit/helper/ConcurrencySemaphoreThread.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.testing.tests.junit.helper;
+
+import org.eclipse.persistence.internal.helper.ConcurrencySemaphore;
+
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertTrue;
+
+public class ConcurrencySemaphoreThread implements Runnable {
+
+    /**
+     * Semaphore related properties.
+     */
+    private static final ThreadLocal<Boolean> SEMAPHORE_THREAD_LOCAL_VAR = new ThreadLocal<>();
+    private static final int SEMAPHORE_MAX_NUMBER_THREADS = 12;
+    private static final Semaphore SEMAPHORE_LIMIT_MAX_NUMBER_OF_THREADS_IN_TEST = new Semaphore(SEMAPHORE_MAX_NUMBER_THREADS);
+    private ConcurrencySemaphore testSemaphore = new ConcurrencySemaphore(SEMAPHORE_THREAD_LOCAL_VAR, SEMAPHORE_MAX_NUMBER_THREADS, SEMAPHORE_LIMIT_MAX_NUMBER_OF_THREADS_IN_TEST, this, "object_builder_semaphore_acquired_01");
+
+    private static AtomicInteger currentNoOfThreads = new AtomicInteger(0);
+
+    public void run() {
+        boolean semaphoreWasAcquired = false;
+        try {
+            //Semaphore call
+            semaphoreWasAcquired = testSemaphore.acquireSemaphoreIfAppropriate(true);
+            //Current No of threads there can't be more than SEMAPHORE_MAX_NUMBER_THREADS
+            assertTrue(currentNoOfThreads.incrementAndGet() <= SEMAPHORE_MAX_NUMBER_THREADS);
+            //Instead or some code which should take some time is there sleep.
+            Thread.currentThread().sleep(300);
+        } catch (InterruptedException ex) {
+            throw new RuntimeException("Semaphore Test thread was interrupted.  Test failed to run properly");
+        } finally {
+            currentNoOfThreads.decrementAndGet();
+            testSemaphore.releaseSemaphoreAllowOtherThreadsToStartDoingObjectBuilding(semaphoreWasAcquired);
+        }
+    }
+}

--- a/foundation/eclipselink.core.test/src/test/java/org/eclipse/persistence/testing/tests/junit/helper/ConcurrencySemaphoreThread.java
+++ b/foundation/eclipselink.core.test/src/test/java/org/eclipse/persistence/testing/tests/junit/helper/ConcurrencySemaphoreThread.java
@@ -14,10 +14,10 @@
 //     Oracle - initial API and implementation
 package org.eclipse.persistence.testing.tests.junit.helper;
 
-import org.eclipse.persistence.internal.helper.ConcurrencySemaphore;
-
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.persistence.internal.helper.ConcurrencySemaphore;
 
 import static org.junit.Assert.assertTrue;
 


### PR DESCRIPTION
This is unit test for `org.eclipse.persistence.internal.helper.ConcurrencySemaphore` implemented in #1041 .

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>