### PR TITLE
Maven build - JPA JSE test fix on JDK 16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,8 +224,8 @@
         <slf4j.version>2.0.0-alpha1</slf4j.version>
         <!-- CQ #23051, 23052, 23053, 53054, 53055 -->
         <springframework.version>5.3.4</springframework.version>
-        <!-- CQ #23050 -->
-        <weld-se.version>4.0.0.Final</weld-se.version>
+        <!-- CQ #23233 -->
+        <weld-se.version>4.0.1.Final</weld-se.version>
         <weblogic.version>12.2.1-3</weblogic.version>
         <wildfly.version>18.0.0.Final</wildfly.version>
         <wsdl4j.version>1.6.3</wsdl4j.version>


### PR DESCRIPTION
There is Weld SE dependency update to fix org.eclipse.persistence.jpa.test.cachedeadlock.CacheDeadLockDetectionTest in JPA JSE test module.
Test failure happens on JDK 16 only.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>