### PR TITLE
[2.7] ConcurrencySemaphores unit test - backport from master

### DIFF
--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/junit/helper/ConcurrencySemaphoreTest.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/junit/helper/ConcurrencySemaphoreTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.testing.tests.junit.helper;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.persistence.internal.helper.ConcurrencyUtil;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class ConcurrencySemaphoreTest {
+
+    private static final int INITIAL_NO_OF_THREADS = 100;
+    private static final long MAX_TIME_PERMIT = 500L;
+    private static final long TIMEOUT_BETWEEN_LOG_MESSAGES = 20000L;
+
+    @Before
+    public void setup() {
+        //This kind of setup is for test purpose only. Standard way is via persistence.xml properties or system properties.
+        ConcurrencyUtil.SINGLETON.setConcurrencySemaphoreMaxTimePermit(MAX_TIME_PERMIT);
+        ConcurrencyUtil.SINGLETON.setConcurrencySemaphoreLogTimeout(TIMEOUT_BETWEEN_LOG_MESSAGES);
+    }
+
+    @Test
+    public void testConcurrencySemaphore() throws Exception {
+        //Verify setup
+        assertEquals(MAX_TIME_PERMIT, ConcurrencyUtil.SINGLETON.getConcurrencySemaphoreMaxTimePermit());
+        assertEquals(TIMEOUT_BETWEEN_LOG_MESSAGES, ConcurrencyUtil.SINGLETON.getConcurrencySemaphoreLogTimeout());
+        //Prepare executor and start threads
+        ExecutorService executorService = Executors.newFixedThreadPool(INITIAL_NO_OF_THREADS);
+        for (int i = 1; i <= INITIAL_NO_OF_THREADS; i++) {
+            Runnable thread = new ConcurrencySemaphoreThread();
+            executorService.execute(thread);
+        }
+        executorService.shutdown();
+        // Wait for everything to finish.
+        while (!executorService.awaitTermination(20, TimeUnit.SECONDS)) {
+            System.out.println("Awaiting completion of threads.");
+        }
+    }
+}

--- a/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/junit/helper/ConcurrencySemaphoreThread.java
+++ b/foundation/eclipselink.core.test/src/org/eclipse/persistence/testing/tests/junit/helper/ConcurrencySemaphoreThread.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.testing.tests.junit.helper;
+
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.persistence.internal.helper.ConcurrencySemaphore;
+import org.junit.Assert;
+
+import static org.junit.Assert.assertTrue;
+
+public class ConcurrencySemaphoreThread implements Runnable {
+
+    /**
+     * Semaphore related properties.
+     */
+    private static final ThreadLocal<Boolean> SEMAPHORE_THREAD_LOCAL_VAR = new ThreadLocal<>();
+    private static final int SEMAPHORE_MAX_NUMBER_THREADS = 12;
+    private static final Semaphore SEMAPHORE_LIMIT_MAX_NUMBER_OF_THREADS_IN_TEST = new Semaphore(SEMAPHORE_MAX_NUMBER_THREADS);
+    private ConcurrencySemaphore testSemaphore = new ConcurrencySemaphore(SEMAPHORE_THREAD_LOCAL_VAR, SEMAPHORE_MAX_NUMBER_THREADS, SEMAPHORE_LIMIT_MAX_NUMBER_OF_THREADS_IN_TEST, this, "object_builder_semaphore_acquired_01");
+
+    private static AtomicInteger currentNoOfThreads = new AtomicInteger(0);
+
+    public void run() {
+        boolean semaphoreWasAcquired = false;
+        try {
+            //Semaphore call
+            semaphoreWasAcquired = testSemaphore.acquireSemaphoreIfAppropriate(true);
+            //Current No of threads there can't be more than SEMAPHORE_MAX_NUMBER_THREADS
+            assertTrue(currentNoOfThreads.incrementAndGet() <= SEMAPHORE_MAX_NUMBER_THREADS);
+            //Instead of some code which should take some time is there sleep.
+            Thread.currentThread().sleep(300);
+        } catch (InterruptedException ex) {
+            Assert.fail("Semaphore Test thread was interrupted.  Test failed to run properly");
+        } finally {
+            currentNoOfThreads.decrementAndGet();
+            testSemaphore.releaseSemaphoreAllowOtherThreadsToStartDoingObjectBuilding(semaphoreWasAcquired);
+        }
+    }
+}


### PR DESCRIPTION
This is unit test for org.eclipse.persistence.internal.helper.ConcurrencySemaphore.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>