### PR TITLE
Fixes #1069: let JpaEntityManager(Factory) extend (Auto)Closeable

### DIFF
--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/basic/TestSessionCustomizer.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/basic/TestSessionCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2015 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -19,12 +19,12 @@ package org.eclipse.persistence.jpa.test.basic;
 import java.util.HashMap;
 import java.util.Map;
 
-import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.Persistence;
 import jakarta.persistence.PersistenceException;
 
 import org.eclipse.persistence.config.PersistenceUnitProperties;
 import org.eclipse.persistence.config.SessionCustomizer;
+import org.eclipse.persistence.jpa.JpaEntityManagerFactory;
 import org.eclipse.persistence.jpa.test.framework.EmfRunner;
 import org.eclipse.persistence.sessions.Session;
 import org.junit.Assert;
@@ -46,12 +46,9 @@ public class TestSessionCustomizer {
     @Test
     public void stringCustomizerInvoked() {
         props.put(PersistenceUnitProperties.SESSION_CUSTOMIZER, Customizer.class.getName());
-        EntityManagerFactory emf = Persistence.createEntityManagerFactory(PU_NAME, props);
-        try {
+        try (JpaEntityManagerFactory emf = (JpaEntityManagerFactory) Persistence.createEntityManagerFactory(PU_NAME, props)) {
             emf.createEntityManager();
             Assert.assertTrue(Customizer.staticCustomized);
-        } finally {
-            emf.close();
         }
     }
 
@@ -59,12 +56,9 @@ public class TestSessionCustomizer {
     public void customizerInvoked() {
         Customizer customizerInstance = new Customizer();
         props.put(PersistenceUnitProperties.SESSION_CUSTOMIZER, customizerInstance);
-        EntityManagerFactory emf = Persistence.createEntityManagerFactory(PU_NAME, props);
-        try {
+        try (JpaEntityManagerFactory emf = (JpaEntityManagerFactory) Persistence.createEntityManagerFactory(PU_NAME, props)) {
             emf.createEntityManager();
             Assert.assertTrue(customizerInstance.customized);
-        } finally {
-            emf.close();
         }
     }
 
@@ -72,16 +66,11 @@ public class TestSessionCustomizer {
     public void invalidInstance() {
         props.put(PersistenceUnitProperties.SESSION_CUSTOMIZER, new Object());
 
-        EntityManagerFactory emf = Persistence.createEntityManagerFactory(PU_NAME, props);
-        try {
+        try (JpaEntityManagerFactory emf = (JpaEntityManagerFactory) Persistence.createEntityManagerFactory(PU_NAME, props)) {
             emf.createEntityManager();
             Assert.fail();
         } catch (PersistenceException e) {
             Assert.assertTrue(e.toString(), e.getCause() instanceof ClassCastException);
-        } finally {
-            if (emf != null) {
-                emf.close();
-            }
         }
     }
 

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/advanced/EntityManagerJUnitTestSuite.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/advanced/EntityManagerJUnitTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2019 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -4955,11 +4955,8 @@ public class EntityManagerJUnitTestSuite extends JUnitTestCase {
         if (isOnServer()) {
             return;
         }
-        EntityManagerFactory factory = null;
-        try {
-            factory = Persistence.createEntityManagerFactory("broken-PU", JUnitTestCaseHelper.getDatabaseProperties());
-            EntityManager em = factory.createEntityManager();
-            em.close();
+        try (JpaEntityManagerFactory factory = (JpaEntityManagerFactory) Persistence.createEntityManagerFactory("broken-PU", JUnitTestCaseHelper.getDatabaseProperties());
+             JpaEntityManager em = (JpaEntityManager) factory.createEntityManager()) {
         } catch (jakarta.persistence.PersistenceException e)  {
             ArrayList expectedExceptions = new ArrayList();
             expectedExceptions.add(48);
@@ -4972,8 +4969,6 @@ public class EntityManagerJUnitTestSuite extends JUnitTestCase {
             if (expectedExceptions.size() > 0){
                 fail("Not all expected exceptions were caught");
             }
-        } finally {
-            factory.close();
         }
     }
 

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/advanced/EntityManagerJUnitTestSuite.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/advanced/EntityManagerJUnitTestSuite.java
@@ -528,6 +528,7 @@ public class EntityManagerJUnitTestSuite extends JUnitTestCase {
             tests.add("testInheritanceFetchJoinSecondCall");
         }
         tests.add("testDetachChildObjects");
+        tests.add("testAutoCloseable");
 
 
         Collections.sort(tests);
@@ -13169,8 +13170,25 @@ public class EntityManagerJUnitTestSuite extends JUnitTestCase {
 		}
 		rollbackTransaction(em);
 		closeEntityManager(em);
-    
     }
+
+    public void testAutoCloseable() {
+        EntityManagerFactory emfOuter = null;
+        EntityManager emOuter = null;
+        try (JpaEntityManagerFactory emf = (JpaEntityManagerFactory) Persistence.createEntityManagerFactory(getPersistenceUnitName(), JUnitTestCaseHelper.getDatabaseProperties());
+                JpaEntityManager em = (JpaEntityManager) emf.createEntityManager()) {
+            emfOuter = emf;
+            emOuter = em;
+            assertNotNull(emf);
+            assertNotNull(em);
+            assertTrue(emOuter.isOpen());
+            assertTrue(emfOuter.isOpen());
+        } finally {
+            assertFalse(emOuter.isOpen());
+            assertFalse(emfOuter.isOpen());
+        }
+    }
+
     private void InitTestDetachChildObjects(EntityManager em) {
         // test data - manual creation
         try {

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/composite/advanced/EntityManagerJUnitTestSuite.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/composite/advanced/EntityManagerJUnitTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2019 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -4640,11 +4640,8 @@ public class EntityManagerJUnitTestSuite extends JUnitTestCase {
         if (isOnServer()) {
             return;
         }
-        EntityManagerFactory factory = null;
-        try {
-            factory = Persistence.createEntityManagerFactory("broken-PU", JUnitTestCaseHelper.getDatabaseProperties());
-            EntityManager em = factory.createEntityManager();
-            em.close();
+        try (JpaEntityManagerFactory factory = (JpaEntityManagerFactory) Persistence.createEntityManagerFactory("broken-PU", JUnitTestCaseHelper.getDatabaseProperties());
+             JpaEntityManager em = (JpaEntityManager) factory.createEntityManager()) {
         } catch (jakarta.persistence.PersistenceException e)  {
             ArrayList expectedExceptions = new ArrayList();
             expectedExceptions.add(48);
@@ -4657,8 +4654,6 @@ public class EntityManagerJUnitTestSuite extends JUnitTestCase {
             if (expectedExceptions.size() > 0){
                 fail("Not all expected exceptions were caught");
             }
-        } finally {
-            factory.close();
         }
     }
 

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/jpa/JpaEntityManager.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/jpa/JpaEntityManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -36,7 +36,7 @@ import org.eclipse.persistence.sessions.server.ServerSession;
  * @author Gordon Yorke
  */
 
-public interface JpaEntityManager extends jakarta.persistence.EntityManager {
+public interface JpaEntityManager extends jakarta.persistence.EntityManager, AutoCloseable {
 
     /**
      * This method returns the current session to the requester.  The current session

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/jpa/JpaEntityManagerFactory.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/jpa/JpaEntityManagerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,6 +16,7 @@
 //       - 494610: Session Properties map should be Map<String, Object>
 package org.eclipse.persistence.jpa;
 
+import jakarta.persistence.EntityManagerFactory;
 import java.util.Map;
 
 import org.eclipse.persistence.internal.jpa.EntityManagerFactoryDelegate;
@@ -29,7 +30,7 @@ import org.eclipse.persistence.sessions.server.ServerSession;
  * </p>
  * @see jakarta.persistence.EntityManagerFactory
  */
-public interface JpaEntityManagerFactory {
+public interface JpaEntityManagerFactory extends EntityManagerFactory, AutoCloseable {
 
     /**
      * Returns the DatabaseSession that the Factory will be using and


### PR DESCRIPTION
this is to allow EMF/EMF to be used in try-with-resources statements.

Sample usage:
```
try (JpaEntityManagerFactory emf = (JpaEntityManagerFactory) Persistence.createEntityManagerFactory(...);
        JpaEntityManager em = (JpaEntityManager) emf.createEntityManager()) {
    em.find(...);
} catch (PersistenceException pe)  {
    // emf/em are already closed here
}
```