### PR TITLE
[3.0] Extended Thread logging - backport from master

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/PersistenceUnitProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/PersistenceUnitProperties.java
@@ -1305,6 +1305,33 @@ public class PersistenceUnitProperties {
      */
     public static final String CACHE_EXTENDED_LOGGING = "eclipselink.cache.extended.logging";
 
+    /**
+     * The "<code>eclipselink.thread.extended.logging</code>" property control (enable/disable)
+     * some additional logging messages like print error message if cached Entity is picked by different thread,
+     * or if EntityManager/UnitOfWork is reused/passed to different thread.
+     * <p>
+     * <b>Allowed Values:</b>
+     * <ul>
+     * <li>"<code>false</code>" (DEFAULT)
+     * <li>"<code>true</code>"
+     * </ul>
+     */
+    public static final String THREAD_EXTENDED_LOGGING = "eclipselink.thread.extended.logging";
+
+    /**
+     * The "<code>eclipselink.thread.extended.logging.threaddump</code>" property control (enable/disable)
+     * store and display thread dump. This is extension to "<code>eclipselink.thread.extended.logging</code>" which
+     * must be enabled. It prints additionally to some log messages presented by "<code>eclipselink.thread.extended.logging</code>"
+     * creation and current thread stack traces.
+     * <p>
+     * <b>Allowed Values:</b>
+     * <ul>
+     * <li>"<code>false</code>" (DEFAULT)
+     * <li>"<code>true</code>"
+     * </ul>
+     */
+    public static final String THREAD_EXTENDED_LOGGING_THREADDUMP = "eclipselink.thread.extended.logging.threaddump";
+
     /*
      * NOTE: The Canonical Model properties should be kept in sync with those
      * in org.eclipse.persistence.internal.jpa.modelgen.CanonicalModelProperties.

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ConcurrencyUtil.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ConcurrencyUtil.java
@@ -893,7 +893,7 @@ public class ConcurrencyUtil {
      *
      * @return get the stack trace of the current thread.
      */
-    private String enrichGenerateThreadDumpForCurrentThread() {
+    public String enrichGenerateThreadDumpForCurrentThread() {
         final Thread currentThread = Thread.currentThread();
         final long currentThreadId = currentThread.getId();
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/LoggingLocalizationResource.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/LoggingLocalizationResource.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2014, 2020 IBM Corporation and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021 IBM Corporation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -102,7 +102,10 @@ public class LoggingLocalizationResource extends ListResourceBundle {
         { "register_new_for_persist", "PERSIST operation called on: {0}." },
         { "all_registered_clones", "All Registered Clones:" },
         { "new_objects", "New Objects:" },
-
+        { "cache_thread_info", "Cached entity ({0}) with Id ({1}) was stored into cache by another thread (id: {2} name: {3}), than current thread (id: {4} name: {5})" },
+        { "unit_of_work_thread_info", "Current unit of work in session ({0}) was created by another thread (id: {1} name: {2}), than current thread (id: {3} name: {4})" },
+        { "unit_of_work_thread_info_thread_dump", "Creation thread (id: {0} name: {1}) stack trace:\n{2}\n\n" +
+                "Current thread (id: {3} name: {4}) stack trace:\n{5}" },
         { "failed_to_propogate_to", "CacheSynchronization : Failed to propagate to {0}.  {1}" },
         { "exception_thrown_when_attempting_to_shutdown_cache_synch", "Exception thrown when attempting to shutdown cache synch: {0}" },
         { "corrupted_session_announcement", "SessionID: {0}  Discovery manager received corrupted session announcement - ignoring." },

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/TraceLocalizationResource.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/TraceLocalizationResource.java
@@ -49,7 +49,6 @@ public class TraceLocalizationResource extends ListResourceBundle {
         { "cache_class_invalidation", "Entities based on class ({0}) was invalidated from the cache by thread (Id: {1} Name: {2})" },
         { "cache_hit", "Cache hit for entity ({0}) with Id ({1})" },
         { "cache_miss", "Cache miss for entity ({0}) with Id ({1})" },
-        { "cache_thread_info", "Cached entity ({0}) with Id ({1}) was stored into cache by another thread (id: {2} name: {3}), than current thread (id: {4} name: {5})" },
         { "stack_of_visited_objects_that_refer_to_the_corrupt_object", "stack of visited objects that refer to the corrupt object: {0}" },
         { "corrupt_object_referenced_through_mapping", "corrupt object referenced through mapping: {0}" },
         { "corrupt_object", "corrupt object: {0}" },

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
@@ -4116,6 +4116,7 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
                     // check object for cachekey otherwise
                     // a new cache-key is used as there is no original to use for locking.
                     // It read time must be set to avoid it being invalidated.
+                    cacheKey = null;
                     if (objectToRegister instanceof PersistenceEntity){
                         cacheKey = ((PersistenceEntity)objectToRegister)._persistence_getCacheKey();
                     }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/logging/LogCategory.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/logging/LogCategory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -44,6 +44,7 @@ import org.eclipse.persistence.config.PersistenceUnitProperties;
  * <tr><td>&nbsp;</td><td>SEQUENCING</td>     <td>&nbsp;</td><td>= "sequencing"</td></tr>
  * <tr><td>&nbsp;</td><td>SERVER</td>         <td>&nbsp;</td><td>= "server"</td></tr>
  * <tr><td>&nbsp;</td><td>SQL</td>            <td>&nbsp;</td><td>= "sql"</td></tr>
+ * <tr><td>&nbsp;</td><td>THREAD</td>         <td>&nbsp;</td><td>= "thread"</td></tr>
  * <tr><td>&nbsp;</td><td>TRANSACTION</td>    <td>&nbsp;</td><td>= "transaction"</td></tr>
  * <tr><td>&nbsp;</td><td>WEAVER</td>         <td>&nbsp;</td><td>= "weaver"</td></tr>
  * </table>
@@ -71,7 +72,8 @@ public enum LogCategory {
     SERVER(     (byte)0x13, SessionLog.SERVER),
     SQL(        (byte)0x14, SessionLog.SQL),
     TRANSACTION((byte)0x15, SessionLog.TRANSACTION),
-    WEAVER(     (byte)0x16, SessionLog.WEAVER);
+    WEAVER(     (byte)0x16, SessionLog.WEAVER),
+    THREAD(     (byte)0x17, SessionLog.THREAD);
 
     /** Logging categories enumeration length. */
     public static final int length = LogCategory.values().length;

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/logging/SessionLog.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/logging/SessionLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -62,6 +62,7 @@ import org.eclipse.persistence.sessions.Session;
  * <tr><td>&nbsp;</td><td>{@link #SEQUENCING}</td>    <td>&nbsp;</td><td>= {@value #SEQUENCING}</td></tr>
  * <tr><td>&nbsp;</td><td>{@link #SERVER}</td>        <td>&nbsp;</td><td>= {@value #SERVER}</td></tr>
  * <tr><td>&nbsp;</td><td>{@link #SQL}</td>           <td>&nbsp;</td><td>= {@value #SQL}</td></tr>
+ * <tr><td>&nbsp;</td><td>{@link #THREAD}</td>        <td>&nbsp;</td><td>= {@value #THREAD}</td></tr>
  * <tr><td>&nbsp;</td><td>{@link #TRANSACTION}</td>   <td>&nbsp;</td><td>= {@value #TRANSACTION}</td></tr>
  * <tr><td>&nbsp;</td><td>{@link #WEAVER}</td>        <td>&nbsp;</td><td>= {@value #WEAVER}</td></tr>
  * </table>
@@ -134,6 +135,7 @@ public interface SessionLog extends Cloneable {
     String JPARS = "jpars";
     /** ModelGen logging name space. */
     String PROCESSOR = "processor";
+    String THREAD = "thread";
 
     String[] loggerCatagories = new String[] {
         SQL,
@@ -157,7 +159,8 @@ public interface SessionLog extends Cloneable {
         PROPERTIES,
         SERVER,
         DDL,
-        PROCESSOR
+        PROCESSOR,
+        THREAD
     };
 
     /**
@@ -314,6 +317,7 @@ public interface SessionLog extends Cloneable {
      * <tr><td>&nbsp;</td><td>{@link #SEQUENCING}</td>      <td>&nbsp;</td><td>= {@value #SEQUENCING}</td></tr>
      * <tr><td>&nbsp;</td><td>{@link #SERVER}</td>          <td>&nbsp;</td><td>= {@value #SERVER}</td></tr>
      * <tr><td>&nbsp;</td><td>{@link #SQL}</td>             <td>&nbsp;</td><td>= {@value #SQL}</td></tr>
+     * <tr><td>&nbsp;</td><td>{@link #THREAD}</td>          <td>&nbsp;</td><td>= {@value #THREAD}</td></tr>
      * <tr><td>&nbsp;</td><td>{@link #TRANSACTION}</td>     <td>&nbsp;</td><td>= {@value #TRANSACTION}</td></tr>
      * <tr><td>&nbsp;</td><td>{@link #WEAVER}</td>          <td>&nbsp;</td><td>= {@value #WEAVER}</td></tr>
      * </table>
@@ -378,6 +382,7 @@ public interface SessionLog extends Cloneable {
      * <tr><td>&nbsp;</td><td>{@link #SEQUENCING}</td>      <td>&nbsp;</td><td>= {@value #SEQUENCING}</td></tr>
      * <tr><td>&nbsp;</td><td>{@link #SERVER}</td>          <td>&nbsp;</td><td>= {@value #SERVER}</td></tr>
      * <tr><td>&nbsp;</td><td>{@link #SQL}</td>             <td>&nbsp;</td><td>= {@value #SQL}</td></tr>
+     * <tr><td>&nbsp;</td><td>{@link #THREAD}</td>          <td>&nbsp;</td><td>= {@value #THREAD}</td></tr>
      * <tr><td>&nbsp;</td><td>{@link #TRANSACTION}</td>     <td>&nbsp;</td><td>= {@value #TRANSACTION}</td></tr>
      * <tr><td>&nbsp;</td><td>{@link #WEAVER}</td>          <td>&nbsp;</td><td>= {@value #WEAVER}</td></tr>
      * </table>
@@ -443,6 +448,7 @@ public interface SessionLog extends Cloneable {
      * <tr><td>&nbsp;</td><td>{@link #SEQUENCING}</td>      <td>&nbsp;</td><td>= {@value #SEQUENCING}</td></tr>
      * <tr><td>&nbsp;</td><td>{@link #SERVER}</td>          <td>&nbsp;</td><td>= {@value #SERVER}</td></tr>
      * <tr><td>&nbsp;</td><td>{@link #SQL}</td>             <td>&nbsp;</td><td>= {@value #SQL}</td></tr>
+     * <tr><td>&nbsp;</td><td>{@link #THREAD}</td>          <td>&nbsp;</td><td>= {@value #THREAD}</td></tr>
      * <tr><td>&nbsp;</td><td>{@link #TRANSACTION}</td>     <td>&nbsp;</td><td>= {@value #TRANSACTION}</td></tr>
      * <tr><td>&nbsp;</td><td>{@link #WEAVER}</td>          <td>&nbsp;</td><td>= {@value #WEAVER}</td></tr>
      * </table>

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/Project.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/Project.java
@@ -161,6 +161,12 @@ public class Project extends CoreProject<ClassDescriptor, Login, DatabaseSession
     /** Flag that allows extended logging of JPA L2 cache or not. */
     protected boolean allowExtendedCacheLogging = false;
 
+    /** Flag that allows extended thread logging or not. */
+    protected boolean allowExtendedThreadLogging = false;
+
+    /** Flag that allows add to extended thread logging output thread stack trace or not.*/
+    protected boolean allowExtendedThreadLoggingThreadDump = false;
+
     /**
      * Mapped Superclasses (JPA 2) collection of parent non-relational descriptors keyed on MetadataClass
      * without creating a compile time dependency on JPA.
@@ -1330,6 +1336,22 @@ public class Project extends CoreProject<ClassDescriptor, Login, DatabaseSession
     }
 
     /**
+     * INTERNAL:
+     * Return true if extended thread logging is allowed on this project.
+     */
+    public boolean allowExtendedThreadLogging() {
+        return this.allowExtendedThreadLogging;
+    }
+
+    /**
+     * INTERNAL:
+     * Return true if thread dumps will be added to extended thread logging.
+     */
+    public boolean allowExtendedThreadLoggingThreadDump() {
+        return this.allowExtendedThreadLoggingThreadDump;
+    }
+
+    /**
      * PUBLIC:
      * Return the descriptor for  the alias
      */
@@ -1390,6 +1412,22 @@ public class Project extends CoreProject<ClassDescriptor, Login, DatabaseSession
      */
     public void setAllowExtendedCacheLogging(boolean allowExtendedCacheLogging) {
         this.allowExtendedCacheLogging = allowExtendedCacheLogging;
+    }
+
+    /**
+     * INTERNAL:
+     * Set whether extended thread logging is allowed on this project.
+     */
+    public void setAllowExtendedThreadLogging(boolean allowExtendedThreadLogging) {
+        this.allowExtendedThreadLogging = allowExtendedThreadLogging;
+    }
+
+    /**
+     * INTERNAL:
+     * Set if thread dumps will be added to extended thread logging.
+     */
+    public void setAllowExtendedThreadLoggingThreadDump(boolean allowExtendedThreadLoggingThreadDump) {
+        this.allowExtendedThreadLoggingThreadDump = allowExtendedThreadLoggingThreadDump;
     }
 
     /**

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
@@ -2893,6 +2893,8 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
             updateUppercaseSetting(m);
             updateCacheStatementSettings(m);
             updateAllowExtendedCacheLogging(m);
+            updateAllowExtendedThreadLogging(m);
+            updateAllowExtendedThreadLoggingThreadDump(m);
             updateTemporalMutableSetting(m);
             updateTableCreationSettings(m);
             updateIndexForeignKeys(m);
@@ -3922,7 +3924,6 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
      * The method needs to be called in deploy stage.
      */
     protected void updateAllowExtendedCacheLogging(Map m){
-        // Set allow native SQL queries flag if it was specified.
         String allowExtendedCacheLogging = EntityManagerFactoryProvider.getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.CACHE_EXTENDED_LOGGING, m, session);
 
         if (allowExtendedCacheLogging != null) {
@@ -3931,11 +3932,46 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
             } else if (allowExtendedCacheLogging.equalsIgnoreCase("false")) {
                 session.getProject().setAllowExtendedCacheLogging(false);
             } else {
-                session.handleException(ValidationException.invalidBooleanValueForSettingAllowNativeSQLQueries(allowExtendedCacheLogging));
+                session.handleException(ValidationException.invalidBooleanValueForProperty(allowExtendedCacheLogging, PersistenceUnitProperties.CACHE_EXTENDED_LOGGING));
             }
         }
     }
 
+    /**
+     * Enable or disable extended thread logging.
+     * The method needs to be called in deploy stage.
+     */
+    protected void updateAllowExtendedThreadLogging(Map m){
+        String allowExtendedThreadLogging = EntityManagerFactoryProvider.getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.THREAD_EXTENDED_LOGGING, m, session);
+
+        if (allowExtendedThreadLogging != null) {
+            if (allowExtendedThreadLogging.equalsIgnoreCase("true")) {
+                session.getProject().setAllowExtendedThreadLogging(true);
+            } else if (allowExtendedThreadLogging.equalsIgnoreCase("false")) {
+                session.getProject().setAllowExtendedThreadLogging(false);
+            } else {
+                session.handleException(ValidationException.invalidBooleanValueForProperty(allowExtendedThreadLogging, PersistenceUnitProperties.THREAD_EXTENDED_LOGGING));
+            }
+        }
+    }
+
+    /**
+     * Enable or disable thread dump addition to extended thread logging.
+     * The method needs to be called in deploy stage.
+     */
+    protected void updateAllowExtendedThreadLoggingThreadDump(Map m){
+        String allowExtendedThreadLoggingThreadDump = EntityManagerFactoryProvider.getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.THREAD_EXTENDED_LOGGING_THREADDUMP, m, session);
+
+        if (allowExtendedThreadLoggingThreadDump != null) {
+            if (allowExtendedThreadLoggingThreadDump.equalsIgnoreCase("true")) {
+                session.getProject().setAllowExtendedThreadLoggingThreadDump(true);
+            } else if (allowExtendedThreadLoggingThreadDump.equalsIgnoreCase("false")) {
+                session.getProject().setAllowExtendedThreadLoggingThreadDump(false);
+            } else {
+                session.handleException(ValidationException.invalidBooleanValueForProperty(allowExtendedThreadLoggingThreadDump, PersistenceUnitProperties.THREAD_EXTENDED_LOGGING_THREADDUMP));
+            }
+        }
+    }
 
     /**
      * If Bean Validation is enabled, bootstraps Bean Validation on descriptors.


### PR DESCRIPTION
This commit contains extension to logging code.
Main purpose is display info if cached entity is picked by another thread and WorkManager is called in different threads.
This logging is by default disabled and must be enabled by persistence properties
Major changes are:

   - new thread log category specified in org.eclipse.persistence.logging.LogCategory and org.eclipse.persistence.logging.SessionLog
   - Two new persistence unit properties eclipselink.thread.extended.logging to enable this logging and eclipselink.thread.extended.logging.threaddump to add to the log output threads stack trace
   - new log messages are called from org.eclipse.persistence.internal.sessions.UnitOfWorkImpl

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>
(cherry picked from commit f2027611a6f04e385ce9b2a7d3b0ae3e8ae34172)