### PR TITLE
Bump master to SE 11, introduce JPMS descriptors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at
@@ -50,7 +50,6 @@ jobs:
     - env: MAVEN_TEST=jpa-lrg-server2-mysql
 
 jdk:
-  - openjdk8
   - openjdk11
   - openjdk15
 

--- a/bundles/eclipselink/pom.xml
+++ b/bundles/eclipselink/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -243,72 +243,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- included sources artifacts -->
-        <dependency>
-            <groupId>org.eclipse.persistence</groupId>
-            <artifactId>org.eclipse.persistence.asm</artifactId>
-            <classifier>sources</classifier>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.persistence</groupId>
-            <artifactId>org.eclipse.persistence.core</artifactId>
-            <classifier>sources</classifier>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.persistence</groupId>
-            <artifactId>org.eclipse.persistence.corba</artifactId>
-            <classifier>sources</classifier>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.persistence</groupId>
-            <artifactId>org.eclipse.persistence.oracle</artifactId>
-            <classifier>sources</classifier>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.eclipse.persistence</groupId>
-            <artifactId>org.eclipse.persistence.jpa</artifactId>
-            <classifier>sources</classifier>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.persistence</groupId>
-            <artifactId>org.eclipse.persistence.jpa.jpql</artifactId>
-            <classifier>sources</classifier>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.eclipse.persistence</groupId>
-            <artifactId>org.eclipse.persistence.moxy</artifactId>
-            <classifier>sources</classifier>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.persistence</groupId>
-            <artifactId>org.eclipse.persistence.moxy.utils.xjc</artifactId>
-            <classifier>sources</classifier>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.eclipse.persistence</groupId>
-            <artifactId>org.eclipse.persistence.sdo</artifactId>
-            <classifier>sources</classifier>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.eclipse.persistence</groupId>
-            <artifactId>org.eclipse.persistence.dbws</artifactId>
-            <classifier>sources</classifier>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- artifacts for zip -->
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
@@ -359,49 +293,6 @@
 
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
-            <artifactId>org.eclipse.persistence.dbws.builder</artifactId>
-            <classifier>sources</classifier>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.persistence</groupId>
-            <artifactId>org.eclipse.persistence.extension</artifactId>
-            <classifier>sources</classifier>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.persistence</groupId>
-            <artifactId>org.eclipse.persistence.jpa.modelgen.processor</artifactId>
-            <classifier>sources</classifier>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.persistence</groupId>
-            <artifactId>org.eclipse.persistence.jpars</artifactId>
-            <classifier>sources</classifier>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.persistence</groupId>
-            <artifactId>org.eclipse.persistence.oracleddlparser</artifactId>
-            <classifier>sources</classifier>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.persistence</groupId>
-            <artifactId>org.eclipse.persistence.nosql</artifactId>
-            <classifier>sources</classifier>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.persistence</groupId>
-            <artifactId>org.eclipse.persistence.oracle.nosql</artifactId>
-            <classifier>sources</classifier>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.eclipse.persistence</groupId>
             <artifactId>org.eclipse.persistence.jpars</artifactId>
             <classifier>javadoc</classifier>
             <scope>provided</scope>
@@ -431,36 +322,8 @@
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>unpack-classes</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <excludeTransitive>true</excludeTransitive>
-                            <includeGroupIds>${project.groupId}</includeGroupIds>
-                            <includeScope>provided</includeScope>
-                            <includeArtifactIds>
-                                org.eclipse.persistence.asm,
-                                org.eclipse.persistence.core,
-                                org.eclipse.persistence.corba,
-                                org.eclipse.persistence.dbws,
-                                org.eclipse.persistence.jpa,
-                                org.eclipse.persistence.jpa.jpql,
-                                org.eclipse.persistence.moxy,
-                                org.eclipse.persistence.moxy.utils.xjc,
-                                org.eclipse.persistence.oracle,
-                                org.eclipse.persistence.sdo
-                            </includeArtifactIds>
-                            <excludeClassifiers>sources,javadoc</excludeClassifiers>
-                            <excludes>META-INF/MANIFEST.MF,*.html,org/eclipse/persistence/jpa/jpql/tools/**</excludes>
-                            <overWriteSnapshots>true</overWriteSnapshots>
-                            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>unpack-sources</id>
-                        <phase>prepare-package</phase>
+                        <phase>generate-sources</phase>
                         <goals>
                             <goal>unpack-dependencies</goal>
                         </goals>
@@ -468,7 +331,7 @@
                             <excludeTransitive>true</excludeTransitive>
                             <includeGroupIds>${project.groupId}</includeGroupIds>
                             <includeScope>provided</includeScope>
-                            <includeClassifiers>sources</includeClassifiers>
+                            <classifier>sources</classifier>
                             <includeArtifactIds>
                                 org.eclipse.persistence.asm,
                                 org.eclipse.persistence.core,
@@ -481,7 +344,7 @@
                                 org.eclipse.persistence.oracle,
                                 org.eclipse.persistence.sdo
                             </includeArtifactIds>
-                            <excludes>META-INF/MANIFEST.MF,*.html,org/eclipse/persistence/jpa/jpql/tools/**</excludes>
+                            <excludes>module-info.*,META-INF/versions/**,META-INF/MANIFEST.MF,*.html,org/eclipse/persistence/jpa/jpql/tools/**</excludes>
                             <overWriteSnapshots>true</overWriteSnapshots>
                             <outputDirectory>${gen.src.dir}</outputDirectory>
                         </configuration>
@@ -555,8 +418,25 @@
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>add-resource</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>add-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>${gen.src.dir}</directory>
+                                    <excludes>
+                                        <exclude>**/*.java</exclude>
+                                    </excludes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>add-generated-sources</id>
-                        <phase>prepare-package</phase>
+                        <phase>generate-sources</phase>
                         <goals>
                             <goal>add-source</goal>
                         </goals>
@@ -564,6 +444,23 @@
                             <sources>
                                 <source>${gen.src.dir}</source>
                             </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>--add-reads</arg>
+                                <arg>eclipselink=ALL-UNNAMED</arg>
+                                <arg>--add-exports</arg>
+                                <arg>com.sun.tools.xjc/com.sun.xml.xsom.impl.parser=eclipselink</arg>
+                            </compilerArgs>
                         </configuration>
                     </execution>
                 </executions>
@@ -622,7 +519,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <additionalJOption>-Xdoclint:none</additionalJOption>
+                    <additionalOptions>
+                        --add-reads eclipselink=ALL-UNNAMED
+                        --add-exports com.sun.tools.xjc/com.sun.xml.xsom.impl.parser=eclipselink
+                    </additionalOptions>
+                    <doclint>none</doclint>
                     <detectOfflineLinks>false</detectOfflineLinks>
                     <use>false</use>
                     <quiet>true</quiet>
@@ -631,9 +532,6 @@
                     <header><![CDATA[${javadoc.prefixTitle}, ${javadoc.postfixTitle}]]></header>
                     <windowtitle>${javadoc.prefixTitle}, ${javadoc.postfixTitle}</windowtitle>
                     <excludePackageNames>org.eclipse.persistence.internal.*,META-INF.*</excludePackageNames>
-                    <sourceFileExcludes>
-                        <sourceFileExclude>module-info.java</sourceFileExclude>
-                    </sourceFileExcludes>
                     <tags>
                         <tag>
                             <name>author</name>
@@ -686,38 +584,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <!-- sdo: api dependencies -->
-        <profile>
-            <id>jdk8</id>
-            <activation>
-                <jdk>1.8</jdk>
-            </activation>
-            <dependencies>
-                <!-- Required on Java SE 8 -->
-                <dependency>
-                    <groupId>org.eclipse.persistence</groupId>
-                    <artifactId>commonj.sdo</artifactId>
-                    <optional>true</optional>
-                </dependency>
-            </dependencies>
-        </profile>
-        <profile>
-            <id>jdk9</id>
-            <activation>
-                <jdk>(1.8,)</jdk>
-            </activation>
-            <dependencies>
-                <!-- Let's treat this as provided for now on JDK 9+ since we're including this under META-INF/versions/9
-                     to get around the split package problem with commonj.sdo.impl.HelperProviderImpl -->
-                <dependency>
-                    <groupId>org.eclipse.persistence</groupId>
-                    <artifactId>commonj.sdo</artifactId>
-                    <scope>provided</scope>
-                    <optional>true</optional>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles>
 </project>

--- a/bundles/eclipselink/src/main/java/module-info.java
+++ b/bundles/eclipselink/src/main/java/module-info.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+module eclipselink {
+
+    requires java.desktop;
+    requires java.management;
+    requires java.naming;
+    requires java.rmi;
+    requires java.sql;
+    requires java.xml;
+
+    requires static jakarta.activation;
+    requires static jakarta.annotation;
+    requires static jakarta.json;
+    requires static jakarta.mail;
+    requires static jakarta.persistence;
+    requires static jakarta.validation;
+    requires static jakarta.ws.rs;
+    requires static jakarta.xml.bind;
+
+    requires static jakarta.cdi; //AM
+    requires static jakarta.el; //AM
+    requires static jakarta.inject; //AM
+    requires static jakarta.transaction; //AM
+
+    requires static com.sun.tools.xjc;
+    requires static com.sun.xml.bind.core;
+
+    exports org.eclipse.persistence.jpa.jpql;
+    exports org.eclipse.persistence.jpa.jpql.parser;
+    exports org.eclipse.persistence.jpa.jpql.utility.iterable;
+
+    exports org.eclipse.persistence;
+    exports org.eclipse.persistence.annotations;
+    exports org.eclipse.persistence.config;
+    exports org.eclipse.persistence.core.descriptors;
+    exports org.eclipse.persistence.core.mappings;
+    exports org.eclipse.persistence.core.mappings.converters;
+    exports org.eclipse.persistence.core.mappings.transformers;
+    exports org.eclipse.persistence.core.queries;
+    exports org.eclipse.persistence.core.sessions;
+    exports org.eclipse.persistence.descriptors;
+    exports org.eclipse.persistence.descriptors.changetracking;
+    exports org.eclipse.persistence.descriptors.copying;
+    exports org.eclipse.persistence.descriptors.invalidation;
+    exports org.eclipse.persistence.descriptors.partitioning;
+    exports org.eclipse.persistence.dynamic;
+    exports org.eclipse.persistence.eis;
+    exports org.eclipse.persistence.eis.interactions;
+    exports org.eclipse.persistence.eis.mappings;
+    exports org.eclipse.persistence.exceptions;
+    exports org.eclipse.persistence.exceptions.i18n;
+    exports org.eclipse.persistence.expressions;
+    exports org.eclipse.persistence.history;
+    exports org.eclipse.persistence.indirection;
+    exports org.eclipse.persistence.logging;
+    exports org.eclipse.persistence.mappings;
+    exports org.eclipse.persistence.mappings.converters;
+    exports org.eclipse.persistence.mappings.foundation;
+    exports org.eclipse.persistence.mappings.querykeys;
+    exports org.eclipse.persistence.mappings.structures;
+    exports org.eclipse.persistence.mappings.transformers;
+    exports org.eclipse.persistence.mappings.xdb;
+    exports org.eclipse.persistence.oxm;
+    exports org.eclipse.persistence.oxm.annotations;
+    exports org.eclipse.persistence.oxm.attachment;
+    exports org.eclipse.persistence.oxm.documentpreservation;
+    exports org.eclipse.persistence.oxm.json;
+    exports org.eclipse.persistence.oxm.mappings;
+    exports org.eclipse.persistence.oxm.mappings.converters;
+    exports org.eclipse.persistence.oxm.mappings.nullpolicy;
+    exports org.eclipse.persistence.oxm.platform;
+    exports org.eclipse.persistence.oxm.record;
+    exports org.eclipse.persistence.oxm.schema;
+    exports org.eclipse.persistence.oxm.sequenced;
+    exports org.eclipse.persistence.oxm.unmapped;
+    exports org.eclipse.persistence.platform.database;
+    exports org.eclipse.persistence.platform.database.converters;
+    exports org.eclipse.persistence.platform.database.events;
+    exports org.eclipse.persistence.platform.database.jdbc;
+    exports org.eclipse.persistence.platform.database.oracle.annotations;
+    exports org.eclipse.persistence.platform.database.oracle.jdbc;
+    exports org.eclipse.persistence.platform.database.oracle.plsql;
+    exports org.eclipse.persistence.platform.database.partitioning;
+    exports org.eclipse.persistence.platform.server;
+    exports org.eclipse.persistence.platform.server.glassfish;
+    exports org.eclipse.persistence.platform.server.was;
+    exports org.eclipse.persistence.platform.server.wls;
+    exports org.eclipse.persistence.platform.xml;
+    exports org.eclipse.persistence.queries;
+    exports org.eclipse.persistence.sequencing;
+    exports org.eclipse.persistence.services;
+    exports org.eclipse.persistence.services.glassfish;
+    exports org.eclipse.persistence.services.jboss;
+    exports org.eclipse.persistence.services.mbean;
+    exports org.eclipse.persistence.services.weblogic;
+    exports org.eclipse.persistence.services.websphere;
+    exports org.eclipse.persistence.sessions;
+    exports org.eclipse.persistence.sessions.broker;
+    exports org.eclipse.persistence.sessions.changesets;
+    exports org.eclipse.persistence.sessions.coordination;
+    exports org.eclipse.persistence.sessions.coordination.broadcast;
+    exports org.eclipse.persistence.sessions.coordination.jms;
+    exports org.eclipse.persistence.sessions.coordination.rmi;
+    exports org.eclipse.persistence.sessions.factories;
+    exports org.eclipse.persistence.sessions.remote;
+    exports org.eclipse.persistence.sessions.remote.rmi;
+    exports org.eclipse.persistence.sessions.serializers;
+    exports org.eclipse.persistence.sessions.server;
+    exports org.eclipse.persistence.tools.profiler;
+    exports org.eclipse.persistence.tools.schemaframework;
+    exports org.eclipse.persistence.tools.tuning;
+    exports org.eclipse.persistence.transaction;
+    exports org.eclipse.persistence.transaction.glassfish;
+    exports org.eclipse.persistence.transaction.jboss;
+    exports org.eclipse.persistence.transaction.oc4j;
+    exports org.eclipse.persistence.transaction.sap;
+    exports org.eclipse.persistence.transaction.was;
+    exports org.eclipse.persistence.transaction.wls;
+
+    exports org.eclipse.persistence.sessions.coordination.corba;
+    exports org.eclipse.persistence.sessions.coordination.corba.sun;
+    exports org.eclipse.persistence.sessions.remote.corba.sun;
+    exports org.eclipse.persistence.sessions.remote.rmi.iiop;
+
+    exports org.eclipse.persistence.platform.database.oracle;
+    exports org.eclipse.persistence.platform.database.oracle.converters;
+    exports org.eclipse.persistence.platform.database.oracle.dcn;
+    exports org.eclipse.persistence.platform.database.oracle.ucp;
+    exports org.eclipse.persistence.platform.xml.xdk;
+    exports org.eclipse.persistence.tools.profiler.oracle;
+
+    exports org.eclipse.persistence.jpa;
+    exports org.eclipse.persistence.jpa.config;
+    exports org.eclipse.persistence.jpa.dynamic;
+    exports org.eclipse.persistence.jpa.metadata;
+    exports org.eclipse.persistence.tools.weaving.jpa;
+
+    exports org.eclipse.persistence.jaxb;
+    exports org.eclipse.persistence.jaxb.attachment;
+    exports org.eclipse.persistence.jaxb.compiler;
+    exports org.eclipse.persistence.jaxb.compiler.builder;
+    exports org.eclipse.persistence.jaxb.compiler.builder.helper;
+    exports org.eclipse.persistence.jaxb.compiler.facets;
+    exports org.eclipse.persistence.jaxb.dynamic;
+    exports org.eclipse.persistence.jaxb.dynamic.metadata;
+    exports org.eclipse.persistence.jaxb.javamodel;
+    exports org.eclipse.persistence.jaxb.javamodel.oxm;
+    exports org.eclipse.persistence.jaxb.javamodel.reflection;
+    exports org.eclipse.persistence.jaxb.javamodel.xjc;
+    exports org.eclipse.persistence.jaxb.json;
+    exports org.eclipse.persistence.jaxb.metadata;
+    exports org.eclipse.persistence.jaxb.plugins;
+    exports org.eclipse.persistence.jaxb.rs;
+    exports org.eclipse.persistence.jaxb.xmlmodel;
+
+    exports org.eclipse.persistence.jaxb.xjc;
+
+    exports commonj.sdo;
+    exports commonj.sdo.helper;
+    exports commonj.sdo.impl;
+
+    exports org.eclipse.persistence.sdo;
+    exports org.eclipse.persistence.sdo.helper;
+    exports org.eclipse.persistence.sdo.types;
+
+    exports org.eclipse.persistence.dbws;
+    exports org.eclipse.persistence.jpa.rs;
+    exports org.eclipse.persistence.jpa.rs.annotations;
+    exports org.eclipse.persistence.jpa.rs.eventlistener;
+    exports org.eclipse.persistence.jpa.rs.exceptions;
+    exports org.eclipse.persistence.jpa.rs.features;
+    exports org.eclipse.persistence.jpa.rs.features.core.selflinks;
+    exports org.eclipse.persistence.jpa.rs.features.fieldsfiltering;
+    exports org.eclipse.persistence.jpa.rs.features.paging;
+    exports org.eclipse.persistence.jpa.rs.logging;
+    exports org.eclipse.persistence.jpa.rs.resources;
+    exports org.eclipse.persistence.jpa.rs.resources.common;
+    exports org.eclipse.persistence.jpa.rs.resources.unversioned;
+    exports org.eclipse.persistence.jpa.rs.util;
+    exports org.eclipse.persistence.jpa.rs.util.list;
+    exports org.eclipse.persistence.jpa.rs.util.metadatasources;
+    exports org.eclipse.persistence.jpa.rs.util.xmladapters;
+
+    provides jakarta.persistence.spi.PersistenceProvider with org.eclipse.persistence.jpa.PersistenceProvider;
+    provides com.sun.tools.xjc.Plugin with org.eclipse.persistence.jaxb.plugins.BeanValidationPlugin;
+
+}

--- a/bundles/others/pom.xml
+++ b/bundles/others/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -358,6 +358,23 @@
             <artifactId>jakarta.xml.bind-api</artifactId>
             <classifier>sources</classifier>
         </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.jpars</artifactId>
+            <classifier>javadoc</classifier>
+            <scope>provided</scope>
+            <!-- ### fix me -->
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.sdo</artifactId>
+            <classifier>javadoc</classifier>
+            <scope>provided</scope>
+            <!-- ### fix me -->
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -377,7 +394,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <additionalJOption>-Xdoclint:none</additionalJOption>
+                    <doclint>none</doclint>
                     <detectOfflineLinks>false</detectOfflineLinks>
                     <use>false</use>
                     <quiet>true</quiet>
@@ -442,24 +459,7 @@
                             <finalName>eclipselink</finalName>
                         </configuration>
                     </execution>
-                    <execution>
-                        <id>eclipselink-jpars-javadoc.jar</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${project.build.directory}/apidocs/eclipselink-jpars-javadoc.jar/</outputDirectory>
-                            <includeDependencySources>true</includeDependencySources>
-                            <doctitle><![CDATA[${javadoc.jpars.prefixTitle}]]></doctitle>
-                            <header><![CDATA[${javadoc.jpars.prefixTitle}]]></header>
-                            <windowtitle>${javadoc.jpars.prefixTitle}</windowtitle>
-                            <dependencySourceIncludes>
-                                <dependencySourceInclude>org.eclipse.persistence:org.eclipse.persistence.jpars</dependencySourceInclude>
-                            </dependencySourceIncludes>
-                            <finalName>eclipselink-jpars</finalName>
-                        </configuration>
-                    </execution>
+                    <!--Disabled by default-->
                     <execution>
                         <id>nosql-javadoc.jar</id>
                         <phase>prepare-package</phase>
@@ -467,6 +467,7 @@
                             <goal>jar</goal>
                         </goals>
                         <configuration>
+                            <skip>true</skip>
                             <outputDirectory>${project.build.directory}/apidocs/nosql-javadoc.jar/</outputDirectory>
                             <includeDependencySources>true</includeDependencySources>
                             <doctitle><![CDATA[${javadoc.nosql.prefixTitle}]]></doctitle>
@@ -481,26 +482,6 @@
                                 <sourceFileExclude>**/org/eclipse/persistence/internal/**</sourceFileExclude>
                             </sourceFileExcludes>
                             <finalName>nosql</finalName>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>sdo-javadoc.jar</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${project.build.directory}/apidocs/sdo-javadoc.jar/</outputDirectory>
-                            <includeDependencySources>true</includeDependencySources>
-                            <doctitle><![CDATA[${javadoc.prefixTitle}, ${javadoc.postfixTitle}]]></doctitle>
-                            <header><![CDATA[${javadoc.prefixTitle}, ${javadoc.postfixTitle}]]></header>
-                            <windowtitle>${javadoc.prefixTitle}, ${javadoc.postfixTitle}</windowtitle>
-                            <dependencySourceIncludes>
-                                <!--Eclipselink SDO modules-->
-                                <dependencySourceInclude>org.eclipse.persistence:org.eclipse.persistence.sdo</dependencySourceInclude>
-                                <dependencySourceInclude>org.eclipse.persistence:commonj.sdo</dependencySourceInclude>
-                            </dependencySourceIncludes>
-                            <finalName>sdo</finalName>
                         </configuration>
                     </execution>
                 </executions>
@@ -530,13 +511,26 @@
                                     <version>${jpa.api.version}</version>
                                     <outputDirectory>${project.build.directory}/${archive.tmp.dir}/eclipselink-test-src.zip/jpa/plugins/</outputDirectory>
                                 </artifactItem>
-                                <artifactItem>
-                                    <groupId>${project.parent.groupId}</groupId>
-                                    <artifactId>commonj.sdo</artifactId>
-                                    <outputDirectory>${project.build.directory}/${archive.tmp.dir}/eclipselink-test-src.zip/sdo/plugins/</outputDirectory>
-                                    <destFileName>commonj.sdo_2.1.1.v201112051852.jar</destFileName>
-                                </artifactItem>
                             </artifactItems>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>sdo-jpars-javadoc.jar</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <excludeTransitive>true</excludeTransitive>
+                            <includeGroupIds>${project.groupId}</includeGroupIds>
+                            <includeScope>provided</includeScope>
+                            <classifier>javadoc</classifier>
+                            <includeArtifactIds>
+                                org.eclipse.persistence.jpars,
+                                org.eclipse.persistence.sdo
+                            </includeArtifactIds>
+                            <stripVersion>true</stripVersion>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>

--- a/bundles/others/src/main/assembly/eclipselink-plugins-nosql.zip.xml
+++ b/bundles/others/src/main/assembly/eclipselink-plugins-nosql.zip.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -36,11 +36,11 @@
             </includes>
         </dependencySet>
     </dependencySets>
-    <files>
+<!--    <files>
         <file>
             <source>${project.build.directory}/nosql-javadoc.jar</source>
             <outputDirectory>.</outputDirectory>
         </file>
-    </files>
+    </files>-->
 
 </assembly>

--- a/dbws/org.eclipse.persistence.dbws/src/main/java/module-info.java
+++ b/dbws/org.eclipse.persistence.dbws/src/main/java/module-info.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+module org.eclipse.persistence.dbws {
+
+    requires java.desktop;
+    requires java.naming;
+
+    requires jakarta.activation;
+    requires jakarta.mail;
+    requires jakarta.persistence;
+    requires static jakarta.ws.rs;
+    requires jakarta.xml.bind;
+    requires static jakarta.xml.soap;
+    requires static jakarta.xml.ws;
+
+    requires static jakarta.servlet; //AM
+
+    requires org.eclipse.persistence.asm;
+    requires org.eclipse.persistence.core;
+    requires org.eclipse.persistence.jpa;
+    requires org.eclipse.persistence.jpa.jpql;
+    requires org.eclipse.persistence.moxy;
+
+    exports org.eclipse.persistence.dbws;
+    exports org.eclipse.persistence.jpa.rs;
+    exports org.eclipse.persistence.jpa.rs.annotations;
+    exports org.eclipse.persistence.jpa.rs.eventlistener;
+    exports org.eclipse.persistence.jpa.rs.exceptions;
+    exports org.eclipse.persistence.jpa.rs.features;
+    exports org.eclipse.persistence.jpa.rs.features.core.selflinks;
+    exports org.eclipse.persistence.jpa.rs.features.fieldsfiltering;
+    exports org.eclipse.persistence.jpa.rs.features.paging;
+    exports org.eclipse.persistence.jpa.rs.logging;
+    exports org.eclipse.persistence.jpa.rs.resources;
+    exports org.eclipse.persistence.jpa.rs.resources.common;
+    exports org.eclipse.persistence.jpa.rs.resources.unversioned;
+    exports org.eclipse.persistence.jpa.rs.util;
+    exports org.eclipse.persistence.jpa.rs.util.list;
+    exports org.eclipse.persistence.jpa.rs.util.metadatasources;
+    exports org.eclipse.persistence.jpa.rs.util.xmladapters;
+
+    // dbws builder
+    exports org.eclipse.persistence.internal.dbws;
+    exports org.eclipse.persistence.internal.xr;
+    exports org.eclipse.persistence.internal.xr.sxf;
+
+    uses org.eclipse.persistence.jpa.rs.PersistenceContextFactoryProvider;
+}

--- a/foundation/org.eclipse.persistence.corba/pom.xml
+++ b/foundation/org.eclipse.persistence.corba/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -116,6 +116,27 @@
 
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>--add-reads</arg>
+                                <arg>org.eclipse.persistence.corba=ALL-UNNAMED</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <configuration>
+                            <release>8</release>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <executions>
@@ -145,6 +166,13 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <additionalOptions>--add-reads org.eclipse.persistence.corba=ALL-UNNAMED</additionalOptions>
                 </configuration>
             </plugin>
         </plugins>

--- a/foundation/org.eclipse.persistence.corba/src/main/java/module-info.java
+++ b/foundation/org.eclipse.persistence.corba/src/main/java/module-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+module org.eclipse.persistence.corba {
+
+    requires java.rmi;
+
+    requires org.eclipse.persistence.core;
+
+    exports org.eclipse.persistence.sessions.coordination.corba;
+    exports org.eclipse.persistence.sessions.coordination.corba.sun;
+    exports org.eclipse.persistence.sessions.remote.corba.sun;
+    exports org.eclipse.persistence.sessions.remote.rmi.iiop;
+}

--- a/foundation/org.eclipse.persistence.core/pom.xml
+++ b/foundation/org.eclipse.persistence.core/pom.xml
@@ -146,6 +146,21 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>--add-reads</arg>
+                                <arg>org.eclipse.persistence.core=ALL-UNNAMED</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <!--Generate OSGi bundle/manifest-->
             <plugin>
                 <groupId>org.apache.felix</groupId>
@@ -242,6 +257,13 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <additionalOptions>--add-reads org.eclipse.persistence.core=ALL-UNNAMED</additionalOptions>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/foundation/org.eclipse.persistence.core/src/main/java/module-info.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/module-info.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+module org.eclipse.persistence.core {
+
+    requires java.desktop;
+    requires java.management;
+    requires java.naming;
+    requires java.rmi;
+    requires java.sql;
+
+    requires static jakarta.activation;
+    requires static jakarta.annotation;
+    requires static jakarta.json;
+    requires static jakarta.mail;
+    requires static jakarta.persistence;
+    requires static jakarta.xml.bind;
+
+    requires static org.eclipse.persistence.asm;
+    requires static org.eclipse.persistence.jpa.jpql;
+
+    requires static jakarta.cdi; //AM
+    requires static jakarta.el; //AM
+    requires static jakarta.inject; //AM
+    requires static jakarta.transaction; //AM
+
+//    requires jakarta.interceptor.api;
+//    requires jakarta.jms.api;
+//    requires jakarta.resource.api;
+//    requires glassfish.corba.omgapi;
+
+    exports org.eclipse.persistence;
+    exports org.eclipse.persistence.annotations;
+    exports org.eclipse.persistence.config;
+    exports org.eclipse.persistence.core.descriptors;
+    exports org.eclipse.persistence.core.mappings;
+    exports org.eclipse.persistence.core.mappings.converters;
+    exports org.eclipse.persistence.core.mappings.transformers;
+    exports org.eclipse.persistence.core.queries;
+    exports org.eclipse.persistence.core.sessions;
+    exports org.eclipse.persistence.descriptors;
+    exports org.eclipse.persistence.descriptors.changetracking;
+    exports org.eclipse.persistence.descriptors.copying;
+    exports org.eclipse.persistence.descriptors.invalidation;
+    exports org.eclipse.persistence.descriptors.partitioning;
+    exports org.eclipse.persistence.dynamic;
+    exports org.eclipse.persistence.eis;
+    exports org.eclipse.persistence.eis.interactions;
+    exports org.eclipse.persistence.eis.mappings;
+    exports org.eclipse.persistence.exceptions;
+    exports org.eclipse.persistence.exceptions.i18n;
+    exports org.eclipse.persistence.expressions;
+    exports org.eclipse.persistence.history;
+    exports org.eclipse.persistence.indirection;
+    exports org.eclipse.persistence.logging;
+    exports org.eclipse.persistence.mappings;
+    exports org.eclipse.persistence.mappings.converters;
+    exports org.eclipse.persistence.mappings.foundation;
+    exports org.eclipse.persistence.mappings.querykeys;
+    exports org.eclipse.persistence.mappings.structures;
+    exports org.eclipse.persistence.mappings.transformers;
+    exports org.eclipse.persistence.mappings.xdb;
+    exports org.eclipse.persistence.oxm;
+    exports org.eclipse.persistence.oxm.annotations;
+    exports org.eclipse.persistence.oxm.attachment;
+    exports org.eclipse.persistence.oxm.documentpreservation;
+    exports org.eclipse.persistence.oxm.json;
+    exports org.eclipse.persistence.oxm.mappings;
+    exports org.eclipse.persistence.oxm.mappings.converters;
+    exports org.eclipse.persistence.oxm.mappings.nullpolicy;
+    exports org.eclipse.persistence.oxm.platform;
+    exports org.eclipse.persistence.oxm.record;
+    exports org.eclipse.persistence.oxm.schema;
+    exports org.eclipse.persistence.oxm.sequenced;
+    exports org.eclipse.persistence.oxm.unmapped;
+    exports org.eclipse.persistence.platform.database;
+    exports org.eclipse.persistence.platform.database.converters;
+    exports org.eclipse.persistence.platform.database.events;
+    exports org.eclipse.persistence.platform.database.jdbc;
+    exports org.eclipse.persistence.platform.database.oracle.annotations;
+    exports org.eclipse.persistence.platform.database.oracle.jdbc;
+    exports org.eclipse.persistence.platform.database.oracle.plsql;
+    exports org.eclipse.persistence.platform.database.partitioning;
+    exports org.eclipse.persistence.platform.server;
+    exports org.eclipse.persistence.platform.server.glassfish;
+    exports org.eclipse.persistence.platform.server.was;
+    exports org.eclipse.persistence.platform.server.wls;
+    exports org.eclipse.persistence.platform.xml;
+    exports org.eclipse.persistence.queries;
+    exports org.eclipse.persistence.sequencing;
+    exports org.eclipse.persistence.services;
+    exports org.eclipse.persistence.services.glassfish;
+    exports org.eclipse.persistence.services.jboss;
+    exports org.eclipse.persistence.services.mbean;
+    exports org.eclipse.persistence.services.weblogic;
+    exports org.eclipse.persistence.services.websphere;
+    exports org.eclipse.persistence.sessions;
+    exports org.eclipse.persistence.sessions.broker;
+    exports org.eclipse.persistence.sessions.changesets;
+    exports org.eclipse.persistence.sessions.coordination;
+    exports org.eclipse.persistence.sessions.coordination.broadcast;
+    exports org.eclipse.persistence.sessions.coordination.jms;
+    exports org.eclipse.persistence.sessions.coordination.rmi;
+    exports org.eclipse.persistence.sessions.factories;
+    exports org.eclipse.persistence.sessions.remote;
+    exports org.eclipse.persistence.sessions.remote.rmi;
+    exports org.eclipse.persistence.sessions.serializers;
+    exports org.eclipse.persistence.sessions.server;
+    exports org.eclipse.persistence.tools.profiler;
+    exports org.eclipse.persistence.tools.schemaframework;
+    exports org.eclipse.persistence.tools.tuning;
+    exports org.eclipse.persistence.transaction;
+    exports org.eclipse.persistence.transaction.glassfish;
+    exports org.eclipse.persistence.transaction.jboss;
+    exports org.eclipse.persistence.transaction.oc4j;
+    exports org.eclipse.persistence.transaction.sap;
+    exports org.eclipse.persistence.transaction.was;
+    exports org.eclipse.persistence.transaction.wls;
+
+    exports org.eclipse.persistence.internal.cache;
+    exports org.eclipse.persistence.internal.codegen;
+    exports org.eclipse.persistence.internal.core.databaseaccess;
+    exports org.eclipse.persistence.internal.core.descriptors;
+    exports org.eclipse.persistence.internal.core.helper;
+    exports org.eclipse.persistence.internal.core.queries;
+    exports org.eclipse.persistence.internal.core.sessions;
+    exports org.eclipse.persistence.internal.databaseaccess;
+    exports org.eclipse.persistence.internal.descriptors;
+    exports org.eclipse.persistence.internal.descriptors.changetracking;
+    exports org.eclipse.persistence.internal.dynamic;
+    exports org.eclipse.persistence.internal.expressions;
+    exports org.eclipse.persistence.internal.helper;
+    exports org.eclipse.persistence.internal.helper.linkedlist;
+    exports org.eclipse.persistence.internal.helper.type;
+    exports org.eclipse.persistence.internal.history;
+    exports org.eclipse.persistence.internal.identitymaps;
+    exports org.eclipse.persistence.internal.indirection;
+    exports org.eclipse.persistence.internal.jpa.jpql;
+    exports org.eclipse.persistence.internal.localization;
+    exports org.eclipse.persistence.internal.mappings.converters;
+    exports org.eclipse.persistence.internal.oxm;
+    exports org.eclipse.persistence.internal.oxm.accessor;
+    exports org.eclipse.persistence.internal.oxm.conversion;
+    exports org.eclipse.persistence.internal.oxm.documentpreservation;
+    exports org.eclipse.persistence.internal.oxm.mappings;
+    exports org.eclipse.persistence.internal.oxm.record;
+    exports org.eclipse.persistence.internal.oxm.record.deferred;
+    exports org.eclipse.persistence.internal.oxm.record.json;
+    exports org.eclipse.persistence.internal.oxm.record.namespaces;
+    exports org.eclipse.persistence.internal.oxm.schema;
+    exports org.eclipse.persistence.internal.oxm.schema.model;
+    exports org.eclipse.persistence.internal.oxm.unmapped;
+    exports org.eclipse.persistence.internal.platform.database;
+    exports org.eclipse.persistence.internal.queries;
+    exports org.eclipse.persistence.internal.security;
+    exports org.eclipse.persistence.internal.sequencing;
+    exports org.eclipse.persistence.internal.sessions;
+    exports org.eclipse.persistence.internal.sessions.cdi;
+    exports org.eclipse.persistence.internal.sessions.coordination;
+    exports org.eclipse.persistence.internal.sessions.coordination.broadcast;
+    exports org.eclipse.persistence.internal.sessions.coordination.jms;
+    exports org.eclipse.persistence.internal.sessions.coordination.rmi;
+    exports org.eclipse.persistence.internal.sessions.factories;
+    exports org.eclipse.persistence.internal.sessions.factories.model;
+    exports org.eclipse.persistence.internal.sessions.factories.model.event;
+    exports org.eclipse.persistence.internal.sessions.factories.model.log;
+    exports org.eclipse.persistence.internal.sessions.factories.model.login;
+    exports org.eclipse.persistence.internal.sessions.factories.model.platform;
+    exports org.eclipse.persistence.internal.sessions.factories.model.pool;
+    exports org.eclipse.persistence.internal.sessions.factories.model.project;
+    exports org.eclipse.persistence.internal.sessions.factories.model.property;
+    exports org.eclipse.persistence.internal.sessions.factories.model.rcm;
+    exports org.eclipse.persistence.internal.sessions.factories.model.rcm.command;
+    exports org.eclipse.persistence.internal.sessions.factories.model.sequencing;
+    exports org.eclipse.persistence.internal.sessions.factories.model.session;
+    exports org.eclipse.persistence.internal.sessions.factories.model.transport;
+    exports org.eclipse.persistence.internal.sessions.factories.model.transport.discovery;
+    exports org.eclipse.persistence.internal.sessions.factories.model.transport.naming;
+    exports org.eclipse.persistence.internal.sessions.remote;
+    exports org.eclipse.persistence.internal.weaving;
+}

--- a/foundation/org.eclipse.persistence.extension/pom.xml
+++ b/foundation/org.eclipse.persistence.extension/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -77,6 +77,21 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>--add-reads</arg>
+                                <arg>org.eclipse.persistence.extension=ALL-UNNAMED</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <executions>
@@ -96,6 +111,13 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <additionalOptions>--add-reads org.eclipse.persistence.extension=ALL-UNNAMED</additionalOptions>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/foundation/org.eclipse.persistence.extension/src/main/java/module-info.java
+++ b/foundation/org.eclipse.persistence.extension/src/main/java/module-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+module org.eclipse.persistence.extension {
+    requires org.eclipse.persistence.core;
+
+    exports org.eclipse.persistence.logging.slf4j;
+    exports org.eclipse.persistence.sessions.coordination.jgroups;
+    exports org.eclipse.persistence.sessions.serializers.kryo;
+}

--- a/foundation/org.eclipse.persistence.nosql/pom.xml
+++ b/foundation/org.eclipse.persistence.nosql/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -104,6 +104,18 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgs>
+                        <arg>--add-reads</arg>
+                        <arg>org.eclipse.persistence.core=ALL-UNNAMED</arg>
+                        <arg>--add-reads</arg>
+                        <arg>org.eclipse.persistence.nosql=ALL-UNNAMED</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
@@ -176,6 +188,16 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <additionalOptions>
+                        --add-reads org.eclipse.persistence.core=ALL-UNNAMED
+                        --add-reads org.eclipse.persistence.nosql=ALL-UNNAMED
+                    </additionalOptions>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/foundation/org.eclipse.persistence.nosql/src/main/java/module-info.java
+++ b/foundation/org.eclipse.persistence.nosql/src/main/java/module-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+module org.eclipse.persistence.nosql {
+
+    requires jakarta.transaction;
+    requires jakarta.annotation;
+
+    requires org.eclipse.persistence.core;
+
+    exports org.eclipse.persistence.eis.adapters.jms;
+    exports org.eclipse.persistence.eis.adapters.xmlfile;
+    exports org.eclipse.persistence.nosql.adapters.mongo;
+    exports org.eclipse.persistence.nosql.annotations;
+}

--- a/foundation/org.eclipse.persistence.oracle.nosql/pom.xml
+++ b/foundation/org.eclipse.persistence.oracle.nosql/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -125,6 +125,29 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>--add-reads</arg>
+                                <arg>org.eclipse.persistence.core=ALL-UNNAMED</arg>
+                                <arg>--add-reads</arg>
+                                <arg>org.eclipse.persistence.oracle.nosql=ALL-UNNAMED</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <configuration>
+                            <release>8</release>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <executions>
@@ -152,6 +175,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <additionalOptions>
+                        --add-reads org.eclipse.persistence.core=ALL-UNNAMED
+                        --add-reads org.eclipse.persistence.oracle.nosql=ALL-UNNAMED
+                    </additionalOptions>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/module-info.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/module-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+module org.eclipse.persistence.oracle.nosql {
+
+    requires jakarta.transaction;
+
+    requires org.eclipse.persistence.core;
+
+}

--- a/foundation/org.eclipse.persistence.oracle/pom.xml
+++ b/foundation/org.eclipse.persistence.oracle/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -74,6 +74,21 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>--add-reads</arg>
+                                <arg>org.eclipse.persistence.oracle=ALL-UNNAMED</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <executions>
@@ -90,6 +105,13 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <additionalOptions>--add-reads org.eclipse.persistence.oracle=ALL-UNNAMED</additionalOptions>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/foundation/org.eclipse.persistence.oracle/src/main/java/module-info.java
+++ b/foundation/org.eclipse.persistence.oracle/src/main/java/module-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+module org.eclipse.persistence.oracle {
+    requires org.eclipse.persistence.core;
+
+    exports org.eclipse.persistence.platform.database.oracle;
+    exports org.eclipse.persistence.platform.database.oracle.converters;
+    exports org.eclipse.persistence.platform.database.oracle.dcn;
+    exports org.eclipse.persistence.platform.database.oracle.ucp;
+    exports org.eclipse.persistence.platform.xml.xdk;
+    exports org.eclipse.persistence.tools.profiler.oracle;
+}

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/module-info.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/module-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+module org.eclipse.persistence.jpa.jpql {
+
+    requires transitive java.sql;
+
+    exports org.eclipse.persistence.jpa.jpql;
+    exports org.eclipse.persistence.jpa.jpql.parser;
+    exports org.eclipse.persistence.jpa.jpql.utility.iterable;
+}

--- a/jpa/org.eclipse.persistence.jpa.modelgen/pom.xml
+++ b/jpa/org.eclipse.persistence.jpa.modelgen/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -58,23 +58,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <executions>
-                    <!--Compile CanonicalModelProcessor with disabled annotation processing first-->
                     <execution>
                         <id>default-compile</id>
                         <configuration>
-                            <compilerArgument>-proc:none</compilerArgument>
-                            <includes>
-                                <include>org/eclipse/persistence/internal/jpa/modelgen/CanonicalModelProcessor.java</include>
-                                <!--include dependencies required for CanonicalModelProcessor -->
-                            </includes>
+                            <proc>none</proc>
                         </configuration>
-                    </execution>
-                    <execution>
-                        <id>compile-project</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/jpa/org.eclipse.persistence.jpa.modelgen/src/main/java/module-info.java
+++ b/jpa/org.eclipse.persistence.jpa.modelgen/src/main/java/module-info.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+
+module org.eclipse.persistence.jpa.modelgen {
+
+    requires java.compiler;
+
+    requires jakarta.persistence;
+    requires jakarta.annotation;
+
+    requires org.eclipse.persistence.jpa;
+    requires org.eclipse.persistence.core;
+
+    exports org.eclipse.persistence.internal.jpa.modelgen;
+
+    provides javax.annotation.processing.Processor with
+           org.eclipse.persistence.internal.jpa.modelgen.CanonicalModelProcessor;
+}

--- a/jpa/org.eclipse.persistence.jpa.test.framework/pom.xml
+++ b/jpa/org.eclipse.persistence.jpa.test.framework/pom.xml
@@ -73,6 +73,8 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                     <release>8</release>
+                    <!-- openjdk11 fails without this being set -->
+                    <detectOfflineLinks>false</detectOfflineLinks>
                 </configuration>
             </plugin>
         </plugins>

--- a/jpa/org.eclipse.persistence.jpa.test.framework/pom.xml
+++ b/jpa/org.eclipse.persistence.jpa.test.framework/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -65,6 +65,18 @@
             <artifactId>junit</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <release>8</release>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <profiles>
         <profile>

--- a/jpa/org.eclipse.persistence.jpa/pom.xml
+++ b/jpa/org.eclipse.persistence.jpa/pom.xml
@@ -65,6 +65,12 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>com.sun.activation</groupId>
+            <artifactId>jakarta.activation</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
         <!--Other libraries dependencies-->
         <dependency>
             <groupId>org.apache.ant</groupId>
@@ -75,6 +81,21 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>--add-reads</arg>
+                                <arg>org.eclipse.persistence.jpa=ALL-UNNAMED</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <!--Generate OSGi bundle/manifest-->
             <plugin>
                 <groupId>org.apache.felix</groupId>
@@ -131,6 +152,13 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <additionalOptions>--add-reads org.eclipse.persistence.jpa=ALL-UNNAMED</additionalOptions>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/module-info.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/module-info.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+module org.eclipse.persistence.jpa {
+    requires java.rmi;
+
+    requires org.eclipse.persistence.asm;
+    requires org.eclipse.persistence.core;
+    requires org.eclipse.persistence.jpa.jpql;
+
+    requires jakarta.persistence;
+
+    requires static jakarta.transaction;
+    requires static jakarta.validation;
+    requires static jakarta.xml.bind;
+
+    exports org.eclipse.persistence.jpa;
+    exports org.eclipse.persistence.jpa.config;
+    exports org.eclipse.persistence.jpa.dynamic;
+    exports org.eclipse.persistence.jpa.metadata;
+    exports org.eclipse.persistence.tools.weaving.jpa;
+
+    // modelgen
+    exports org.eclipse.persistence.internal.jpa.deployment;
+    exports org.eclipse.persistence.internal.jpa.metadata;
+    exports org.eclipse.persistence.internal.jpa.metadata.accessors.classes;
+    exports org.eclipse.persistence.internal.jpa.metadata.accessors.mappings;
+    exports org.eclipse.persistence.internal.jpa.metadata.accessors.objects;
+    exports org.eclipse.persistence.internal.jpa.metadata.xml;
+
+    // dbws
+    exports org.eclipse.persistence.internal.jpa;
+    exports org.eclipse.persistence.internal.jpa.weaving;
+
+    // dbws builder
+    exports org.eclipse.persistence.internal.jpa.metadata.accessors;
+    exports org.eclipse.persistence.internal.jpa.metadata.columns;
+    exports org.eclipse.persistence.internal.jpa.metadata.converters;
+    exports org.eclipse.persistence.internal.jpa.metadata.partitioning;
+    exports org.eclipse.persistence.internal.jpa.metadata.queries;
+    exports org.eclipse.persistence.internal.jpa.metadata.sequencing;
+    exports org.eclipse.persistence.internal.jpa.metadata.structures;
+    exports org.eclipse.persistence.internal.jpa.metadata.tables;
+
+    provides jakarta.persistence.spi.PersistenceProvider with org.eclipse.persistence.jpa.PersistenceProvider;
+}

--- a/jpa/org.eclipse.persistence.jpars/src/main/java/module-info.java
+++ b/jpa/org.eclipse.persistence.jpars/src/main/java/module-info.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+module org.eclipse.persistence.jpars {
+
+    requires jakarta.persistence;
+    requires jakarta.xml.bind;
+    requires jakarta.activation;
+    requires jakarta.annotation;
+    requires jakarta.ws.rs;
+
+    requires org.eclipse.persistence.dbws;
+    requires org.eclipse.persistence.jpa;
+    requires org.eclipse.persistence.asm;
+    requires org.eclipse.persistence.core;
+    requires org.eclipse.persistence.jpa.jpql;
+    requires org.eclipse.persistence.moxy;
+
+    exports org.eclipse.persistence.jpa.rs.service;
+
+    provides org.eclipse.persistence.jpa.rs.PersistenceContextFactoryProvider with
+            org.eclipse.persistence.jpa.rs.service.JPARSPersistenceContextFactoryProvider;
+}

--- a/moxy/org.eclipse.persistence.moxy.utils.xjc/src/main/java/module-info.java
+++ b/moxy/org.eclipse.persistence.moxy.utils.xjc/src/main/java/module-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+module org.eclipse.persistence.moxy.xjc {
+
+    requires com.sun.tools.xjc;
+
+    exports org.eclipse.persistence.jaxb.xjc;
+}

--- a/moxy/org.eclipse.persistence.moxy/pom.xml
+++ b/moxy/org.eclipse.persistence.moxy/pom.xml
@@ -187,6 +187,21 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>--add-exports</arg>
+                                <arg>com.sun.tools.xjc/com.sun.xml.xsom.impl.parser=org.eclipse.persistence.moxy</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <!--Run specified tests/test suite-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -483,6 +498,13 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <additionalOptions>--add-exports com.sun.tools.xjc/com.sun.xml.xsom.impl.parser=org.eclipse.persistence.moxy</additionalOptions>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/moxy/org.eclipse.persistence.moxy/src/main/java/module-info.java
+++ b/moxy/org.eclipse.persistence.moxy/src/main/java/module-info.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+module org.eclipse.persistence.moxy {
+
+    requires java.naming;
+    requires java.xml;
+
+    requires transitive jakarta.xml.bind;
+    requires jakarta.activation;
+    requires jakarta.mail;
+    requires static jakarta.validation;
+    requires static jakarta.ws.rs;
+    requires org.eclipse.persistence.asm;
+    requires org.eclipse.persistence.core;
+    requires static com.sun.tools.xjc;
+    requires static com.sun.xml.bind.core;
+
+    exports org.eclipse.persistence.jaxb;
+    exports org.eclipse.persistence.jaxb.attachment;
+    exports org.eclipse.persistence.jaxb.compiler;
+    exports org.eclipse.persistence.jaxb.compiler.builder;
+    exports org.eclipse.persistence.jaxb.compiler.builder.helper;
+    exports org.eclipse.persistence.jaxb.compiler.facets;
+    exports org.eclipse.persistence.jaxb.dynamic;
+    exports org.eclipse.persistence.jaxb.dynamic.metadata;
+    exports org.eclipse.persistence.jaxb.javamodel;
+    exports org.eclipse.persistence.jaxb.javamodel.oxm;
+    exports org.eclipse.persistence.jaxb.javamodel.reflection;
+    exports org.eclipse.persistence.jaxb.javamodel.xjc;
+    exports org.eclipse.persistence.jaxb.json;
+    exports org.eclipse.persistence.jaxb.metadata;
+    exports org.eclipse.persistence.jaxb.plugins;
+    exports org.eclipse.persistence.jaxb.rs;
+    exports org.eclipse.persistence.jaxb.xmlmodel;
+
+    // dbws
+    exports org.eclipse.persistence.internal.jaxb;
+
+    provides com.sun.tools.xjc.Plugin with org.eclipse.persistence.jaxb.plugins.BeanValidationPlugin;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1056,12 +1056,15 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M4</version>
+                    <version>3.0.0-M5</version>
+                    <configuration>
+                        <useModulePath>false</useModulePath>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-report-plugin</artifactId>
-                    <version>3.0.0-M4</version>
+                    <version>3.0.0-M5</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -1186,8 +1189,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <release>11</release>>
                 </configuration>
             </plugin>
             <plugin>
@@ -1316,7 +1318,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0-M2</version>
+                <version>3.0.0-M3</version>
                 <executions>
                     <execution>
                         <id>enforce-maven</id>
@@ -1325,8 +1327,11 @@
                         </goals>
                         <configuration>
                             <rules>
+                                <requireJavaVersion>
+                                    <version>[11,)</version>
+                                </requireJavaVersion>
                                 <requireMavenVersion>
-                                    <version>3.5.0</version>
+                                    <version>[3.6.3,)</version>
                                 </requireMavenVersion>
                             </rules>
                         </configuration>
@@ -1462,7 +1467,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <source>8</source>
+                    <release>11</release>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -161,8 +161,7 @@
         <test.xml.parser>org.eclipse.persistence.platform.xml.jaxp.JAXPParser</test.xml.parser>
 
         <!--Eclipse Dependencies version-->
-        <!-- TODO: FIX ME before merge-->
-        <eclipselink.asm.version>9.1.0-SNAPSHOT</eclipselink.asm.version>
+        <eclipselink.asm.version>9.1.0</eclipselink.asm.version>
         <activation.version>2.0.1</activation.version>
         <annotation.version>2.0.0</annotation.version>
         <cdi.version>3.0.0</cdi.version>

--- a/sdo/org.eclipse.persistence.sdo/pom.xml
+++ b/sdo/org.eclipse.persistence.sdo/pom.xml
@@ -31,7 +31,7 @@
     </parent>
 
     <properties>
-        <dep.sources.mr>${project.build.directory}/generated-sources/dependencies-mr</dep.sources.mr>
+        <dep.sources>${project.build.directory}/generated-sources/dependencies</dep.sources>
 
         <test-skip-sdo-srg>${skipTests}</test-skip-sdo-srg>
         <test-skip-sdo>true</test-skip-sdo>
@@ -62,6 +62,12 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>commonj.sdo</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!--Test dependencies-->
         <!--Test framework-->
         <dependency>
@@ -88,7 +94,7 @@
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>unpack-sources-mr</id>
+                        <id>unpack-sources</id>
                         <phase>generate-sources</phase>
                         <goals>
                             <goal>unpack-dependencies</goal>
@@ -99,8 +105,8 @@
                             <classifier>sources</classifier>
                             <excludeTransitive>true</excludeTransitive>
                             <excludes>module-info.*,META-INF/versions/**,META-INF/MANIFEST.MF,
-                                META-INF/*.SF,META-INF/*.DSA,META-INF/*.RSA,META-INF/*.inf</excludes>
-                            <outputDirectory>${dep.sources.mr}/META-INF/versions/9</outputDirectory>
+                                META-INF/*.SF,META-INF/*.DSA,META-INF/*.RSA,META-INF/*.inf,plugin.properties</excludes>
+                            <outputDirectory>${dep.sources}</outputDirectory>
                         </configuration>
                     </execution>
                     <!--Resolve and store into maven property build classpath-->
@@ -115,40 +121,37 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
+           <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>add-mr-resource</id>
-                        <phase>prepare-package</phase>
+                        <id>add-resource</id>
+                        <phase>generate-resources</phase>
                         <goals>
                             <goal>add-resource</goal>
                         </goals>
                         <configuration>
                             <resources>
                                 <resource>
-                                    <directory>${dep.sources.mr}</directory>
+                                    <directory>${dep.sources}</directory>
+                                    <excludes>
+                                        <exclude>**/*.java</exclude>
+                                    </excludes>
                                 </resource>
                             </resources>
                         </configuration>
                     </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <executions>
                     <execution>
-                        <id>default-compile-mr</id>
+                        <id>add-source</id>
+                        <phase>generate-sources</phase>
                         <goals>
-                            <goal>compile</goal>
+                            <goal>add-source</goal>
                         </goals>
                         <configuration>
-                            <compileSourceRoots>
-                                <compileSourceRoot>${dep.sources.mr}/META-INF/versions/9</compileSourceRoot>
-                            </compileSourceRoots>
-                            <outputDirectory>${project.build.outputDirectory}/META-INF/versions/9</outputDirectory>
+                            <sources>
+                                <source>${dep.sources}</source>
+                            </sources>
                         </configuration>
                     </execution>
                 </executions>
@@ -279,44 +282,30 @@
                         <manifest>
                             <addDefaultEntries>false</addDefaultEntries>
                         </manifest>
-                        <manifestEntries>
-                            <Multi-Release>true</Multi-Release>
-                        </manifestEntries>
                     </archive>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <doclint>none</doclint>
+                </configuration>
+                <executions>
+                    <!-- need javadoc even in normal/short build
+                        for inclusion in binary distribution -->
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
 
     <profiles>
-        <profile>
-            <id>jdk8</id>
-            <activation>
-                <jdk>1.8</jdk>
-            </activation>
-            <dependencies>
-                <!-- Required on Java SE 8 -->
-                <dependency>
-                    <groupId>org.eclipse.persistence</groupId>
-                    <artifactId>commonj.sdo</artifactId>
-                </dependency>
-            </dependencies>
-        </profile>
-        <profile>
-            <id>jdk9</id>
-            <activation>
-                <jdk>(1.8,)</jdk>
-            </activation>
-            <dependencies>
-                <!-- Let's treat this as provided for now on JDK 9+ since we're including this under META-INF/versions/9
-                     to get around the split package problem with commonj.sdo.impl.HelperProviderImpl -->
-                <dependency>
-                    <groupId>org.eclipse.persistence</groupId>
-                    <artifactId>commonj.sdo</artifactId>
-                    <scope>provided</scope>
-                </dependency>
-            </dependencies>
-        </profile>
         <!--SDO related profiles-->
         <profile>
             <id>test-sdo-srg</id>

--- a/sdo/org.eclipse.persistence.sdo/src/main/java/module-info.java
+++ b/sdo/org.eclipse.persistence.sdo/src/main/java/module-info.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+module org.eclipse.persistence.sdo {
+    requires java.management;
+    requires java.naming;
+
+    requires org.eclipse.persistence.asm;
+    requires org.eclipse.persistence.core;
+    requires org.eclipse.persistence.moxy;
+    requires jakarta.activation;
+    requires jakarta.mail;
+    requires jakarta.xml.bind;
+
+    exports org.eclipse.persistence.sdo;
+    exports org.eclipse.persistence.sdo.helper;
+    exports org.eclipse.persistence.sdo.types;
+
+    exports commonj.sdo;
+    exports commonj.sdo.helper;
+    exports commonj.sdo.impl;
+
+    opens org.eclipse.persistence.sdo to org.eclipse.persistence.core;
+}

--- a/utils/org.eclipse.persistence.dbws.builder/pom.xml
+++ b/utils/org.eclipse.persistence.dbws.builder/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -41,6 +41,12 @@
             <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
             <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>com.sun.activation</groupId>
+            <artifactId>jakarta.activation</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!--Other modules-->
@@ -107,9 +113,31 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>--add-reads</arg>
+                                <arg>org.eclipse.persistence.dbws.builder=ALL-UNNAMED</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <additionalOptions>--add-reads org.eclipse.persistence.dbws.builder=ALL-UNNAMED</additionalOptions>
                 </configuration>
             </plugin>
         </plugins>

--- a/utils/org.eclipse.persistence.dbws.builder/src/main/java/module-info.java
+++ b/utils/org.eclipse.persistence.dbws.builder/src/main/java/module-info.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+module org.eclipse.persistence.dbws.builder {
+
+    requires java.compiler;
+
+    requires jakarta.activation;
+    requires jakarta.persistence;
+    requires jakarta.xml.bind;
+
+    requires jakarta.servlet; //AM
+
+    requires org.eclipse.persistence.asm;
+    requires org.eclipse.persistence.core;
+    requires org.eclipse.persistence.dbws;
+    requires org.eclipse.persistence.jpa;
+    requires org.eclipse.persistence.jpa.jpql;
+    requires org.eclipse.persistence.moxy;
+    requires org.eclipse.persistence.oracleddlparser;
+
+    exports org.eclipse.persistence.tools.dbws;
+
+    uses org.eclipse.persistence.tools.dbws.DBWSPackager;
+    uses org.eclipse.persistence.tools.dbws.NamingConventionTransformer;
+
+    provides org.eclipse.persistence.tools.dbws.DBWSPackager with
+            org.eclipse.persistence.tools.dbws.JavasePackager,
+            org.eclipse.persistence.tools.dbws.WeblogicPackager,
+            org.eclipse.persistence.tools.dbws.WarPackager,
+            org.eclipse.persistence.tools.dbws.JDevPackager,
+            org.eclipse.persistence.tools.dbws.EclipsePackager,
+            org.eclipse.persistence.tools.dbws.GlassfishPackager,
+            org.eclipse.persistence.tools.dbws.JBossPackager,
+            org.eclipse.persistence.tools.dbws.WebSpherePackager;
+    provides org.eclipse.persistence.tools.dbws.NamingConventionTransformer with
+            org.eclipse.persistence.tools.dbws.ToLowerTransformer,
+            org.eclipse.persistence.tools.dbws.TypeSuffixTransformer,
+            org.eclipse.persistence.tools.dbws.SQLX2003Transformer;
+
+}


### PR DESCRIPTION
This adds JPMS descriptors to the project and sets Java SE 11 as the minimal required Java SE version to build & run master. Note that running EclipseLink on the module path should still be considered as highly experimental.