### PR TITLE
[2.6_WAS] Update jpa.jse test antbuild.xml  for jars with git hash

### DIFF
--- a/jpa/eclipselink.jpa.test.jse/antbuild.xml
+++ b/jpa/eclipselink.jpa.test.jse/antbuild.xml
@@ -41,12 +41,14 @@
     <path id="run.jse.path">
         <pathelement path="${jse.classes.dir}" />
         <!-- <pathelement path="${jse.eclipselink.jar}" /> -->
-        <pathelement path="${jse.el.plugins.dir}/org.eclipse.persistence.antlr_3.2.0.v201302191141.jar" />
-        <pathelement path="${jse.el.plugins.dir}/org.eclipse.persistence.asm_9.0.0.v202010221051.jar" />
-        <pathelement path="${jse.el.plugins.dir}/org.eclipse.persistence.core_2.6.8.WAS.jar" />
-        <pathelement path="${jse.el.plugins.dir}/org.eclipse.persistence.jpa_2.6.8.WAS.jar" />
-        <pathelement path="${jse.el.plugins.dir}/org.eclipse.persistence.jpa.jpql_2.6.8.WAS.jar" />
-        <pathelement path="${jse.el.plugins.dir}/org.eclipse.persistence.jpa.modelgen_2.6.8.WAS.jar" />
+        <fileset dir="${jse.el.plugins.dir}">
+          <include name="org.eclipse.persistence.antlr_*.jar"/>
+          <include name="org.eclipse.persistence.asm_*.jar"/>
+          <include name="org.eclipse.persistence.core_*.jar"/>
+          <include name="org.eclipse.persistence.jpa_*.jar"/>
+          <include name="org.eclipse.persistence.jpa.jpql_*.jar"/>
+          <include name="org.eclipse.persistence.jpa.modelgen_*.jar"/>
+        </fileset>
         <pathelement path="${javax.transaction}" />
         <pathelement path="${javax.validation}" />
         <pathelement path="${javax.persistence}" />


### PR DESCRIPTION
The antbuild.xml for the `eclipselink.jpa.test.jse` test bucket has hard coded entries for the core, jpa, jpa.jpql, jpa.modelgen jars, which doesn't play nicely if you build eclipselink with the `-Dgit.hash=$GIT_REVISION` option.  Modifying the antbuild.xml to allow for more flexibility with the version portion of the file name.