### PR TITLE
fix test failures for mysql driver 8.0.24

### DIFF
--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/models/mapping/Employee.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/models/mapping/Employee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -492,10 +492,10 @@ public class Employee implements Serializable {
     }
 
     public String getRankFromRow(org.eclipse.persistence.sessions.Record row, Session aSession) {
-        if (row.get("RANK") == null) {
+        if (row.get("ERANK") == null) {
             return null;
         }
-        Integer value = new Integer(((Number)row.get("RANK")).intValue());
+        Integer value = new Integer(((Number)row.get("ERANK")).intValue());
         String rank = null;
         Employee employee = new Employee();
 
@@ -617,7 +617,7 @@ public class Employee implements Serializable {
         definition.addField("BDAY", java.sql.Date.class);
         definition.addField("BTIME", java.sql.Time.class);
         definition.addField("JDAY", java.sql.Date.class);
-        definition.addField("RANK", Integer.class);
+        definition.addField("ERANK", Integer.class);
         definition.addField("GENDER", String.class, 10);
 
         // The JDESC field will be added after a plaftorm check in

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/models/mapping/MappingProject.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/models/mapping/MappingProject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -31,11 +31,6 @@ import org.eclipse.persistence.mappings.converters.TypeConversionConverter;
 
 import org.eclipse.persistence.sessions.Project;
 
-import org.eclipse.persistence.testing.models.mapping.Address;
-import org.eclipse.persistence.testing.models.mapping.Computer;
-import org.eclipse.persistence.testing.models.mapping.Employee;
-import org.eclipse.persistence.testing.models.mapping.Monitor;
-import org.eclipse.persistence.testing.models.mapping.Shipment;
 
 public class MappingProject extends Project {
     public MappingProject() {
@@ -483,7 +478,7 @@ public class MappingProject extends Project {
         transformationmapping1.setGetMethodName("getDesignation");
         transformationmapping1.setSetMethodName("setDesignation");
         transformationmapping1.setAttributeTransformation("getRankFromRow");
-        transformationmapping1.addFieldTransformation("MAP_EMP.RANK", "getRankFromObject");
+        transformationmapping1.addFieldTransformation("MAP_EMP.ERANK", "getRankFromObject");
         descriptor.addMapping(transformationmapping1);
 
         // SECTION: TYPECONVERSIONMAPPING

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatasourcePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatasourcePlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, 2020 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -369,7 +369,8 @@ public class DatasourcePlatform implements Platform {
             return new java.sql.Timestamp(System.currentTimeMillis());
         } else {
             getTimestampQuery().setSessionName(sessionName);
-            return (java.sql.Timestamp)session.executeQuery(getTimestampQuery());
+            Object result = session.executeQuery(getTimestampQuery());
+            return (java.sql.Timestamp) session.getDatasourcePlatform().convertObject(result, ClassConstants.TIMESTAMP);
         }
     }
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ConversionManager.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ConversionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2020 IBM Corporation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -33,6 +33,7 @@ import java.sql.Clob;
 import java.sql.SQLException;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Calendar;
@@ -830,6 +831,8 @@ public class ConversionManager extends CoreConversionManager implements Serializ
             return Helper.timestampFromCalendar((Calendar)sourceObject);
         } else if (sourceObject instanceof Long) {
             timestamp = Helper.timestampFromLong((Long)sourceObject);
+        } else if (sourceObject instanceof LocalDateTime) {
+            timestamp = Timestamp.valueOf((LocalDateTime) sourceObject);
         } else {
             throw ConversionException.couldNotBeConverted(sourceObject, ClassConstants.TIMESTAMP);
         }
@@ -1087,6 +1090,8 @@ public class ConversionManager extends CoreConversionManager implements Serializ
             date = Helper.utilDateFromLong((Long)sourceObject);
         } else if (sourceObject instanceof java.util.Date) {
             date = new java.util.Date(((java.util.Date) sourceObject).getTime());
+        } else if (sourceObject instanceof LocalDateTime) {
+            date = Helper.utilDateFromTimestamp(java.sql.Timestamp.valueOf((LocalDateTime) sourceObject));
         } else {
             throw ConversionException.couldNotBeConverted(sourceObject, ClassConstants.UTILDATE);
         }

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/advanced/compositepk/CompositePKTableCreator.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/advanced/compositepk/CompositePKTableCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2018 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -671,7 +671,7 @@ public class CompositePKTableCreator extends TogglingFastTableCreator {
         table.setName("JPA_LACKEYCREW");
 
         FieldDefinition fieldNAME = new FieldDefinition();
-        fieldNAME.setName("RANK");
+        fieldNAME.setName("JPA_LACKEYCREW_RANK");
         fieldNAME.setTypeName("NUMERIC");
         fieldNAME.setSize(15);
         fieldNAME.setShouldAllowNull(false);

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/advanced/derivedid/LackeyCrewMember.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/advanced/derivedid/LackeyCrewMember.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,6 +15,7 @@
 //       - Bug#280350: NoSuchFieldException on deploy when using parent's compound PK class as derived ID
 package org.eclipse.persistence.testing.models.jpa.advanced.derivedid;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
@@ -36,6 +37,7 @@ public class LackeyCrewMember {
     Lackey lackey;
 
     @Id
+    @Column(name = "JPA_LACKEYCREW_RANK")
     int rank;
 
     public Lackey getLackey() {


### PR DESCRIPTION
* `RANK` is reserved word in MySQL 8
* Connector/J 8.0.24 returns `LocalDateTime` from `rs.getObject()` for `TimeStamp` type

To test, update MySQL JDBC driver to the latest one (8.0.24)