### PR TITLE
[master] Jenkins build - switch to JDK 11

### DIFF
--- a/etc/jenkins/build.groovy
+++ b/etc/jenkins/build.groovy
@@ -99,6 +99,10 @@ spec:
 """
         }
     }
+    tools {
+        maven 'apache-maven-latest'
+        jdk 'openjdk-jdk11-latest'
+    }
     stages {
         // Initialize build environment
         stage('Init') {
@@ -210,6 +214,21 @@ spec:
                     }
                 }
             }
+        }
+    }
+    post {
+        // Send a mail on unsuccessful and fixed builds
+        unsuccessful { // means unstable || failure || aborted
+            emailext subject: 'Build $BUILD_STATUS $PROJECT_NAME #$BUILD_NUMBER failed!',
+                    body: '''Check console output at $BUILD_URL to view the results.''',
+                    recipientProviders: [culprits(), requestor()],
+                    to: '${NOTIFICATION_ADDRESS}'
+        }
+        fixed { // back to normal
+            emailext subject: 'Build $BUILD_STATUS $PROJECT_NAME #$BUILD_NUMBER is back to normal!',
+                    body: '''Check console output at $BUILD_URL to view the results.''',
+                    recipientProviders: [culprits(), requestor()],
+                    to: '${NOTIFICATION_ADDRESS}'
         }
     }
 }

--- a/etc/jenkins/build.sh
+++ b/etc/jenkins/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -13,5 +13,4 @@
 #  N/A
 
 echo '-[ EclipseLink Build ]-----------------------------------------------------------'
-. /etc/profile
 mvn install -DskipTests -Poss-release

--- a/etc/jenkins/publish_snapshots.sh
+++ b/etc/jenkins/publish_snapshots.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -16,7 +16,6 @@ if [ ${CONTINUOUS_BUILD} = "true" ]; then
     echo '-[ EclipseLink Publish to Jakarta Snapshots -> No publishing any artifacts]-----------------------------------------------------------'
 else
     echo '-[ EclipseLink Publish to Jakarta Snapshots ]-----------------------------------------------------------'
-    . /etc/profile
     mvn --no-transfer-progress -U -C -B -V \
       -Psnapshots -DskipTests \
       -Ddoclint=none -Ddeploy \

--- a/etc/jenkins/release.groovy
+++ b/etc/jenkins/release.groovy
@@ -94,6 +94,10 @@ spec:
 """
         }
     }
+    tools {
+        maven 'apache-maven-latest'
+        jdk 'openjdk-jdk11-latest'
+    }
     stages {
 
         // Prepare and promote EclipseLink artifacts to oss.sonatype.org (staging) and to the Eclipse.org Milestone Builds area
@@ -138,6 +142,21 @@ spec:
                     }
                 }
             }
+        }
+    }
+    post {
+        // Send a mail on unsuccessful and fixed builds
+        unsuccessful { // means unstable || failure || aborted
+            emailext subject: 'Build $BUILD_STATUS $PROJECT_NAME #$BUILD_NUMBER failed!',
+                    body: '''Check console output at $BUILD_URL to view the results.''',
+                    recipientProviders: [culprits(), requestor()],
+                    to: '${NOTIFICATION_ADDRESS}'
+        }
+        fixed { // back to normal
+            emailext subject: 'Build $BUILD_STATUS $PROJECT_NAME #$BUILD_NUMBER is back to normal!',
+                    body: '''Check console output at $BUILD_URL to view the results.''',
+                    recipientProviders: [culprits(), requestor()],
+                    to: '${NOTIFICATION_ADDRESS}'
         }
     }
 }

--- a/etc/jenkins/release_asm.sh
+++ b/etc/jenkins/release_asm.sh
@@ -15,15 +15,18 @@
 
 #
 # Arguments:
-#  $1 - ASM_VERSION
-#  $2 - NEXT_ASM_VERSION
-#  $3 - DRY_RUN
-#  $4 - OVERWRITE
+# $1 -  ASM_VERSION                 - Version to release
+# $2 -  NEXT_ASM_VERSION            - Next snapshot version to set (e.g. 3.0.1-SNAPSHOT).
+# $3 -  DRY_RUN                     - Do not publish artifacts to OSSRH and code changes to GitHub.
+# $4 -  OVERWRITE_GIT               - Allows to overwrite existing version in git
+# $5 -  OVERWRITE_STAGING           - Allows to overwrite existing version in OSSRH (Jakarta) staging repositories
+
 
 ASM_VERSION="${1}"
 NEXT_ASM_VERSION="${2}"
 DRY_RUN="${3}"
-OVERWRITE="${4}"
+OVERWRITE_GIT="${4}"
+OVERWRITE_STAGING="${5}"
 
 
 export MAVEN_SKIP_RC="true"
@@ -50,7 +53,7 @@ else
   GIT_ORIGIN=`git remote`
   echo '-[ Prepare branch ]-------------------------------------------------------------'
   if [[ -n `git branch -r | grep "${GIT_ORIGIN}/${RELEASE_BRANCH}"` ]]; then
-    if [ "${OVERWRITE}" = 'true' ]; then
+    if [ "${OVERWRITE_GIT}" = 'true' ]; then
       echo "${GIT_ORIGIN}/${RELEASE_BRANCH} branch already exists, deleting"
       git push --delete origin "${RELEASE_BRANCH}" && true
     else
@@ -60,7 +63,7 @@ else
   fi
   echo '-[ Release tag cleanup ]--------------------------------------------------------'
   if [[ -n `git ls-remote --tags ${GIT_ORIGIN} | grep "${RELEASE_TAG}"` ]]; then
-    if [ "${OVERWRITE}" = 'true' ]; then
+    if [ "${OVERWRITE_GIT}" = 'true' ]; then
       echo "${RELEASE_TAG} tag already exists, deleting"
       git push --delete origin "${RELEASE_TAG}" && true
     else
@@ -88,8 +91,8 @@ ASM_STAGING_KEY=$(echo ${ASM_STAGING_DESC} | sed -e 's/\./\\\./g')
 echo '-[ EclipseLink ASM release version ]--------------------------------------------------------'
 set_version 'ASM' "${ASM_DIR}" "${ASM_RELEASE_VERSION}" "${ASM_GROUP_ID}" "${ASM_ARTIFACT_ID}" ''
 
-if [ "${OVERWRITE}" = 'true' ]; then
-  drop_artifacts "${ASM_STAGING_KEY}" "${ASM_DIR}"
+if [ "${OVERWRITE_STAGING}" = 'true' ]; then
+  drop_artifacts "${ECLIPSELINK_STAGING_KEY}" "${ECLIPSELINK_DIR}"
 fi
 
 echo '-[ Deploy artifacts to staging repository ]-----------------------------'

--- a/etc/jenkins/test.sh
+++ b/etc/jenkins/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -13,7 +13,6 @@
 #  N/A
 
 echo '-[ EclipseLink Tests LRG ]-----------------------------------------------------------'
-. /etc/profile
 
 if [ ${CONTINUOUS_BUILD} = "true" ]; then
     echo '-[ EclipseLink SRG Tests ]-----------------------------------------------------------'

--- a/etc/jenkins/test_nosql.sh
+++ b/etc/jenkins/test_nosql.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -13,7 +13,6 @@
 #  N/A
 
 echo '-[ EclipseLink Test NoSQL ]-----------------------------------------------------------'
-. /etc/profile
 /opt/bin/mongo-start.sh
 mvn verify -pl :org.eclipse.persistence.nosql -P mongodb
 /opt/bin/mongo-stop.sh

--- a/etc/jenkins/test_server.sh
+++ b/etc/jenkins/test_server.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -16,7 +16,6 @@ if [ ${CONTINUOUS_BUILD} = "true" ]; then
     echo '-[ EclipseLink Continuous Build -> No server tests]-------------------------------'
 else
     echo '-[ EclipseLink Test Server ]-----------------------------------------------------------'
-    . /etc/profile
     echo '-[ INFO Server tests are temporary disabled until server with Jakarta packages will be available]-'
 #    /opt/bin/mysql-start.sh
 #    mvn --batch-mode verify -pl :org.eclipse.persistence.jpa.test -P server-test-jpa-lrg1,mysql


### PR DESCRIPTION
Default JDK for build and tests will be Open JDK 11 instead of previous Oracle JDK 8.0.
Maven is switched to latest version 3.6.3.
This change is related with implementation/activation Java Module System JPMS  in PR #1093.
There is also notification system enabled in the Jenkins pipeline to send a mail on unsuccessful and fixed builds and some minor release scripts changes.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>