### PR TITLE
[master] Maven build - Plugin bundle content fix

### DIFF
--- a/bundles/eclipselink/pom.xml
+++ b/bundles/eclipselink/pom.xml
@@ -303,6 +303,41 @@
 
     <build>
         <plugins>
+            <!--Initialize build.date and build.time buildNumber properties. Used to generate version.properties in org.eclipse.persistence:eclipselink module-->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>buildnumber-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>build.date</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>create-timestamp</goal>
+                        </goals>
+                        <configuration>
+                            <timestampFormat>yyyyMMdd</timestampFormat>
+                            <timestampPropertyName>build.date</timestampPropertyName>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>build.time</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>create-timestamp</goal>
+                        </goals>
+                        <configuration>
+                            <timestampFormat>HHmm</timestampFormat>
+                            <timestampPropertyName>build.time</timestampPropertyName>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>create</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
@@ -430,6 +465,7 @@
                                     <excludes>
                                         <exclude>**/*.java</exclude>
                                     </excludes>
+                                    <filtering>true</filtering>
                                 </resource>
                             </resources>
                         </configuration>

--- a/bundles/others/src/main/assembly/eclipselink-plugins.zip.xml
+++ b/bundles/others/src/main/assembly/eclipselink-plugins.zip.xml
@@ -26,20 +26,31 @@
     </componentDescriptors>
     <dependencySets>
         <dependencySet>
+            <outputFileNameMapping>${artifact.artifactId}_${release.version}.${build.qualifier}.${artifact.extension}</outputFileNameMapping>
             <includes>
-                <include>org.eclipse.persistence:*</include>
+                <include>org.eclipse.persistence:*:*:*:${project.version}</include>
             </includes>
             <excludes>
                 <exclude>org.eclipse.persistence:*:*:tests</exclude>
+                <exclude>org.eclipse.persistence:org.eclipse.persistence.asm:*</exclude>
+                <exclude>org.eclipse.persistence:org.eclipse.persistence.oracleddlparser:*</exclude>
+                <exclude>org.eclipse.persistence:commonj.sdo:*</exclude>
             </excludes>
             <scope>test</scope>
+        </dependencySet>
+        <dependencySet>
+            <outputFileNameMapping>${artifact.artifactId}_${artifact.version}.${artifact.extension}</outputFileNameMapping>
+            <includes>
+                <include>org.eclipse.persistence:org.eclipse.persistence.asm:*</include>
+                <include>org.eclipse.persistence:org.eclipse.persistence.oracleddlparser:*</include>
+                <include>org.eclipse.persistence:commonj.sdo:*</include>
+            </includes>
         </dependencySet>
         <dependencySet>
             <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
             <excludes>
                 <exclude>com.sun:tools</exclude>
                 <exclude>junit:*</exclude>
-                <exclude>org.antlr:*</exclude>
                 <exclude>org.apache.ant:*</exclude>
                 <exclude>org.eclipse.persistence:*</exclude>
                 <exclude>org.hamcrest:*</exclude>
@@ -65,27 +76,6 @@
             <includes>
                 <include>jakarta.inject:jakarta.inject</include>
             </includes>
-            <scope>test</scope>
-        </dependencySet>
-        <!--Just for backward compatibility with Ant tests in eclipselink-test-src.zip-->
-        <dependencySet>
-            <outputFileNameMapping>${artifact.artifactId}_${release.version}.qualifier.${artifact.extension}</outputFileNameMapping>
-            <includes>
-                <include>org.eclipse.persistence:*</include>
-            </includes>
-            <excludes>
-                <exclude>org.eclipse.persistence:*:*:tests</exclude>
-            </excludes>
-            <scope>test</scope>
-        </dependencySet>
-        <dependencySet>
-            <outputFileNameMapping>org.eclipse.persistence.asm_7.0.0.v201811131354.jar</outputFileNameMapping>
-            <includes>
-                <include>org.eclipse.persistence:org.eclipse.persistence.asm</include>
-            </includes>
-            <excludes>
-                <exclude>org.eclipse.persistence:*:*:tests</exclude>
-            </excludes>
             <scope>test</scope>
         </dependencySet>
     </dependencySets>

--- a/etc/jenkins/build.groovy
+++ b/etc/jenkins/build.groovy
@@ -101,7 +101,7 @@ spec:
     }
     tools {
         maven 'apache-maven-latest'
-        jdk 'openjdk-jdk11-latest'
+        jdk 'adoptopenjdk-hotspot-jdk11-latest'
     }
     stages {
         // Initialize build environment

--- a/etc/jenkins/build_asm.groovy
+++ b/etc/jenkins/build_asm.groovy
@@ -22,7 +22,7 @@ pipeline {
     agent any
 
     tools {
-        jdk 'openjdk-jdk11-latest'
+        jdk 'adoptopenjdk-hotspot-jdk11-latest'
         maven 'apache-maven-latest'
     }
 

--- a/etc/jenkins/release.groovy
+++ b/etc/jenkins/release.groovy
@@ -98,7 +98,7 @@ spec:
     }
     tools {
         maven 'apache-maven-latest'
-        jdk 'openjdk-jdk11-latest'
+        jdk 'adoptopenjdk-hotspot-jdk11-latest'
     }
     stages {
 

--- a/etc/jenkins/release_asm.groovy
+++ b/etc/jenkins/release_asm.groovy
@@ -106,7 +106,7 @@ spec:
     }
 
     tools {
-        jdk 'openjdk-jdk11-latest'
+        jdk 'adoptopenjdk-hotspot-jdk11-latest'
         maven 'apache-maven-latest'
     }
 


### PR DESCRIPTION
This is fix for the bug #1107 "Incorrect content of the bundles at Eclipse.org download pages for versions 3.0.0 and higher."
There is also change in Jenkins pipelines from OpenJDK to AdoptOpenJDK as AdoptOpenJDK integrates latest JDK fixes more quickly.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>