### PR TITLE
Moving MOXy on JPMS to experimental stage

### DIFF
--- a/.LCKpom.xml~
+++ b/.LCKpom.xml~
@@ -1,1 +1,0 @@
-/Users/lukas/development/github/eclipse-ee4j/eclipselink/pom.xml

--- a/.LCKpom.xml~
+++ b/.LCKpom.xml~
@@ -1,0 +1,1 @@
+/Users/lukas/development/github/eclipse-ee4j/eclipselink/pom.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,6 @@ jobs:
   allow_failures:
     - env: MAVEN_TEST=jpa-lrg-server1-mysql
     - env: MAVEN_TEST=jpa-lrg-server2-mysql
-    - env: MAVEN_TEST=javadoc
-      jdk: openjdk11
     - jdk: openjdk-ea
 
 jdk:

--- a/bundles/eclipselink/pom.xml
+++ b/bundles/eclipselink/pom.xml
@@ -52,7 +52,6 @@
         <dependency>
             <groupId>jakarta.persistence</groupId>
             <artifactId>jakarta.persistence-api</artifactId>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>jakarta.annotation</groupId>
@@ -79,7 +78,6 @@
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-xjc</artifactId>
-            <optional>true</optional>
         </dependency>
 
         <!-- dbws: api dependencies -->
@@ -494,8 +492,6 @@
                             <compilerArgs>
                                 <arg>--add-reads</arg>
                                 <arg>eclipselink=ALL-UNNAMED</arg>
-                                <arg>--add-exports</arg>
-                                <arg>com.sun.tools.xjc/com.sun.xml.xsom.impl.parser=eclipselink</arg>
                             </compilerArgs>
                         </configuration>
                     </execution>
@@ -557,7 +553,6 @@
                 <configuration>
                     <additionalOptions>
                         --add-reads eclipselink=ALL-UNNAMED
-                        --add-exports com.sun.tools.xjc/com.sun.xml.xsom.impl.parser=eclipselink
                     </additionalOptions>
                     <doclint>none</doclint>
                     <detectOfflineLinks>false</detectOfflineLinks>

--- a/bundles/eclipselink/src/main/java/module-info.java
+++ b/bundles/eclipselink/src/main/java/module-info.java
@@ -19,11 +19,16 @@ module eclipselink {
     requires java.sql;
     requires java.xml;
 
+    //following cannot be optional because we provide
+    //implementation of its spi/extension here
+    requires jakarta.persistence;
+    requires com.sun.tools.xjc;
+
+
     requires static jakarta.activation;
     requires static jakarta.annotation;
     requires static jakarta.json;
     requires static jakarta.mail;
-    requires static jakarta.persistence;
     requires static jakarta.validation;
     requires static jakarta.ws.rs;
     requires static jakarta.xml.bind;
@@ -33,7 +38,6 @@ module eclipselink {
     requires static jakarta.inject; //AM
     requires static jakarta.transaction; //AM
 
-    requires static com.sun.tools.xjc;
     requires static com.sun.xml.bind.core;
 
     exports org.eclipse.persistence.jpa.jpql;

--- a/bundles/eclipselink/src/main/scripts/bin/jaxb-compiler.cmd
+++ b/bundles/eclipselink/src/main/scripts/bin/jaxb-compiler.cmd
@@ -25,38 +25,14 @@ set JVM_ARGS=-Xmx256m -Djakarta.xml.bind.JAXBContextFactory=org.eclipse.persiste
 set _FIXPATH=
 call :fixpath "%~dp0"
 set THIS=%_FIXPATH:~1%
-set CLASSPATH=%THIS%..\jlib\moxy
-set CLASSPATH=%CLASSPATH%;%THIS%..\jlib\eclipselink.jar
-set CLASSPATH=%CLASSPATH%;%THIS%..\jlib\jpa\jakarta.persistence-api.jar
-
+set MODULEPATH=%THIS%..\jlib\moxy
+set MODULEPATH=%MODULEPATH%;%THIS%..\jlib\eclipselink.jar
+set MODULEPATH=%MODULEPATH%;%THIS%..\jlib\jpa\jakarta.persistence-api.jar
 set MAIN_CLASS=org.eclipse.persistence.jaxb.xjc.MOXyXJC
 set JAVA_ARGS=%*
 
-rem Set Java Version
-for /f "tokens=3" %%i in ('java -version 2^>^&1 ^| %SystemRoot%\system32\find.exe "version"') do (
-  set JAVA_VERSION1=%%i
-)
-for /f "tokens=1,2 delims=." %%j in ('echo %JAVA_VERSION1:~1,-1%') do (
-  if "1" EQU "%%j" (
-    set JAVA_VERSION2=%%k
-  ) else (
-    set JAVA_VERSION2=%%j
-  )
-)
+%JAVA_HOME%\bin\java.exe %JVM_ARGS% --add-modules jakarta.validation -p %MODULEPATH% -m eclipselink/%MAIN_CLASS% %JAVA_ARGS%
 
-rem Remove -ea
-for /f "delims=-" %%i in ('echo %JAVA_VERSION2%') do set JAVA_VERSION=%%i
-echo Java major version: %JAVA_VERSION%
-
-if %JAVA_VERSION% GEQ 9 goto JDK9_OR_GREATER
-rem Java 8
-%JAVA_HOME%\bin\java.exe %JVM_ARGS% -cp %CLASSPATH% %MAIN_CLASS% %JAVA_ARGS%
-@endlocal
-goto :EOF
-
-:JDK9_OR_GREATER
-rem Java
-%JAVA_HOME%\bin\java.exe %JVM_ARGS% --add-modules jakarta.validation -p %CLASSPATH% -m eclipselink/%MAIN_CLASS% %JAVA_ARGS%
 @endlocal
 goto :EOF
 

--- a/bundles/eclipselink/src/main/scripts/bin/jaxb-compiler.cmd
+++ b/bundles/eclipselink/src/main/scripts/bin/jaxb-compiler.cmd
@@ -25,13 +25,10 @@ set JVM_ARGS=-Xmx256m -Djakarta.xml.bind.JAXBContextFactory=org.eclipse.persiste
 set _FIXPATH=
 call :fixpath "%~dp0"
 set THIS=%_FIXPATH:~1%
-set CLASSPATH=%THIS%..\jlib\moxy\jakarta.json.jar
-set CLASSPATH=%CLASSPATH%;%THIS%..\jlib\moxy\jaxb-xjc.jar
-set CLASSPATH=%CLASSPATH%;%THIS%..\jlib\moxy\jaxb-core.jar
-set CLASSPATH=%CLASSPATH%;%THIS%..\jlib\moxy\jakarta.activation.jar
-set CLASSPATH=%CLASSPATH%;%THIS%..\jlib\moxy\jakarta.validation-api.jar
+set CLASSPATH=%THIS%..\jlib\moxy
 set CLASSPATH=%CLASSPATH%;%THIS%..\jlib\eclipselink.jar
-set CLASSPATH=%CLASSPATH%;%THIS%..\jlib\moxy\jakarta.xml.bind-api.jar
+set CLASSPATH=%CLASSPATH%;%THIS%..\jlib\jpa\jakarta.persistence-api.jar
+
 set MAIN_CLASS=org.eclipse.persistence.jaxb.xjc.MOXyXJC
 set JAVA_ARGS=%*
 
@@ -59,7 +56,7 @@ goto :EOF
 
 :JDK9_OR_GREATER
 rem Java
-%JAVA_HOME%\bin\java.exe %JVM_ARGS% -cp %CLASSPATH% %MAIN_CLASS% %JAVA_ARGS%
+%JAVA_HOME%\bin\java.exe %JVM_ARGS% --add-modules jakarta.validation -p %CLASSPATH% -m eclipselink/%MAIN_CLASS% %JAVA_ARGS%
 @endlocal
 goto :EOF
 

--- a/bundles/eclipselink/src/main/scripts/bin/jaxb-compiler.sh
+++ b/bundles/eclipselink/src/main/scripts/bin/jaxb-compiler.sh
@@ -20,21 +20,10 @@ JVM_ARGS="-Xmx256m -Djakarta.xml.bind.JAXBContextFactory=org.eclipse.persistence
 # JVM_ARGS="${JVM_ARGS} -DproxySet=true -Dhttp.proxyHost= -Dhttp.proxyPort="
 
 # Please do not change any of the following lines:
-CLASSPATH=`dirname $0`/../jlib/moxy:\
+MODULEPATH=`dirname $0`/../jlib/moxy:\
 `dirname $0`/../jlib/eclipselink.jar:\
 `dirname $0`/../jlib/jpa/jakarta.persistence-api.jar
 MAIN_CLASS=org.eclipse.persistence.jaxb.xjc.MOXyXJC
 JAVA_ARGS="$@"
 
-JAVA_VERSION=`${JAVA_HOME}/bin/java -version 2>&1 | head -n 1 | cut -d'"' -f2 | sed -E 's/^(1\.)?([0-9]+).*$/\2/'`
-echo "Java major version: ${JAVA_VERSION}"
-
-# Check if supports module path
-if [ ${JAVA_VERSION} -lt 9 ];
-then
-    #Java 8
-    ${JAVA_HOME}/bin/java ${JVM_ARGS} -cp ${CLASSPATH} ${MAIN_CLASS} ${JAVA_ARGS}
-else
-    #Java >8
-    ${JAVA_HOME}/bin/java ${JVM_ARGS} --add-modules jakarta.validation -p "${CLASSPATH}" -m eclipselink/${MAIN_CLASS} ${JAVA_ARGS}
-fi
+${JAVA_HOME}/bin/java ${JVM_ARGS} --add-modules jakarta.validation -p "${MODULEPATH}" -m eclipselink/${MAIN_CLASS} ${JAVA_ARGS}

--- a/bundles/eclipselink/src/main/scripts/bin/jaxb-compiler.sh
+++ b/bundles/eclipselink/src/main/scripts/bin/jaxb-compiler.sh
@@ -20,17 +20,13 @@ JVM_ARGS="-Xmx256m -Djakarta.xml.bind.JAXBContextFactory=org.eclipse.persistence
 # JVM_ARGS="${JVM_ARGS} -DproxySet=true -Dhttp.proxyHost= -Dhttp.proxyPort="
 
 # Please do not change any of the following lines:
-CLASSPATH=`dirname $0`/../jlib/moxy/jaxb-xjc.jar:\
-`dirname $0`/../jlib/moxy/jaxb-core.jar:\
-`dirname $0`/../jlib/moxy/jakarta.activation.jar:\
-`dirname $0`/../jlib/moxy/jakarta.json.jar:\
-`dirname $0`/../jlib/moxy/jakarta.validation-api.jar:\
+CLASSPATH=`dirname $0`/../jlib/moxy:\
 `dirname $0`/../jlib/eclipselink.jar:\
-`dirname $0`/../jlib/moxy/jakarta.xml.bind-api.jar
+`dirname $0`/../jlib/jpa/jakarta.persistence-api.jar
 MAIN_CLASS=org.eclipse.persistence.jaxb.xjc.MOXyXJC
 JAVA_ARGS="$@"
 
-JAVA_VERSION=`${JAVA_HOME}/bin/java -version 2>&1 | head -n 1 | cut -d'"' -f2 | sed -E 's/^(1\.)?([0-9]+).+$/\2/'`
+JAVA_VERSION=`${JAVA_HOME}/bin/java -version 2>&1 | head -n 1 | cut -d'"' -f2 | sed -E 's/^(1\.)?([0-9]+).*$/\2/'`
 echo "Java major version: ${JAVA_VERSION}"
 
 # Check if supports module path
@@ -40,5 +36,5 @@ then
     ${JAVA_HOME}/bin/java ${JVM_ARGS} -cp ${CLASSPATH} ${MAIN_CLASS} ${JAVA_ARGS}
 else
     #Java >8
-    ${JAVA_HOME}/bin/java ${JVM_ARGS} -cp ${CLASSPATH} ${MAIN_CLASS} ${JAVA_ARGS}
+    ${JAVA_HOME}/bin/java ${JVM_ARGS} --add-modules jakarta.validation -p "${CLASSPATH}" -m eclipselink/${MAIN_CLASS} ${JAVA_ARGS}
 fi

--- a/bundles/moxy-standalone/src/main/scripts/jaxb-compiler.cmd
+++ b/bundles/moxy-standalone/src/main/scripts/jaxb-compiler.cmd
@@ -25,7 +25,7 @@ set JVM_ARGS=-Xmx256m -Djakarta.xml.bind.JAXBContextFactory=org.eclipse.persiste
 set _FIXPATH=
 call :fixpath "%~dp0"
 set THIS=%_FIXPATH:~1%
-set CLASSPATH=%THIS%..\jlib\*
+set CLASSPATH=%THIS%..\jlib
 set MAIN_CLASS=org.eclipse.persistence.jaxb.xjc.MOXyXJC
 set JAVA_ARGS=%*
 
@@ -53,7 +53,7 @@ goto :EOF
 
 :JDK9_OR_GREATER
 rem Java
-%JAVA_HOME%\bin\java.exe %JVM_ARGS% -cp "%CLASSPATH%" %MAIN_CLASS% %JAVA_ARGS%
+%JAVA_HOME%\bin\java.exe %JVM_ARGS% -p "%CLASSPATH%" -m org.eclipse.persistence.moxy.xjc %JAVA_ARGS%
 @endlocal
 goto :EOF
 

--- a/bundles/moxy-standalone/src/main/scripts/jaxb-compiler.cmd
+++ b/bundles/moxy-standalone/src/main/scripts/jaxb-compiler.cmd
@@ -25,11 +25,11 @@ set JVM_ARGS=-Xmx256m -Djakarta.xml.bind.JAXBContextFactory=org.eclipse.persiste
 set _FIXPATH=
 call :fixpath "%~dp0"
 set THIS=%_FIXPATH:~1%
-set CLASSPATH=%THIS%..\jlib
+set MODULEPATH=%THIS%..\jlib
 set MAIN_CLASS=org.eclipse.persistence.jaxb.xjc.MOXyXJC
 set JAVA_ARGS=%*
 
-%JAVA_HOME%\bin\java.exe %JVM_ARGS% -p "%CLASSPATH%" -m org.eclipse.persistence.moxy.xjc %JAVA_ARGS%
+%JAVA_HOME%\bin\java.exe %JVM_ARGS% -p "%MODULEPATH%" -m org.eclipse.persistence.moxy.xjc %JAVA_ARGS%
 
 @endlocal
 goto :EOF

--- a/bundles/moxy-standalone/src/main/scripts/jaxb-compiler.cmd
+++ b/bundles/moxy-standalone/src/main/scripts/jaxb-compiler.cmd
@@ -29,31 +29,8 @@ set CLASSPATH=%THIS%..\jlib
 set MAIN_CLASS=org.eclipse.persistence.jaxb.xjc.MOXyXJC
 set JAVA_ARGS=%*
 
-rem Set Java Version
-for /f "tokens=3" %%i in ('java -version 2^>^&1 ^| %SystemRoot%\system32\find.exe "version"') do (
-  set JAVA_VERSION1=%%i
-)
-for /f "tokens=1,2 delims=." %%j in ('echo %JAVA_VERSION1:~1,-1%') do (
-  if "1" EQU "%%j" (
-    set JAVA_VERSION2=%%k
-  ) else (
-    set JAVA_VERSION2=%%j
-  )
-)
-
-rem Remove -ea
-for /f "delims=-" %%i in ('echo %JAVA_VERSION2%') do set JAVA_VERSION=%%i
-echo Java major version: %JAVA_VERSION%
-
-if %JAVA_VERSION% GEQ 9 goto JDK9_OR_GREATER
-rem Java 8
-%JAVA_HOME%\bin\java.exe %JVM_ARGS% -cp "%CLASSPATH%" %MAIN_CLASS% %JAVA_ARGS%
-@endlocal
-goto :EOF
-
-:JDK9_OR_GREATER
-rem Java
 %JAVA_HOME%\bin\java.exe %JVM_ARGS% -p "%CLASSPATH%" -m org.eclipse.persistence.moxy.xjc %JAVA_ARGS%
+
 @endlocal
 goto :EOF
 

--- a/bundles/moxy-standalone/src/main/scripts/jaxb-compiler.sh
+++ b/bundles/moxy-standalone/src/main/scripts/jaxb-compiler.sh
@@ -20,19 +20,8 @@ JVM_ARGS="-Xmx256m -Djakarta.xml.bind.JAXBContextFactory=org.eclipse.persistence
 # JVM_ARGS="${JVM_ARGS} -DproxySet=true -Dhttp.proxyHost= -Dhttp.proxyPort="
 
 # Please do not change any of the following lines:
-CLASSPATH=`dirname $0`/../jlib
+MODULEPATH=`dirname $0`/../jlib
 MAIN_CLASS=org.eclipse.persistence.jaxb.xjc.MOXyXJC
 JAVA_ARGS="$@"
 
-JAVA_VERSION=`${JAVA_HOME}/bin/java -version 2>&1 | head -n 1 | cut -d'"' -f2 | sed -E 's/^(1\.)?([0-9]+).*$/\2/'`
-echo "Java major version: ${JAVA_VERSION}"
-
-# Check if supports module path
-if [ ${JAVA_VERSION} -lt 9 ];
-then
-    #Java 8
-    ${JAVA_HOME}/bin/java ${JVM_ARGS} -cp "${CLASSPATH}" ${MAIN_CLASS} ${JAVA_ARGS}
-else
-    #Java >8
-    ${JAVA_HOME}/bin/java ${JVM_ARGS} -p "${CLASSPATH}" -m org.eclipse.persistence.moxy.xjc ${JAVA_ARGS}
-fi
+${JAVA_HOME}/bin/java ${JVM_ARGS} -p "${MODULEPATH}" -m org.eclipse.persistence.moxy.xjc ${JAVA_ARGS}

--- a/bundles/moxy-standalone/src/main/scripts/jaxb-compiler.sh
+++ b/bundles/moxy-standalone/src/main/scripts/jaxb-compiler.sh
@@ -20,11 +20,11 @@ JVM_ARGS="-Xmx256m -Djakarta.xml.bind.JAXBContextFactory=org.eclipse.persistence
 # JVM_ARGS="${JVM_ARGS} -DproxySet=true -Dhttp.proxyHost= -Dhttp.proxyPort="
 
 # Please do not change any of the following lines:
-CLASSPATH=`dirname $0`/../jlib/*
+CLASSPATH=`dirname $0`/../jlib
 MAIN_CLASS=org.eclipse.persistence.jaxb.xjc.MOXyXJC
 JAVA_ARGS="$@"
 
-JAVA_VERSION=`${JAVA_HOME}/bin/java -version 2>&1 | head -n 1 | cut -d'"' -f2 | sed -E 's/^(1\.)?([0-9]+).+$/\2/'`
+JAVA_VERSION=`${JAVA_HOME}/bin/java -version 2>&1 | head -n 1 | cut -d'"' -f2 | sed -E 's/^(1\.)?([0-9]+).*$/\2/'`
 echo "Java major version: ${JAVA_VERSION}"
 
 # Check if supports module path
@@ -34,5 +34,5 @@ then
     ${JAVA_HOME}/bin/java ${JVM_ARGS} -cp "${CLASSPATH}" ${MAIN_CLASS} ${JAVA_ARGS}
 else
     #Java >8
-    ${JAVA_HOME}/bin/java ${JVM_ARGS} -cp "${CLASSPATH}" ${MAIN_CLASS} ${JAVA_ARGS}
+    ${JAVA_HOME}/bin/java ${JVM_ARGS} -p "${CLASSPATH}" -m org.eclipse.persistence.moxy.xjc ${JAVA_ARGS}
 fi

--- a/foundation/org.eclipse.persistence.core.test.framework/pom.xml
+++ b/foundation/org.eclipse.persistence.core.test.framework/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -49,18 +49,20 @@
         </dependency>
     </dependencies>
 
-<!--    <build>
+    <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <source>8</source>
+                    <release>8</release>
+                    <!-- openjdk11 fails without this being set -->
+                    <detectOfflineLinks>false</detectOfflineLinks>
                     <additionalJOptions>
                         <additionalJOption>-Xdoclint:-html</additionalJOption>
                     </additionalJOptions>
                 </configuration>
             </plugin>
         </plugins>
-    </build>-->
+    </build>
 </project>

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/TraceLocalizationResource.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/TraceLocalizationResource.java
@@ -545,7 +545,10 @@ public class TraceLocalizationResource extends ListResourceBundle {
         { "moxy_set_jaxb_context_property", "Setting JAXBContext property (name/value): {0}/{1}"},
         { "invalid_tzone", "Invalid timezone conversion property {0} value: {1}.  Will attempt to resolve default." },
         { "invalid_default_tzone", "Invalid timezone conversion property {0} value: {1}.  Defaulting to UTC." },
-        { "using_conversion_tzone", "ConversionManager using default zone offset: {1}." }
+        { "using_conversion_tzone", "ConversionManager using default zone offset: {1}."},
+        { "open_pkg", "Opening package {0} in {1} to {2} for reflection access."},
+        { "set_accessible", "Cannot setAccessible {0} for {1}."},
+        { "set_accessible", "Cannot setAccessible {0} {1} in {2}."}
     };
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/TraceLocalizationResource.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/TraceLocalizationResource.java
@@ -548,7 +548,7 @@ public class TraceLocalizationResource extends ListResourceBundle {
         { "using_conversion_tzone", "ConversionManager using default zone offset: {1}."},
         { "open_pkg", "Opening package {0} in {1} to {2} for reflection access."},
         { "set_accessible", "Cannot setAccessible {0} for {1}."},
-        { "set_accessible", "Cannot setAccessible {0} {1} in {2}."}
+        { "set_accessible_in", "Cannot setAccessible {0} {1} in {2}."}
     };
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/security/PrivilegedAccessHelper.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/security/PrivilegedAccessHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -39,6 +39,8 @@ import org.eclipse.persistence.config.SystemProperties;
 import org.eclipse.persistence.internal.helper.Helper;
 import org.eclipse.persistence.internal.helper.JavaVersion;
 import org.eclipse.persistence.internal.localization.ExceptionLocalization;
+import org.eclipse.persistence.logging.AbstractSessionLog;
+import org.eclipse.persistence.logging.SessionLog;
 import org.eclipse.persistence.platform.server.ServerPlatformBase;
 import org.eclipse.persistence.platform.xml.XMLPlatformFactory;
 
@@ -214,7 +216,10 @@ public class PrivilegedAccessHelper {
             }
         }
         if (shouldSetAccessible) {
-            result.setAccessible(true);
+            if (!result.trySetAccessible()) {
+                AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MISC, "Cannot setAccessible constructor for {0}.",
+                        new String[]{javaClass.getName()}, false);
+            }
         }
         return result;
     }
@@ -239,7 +244,10 @@ public class PrivilegedAccessHelper {
     public static Constructor getDeclaredConstructorFor(final Class javaClass, final Class[] args, final boolean shouldSetAccessible) throws NoSuchMethodException {
         Constructor result = javaClass.getDeclaredConstructor(args);
         if (shouldSetAccessible) {
-            result.setAccessible(true);
+            if (!result.trySetAccessible()) {
+                AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MISC, "Cannot setAccessible declared constructor for {0}.",
+                        new String[]{javaClass.getName()}, false);
+            }
         }
         return result;
     }
@@ -256,7 +264,10 @@ public class PrivilegedAccessHelper {
     public static Field getField(final Class javaClass, final String fieldName, final boolean shouldSetAccessible) throws NoSuchFieldException {
         Field field = findDeclaredField(javaClass, fieldName);
         if (shouldSetAccessible) {
-            field.setAccessible(true);
+            if (!field.trySetAccessible()) {
+                AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MISC, "Cannot setAccessible field {0} in {1}.",
+                        new String[]{fieldName, javaClass.getName()}, false);
+            }
         }
         return field;
     }
@@ -273,7 +284,10 @@ public class PrivilegedAccessHelper {
     public static Field getDeclaredField(final Class javaClass, final String fieldName, final boolean shouldSetAccessible) throws NoSuchFieldException {
         Field field = javaClass.getDeclaredField(fieldName);
         if (shouldSetAccessible) {
-            field.setAccessible(true);
+            if (!field.trySetAccessible()) {
+                AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MISC, "Cannot setAccessible declared field {0} in {1}.",
+                        new String[]{fieldName, javaClass.getName()}, false);
+            }
         }
         return field;
     }
@@ -323,7 +337,10 @@ public class PrivilegedAccessHelper {
     public static Method getMethod(final Class javaClass, final String methodName, final Class[] methodParameterTypes, final boolean shouldSetAccessible) throws NoSuchMethodException {
         Method method = findMethod(javaClass, methodName, methodParameterTypes);
         if (shouldSetAccessible) {
-            method.setAccessible(true);
+            if (!method.trySetAccessible()) {
+                AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MISC, "Cannot setAccessible method {0} in {1}.",
+                        new String[]{methodName, javaClass.getName()}, false);
+            }
         }
         return method;
     }
@@ -344,7 +361,10 @@ public class PrivilegedAccessHelper {
         // Return the (public) method - will traverse superclass(es) if necessary
         Method method = javaClass.getMethod(methodName, methodParameterTypes);
         if (shouldSetAccessible) {
-            method.setAccessible(true);
+            if (!method.trySetAccessible()) {
+                AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MISC, "Cannot setAccessible public method {0} in {1}.",
+                        new String[]{methodName, javaClass.getName()}, false);
+            }
         }
         return method;
     }
@@ -511,7 +531,10 @@ public class PrivilegedAccessHelper {
     public static Object invokeMethod(final Method method, final Object object, final Object[] parameters) throws IllegalAccessException, InvocationTargetException {
         // Ensure the method is accessible.
         if (!method.isAccessible()) {
-            method.setAccessible(true);
+            if (!method.trySetAccessible()) {
+                AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MISC, "Cannot setAccessible method {0} in {1} for invokation.",
+                        new String[]{method.getName(), method.getDeclaringClass().getName()}, false);
+            }
         }
         return method.invoke(object, parameters);
     }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/security/PrivilegedAccessHelper.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/security/PrivilegedAccessHelper.java
@@ -217,8 +217,8 @@ public class PrivilegedAccessHelper {
         }
         if (shouldSetAccessible) {
             if (!result.trySetAccessible()) {
-                AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MISC, "Cannot setAccessible constructor for {0}.",
-                        new String[]{javaClass.getName()}, false);
+                AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MISC, "set_accessible",
+                        "constructor", javaClass.getName());
             }
         }
         return result;
@@ -245,8 +245,8 @@ public class PrivilegedAccessHelper {
         Constructor result = javaClass.getDeclaredConstructor(args);
         if (shouldSetAccessible) {
             if (!result.trySetAccessible()) {
-                AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MISC, "Cannot setAccessible declared constructor for {0}.",
-                        new String[]{javaClass.getName()}, false);
+                AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MISC, "set_accessible",
+                        "declared constructor", javaClass.getName());
             }
         }
         return result;
@@ -265,8 +265,8 @@ public class PrivilegedAccessHelper {
         Field field = findDeclaredField(javaClass, fieldName);
         if (shouldSetAccessible) {
             if (!field.trySetAccessible()) {
-                AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MISC, "Cannot setAccessible field {0} in {1}.",
-                        new String[]{fieldName, javaClass.getName()}, false);
+                AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MISC, "set_accessible_in",
+                        "field", fieldName, javaClass.getName());
             }
         }
         return field;
@@ -285,8 +285,8 @@ public class PrivilegedAccessHelper {
         Field field = javaClass.getDeclaredField(fieldName);
         if (shouldSetAccessible) {
             if (!field.trySetAccessible()) {
-                AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MISC, "Cannot setAccessible declared field {0} in {1}.",
-                        new String[]{fieldName, javaClass.getName()}, false);
+                AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MISC, "set_accessible_in",
+                        "declared field", fieldName, javaClass.getName());
             }
         }
         return field;
@@ -338,8 +338,8 @@ public class PrivilegedAccessHelper {
         Method method = findMethod(javaClass, methodName, methodParameterTypes);
         if (shouldSetAccessible) {
             if (!method.trySetAccessible()) {
-                AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MISC, "Cannot setAccessible method {0} in {1}.",
-                        new String[]{methodName, javaClass.getName()}, false);
+                AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MISC, "set_accessible_in",
+                        "method", methodName, javaClass.getName());
             }
         }
         return method;
@@ -362,8 +362,8 @@ public class PrivilegedAccessHelper {
         Method method = javaClass.getMethod(methodName, methodParameterTypes);
         if (shouldSetAccessible) {
             if (!method.trySetAccessible()) {
-                AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MISC, "Cannot setAccessible public method {0} in {1}.",
-                        new String[]{methodName, javaClass.getName()}, false);
+                AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MISC, "set_accessible_in",
+                        "public method", methodName, javaClass.getName());
             }
         }
         return method;
@@ -532,8 +532,8 @@ public class PrivilegedAccessHelper {
         // Ensure the method is accessible.
         if (!method.isAccessible()) {
             if (!method.trySetAccessible()) {
-                AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MISC, "Cannot setAccessible method {0} in {1} for invokation.",
-                        new String[]{method.getName(), method.getDeclaringClass().getName()}, false);
+                AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MISC, "set_accessible_in",
+                        "method", method.getName(), method.getDeclaringClass().getName() + " for invokation");
             }
         }
         return method.invoke(object, parameters);

--- a/moxy/org.eclipse.persistence.moxy.utils.xjc/pom.xml
+++ b/moxy/org.eclipse.persistence.moxy.utils.xjc/pom.xml
@@ -36,4 +36,20 @@
             <artifactId>jaxb-xjc</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>org.eclipse.persistence.jaxb.xjc.MOXyXJC</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/moxy/org.eclipse.persistence.moxy/pom.xml
+++ b/moxy/org.eclipse.persistence.moxy/pom.xml
@@ -47,16 +47,6 @@
             <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.activation</groupId>
-            <artifactId>jakarta.activation-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.mail</groupId>
-            <artifactId>jakarta.mail-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
             <optional>true</optional>
@@ -87,12 +77,10 @@
         <dependency>
             <groupId>com.sun.activation</groupId>
             <artifactId>jakarta.activation</artifactId>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>com.sun.mail</groupId>
             <artifactId>jakarta.mail</artifactId>
-            <scope>runtime</scope>
         </dependency>
 
         <!--Test dependencies-->
@@ -178,21 +166,6 @@
                                     *
                                 </Import-Package>
                             </instructions>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-compile</id>
-                        <configuration>
-                            <compilerArgs>
-                                <arg>--add-exports</arg>
-                                <arg>com.sun.tools.xjc/com.sun.xml.xsom.impl.parser=org.eclipse.persistence.moxy</arg>
-                            </compilerArgs>
                         </configuration>
                     </execution>
                 </executions>
@@ -517,13 +490,146 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
+            <!--
+            To run tests on JPMS, remove all surefire executions except of the default-test
+            and uncomment following:
+            -->
+<!--        <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <additionalOptions>--add-exports com.sun.tools.xjc/com.sun.xml.xsom.impl.parser=org.eclipse.persistence.moxy</additionalOptions>
-                </configuration>
-            </plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.ant</groupId>
+                        <artifactId>ant</artifactId>
+                        <version>${ant.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.ant</groupId>
+                        <artifactId>ant-junitlauncher</artifactId>
+                        <version>${ant.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.ant</groupId>
+                        <artifactId>ant-junit</artifactId>
+                        <version>${ant.version}</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <record name="${project.build.directory}/build.txt" loglevel="verbose" action="start" />
+
+                                <path id="moxy.test.module.path">
+                                    <pathelement path="${project.build.outputDirectory}"/>
+                                    <pathelement path="${project.build.testOutputDirectory}"/>
+
+                                    <pathelement path="${org.glassfish:jakarta.json:jar}"/>
+
+                                    <pathelement path="${org.eclipse.persistence:org.eclipse.persistence.asm:jar}"/>
+                                    <pathelement path="${org.eclipse.persistence:org.eclipse.persistence.core:jar}"/>
+
+                                    <pathelement path="${jakarta.annotation:jakarta.annotation-api:jar}"/>
+                                    <pathelement path="${jakarta.el:jakarta.el-api:jar}"/>
+                                    <pathelement path="${jakarta.inject:jakarta.inject-api:jar}"/>
+                                    <pathelement path="${jakarta.validation:jakarta.validation-api:jar}"/>
+                                    <pathelement path="${jakarta.ws.rs:jakarta.ws.rs-api:jar}"/>
+                                    <pathelement path="${jakarta.xml.bind:jakarta.xml.bind-api:jar}"/>
+
+                                    <pathelement path="${com.fasterxml:classmate:jar}"/>
+                                    <pathelement path="${com.sun.activation:jakarta.activation:jar}"/>
+                                    <pathelement path="${com.sun.mail:jakarta.mail:jar}"/>
+                                    <pathelement path="${com.sun.xml.bind:jaxb-core:jar}"/>
+                                    <pathelement path="${com.sun.xml.bind:jaxb-impl:jar}"/>
+                                    <pathelement path="${com.sun.xml.bind:jaxb-xjc:jar}"/>
+
+                                    <pathelement path="${org.glassfish:jakarta.el:jar}"/>
+                                    <pathelement path="${org.glassfish.jersey.core:jersey-common:jar}"/>
+                                    <pathelement path="${org.hamcrest:hamcrest-core:jar}"/>
+                                    <pathelement path="${org.hibernate.validator:hibernate-validator:jar}"/>
+                                    <pathelement path="${org.jboss.logging:jboss-logging:jar}"/>
+                                    <pathelement path="${junit:junit:jar}"/>
+                                </path>
+
+                                <path id="moxy.test.class.path">
+                                    <pathelement path="${org.glassfish.hk2:osgi-resource-locator:jar}"/>
+                                </path>
+
+                                <echo message="Running moxy tests on JPMS"/>
+                                <property name="report.dir" location="${project.build.directory}"/>
+                                <property name="src.dir" location="${project.build.testSourceDirectory}"/>
+                                <property name="build.dir" location="${project.build.directory}/ant-run"/>
+                                <delete dir="${report.dir}/jaxb" failonerror="false"/>
+                                <mkdir dir="${report.dir}/jaxb"/>
+                                <mkdir dir="${build.dir}"/>
+                                <mkdir dir="${build.dir}/tmp"/>
+
+                                <junit fork="true" failureproperty="junit.failed.jaxb" logfailedtests="true" showoutput="yes" printsummary="yes"
+                                       dir="${build.dir}" tempdir="${build.dir}/tmp" >
+                                    <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"/>
+                                    <modulepath refid="moxy.test.module.path"/>
+                                    <classpath refid="moxy.test.class.path"/>
+                                    <jvmarg value="-ea"/>
+                                    <jvmarg line="- -add-modules jakarta.json,org.eclipse.persistence.moxy.test,com.fasterxml.classmate"/>
+                                    <sysproperty key="platformType" value="SAX"/>
+                                    <sysproperty key="metadataType" value="JAVA"/>
+                                    <sysproperty key="useLogging" value="false"/>
+                                    <sysproperty key="eclipselink.xml.platform" value="org.eclipse.persistence.platform.xml.jaxp.JAXPPlatform"/>
+                                    <sysproperty key="parser" value="org.eclipse.persistence.platform.xml.jaxp.JAXPParser"/>
+                                    <batchtest todir="${report.dir}/jaxb">
+                                        <fileset dir="${src.dir}">
+                                            <include name="org/eclipse/persistence/testing/jaxb/JAXBTestSuite.java"/>
+                                            <include name="org/eclipse/persistence/testing/jaxb/JAXBTestSuite2.java"/>
+                                            <include name="org/eclipse/persistence/testing/jaxb/JAXBTestSuite3.java"/>
+                                            <include name="org/eclipse/persistence/testing/jaxb/JAXBTestSuite4.java"/>
+                                            <include name="org/eclipse/persistence/testing/jaxb/JAXBBeanValidationTestSuite.java" />
+                                            <include name="org/eclipse/persistence/testing/jaxb/beanvalidation/BeanValidationHelperTestCase.java"/>
+                                            <include name="org/eclipse/persistence/testing/jaxb/listofobjects/JAXBListOfObjectsSuite.java"/>
+                                            <include name="org/eclipse/persistence/testing/jaxb/annotations/AnnotationsTestSuite.java"/>
+                                            <include
+                                                name="org/eclipse/persistence/testing/jaxb/externalizedmetadata/ExternalizedMetadataTestSuite.java"/>
+                                            <include
+                                                name="org/eclipse/persistence/testing/jaxb/javadoc/JavadocAnnotationExamplesTestSuite.java"/>
+                                            <include
+                                                name="org/eclipse/persistence/testing/jaxb/typemappinginfo/TypeMappingInfoTestSuite.java"/>
+                                            <include name="org/eclipse/persistence/testing/jaxb/schemagen/SchemaGenTestSuite.java"/>
+                                            <include name="org/eclipse/persistence/testing/jaxb/xmladapter/XmlAdapterTestSuite.java"/>
+                                            <include name="org/eclipse/persistence/testing/jaxb/dynamic/DynamicJAXBTestSuite.java"/>
+                                            <include name="org/eclipse/persistence/testing/jaxb/json/JSONTestSuite.java"/>
+                                            <include name="org/eclipse/persistence/testing/jaxb/rs/RESTfulTestSuite.java"/>
+                                            <include name="org/eclipse/persistence/testing/moxy/unit/**/*TestCase.java"/>
+                                            <include name="org/eclipse/persistence/testing/jaxb/annotations/xmlidref/XmlIdSystemPropertyNotSetTestCase.java"/>
+                                            <include name="org/eclipse/persistence/testing/jaxb/annotations/xmlidref/XmlValueSystemPropertyNotSetTestCase.java"/>
+                                            <include name="org/eclipse/persistence/testing/jaxb/annotations/xmlidref/XmlValueSystemPropertyTestCase.java"/>
+                                        </fileset>
+                                        <formatter type="xml"/>
+                                    </batchtest>
+                                </junit>
+
+                                <junitreport todir="${report.dir}/jaxb">
+                                    <fileset dir="${report.dir}/jaxb">
+                                        <include name="**/*.xml"/>
+                                    </fileset>
+                                    <report todir="${report.dir}/jaxb"/>
+                                </junitreport>
+
+                                <fail message="TESTS FAILED !">
+                                    <condition>
+                                        <and>
+                                            <isset property="junit.failed.jaxb"/>
+                                            <istrue value="${test.fail.fast}"/>
+                                        </and>
+                                    </condition>
+                                </fail>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>-->
         </plugins>
     </build>
 

--- a/moxy/org.eclipse.persistence.moxy/src/main/java/module-info.java
+++ b/moxy/org.eclipse.persistence.moxy/src/main/java/module-info.java
@@ -12,6 +12,7 @@
 
 module org.eclipse.persistence.moxy {
 
+    requires java.desktop;
     requires java.naming;
     requires java.xml;
 
@@ -21,11 +22,12 @@ module org.eclipse.persistence.moxy {
     requires static jakarta.validation;
     requires static jakarta.ws.rs;
     requires org.eclipse.persistence.asm;
-    requires org.eclipse.persistence.core;
+    requires transitive org.eclipse.persistence.core;
     requires static com.sun.tools.xjc;
     requires static com.sun.xml.bind.core;
 
     exports org.eclipse.persistence.jaxb;
+    opens org.eclipse.persistence.jaxb;
     exports org.eclipse.persistence.jaxb.attachment;
     exports org.eclipse.persistence.jaxb.compiler;
     exports org.eclipse.persistence.jaxb.compiler.builder;
@@ -42,9 +44,16 @@ module org.eclipse.persistence.moxy {
     exports org.eclipse.persistence.jaxb.plugins;
     exports org.eclipse.persistence.jaxb.rs;
     exports org.eclipse.persistence.jaxb.xmlmodel;
+    opens org.eclipse.persistence.jaxb.xmlmodel to jakarta.xml.bind;
 
     // dbws
     exports org.eclipse.persistence.internal.jaxb;
+
+    //tests
+    exports org.eclipse.persistence.internal.jaxb.many;
+
+    exports org.eclipse.persistence.internal.jaxb.json.schema;
+    exports org.eclipse.persistence.internal.jaxb.json.schema.model;
 
     provides com.sun.tools.xjc.Plugin with org.eclipse.persistence.jaxb.plugins.BeanValidationPlugin;
 }

--- a/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/JAXBContext.java
+++ b/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/JAXBContext.java
@@ -1735,8 +1735,8 @@ public class JAXBContext extends jakarta.xml.bind.JAXBContext {
                 //propagate openness to o.e.p.core module
                 if (classModule.isOpen(packageName, moxyModule) && !classModule.isOpen(packageName, coreModule)) {
                     classModule.addOpens(packageName, coreModule);
-                    AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MOXY, "Openning package {0} in {1} to {2} for reflection access.",
-                            new String[]{packageName, classModule.getName(), coreModule.getName()}, false);
+                    AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MOXY, "open_pkg",
+                            packageName, classModule.getName(), coreModule.getName());
                 }
             }
         }

--- a/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/JAXBContext.java
+++ b/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/JAXBContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -49,10 +49,12 @@ import jakarta.xml.bind.SchemaOutputResolver;
 import jakarta.xml.bind.ValidationEvent;
 import jakarta.xml.bind.ValidationEventHandler;
 import jakarta.xml.bind.annotation.adapters.XmlAdapter;
+import java.util.HashSet;
 import javax.xml.namespace.QName;
 import javax.xml.stream.FactoryConfigurationError;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.transform.Source;
+import org.eclipse.persistence.Version;
 
 import org.eclipse.persistence.core.queries.CoreAttributeGroup;
 import org.eclipse.persistence.core.sessions.CoreProject;
@@ -68,7 +70,6 @@ import org.eclipse.persistence.internal.jaxb.WrappedValue;
 import org.eclipse.persistence.internal.jaxb.json.schema.JsonSchemaGenerator;
 import org.eclipse.persistence.internal.jaxb.json.schema.model.JsonSchema;
 import org.eclipse.persistence.internal.jaxb.many.ManyValue;
-import org.eclipse.persistence.internal.localization.JAXBLocalization;
 import org.eclipse.persistence.internal.oxm.Constants;
 import org.eclipse.persistence.internal.oxm.Root;
 import org.eclipse.persistence.internal.oxm.XMLConversionManager;
@@ -85,6 +86,7 @@ import org.eclipse.persistence.jaxb.compiler.MarshalCallback;
 import org.eclipse.persistence.jaxb.compiler.UnmarshalCallback;
 import org.eclipse.persistence.jaxb.javamodel.JavaClass;
 import org.eclipse.persistence.jaxb.javamodel.reflection.AnnotationHelper;
+import org.eclipse.persistence.jaxb.javamodel.reflection.JavaClassImpl;
 import org.eclipse.persistence.jaxb.javamodel.reflection.JavaModelImpl;
 import org.eclipse.persistence.jaxb.javamodel.reflection.JavaModelInputImpl;
 import org.eclipse.persistence.jaxb.json.JsonSchemaOutputResolver;
@@ -832,14 +834,14 @@ public class JAXBContext extends jakarta.xml.bind.JAXBContext {
             List<SessionEventListener> eventListeners = null;
 
             if (null == eventListenerFromProperties) {
-                eventListeners = new ArrayList<SessionEventListener>(1);
+                eventListeners = new ArrayList<>(1);
             } else {
                 if (eventListenerFromProperties instanceof SessionEventListener) {
-                    eventListeners = new ArrayList<SessionEventListener>(2);
+                    eventListeners = new ArrayList<>(2);
                     eventListeners.add((SessionEventListener) eventListenerFromProperties);
                 } else if (eventListenerFromProperties instanceof Collection) {
                     List<SessionEventListener> listeners = (List<SessionEventListener>) eventListenerFromProperties;
-                    eventListeners = new ArrayList<SessionEventListener>(listeners.size() + 1);
+                    eventListeners = new ArrayList<>(listeners.size() + 1);
                     eventListeners.addAll(listeners);
                 }
             }
@@ -865,7 +867,7 @@ public class JAXBContext extends jakarta.xml.bind.JAXBContext {
         @Override
         protected JAXBContextState createContextState() throws jakarta.xml.bind.JAXBException {
             boolean foundMetadata = false;
-            List<Class> classes = new ArrayList<Class>();
+            List<Class> classes = new ArrayList<>();
 
             // Check properties map for eclipselink-oxm.xml entries
             Map<String, XmlBindings> xmlBindingMap = JAXBContextFactory.getXmlBindingsFromProperties(properties, classLoader);
@@ -920,11 +922,13 @@ public class JAXBContext extends jakarta.xml.bind.JAXBContext {
                 for (int i = 0; i < classes.size(); i++) {
                     classArray[i] = classes.get(i);
                 }
+                openToCore(classes);
                 return createContextState(classArray, xmlBindingMap);
             }
 
             Exception sessionLoadingException = null;
             try {
+                openToCore(classes);
                 XMLContext xmlContext = new XMLContext(contextPath, classLoader);
                 return new JAXBContextState(xmlContext);
             } catch (Exception exception) {
@@ -978,7 +982,7 @@ public class JAXBContext extends jakarta.xml.bind.JAXBContext {
             }
 
             // create Map of package names to metadata complete indicators
-            Map<String, Boolean> metadataComplete = new HashMap<String, Boolean>();
+            Map<String, Boolean> metadataComplete = new HashMap<>();
             for (String packageName : xmlBindings.keySet()) {
                 if (xmlBindings.get(packageName).isXmlMappingMetadataComplete()) {
                     metadataComplete.put(packageName, true);
@@ -1149,7 +1153,6 @@ public class JAXBContext extends jakarta.xml.bind.JAXBContext {
                         }
                     })
                     : new JaxbClassLoader(classLoader, types);
-
             JavaModelImpl jModel;
             if (annotationHelper != null) {
                 jModel = new JavaModelImpl(loader, annotationHelper);
@@ -1160,7 +1163,7 @@ public class JAXBContext extends jakarta.xml.bind.JAXBContext {
             if (xmlBindings != null) {
                 jModel.setHasXmlBindings(!xmlBindings.isEmpty());
                 // create Map of package names to metadata complete indicators
-                Map<String, Boolean> metadataComplete = new HashMap<String, Boolean>();
+                Map<String, Boolean> metadataComplete = new HashMap<>();
                 for (String packageName : xmlBindings.keySet()) {
                     if (xmlBindings.get(packageName).isXmlMappingMetadataComplete()) {
                         metadataComplete.put(packageName, true);
@@ -1175,6 +1178,7 @@ public class JAXBContext extends jakarta.xml.bind.JAXBContext {
             JavaModelInputImpl inputImpl = new JavaModelInputImpl(typesToBeBound, jModel);
             if (properties != null) enableFacetsIfPropertySetTrue(inputImpl, properties);
             try {
+                openToCore(inputImpl);
                 Generator generator = new Generator(inputImpl, typesToBeBound, inputImpl.getJavaClasses(), null, xmlBindings, classLoader, defaultTargetNamespace, enableXmlAccessorFactory);
                 JAXBContextState contextState = createContextState(generator, loader, typesToBeBound, properties);
                 return contextState;
@@ -1233,7 +1237,7 @@ public class JAXBContext extends jakarta.xml.bind.JAXBContext {
         private static TypeMappingInfo[] getXmlBindingsClasses(XmlBindings xmlBindings, ClassLoader classLoader, TypeMappingInfo[] existingTypes) {
             JavaTypes jTypes = xmlBindings.getJavaTypes();
             if (jTypes != null) {
-                List<Class> existingClasses = new ArrayList<Class>(existingTypes.length);
+                List<Class> existingClasses = new ArrayList<>(existingTypes.length);
                 for (TypeMappingInfo typeMappingInfo : existingTypes) {
                     Type type = typeMappingInfo.getType();
                     if (type == null) {
@@ -1246,7 +1250,7 @@ public class JAXBContext extends jakarta.xml.bind.JAXBContext {
                     }
                 }
 
-                List<TypeMappingInfo> additionalTypeMappingInfos = new ArrayList<TypeMappingInfo>(jTypes.getJavaType().size());
+                List<TypeMappingInfo> additionalTypeMappingInfos = new ArrayList<>(jTypes.getJavaType().size());
 
                 for (JavaType javaType : jTypes.getJavaType()) {
                     try {
@@ -1326,7 +1330,7 @@ public class JAXBContext extends jakarta.xml.bind.JAXBContext {
         }
 
         private Map<TypeMappingInfo, JAXBContext.RootLevelXmlAdapter> createAdaptersForAdapterClasses(Map<TypeMappingInfo, Class> typeMappingInfoToAdapterClasses) {
-            Map<TypeMappingInfo, JAXBContext.RootLevelXmlAdapter> typeMappingInfoToAdapters = new HashMap<TypeMappingInfo, JAXBContext.RootLevelXmlAdapter>();
+            Map<TypeMappingInfo, JAXBContext.RootLevelXmlAdapter> typeMappingInfoToAdapters = new HashMap<>();
             for (Entry<TypeMappingInfo, Class> entry : typeMappingInfoToAdapterClasses.entrySet()) {
                 Class adapterClass = entry.getValue();
                 if (adapterClass != null) {
@@ -1364,7 +1368,7 @@ public class JAXBContext extends jakarta.xml.bind.JAXBContext {
 
             for (Object descriptor : descriptors) {
                 Descriptor desc = (Descriptor) descriptor;
-                processXMLDescriptor(new ArrayList<Descriptor>(), desc, desc.getNonNullNamespaceResolver());
+                processXMLDescriptor(new ArrayList<>(), desc, desc.getNonNullNamespaceResolver());
             }
 
         }
@@ -1463,7 +1467,7 @@ public class JAXBContext extends jakarta.xml.bind.JAXBContext {
 
         private Map<TypeMappingInfo, QName> getTypeMappingInfoToSchemaType() {
             if (typeToTypeMappingInfo != null && typeToTypeMappingInfo.size() > 0) {
-                return new HashMap<TypeMappingInfo, QName>();
+                return new HashMap<>();
             }
             return generator.getAnnotationsProcessor().getTypeMappingInfosToSchemaTypes();
         }
@@ -1506,7 +1510,7 @@ public class JAXBContext extends jakarta.xml.bind.JAXBContext {
         }
 
         private void initTypeToSchemaType() {
-            this.typeToSchemaType = new HashMap<Type, QName>();
+            this.typeToSchemaType = new HashMap<>();
 
             if (typeToTypeMappingInfo == null || typeToTypeMappingInfo.size() == 0) {
                 return;
@@ -1700,4 +1704,44 @@ public class JAXBContext extends jakarta.xml.bind.JAXBContext {
         Object propertyValue = properties.get(JAXBContextProperties.BEAN_VALIDATION_FACETS);
         if (propertyValue != null) inputImpl.setFacets((Boolean) propertyValue);
     }
+
+    private static void openToCore(JavaModelInputImpl input) {
+        JavaClass[] javaClasses = input.getJavaClasses();
+        Set<Class> classes = new HashSet<>();
+        for (JavaClass jc: javaClasses) {
+            classes.add(((JavaClassImpl) jc).getJavaClass());
+        }
+        openToCore(classes);
+    }
+
+    //we need to open what has been opened to us either directly
+    //or by jakarta.xml.bind API also to core on which we depend
+    //to allow reflection access to code we use from that module
+    private static void openToCore(Collection<Class> classes) {
+        // need to open to core IF we're not eclipselink.jar
+        if (NEEDS_OPEN) {
+            final Module moxyModule = JAXBContext.class.getModule();
+            final Module coreModule = Version.class.getModule();
+            for (Class cls : classes) {
+                Class jaxbClass = cls.isArray()
+                        ? cls.getComponentType() : cls;
+
+                final Module classModule = jaxbClass.getModule();
+                final String packageName = jaxbClass.getPackageName();
+                //no need for unnamed and java.base types
+                if (!classModule.isNamed() || classModule.getName().equals("java.base")) {
+                    continue;
+                }
+                //propagate openness to o.e.p.core module
+                if (classModule.isOpen(packageName, moxyModule) && !classModule.isOpen(packageName, coreModule)) {
+                    classModule.addOpens(packageName, coreModule);
+                    AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MOXY, "Openning package {0} in {1} to {2} for reflection access.",
+                            new String[]{packageName, classModule.getName(), coreModule.getName()}, false);
+                }
+            }
+        }
+    }
+
+    private static final boolean NEEDS_OPEN = JAXBContext.class.getModule() != Version.class.getModule();
+
 }

--- a/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/compiler/MappingsGenerator.java
+++ b/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/compiler/MappingsGenerator.java
@@ -217,9 +217,9 @@ public class MappingsGenerator {
         jotHashMap = helper.getJavaClass(HashMap.class);
         jotLinkedList = helper.getJavaClass(LinkedList.class);
         jotTreeSet = helper.getJavaClass(TreeSet.class);
-        qNamesToGeneratedClasses = new HashMap<QName, Class>();
-        qNamesToDeclaredClasses = new HashMap<QName, Class>();
-        classToGeneratedClasses = new HashMap<String, Class>();
+        qNamesToGeneratedClasses = new HashMap<>();
+        qNamesToDeclaredClasses = new HashMap<>();
+        classToGeneratedClasses = new HashMap<>();
         globalNamespaceResolver = new org.eclipse.persistence.oxm.NamespaceResolver();
         isDefaultNamespaceAllowed = true;
     }
@@ -355,7 +355,7 @@ public class MappingsGenerator {
     }
 
     private Map<String, List<CoreAttributeGroup>> processSubgraphs(List<XmlNamedSubgraph> subgraphs) {
-        Map<String, List<CoreAttributeGroup>> subgroups = new HashMap<String, List<CoreAttributeGroup>>();
+        Map<String, List<CoreAttributeGroup>> subgroups = new HashMap<>();
         //Iterate through once and create all the AttributeGroups
         for(XmlNamedSubgraph next: subgraphs) {
             String type = next.getType();
@@ -367,7 +367,7 @@ public class MappingsGenerator {
                 List<CoreAttributeGroup> groups = subgroups.get(group.getName());
                 groups.add(group);
             } else {
-                List<CoreAttributeGroup> groups = new ArrayList<CoreAttributeGroup>(1);
+                List<CoreAttributeGroup> groups = new ArrayList<>(1);
                 groups.add(group);
                 subgroups.put(group.getName(), groups);
             }
@@ -1130,8 +1130,8 @@ public class MappingsGenerator {
             }
             if (next.getXmlJoinNodes() != null) {
                 // handle XmlJoinNodes
-                List<Field> srcFlds = new ArrayList<Field>();
-                List<Field> tgtFlds = new ArrayList<Field>();
+                List<Field> srcFlds = new ArrayList<>();
+                List<Field> tgtFlds = new ArrayList<>();
                 for (XmlJoinNode xmlJoinNode: next.getXmlJoinNodes().getXmlJoinNode()) {
                     srcFlds.add(new XMLField(xmlJoinNode.getXmlPath()));
                     tgtFlds.add(new XMLField(xmlJoinNode.getReferencedXmlPath()));
@@ -1235,8 +1235,8 @@ public class MappingsGenerator {
 
             if (next.getXmlJoinNodes() != null) {
                 // handle XmlJoinNodes
-                List<Field> srcFlds = new ArrayList<Field>();
-                List<Field> tgtFlds = new ArrayList<Field>();
+                List<Field> srcFlds = new ArrayList<>();
+                List<Field> tgtFlds = new ArrayList<>();
                 for (XmlJoinNode xmlJoinNode: next.getXmlJoinNodes().getXmlJoinNode()) {
                     srcFlds.add(new XMLField(xmlJoinNode.getXmlPath()));
                     tgtFlds.add(new XMLField(xmlJoinNode.getReferencedXmlPath()));
@@ -2617,7 +2617,7 @@ public class MappingsGenerator {
     }
 
     private void generateInheritedMappingsForAnonymousType(TypeInfo info, Descriptor descriptor, JavaClass descriptorJavaClass, NamespaceInfo namespaceInfo) {
-        List<TypeInfo> mappedParents = new ArrayList<TypeInfo>();
+        List<TypeInfo> mappedParents = new ArrayList<>();
         JavaClass next = CompilerHelper.getNextMappedSuperClass(descriptorJavaClass, typeInfo, helper);
         while(next != null) {
             TypeInfo nextInfo = this.typeInfo.get(next.getName());
@@ -2977,7 +2977,7 @@ public class MappingsGenerator {
         if(this.globalElements == null && this.localElements == null) {
             return;
         }
-        List<ElementDeclaration> elements = new ArrayList<ElementDeclaration>();
+        List<ElementDeclaration> elements = new ArrayList<>();
         elements.addAll(this.localElements);
         elements.addAll(this.globalElements.values());
         for(ElementDeclaration nextElement:elements) {
@@ -3325,6 +3325,12 @@ public class MappingsGenerator {
         byte[] classBytes = cw.toByteArray();
         //byte[] classBytes = new byte[]{};
 
+        Module moxyModule = MappingsGenerator.class.getModule();
+        if (moxyModule.isNamed() && !moxyModule.isExported(WrappedValue.class.getPackageName(), getJaxbClassLoader().getUnnamedModule())) {
+            // our generated classes live in unnamed module, therefore we need to export our private class
+            // to the unnamed module as we don't want to export internal package from eclipselink.jar
+            moxyModule.addExports(WrappedValue.class.getPackageName(), getJaxbClassLoader().getUnnamedModule());
+        }
         Class generatedClass = getJaxbClassLoader().generateClass(className, classBytes);
         return generatedClass;
     }
@@ -3342,7 +3348,7 @@ public class MappingsGenerator {
 
     private Map<MapEntryGeneratedKey, Class> getGeneratedMapEntryClasses() {
         if(generatedMapEntryClasses == null){
-            generatedMapEntryClasses = new HashMap<MapEntryGeneratedKey, Class>();
+            generatedMapEntryClasses = new HashMap<>();
         }
         return generatedMapEntryClasses;
     }
@@ -3405,8 +3411,8 @@ public class MappingsGenerator {
             IsSetNullPolicy isSetNullPolicy = new IsSetNullPolicy();
             isSetNullPolicy.setIsSetMethodName(xmlIsSetNullPolicy.getIsSetMethodName());
             // handle isSetParams
-            ArrayList<Object> parameters = new ArrayList<Object>();
-            ArrayList<Class> parameterTypes = new ArrayList<Class>();
+            ArrayList<Object> parameters = new ArrayList<>();
+            ArrayList<Class> parameterTypes = new ArrayList<>();
             List<XmlIsSetNullPolicy.IsSetParameter> params = xmlIsSetNullPolicy.getIsSetParameter();
             for (XmlIsSetNullPolicy.IsSetParameter param : params) {
                 String valueStr = param.getValue();

--- a/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/javamodel/reflection/JavaClassImpl.java
+++ b/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/javamodel/reflection/JavaClassImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -38,6 +38,8 @@ import org.eclipse.persistence.jaxb.javamodel.JavaConstructor;
 import org.eclipse.persistence.jaxb.javamodel.JavaField;
 import org.eclipse.persistence.jaxb.javamodel.JavaMethod;
 import org.eclipse.persistence.jaxb.javamodel.JavaPackage;
+import org.eclipse.persistence.logging.AbstractSessionLog;
+import org.eclipse.persistence.logging.SessionLog;
 
 /**
  * INTERNAL:
@@ -83,7 +85,7 @@ public class JavaClassImpl implements JavaClass {
     }
     @Override
     public Collection getActualTypeArguments() {
-        ArrayList<JavaClass> argCollection = new ArrayList<JavaClass>();
+        ArrayList<JavaClass> argCollection = new ArrayList<>();
         if (jType != null) {
             Type[] params = jType.getActualTypeArguments();
             for (Type type : params) {
@@ -140,7 +142,7 @@ public class JavaClassImpl implements JavaClass {
 
     @Override
     public Collection<JavaAnnotation> getAnnotations() {
-        List<JavaAnnotation> annotationCollection = new ArrayList<JavaAnnotation>();
+        List<JavaAnnotation> annotationCollection = new ArrayList<>();
         if (!isMetadataComplete) {
             Annotation[] annotations = javaModelImpl.getAnnotationHelper().getAnnotations(getAnnotatedElement());
             for (Annotation annotation : annotations) {
@@ -152,7 +154,7 @@ public class JavaClassImpl implements JavaClass {
 
     @Override
     public Collection<JavaClass> getDeclaredClasses() {
-        List<JavaClass> classCollection = new ArrayList<JavaClass>();
+        List<JavaClass> classCollection = new ArrayList<>();
         Class[] classes = jClass.getDeclaredClasses();
         for (Class javaClass : classes) {
             classCollection.add(javaModelImpl.getClass(javaClass));
@@ -171,11 +173,14 @@ public class JavaClassImpl implements JavaClass {
 
     @Override
     public Collection<JavaField> getDeclaredFields() {
-        List<JavaField> fieldCollection = new ArrayList<JavaField>();
+        List<JavaField> fieldCollection = new ArrayList<>();
         Field[] fields = PrivilegedAccessHelper.getDeclaredFields(jClass);
 
         for (Field field : fields) {
-            field.setAccessible(true);
+            if (!field.trySetAccessible()) {
+                AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MOXY, "Cannot setAccessible field {0} in {1}.",
+                        new String[]{field.getName(), jClass.getName()}, false);
+            }
             fieldCollection.add(getJavaField(field));
         }
         return fieldCollection;
@@ -205,7 +210,7 @@ public class JavaClassImpl implements JavaClass {
 
     @Override
     public Collection getDeclaredMethods() {
-        ArrayList<JavaMethod> methodCollection = new ArrayList<JavaMethod>();
+        ArrayList<JavaMethod> methodCollection = new ArrayList<>();
         Method[] methods = jClass.getDeclaredMethods();
         for (Method method : methods) {
             methodCollection.add(getJavaMethod(method));
@@ -282,7 +287,7 @@ public class JavaClassImpl implements JavaClass {
     }
 
     public Collection getFields() {
-        ArrayList<JavaField> fieldCollection = new ArrayList<JavaField>();
+        ArrayList<JavaField> fieldCollection = new ArrayList<>();
         Field[] fields = PrivilegedAccessHelper.getFields(jClass);
         for (Field field : fields) {
             fieldCollection.add(getJavaField(field));
@@ -319,7 +324,7 @@ public class JavaClassImpl implements JavaClass {
 
     @Override
     public Collection getMethods() {
-        ArrayList<JavaMethod> methodCollection = new ArrayList<JavaMethod>();
+        ArrayList<JavaMethod> methodCollection = new ArrayList<>();
         Method[] methods = PrivilegedAccessHelper.getMethods(jClass);
         for (Method method : methods) {
             methodCollection.add(getJavaMethod(method));
@@ -604,7 +609,7 @@ public class JavaClassImpl implements JavaClass {
 
     @Override
     public Collection getDeclaredAnnotations() {
-        List<JavaAnnotation> annotationCollection = new ArrayList<JavaAnnotation>();
+        List<JavaAnnotation> annotationCollection = new ArrayList<>();
         if (!isMetadataComplete) {
             Annotation[] annotations = javaModelImpl.getAnnotationHelper().getDeclaredAnnotations(getAnnotatedElement());
             for (Annotation annotation : annotations) {

--- a/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/javamodel/reflection/JavaClassImpl.java
+++ b/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/javamodel/reflection/JavaClassImpl.java
@@ -178,8 +178,8 @@ public class JavaClassImpl implements JavaClass {
 
         for (Field field : fields) {
             if (!field.trySetAccessible()) {
-                AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MOXY, "Cannot setAccessible field {0} in {1}.",
-                        new String[]{field.getName(), jClass.getName()}, false);
+                AbstractSessionLog.getLog().log(SessionLog.FINE, SessionLog.MISC, "set_accessible_in",
+                        "field", field.getName(), jClass.getName());
             }
             fieldCollection.add(getJavaField(field));
         }

--- a/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/javamodel/xjc/XJCJavaModelImpl.java
+++ b/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/javamodel/xjc/XJCJavaModelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -50,7 +50,7 @@ public class XJCJavaModelImpl implements JavaModel {
 
     private JCodeModel jCodeModel;
     private DynamicClassLoader dynamicClassLoader;
-    private Map<String, JavaClass> javaModelClasses = new HashMap<String, JavaClass>();
+    private Map<String, JavaClass> javaModelClasses = new HashMap<>();
 
     /**
      * Construct a new instance of <code>XJCJavaModelImpl</code>.

--- a/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/javamodel/xjc/XJCJavaPackageImpl.java
+++ b/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/javamodel/xjc/XJCJavaPackageImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,13 +14,10 @@
 //     Rick Barkhouse - 2.1 - Initial implementation
 package org.eclipse.persistence.jaxb.javamodel.xjc;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
 
 import org.eclipse.persistence.dynamic.DynamicClassLoader;
-import org.eclipse.persistence.exceptions.JAXBException;
-import org.eclipse.persistence.internal.security.PrivilegedAccessHelper;
 import org.eclipse.persistence.jaxb.javamodel.JavaAnnotation;
 import org.eclipse.persistence.jaxb.javamodel.JavaClass;
 import org.eclipse.persistence.jaxb.javamodel.JavaPackage;
@@ -51,15 +48,6 @@ public class XJCJavaPackageImpl implements JavaPackage {
     protected JPackage xjcPackage;
     private DynamicClassLoader dynamicClassLoader;
 
-    private static Field JPACKAGE_ANNOTATIONS = null;
-    static {
-        try {
-            JPACKAGE_ANNOTATIONS = PrivilegedAccessHelper.getDeclaredField(JPackage.class, "annotations", true);
-        } catch (Exception e) {
-            throw JAXBException.errorCreatingDynamicJAXBContext(e);
-        }
-    }
-
     /**
      * Construct a new instance of <code>XJCJavaPackageImpl</code>.
      *
@@ -84,17 +72,7 @@ public class XJCJavaPackageImpl implements JavaPackage {
     public JavaAnnotation getAnnotation(JavaClass aClass) {
         if (aClass != null) {
 
-            Collection<JAnnotationUse> annotations = null;
-            try {
-                annotations = (Collection<JAnnotationUse>) PrivilegedAccessHelper.getValueFromField(JPACKAGE_ANNOTATIONS, xjcPackage);
-            } catch (Exception e) {
-                throw JAXBException.errorCreatingDynamicJAXBContext(e);
-            }
-
-            if (annotations == null) {
-                return null;
-            }
-
+            Collection<JAnnotationUse> annotations = xjcPackage.annotations();
             for (JAnnotationUse annotationUse : annotations) {
                 XJCJavaAnnotationImpl xjcAnnotation = new XJCJavaAnnotationImpl(annotationUse, dynamicClassLoader);
                 if (xjcAnnotation.getJavaAnnotationClass().getCanonicalName().equals(aClass.getQualifiedName())) {
@@ -116,18 +94,9 @@ public class XJCJavaPackageImpl implements JavaPackage {
     @Override
     @SuppressWarnings("unchecked")
     public Collection<JavaAnnotation> getAnnotations() {
-        ArrayList<JavaAnnotation> annotationsList = new ArrayList<JavaAnnotation>();
+        ArrayList<JavaAnnotation> annotationsList = new ArrayList<>();
 
-        Collection<JAnnotationUse> annotations = null;
-        try {
-            annotations = (Collection<JAnnotationUse>) PrivilegedAccessHelper.getValueFromField(JPACKAGE_ANNOTATIONS, xjcPackage);
-        } catch (Exception e) {
-            throw JAXBException.errorCreatingDynamicJAXBContext(e);
-        }
-
-        if (annotations == null) {
-            return annotationsList;
-        }
+        Collection<JAnnotationUse> annotations = xjcPackage.annotations();
 
         for (JAnnotationUse annotationUse : annotations) {
             XJCJavaAnnotationImpl xjcAnnotation = new XJCJavaAnnotationImpl(annotationUse, dynamicClassLoader);

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/module-info.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/module-info.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+open module org.eclipse.persistence.moxy.test {
+
+    requires java.compiler;
+    requires java.logging;
+    requires java.sql;
+
+    requires jakarta.mail;
+    requires jakarta.json;
+    requires jakarta.ws.rs;
+    
+    requires com.sun.xml.bind;
+    requires com.sun.tools.xjc;
+    requires org.eclipse.persistence.asm;
+    requires org.eclipse.persistence.moxy;
+    requires junit;
+}

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/beanvalidation/BeanValidationBindingsTestCase.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/beanvalidation/BeanValidationBindingsTestCase.java
@@ -392,7 +392,7 @@ public class BeanValidationBindingsTestCase extends junit.framework.TestCase {
         List<File> cp = new ArrayList<>();
         String value = System.getProperty(property, "").trim();
         if (!value.isEmpty()) {
-            StringTokenizer st = new StringTokenizer(value, ":");
+            StringTokenizer st = new StringTokenizer(value, File.pathSeparator);
             while (st.hasMoreTokens()) {
                 cp.add(new File(st.nextToken()));
             }

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/beanvalidation/BeanValidationBindingsTestCase.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/beanvalidation/BeanValidationBindingsTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -52,7 +52,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Field;
 import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.StringTokenizer;
+import javax.tools.StandardLocation;
 
 import static org.eclipse.persistence.testing.jaxb.beanvalidation.ContentComparator.equalsXML;
 
@@ -112,7 +118,7 @@ public class BeanValidationBindingsTestCase extends junit.framework.TestCase {
      * of post round-trip schema with the original, not identity.
      * This test should still pass even if changes are done to our code.
      */
-    public void testGoldenFileIdentity() throws Exception {
+    public void testGoldenFileIdentity() throws Throwable {
         pkg = "gf";
 
         roundTrip(GOLDEN_FILE_PATH, pkg);
@@ -125,7 +131,7 @@ public class BeanValidationBindingsTestCase extends junit.framework.TestCase {
      * Also tests equality of generated Java classes from the original schema
      * and from the schema after round-trip.
      */
-    public void testEqualitySchemaAndJava() throws Exception {
+    public void testEqualitySchemaAndJava() throws Throwable {
         pkg = "rs";
 
         Class<?>[] cTenured = roundTrip(RICH_SCHEMA_PATH, pkg);
@@ -141,7 +147,7 @@ public class BeanValidationBindingsTestCase extends junit.framework.TestCase {
      * Tests customizations, i.e. facet customizations + custom facets, i.e.
      * Future, Past, AssertTrue, AssertFalse.
      */
-    public void testFacetCustomizationsAndCustomFacets() throws Exception {
+    public void testFacetCustomizationsAndCustomFacets() throws Throwable {
         pkg = "cs";
 
         xjcGenerateJavaSourcesWithCustomizations(CUSTOMIZED_SCHEMA_PATH);
@@ -188,7 +194,7 @@ public class BeanValidationBindingsTestCase extends junit.framework.TestCase {
      * Tests that the XJC detects all facets and generates their respective
      * annotations correctly.
      */
-    public void testAllFacetsAndAnnotations() throws Exception {
+    public void testAllFacetsAndAnnotations() throws Throwable {
         pkg = "rs";
 
         Class<?>[] c = roundTrip(RICH_SCHEMA_PATH, pkg);
@@ -325,7 +331,7 @@ public class BeanValidationBindingsTestCase extends junit.framework.TestCase {
         assertTrue(minLength.getAnnotation(Size.class).min() == 0);
     }
 
-    private Class<?>[] roundTrip(String schemaPath, String pkg) throws Exception {
+    private Class<?>[] roundTrip(String schemaPath, String pkg) throws Throwable {
         xjcGenerateJavaSources(schemaPath);
         compileGeneratedSources(createCompileList(pkg));
         Class<?>[] classes = loadCompiledClasses(createLoadList(pkg));
@@ -349,20 +355,49 @@ public class BeanValidationBindingsTestCase extends junit.framework.TestCase {
         gen.generateSchemaFiles(PATH_TO_SCHEMA_DIRECTORY, null);
     }
 
-    private void compileGeneratedSources(File... compileList) {
+    private void compileGeneratedSources(File... compileList) throws Exception {
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
-        DiagnosticCollector<? super JavaFileObject> diag = new DiagnosticCollector<JavaFileObject>();
+        DiagnosticCollector<? super JavaFileObject> diag = new DiagnosticCollector<>();
         StandardJavaFileManager fm = compiler.getStandardFileManager(diag, null, null);
+        List<File> pathElements = getPath("jdk.module.path");
+        if (!pathElements.isEmpty()) {
+            //running on module-path:
+            fm.setLocation(StandardLocation.MODULE_PATH, pathElements);
+            pathElements = getPath("java.class.path");
+            if (!pathElements.isEmpty()) {
+                fm.setLocation(StandardLocation.CLASS_PATH, pathElements);
+            }
+        } else {
+            //on cp - move everythig to mp
+            pathElements = getPath("java.class.path");
+            if (!pathElements.isEmpty()) {
+                fm.setLocation(StandardLocation.MODULE_PATH, pathElements);
+            }
+        }
+        fm.setLocation(StandardLocation.CLASS_OUTPUT, Arrays.asList(new File(TARGET_PATH)));
         Iterable<? extends JavaFileObject> compilationUnits = fm.getJavaFileObjectsFromFiles(Arrays.asList(compileList));
-        Iterable<String> options = Arrays.asList("-d", TARGET_PATH);
+        List<String> options = new ArrayList<>();
         JavaCompiler.CompilationTask task = compiler.getTask(new OutputStreamWriter(System.out), fm, diag, options,
                 null, compilationUnits);
 
         if (!task.call()) {
-            for (Diagnostic diagnostic : diag.getDiagnostics())
-                System.out.format("Error on line %d in %s", diagnostic.getLineNumber(), diagnostic);
+            for (Diagnostic diagnostic : diag.getDiagnostics()) {
+                System.out.format("Error on line %d in %s\n", diagnostic.getLineNumber(), diagnostic);
+            }
             fail("Compilation of generated classes failed. See the diagnostics output.");
         }
+    }
+
+    private List<File> getPath(String property) {
+        List<File> cp = new ArrayList<>();
+        String value = System.getProperty(property, "").trim();
+        if (!value.isEmpty()) {
+            StringTokenizer st = new StringTokenizer(value, ":");
+            while (st.hasMoreTokens()) {
+                cp.add(new File(st.nextToken()));
+            }
+        }
+        return cp;
     }
 
     private File[] createCompileList(String pkg) {
@@ -378,8 +413,9 @@ public class BeanValidationBindingsTestCase extends junit.framework.TestCase {
                     new File(pkg + "/Strings.java")};
     }
 
-    private Class<?>[] loadCompiledClasses(String... loadList) throws ClassNotFoundException {
-        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+    private Class<?>[] loadCompiledClasses(String... loadList) throws Throwable {
+        ClassLoader cl = new URLClassLoader(new URL[] {new File(TARGET_PATH).toURI().toURL()},
+                Thread.currentThread().getContextClassLoader());
         Class<?>[] loadedClasses = new Class[loadList.length];
         for (int i = 0; i < loadedClasses.length; i++)
             loadedClasses[i] = cl.loadClass(loadList[i]);

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/classloader/DifferentClassLoaderTestCases.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/classloader/DifferentClassLoaderTestCases.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -39,7 +39,7 @@ public class DifferentClassLoaderTestCases extends JAXBWithJSONTestCases {
         Class[] classes = new Class[2];
 
         URL[] urls = new URL[1];
-        urls[0] = Thread.currentThread().getContextClassLoader().getResource("./org/eclipse/persistence/testing/jaxb/classloader/test.jar");
+        urls[0] = Thread.currentThread().getContextClassLoader().getResource("org/eclipse/persistence/testing/jaxb/classloader/test.jar");
         URLClassLoader classLoaderA = new URLClassLoader(urls);
 
 

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/classloader/InnerClassTestCases.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/classloader/InnerClassTestCases.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -30,7 +30,7 @@ public class InnerClassTestCases extends TestCase {
         Class[] classes = new Class[1];
 
         URL[] urls = new URL[1];
-        urls[0] = Thread.currentThread().getContextClassLoader().getResource("./org/eclipse/persistence/testing/jaxb/classloader/innerClass.jar");
+        urls[0] = Thread.currentThread().getContextClassLoader().getResource("org/eclipse/persistence/testing/jaxb/classloader/innerClass.jar");
         URLClassLoader classLoader = new URLClassLoader(urls);
 
         Class classAClass = classLoader.loadClass("org.eclipse.persistence.testing.jaxb.classloader.ClassWithInnerClass");

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/classloader/XmlElementsEnumTestCases.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/classloader/XmlElementsEnumTestCases.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,7 +14,6 @@
 //   Matt MacIvor - 2.4.2 - Inital Implementation
 package org.eclipse.persistence.testing.jaxb.classloader;
 
-import java.io.File;
 import java.net.URL;
 import java.net.URLClassLoader;
 
@@ -30,7 +29,7 @@ public class XmlElementsEnumTestCases extends TestCase {
         Class[] classes = new Class[1];
 
         URL[] urls = new URL[1];
-        urls[0] = Thread.currentThread().getContextClassLoader().getResource("./org/eclipse/persistence/testing/jaxb/classloader/enum.jar");
+        urls[0] = Thread.currentThread().getContextClassLoader().getResource("org/eclipse/persistence/testing/jaxb/classloader/enum.jar");
         URLClassLoader classLoader = new URLClassLoader(urls);
 
         Class classAClass = classLoader.loadClass("org.eclipse.persistence.testing.jaxb.classloader.Root");

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/externalizedmetadata/multiplebindings/MultipleBindingsFourFilesTestCases.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/externalizedmetadata/multiplebindings/MultipleBindingsFourFilesTestCases.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -97,10 +97,10 @@ public class MultipleBindingsFourFilesTestCases extends JAXBWithJSONTestCases {
             StreamSource src3 = null;
             StreamSource src4 = null;
 
-            InputStream iStream = classLoader.getResourceAsStream("./org/eclipse/persistence/testing/jaxb/externalizedmetadata/multiplebindings/eclipselink-oxm1.xml");
-            InputStream iStream2 = classLoader.getResourceAsStream("./org/eclipse/persistence/testing/jaxb/externalizedmetadata/multiplebindings/eclipselink-oxm2.xml");
-            InputStream iStream3 = classLoader.getResourceAsStream("./org/eclipse/persistence/testing/jaxb/externalizedmetadata/multiplebindings/eclipselink-oxm3.xml");
-            InputStream iStream4 = classLoader.getResourceAsStream("./org/eclipse/persistence/testing/jaxb/externalizedmetadata/multiplebindings/eclipselink-oxm4.xml");
+            InputStream iStream = classLoader.getResourceAsStream("org/eclipse/persistence/testing/jaxb/externalizedmetadata/multiplebindings/eclipselink-oxm1.xml");
+            InputStream iStream2 = classLoader.getResourceAsStream("org/eclipse/persistence/testing/jaxb/externalizedmetadata/multiplebindings/eclipselink-oxm2.xml");
+            InputStream iStream3 = classLoader.getResourceAsStream("org/eclipse/persistence/testing/jaxb/externalizedmetadata/multiplebindings/eclipselink-oxm3.xml");
+            InputStream iStream4 = classLoader.getResourceAsStream("org/eclipse/persistence/testing/jaxb/externalizedmetadata/multiplebindings/eclipselink-oxm4.xml");
           //  InputStream iStreamCopy = classLoader.getResourceAsStream("eclipselink-oxm1.xml");
 
             try {

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/externalizedmetadata/multiplebindings/MultipleBindingsSimpleTestCases.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/externalizedmetadata/multiplebindings/MultipleBindingsSimpleTestCases.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -129,8 +129,8 @@ public class MultipleBindingsSimpleTestCases extends JAXBWithJSONTestCases{
         protected Map getProperties() {
             Map overrides = new HashMap();
 
-            InputStream iStream = classLoader.getResourceAsStream("./org/eclipse/persistence/testing/jaxb/externalizedmetadata/multiplebindings/simple-oxm1.xml");
-            InputStream iStream2 = classLoader.getResourceAsStream("./org/eclipse/persistence/testing/jaxb/externalizedmetadata/multiplebindings/simple-oxm2.xml");
+            InputStream iStream = classLoader.getResourceAsStream("org/eclipse/persistence/testing/jaxb/externalizedmetadata/multiplebindings/simple-oxm1.xml");
+            InputStream iStream2 = classLoader.getResourceAsStream("org/eclipse/persistence/testing/jaxb/externalizedmetadata/multiplebindings/simple-oxm2.xml");
 
             ArrayList<Object> bindingsList = new ArrayList();
             bindingsList.add(new StreamSource(iStream));

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/xmlidref/xmlelements/XmlElementsSingleIdRefTestCases.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/xmlidref/xmlelements/XmlElementsSingleIdRefTestCases.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,17 +14,11 @@
 // Oracle = 2.2 - Initial implementation
 package org.eclipse.persistence.testing.jaxb.xmlidref.xmlelements;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
 
-import javax.xml.transform.Result;
-import javax.xml.transform.stream.StreamResult;
-
-import org.eclipse.persistence.internal.jaxb.json.schema.model.JsonSchema;
-import org.eclipse.persistence.jaxb.json.JsonSchemaOutputResolver;
 import org.eclipse.persistence.testing.jaxb.JAXBWithJSONTestCases;
 
 public class XmlElementsSingleIdRefTestCases extends JAXBWithJSONTestCases{

--- a/moxy/org.eclipse.persistence.moxy/src/test/resources/sessions.xml
+++ b/moxy/org.eclipse.persistence.moxy/src/test/resources/sessions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="US-ASCII"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,7 +13,7 @@
 
 -->
 
-<sessions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="file://xsd/eclipselink_sessions_1.0.xsd" version="0">
+<sessions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://www.eclipse.org/eclipselink/xsds/eclipselink_sessions_2.1.xsd" version="0">
     <session xsi:type="database-session">
         <name>org.eclipse.persistence.testing.oxm.jaxb.sax</name>
         <primary-project xsi:type="class">org.eclipse.persistence.testing.jaxb.xmlmarshaller.EmployeeProject</primary-project>

--- a/pom.xml
+++ b/pom.xml
@@ -1461,7 +1461,6 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                     <minmemory>2G</minmemory>
-                    <maxmemory>2G</maxmemory>
                     <release>11</release>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
         <el.version>4.0.1</el.version>
         <glassfish.version>6.0.0</glassfish.version>
         <jaxwsrt.version>3.0.0</jaxwsrt.version>
-        <jaxb.version>3.0.1</jaxb.version>
+        <jaxb.version>3.0.2-b01</jaxb.version>
         <jaxb.api.version>3.0.1</jaxb.api.version>
         <soap.api.version>2.0.1</soap.api.version>
         <jersey.version>3.0.1</jersey.version>
@@ -1295,7 +1295,6 @@
                     <niceManifest>true</niceManifest>
                     <instructions>
                          <_noextraheaders>true</_noextraheaders>
-                        <Automatic-Module-Name>${project.artifactId}</Automatic-Module-Name>
                         <HK2-Bundle-Name>${project.groupId}:${project.artifactId}</HK2-Bundle-Name>
                     </instructions>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1460,6 +1460,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
+                    <minmemory>2G</minmemory>
+                    <maxmemory>2G</maxmemory>
                     <release>11</release>
                 </configuration>
             </plugin>


### PR DESCRIPTION
* integrated jaxb 3.0.2-b01
* removed most refllection calls
* fixed tests to run properly on JDK 11+
* moved jaxb-compiler.sh/cmd on JDK9+ from class-path to module-path
* replaced setAccessible calls by trySetAccessible, added FINE logging for cases when set fails

Notes:
* running tests on modulepath directly in maven currently fails due to some strange issue with jsonp dependency (can be workarounded either by using org.eclipse.jsonp:jakarta.json:2.0.2-SNAPSHOT or possibly also by using standalone API and impl, not the all-in-one jar)
* with previous workaround in place and running tests through ant (commented snippet in the moxy pom), I get to:
```
Tests | Failures | Errors | Skipped | Success rate
-- | -- | -- | -- | -- | --
24573 | 7 | 0 | 0 | 99.97%
```
where ~5 failures are likely configuration/setup issues on my end

* jaxb 3.0.2-b01 is in staging only, I'll push it out once we see more test results on different setups (ie from travis) 