### PR TITLE
[3.0] Bug 573094: TRIM function generates incorrect SQL for CriteriaBuilder (Oracle platform fix) (#1129) - backport from master

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/OraclePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/OraclePlatform.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 1998, 2020 IBM Corporation. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -599,6 +599,8 @@ public class OraclePlatform extends org.eclipse.persistence.platform.database.Da
         addOperator(operatorLocate2());
         addOperator(regexpOperator());
         addOperator(exceptOperator());
+        addOperator(ExpressionOperator.simpleTwoArgumentFunction(ExpressionOperator.LeftTrim2, "LTRIM"));
+        addOperator(ExpressionOperator.simpleTwoArgumentFunction(ExpressionOperator.RightTrim2, "RTRIM"));
     }
 
     /**


### PR DESCRIPTION
This is fix related with changes in #1085 "Bug 573094: TRIM function generates incorrect SQL for CriteriaBuilder" based on bug #1084 "Bug 573094: TRIM function generates incorrect SQL for CriteriaBuilder".
It's cover Oracle DB (OraclePlatform). In Oracle DB `LTRIM` and `RTRIM` are simple SQL functions with two arguments see
LTRIM   https://docs.oracle.com/database/121/SQLRF/functions108.htm#SQLRF00664
RTRIM  https://docs.oracle.com/database/121/SQLRF/functions174.htm#SQLRF06104

Before this fix there were test failures in
CORE: `org.eclipse.persistence.testing.tests.expressions.ReadAllExpressionTest.RightTrim`
JPA: `org.eclipse.persistence.testing.tests.jpa.relationships.ExpressionJUnitTestSuite.testLeftTrimWithTrimChar(ExpressionJUnitTestSuite.java:100)`
`org.eclipse.persistence.testing.tests.jpa.relationships.ExpressionJUnitTestSuite.testRightTrimWithTrimChar(ExpressionJUnitTestSuite.java:205)`

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>
(cherry picked from commit d91883aaac1b683c09e5cb108ac2244549c83e9d)