### PR TITLE
[3.0] Maven build - JPARS module Manifest generation - backport from master

### DIFF
--- a/jpa/org.eclipse.persistence.jpars/pom.xml
+++ b/jpa/org.eclipse.persistence.jpars/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at

--- a/jpa/org.eclipse.persistence.jpars/pom.xml
+++ b/jpa/org.eclipse.persistence.jpars/pom.xml
@@ -32,10 +32,10 @@
     <properties>
         <!--Properties used for test resources filtering/replacement-->
         <!--DB connection properties-->
-        <DB_USER>${db.user}</DB_USER>
-        <DB_PWD>${db.pwd}</DB_PWD>
-        <DB_DRIVER>${db.driver}</DB_DRIVER>
-        <DB_URL>${db.url}</DB_URL>
+        <db_user>${db.user}</db_user>
+        <db_pwd>${db.pwd}</db_pwd>
+        <db_driver>${db.driver}</db_driver>
+        <db_url>${db.url}</db_url>
 
         <test-skip-jpa-jpars>${skipTests}</test-skip-jpa-jpars>
     </properties>

--- a/jpa/org.eclipse.persistence.jpars/src/it/resources/META-INF/persistence.xml
+++ b/jpa/org.eclipse.persistence.jpars/src/it/resources/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at

--- a/jpa/org.eclipse.persistence.jpars/src/it/resources/META-INF/persistence.xml
+++ b/jpa/org.eclipse.persistence.jpars/src/it/resources/META-INF/persistence.xml
@@ -43,10 +43,10 @@
             <property name="eclipselink.logging.level" value="INFO"/>
             <property name="eclipselink.logging.level.jpars" value="FINEST"/>
             <property name="eclipselink.logging.parameters" value="true"/>
-            <property name="jakarta.persistence.jdbc.url" value="@DB_URL@"/>
-            <property name="jakarta.persistence.jdbc.password" value="@DB_PWD@"/>
-            <property name="jakarta.persistence.jdbc.driver" value="@DB_DRIVER@"/>
-            <property name="jakarta.persistence.jdbc.user" value="@DB_USER@"/>
+            <property name="jakarta.persistence.jdbc.url" value="@db_url@"/>
+            <property name="jakarta.persistence.jdbc.password" value="@db_pwd@"/>
+            <property name="jakarta.persistence.jdbc.driver" value="@db_driver@"/>
+            <property name="jakarta.persistence.jdbc.user" value="@db_user@"/>
         </properties>
     </persistence-unit>
 
@@ -60,10 +60,10 @@
             <property name="eclipselink.metadata-source" value="XML"/>
             <property name="eclipselink.weaving" value="static"/>
             <property name="eclipselink.metadata-source.xml.file" value="META-INF/auction-orm.xml"/>
-            <property name="jakarta.persistence.jdbc.url" value="@DB_URL@"/>
-            <property name="jakarta.persistence.jdbc.password" value="@DB_PWD@"/>
-            <property name="jakarta.persistence.jdbc.driver" value="@DB_DRIVER@"/>
-            <property name="jakarta.persistence.jdbc.user" value="@DB_USER@"/>
+            <property name="jakarta.persistence.jdbc.url" value="@db_url@"/>
+            <property name="jakarta.persistence.jdbc.password" value="@db_pwd@"/>
+            <property name="jakarta.persistence.jdbc.driver" value="@db_driver@"/>
+            <property name="jakarta.persistence.jdbc.user" value="@db_user@"/>
         </properties>
     </persistence-unit>
 
@@ -75,10 +75,10 @@
             <property name="eclipselink.metadata-source" value="XML"/>
             <property name="eclipselink.weaving" value="static"/>
             <property name="eclipselink.metadata-source.xml.file" value="META-INF/phonebook-orm.xml"/>
-            <property name="jakarta.persistence.jdbc.url" value="@DB_URL@"/>
-            <property name="jakarta.persistence.jdbc.password" value="@DB_PWD@"/>
-            <property name="jakarta.persistence.jdbc.driver" value="@DB_DRIVER@"/>
-            <property name="jakarta.persistence.jdbc.user" value="@DB_USER@"/>
+            <property name="jakarta.persistence.jdbc.url" value="@db_url@"/>
+            <property name="jakarta.persistence.jdbc.password" value="@db_pwd@"/>
+            <property name="jakarta.persistence.jdbc.driver" value="@db_driver@"/>
+            <property name="jakarta.persistence.jdbc.user" value="@db_user@"/>
         </properties>
     </persistence-unit>
 


### PR DESCRIPTION
Behind this fix is some issue with `org.apache.felix:maven-bundle-plugin`. This plugin inserts into generated `MANIFEST.MF` file Maven project properties, but only properties in capital characters. Maven properties in lowercase characters are ignored and not included into manifest. I tried to upgrade into latest version of `org.apache.felix:maven-bundle-plugin:5.1.2`, but without any change.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>