### PR TITLE
[3.0] Maven build - Plugin bundle content fix - backport from master

### DIFF
--- a/bundles/eclipselink/pom.xml
+++ b/bundles/eclipselink/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -412,6 +412,41 @@
 
     <build>
         <plugins>
+            <!--Initialize build.date and build.time buildNumber properties. Used to generate version.properties in org.eclipse.persistence:eclipselink module-->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>buildnumber-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>build.date</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>create-timestamp</goal>
+                        </goals>
+                        <configuration>
+                            <timestampFormat>yyyyMMdd</timestampFormat>
+                            <timestampPropertyName>build.date</timestampPropertyName>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>build.time</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>create-timestamp</goal>
+                        </goals>
+                        <configuration>
+                            <timestampFormat>HHmm</timestampFormat>
+                            <timestampPropertyName>build.time</timestampPropertyName>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>create</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
@@ -554,6 +589,24 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <executions>
+                    <execution>
+                        <id>add-resource</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>add-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>${gen.src.dir}</directory>
+                                    <excludes>
+                                        <exclude>**/*.java</exclude>
+                                    </excludes>
+                                    <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
                     <execution>
                         <id>add-generated-sources</id>
                         <phase>prepare-package</phase>

--- a/bundles/others/src/main/assembly/eclipselink-plugins.zip.xml
+++ b/bundles/others/src/main/assembly/eclipselink-plugins.zip.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -26,20 +26,31 @@
     </componentDescriptors>
     <dependencySets>
         <dependencySet>
+            <outputFileNameMapping>${artifact.artifactId}_${release.version}.${build.qualifier}.${artifact.extension}</outputFileNameMapping>
             <includes>
-                <include>org.eclipse.persistence:*</include>
+                <include>org.eclipse.persistence:*:*:*:${project.version}</include>
             </includes>
             <excludes>
                 <exclude>org.eclipse.persistence:*:*:tests</exclude>
+                <exclude>org.eclipse.persistence:org.eclipse.persistence.asm:*</exclude>
+                <exclude>org.eclipse.persistence:org.eclipse.persistence.oracleddlparser:*</exclude>
+                <exclude>org.eclipse.persistence:commonj.sdo:*</exclude>
             </excludes>
             <scope>test</scope>
+        </dependencySet>
+        <dependencySet>
+            <outputFileNameMapping>${artifact.artifactId}_${artifact.version}.${artifact.extension}</outputFileNameMapping>
+            <includes>
+                <include>org.eclipse.persistence:org.eclipse.persistence.asm:*</include>
+                <include>org.eclipse.persistence:org.eclipse.persistence.oracleddlparser:*</include>
+                <include>org.eclipse.persistence:commonj.sdo:*</include>
+            </includes>
         </dependencySet>
         <dependencySet>
             <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
             <excludes>
                 <exclude>com.sun:tools</exclude>
                 <exclude>junit:*</exclude>
-                <exclude>org.antlr:*</exclude>
                 <exclude>org.apache.ant:*</exclude>
                 <exclude>org.eclipse.persistence:*</exclude>
                 <exclude>org.hamcrest:*</exclude>
@@ -65,27 +76,6 @@
             <includes>
                 <include>jakarta.inject:jakarta.inject</include>
             </includes>
-            <scope>test</scope>
-        </dependencySet>
-        <!--Just for backward compatibility with Ant tests in eclipselink-test-src.zip-->
-        <dependencySet>
-            <outputFileNameMapping>${artifact.artifactId}_${release.version}.qualifier.${artifact.extension}</outputFileNameMapping>
-            <includes>
-                <include>org.eclipse.persistence:*</include>
-            </includes>
-            <excludes>
-                <exclude>org.eclipse.persistence:*:*:tests</exclude>
-            </excludes>
-            <scope>test</scope>
-        </dependencySet>
-        <dependencySet>
-            <outputFileNameMapping>org.eclipse.persistence.asm_7.0.0.v201811131354.jar</outputFileNameMapping>
-            <includes>
-                <include>org.eclipse.persistence:org.eclipse.persistence.asm</include>
-            </includes>
-            <excludes>
-                <exclude>org.eclipse.persistence:*:*:tests</exclude>
-            </excludes>
             <scope>test</scope>
         </dependencySet>
     </dependencySets>


### PR DESCRIPTION
This is fix for the bug #1107 "Incorrect content of the bundles at Eclipse.org download pages for versions 3.0.0 and higher".

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>