### PR TITLE
[master] Better config for CodeQL analysis

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -17,5 +17,8 @@ path_classifiers:
 extraction:
   java:
     index:
-      build_command: "mvn -DskipTests clean package"
+      java_version: 11
+      maven:
+        version: 3.6.3
+      build_command: "mvn -DskipTests -Denforcer.skip clean package"
 


### PR DESCRIPTION
Updates:

- Set Java and Maven version in the LGTM config. For some reason, jobs on LGTM still fail because Maven Enforcer complains about Maven version. Maybe it's a bug in LGTM. To overcome this, `-Denforcer.skip` has been added to the build command. LGTM uses Maven 3.6.0 by default that works for EclipseLink.
- ~Updated the CodeQL workflow to analyse pull requests against all branches, not only master.~

Java build passes with the updated config:

https://lgtm.com/logs/6866d0b9a7d8f2f98e882d4e5a0115c8d1efab85/lang:java

Fixes #1159

Signed-off-by: Artem Smotrakov <artem.smotrakov@gmail.com>