### PR TITLE
[3.0] Extended Thread logging - backport from master

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/LoggingLocalizationResource.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/LoggingLocalizationResource.java
@@ -102,7 +102,6 @@ public class LoggingLocalizationResource extends ListResourceBundle {
         { "register_new_for_persist", "PERSIST operation called on: {0}." },
         { "all_registered_clones", "All Registered Clones:" },
         { "new_objects", "New Objects:" },
-        { "cache_thread_info", "Cached entity ({0}) with Id ({1}) was stored into cache by another thread (id: {2} name: {3}), than current thread (id: {4} name: {5})" },
         { "unit_of_work_thread_info", "Current unit of work in session ({0}) was created by another thread (id: {1} name: {2}), than current thread (id: {3} name: {4})" },
         { "unit_of_work_thread_info_thread_dump", "Creation thread (id: {0} name: {1}) stack trace:\n{2}\n\n" +
                 "Current thread (id: {3} name: {4}) stack trace:\n{5}" },

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/TraceLocalizationResource.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/TraceLocalizationResource.java
@@ -108,6 +108,7 @@ public class TraceLocalizationResource extends ListResourceBundle {
         { "locked_object", "Locked Object : {0}" },
         { "depth", "Depth : {0}" },
         { "cachekey_released", "This thread is no longer holding the lock.  It must not be a blocking thread."},
+        { "cache_thread_info", "Cached entity ({0}) with Id ({1}) was prepared and stored into cache by another thread (id: {2} name: {3}), than current thread (id: {4} name: {5})" },
         { "deferred_locks", "Deferred lock on : {0}" },
         { "deferred_locks_released", "All deferred locks for thread \"{0}\" have been released." },
         { "acquiring_deferred_lock", "Thread \"{1}\" has acquired a deferred lock on object : {0} in order to avoid deadlock." },

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
@@ -4068,7 +4068,7 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
                 objectToRegisterId = this.getId(objectToRegister);
             }
             if (cacheKey != null && currentThread.hashCode() != cacheKey.CREATION_THREAD_HASHCODE) {
-                log(SessionLog.SEVERE, SessionLog.THREAD, "cache_thread_info", new Object[]{objectToRegister.getClass(), objectToRegisterId,
+                log(SessionLog.FINE, SessionLog.THREAD, "cache_thread_info", new Object[]{objectToRegister.getClass(), objectToRegisterId,
                         cacheKey.CREATION_THREAD_ID, cacheKey.CREATION_THREAD_NAME,
                         currentThread.getId(), currentThread.getName()});
             }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
@@ -4048,6 +4048,7 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
         }
         CacheKey cacheKey = null;
         Object objectToRegisterId = null;
+        Thread currentThread = Thread.currentThread();
         if (project.allowExtendedCacheLogging()) {
             //Not null if objectToRegister exist in cache
             Session rootSession = this.getRootSession(null).getParent() == null ? this.getRootSession(null) : this.getRootSession(null).getParent();
@@ -4058,20 +4059,13 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
             } else {
                 log(SessionLog.FINEST, SessionLog.CACHE, "cache_miss", new Object[] {objectToRegister.getClass(), objectToRegisterId});
             }
-        }
-        if (project.allowExtendedThreadLogging()) {
-            Thread currentThread = Thread.currentThread();
-            if (cacheKey == null) {
-                cacheKey = ((org.eclipse.persistence.internal.sessions.IdentityMapAccessor) this.getRootSession(null).getParent().getIdentityMapAccessor()).getCacheKeyForObject(objectToRegister);
-            }
-            if (objectToRegisterId == null) {
-                objectToRegisterId = this.getId(objectToRegister);
-            }
             if (cacheKey != null && currentThread.hashCode() != cacheKey.CREATION_THREAD_HASHCODE) {
-                log(SessionLog.FINE, SessionLog.THREAD, "cache_thread_info", new Object[]{objectToRegister.getClass(), objectToRegisterId,
+                log(SessionLog.FINEST, SessionLog.CACHE, "cache_thread_info", new Object[]{objectToRegister.getClass(), objectToRegisterId,
                         cacheKey.CREATION_THREAD_ID, cacheKey.CREATION_THREAD_NAME,
                         currentThread.getId(), currentThread.getName()});
             }
+        }
+        if (project.allowExtendedThreadLogging()) {
             if (this.CREATION_THREAD_HASHCODE != currentThread.hashCode()) {
                 log(SessionLog.SEVERE, SessionLog.THREAD, "unit_of_work_thread_info", new Object[]{this.getName(),
                         this.CREATION_THREAD_ID, this.CREATION_THREAD_NAME,


### PR DESCRIPTION
There is change in log message severity and log category. This log message is also produced if persistence `eclipselink.cache.extended.logging` is set to true instead of previous eclipselink.thread.extended.logging.

This is backport from PRs #1100 and #1120 .