### PR TITLE
Extended logging of JPA L2 cache usage and UnitOfWork with thread info - backport from 2.6 and master

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/PersistenceUnitProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/PersistenceUnitProperties.java
@@ -1289,6 +1289,49 @@ public class PersistenceUnitProperties {
      */
     public static final String CACHE_TYPE_DEFAULT = CACHE_TYPE_ + DEFAULT;
 
+    /**
+     * The "<code>eclipselink.cache.extended.logging</code>" property control (enable/disable)
+     * usage logging of JPA L2 cache. In case of "<code>true</code>" EclipseLink generates messages into log output
+     * about cache hit/miss new object population and object removal or invalidation.
+     * This kind of messages will by displayed only if logging level (property "<code>eclipselink.logging.level</code>")
+     * is "<code>FINEST</code>"
+     * It displays Entity class, ID and thread info (ID, Name).
+     * <p>
+     * <b>Allowed Values:</b>
+     * <ul>
+     * <li>"<code>false</code>" (DEFAULT)
+     * <li>"<code>true</code>"
+     * </ul>
+     */
+    public static final String CACHE_EXTENDED_LOGGING = "eclipselink.cache.extended.logging";
+
+    /**
+     * The "<code>eclipselink.thread.extended.logging</code>" property control (enable/disable)
+     * some additional logging messages like print error message if cached Entity is picked by different thread,
+     * or if EntityManager/UnitOfWork is reused/passed to different thread.
+     * <p>
+     * <b>Allowed Values:</b>
+     * <ul>
+     * <li>"<code>false</code>" (DEFAULT)
+     * <li>"<code>true</code>"
+     * </ul>
+     */
+    public static final String THREAD_EXTENDED_LOGGING = "eclipselink.thread.extended.logging";
+
+    /**
+     * The "<code>eclipselink.thread.extended.logging.threaddump</code>" property control (enable/disable)
+     * store and display thread dump. This is extension to "<code>eclipselink.thread.extended.logging</code>" which
+     * must be enabled. It prints additionally to some log messages presented by "<code>eclipselink.thread.extended.logging</code>"
+     * creation and current thread stack traces.
+     * <p>
+     * <b>Allowed Values:</b>
+     * <ul>
+     * <li>"<code>false</code>" (DEFAULT)
+     * <li>"<code>true</code>"
+     * </ul>
+     */
+    public static final String THREAD_EXTENDED_LOGGING_THREADDUMP = "eclipselink.thread.extended.logging.threaddump";
+
     /*
      * NOTE: The Canonical Model properties should be kept in sync with those
      * in org.eclipse.persistence.internal.jpa.modelgen.CanonicalModelProperties.

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/descriptors/ObjectBuilder.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/descriptors/ObjectBuilder.java
@@ -1127,7 +1127,9 @@ public class ObjectBuilder extends CoreObjectBuilder<AbstractRecord, AbstractSes
                 session.load(domainObject, group, query.getDescriptor(), false);
             }
         }
-
+        if (session.getProject().allowExtendedCacheLogging() && cacheKey != null && cacheKey.getObject() != null) {
+            session.log(SessionLog.FINEST, SessionLog.CACHE, "cache_item_creation", new Object[] {domainObject.getClass(), primaryKey, Thread.currentThread().getId(), Thread.currentThread().getName()});
+        }
         if (returnCacheKey) {
             return cacheKey;
         } else {
@@ -1289,7 +1291,9 @@ public class ObjectBuilder extends CoreObjectBuilder<AbstractRecord, AbstractSes
         if (!cacheHit) {
             concreteDescriptor.getObjectBuilder().instantiateEagerMappings(protectedObject, session);
         }
-
+        if (session.getProject().allowExtendedCacheLogging() && cacheKey != null && cacheKey.getObject() != null) {
+            session.log(SessionLog.FINEST, SessionLog.CACHE, "cache_item_creation", new Object[] {protectedObject.getClass(), primaryKey, Thread.currentThread().getId(), Thread.currentThread().getName()});
+        }
         if (returnCacheKey) {
             return cacheKey;
         } else {
@@ -4369,6 +4373,9 @@ public class ObjectBuilder extends CoreObjectBuilder<AbstractRecord, AbstractSes
                 cacheKey.setReadTime(query.getExecutionTime());
                 concreteDescriptor.getObjectBuilder().buildAttributesIntoObject(domainObject, cacheKey, databaseRow, query, joinManager, fetchGroup, true, session);
             }
+        }
+        if (session.getProject().allowExtendedCacheLogging() && cacheKey != null && cacheKey.getObject() != null) {
+            session.log(SessionLog.FINEST, SessionLog.CACHE, "cache_item_refresh", new Object[] {domainObject.getClass(), cacheKey.getKey(), Thread.currentThread().getId(), Thread.currentThread().getName()});
         }
         return cacheHit;
     }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/helper/ConcurrencyUtil.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/helper/ConcurrencyUtil.java
@@ -891,7 +891,7 @@ public class ConcurrencyUtil {
      *
      * @return get the stack trace of the current thread.
      */
-    private String enrichGenerateThreadDumpForCurrentThread() {
+    public String enrichGenerateThreadDumpForCurrentThread() {
         final Thread currentThread = Thread.currentThread();
         final long currentThreadId = currentThread.getId();
 

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/CacheKey.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/CacheKey.java
@@ -31,6 +31,11 @@ import org.eclipse.persistence.sessions.Record;
  */
 public class CacheKey extends ConcurrencyManager implements Cloneable {
 
+    //These constants are used in extended cache logging to compare cache item creation thread and thread which picking item from the cache
+    public final long CREATION_THREAD_ID = Thread.currentThread().getId();
+    public final String CREATION_THREAD_NAME = String.copyValueOf(Thread.currentThread().getName().toCharArray());
+    public final long CREATION_THREAD_HASHCODE = Thread.currentThread().hashCode();
+
     /** The key holds the vector of primary key values for the object. */
     protected Object key;
 

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/IdentityMapManager.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/identitymaps/IdentityMapManager.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 1998, 2018 IBM Corporation. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -1507,6 +1507,9 @@ public class IdentityMapManager implements Serializable, Cloneable {
             this.session.endOperationProfile(SessionProfiler.Caching);
         } else {
             value = map.remove(key, objectToRemove);
+        }
+        if (session.getProject().allowExtendedCacheLogging()) {
+            session.log(SessionLog.FINEST, SessionLog.CACHE, "cache_item_removal", new Object[] {domainClass, key, Thread.currentThread().getId(), Thread.currentThread().getName()});
         }
         return value;
     }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/localization/i18n/LoggingLocalizationResource.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/localization/i18n/LoggingLocalizationResource.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2014, 2020 IBM Corporation and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021 IBM Corporation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -101,7 +101,9 @@ public class LoggingLocalizationResource extends ListResourceBundle {
         { "register_new_for_persist", "PERSIST operation called on: {0}." },
         { "all_registered_clones", "All Registered Clones:" },
         { "new_objects", "New Objects:" },
-
+        { "unit_of_work_thread_info", "Current unit of work in session ({0}) was created by another thread (id: {1} name: {2}), than current thread (id: {3} name: {4})" },
+        { "unit_of_work_thread_info_thread_dump", "Creation thread (id: {0} name: {1}) stack trace:\n{2}\n\n" +
+                "Current thread (id: {3} name: {4}) stack trace:\n{5}" },
         { "failed_to_propogate_to", "CacheSynchronization : Failed to propagate to {0}.  {1}" },
         { "exception_thrown_when_attempting_to_shutdown_cache_synch", "Exception thrown when attempting to shutdown cache synch: {0}" },
         { "corrupted_session_announcement", "SessionID: {0}  Discovery manager received corrupted session announcement - ignoring." },

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/localization/i18n/TraceLocalizationResource.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/localization/i18n/TraceLocalizationResource.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2017, 2020 IBM Corporation. All rights reserved.
+ * Copyright (c) 2017, 2021 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -42,6 +42,13 @@ public class TraceLocalizationResource extends ListResourceBundle {
         { "initialize_identitymaps", "initialize identitymaps" },
         { "external_transaction_has_rolled_back_internally", "external transaction has rolled back internally" },
         { "validate_cache", "validate cache." },
+        { "cache_item_creation", "Entity ({0}) with Id ({1}) was stored in the cache by thread (Id: {2} Name: {3})" },
+        { "cache_item_refresh", "Entity ({0}) with Id ({1}) was refreshed in the cache by thread (Id: {2} Name: {3})" },
+        { "cache_item_removal", "Entity ({0}) with Id ({1}) was removed from the cache by thread (Id: {2} Name: {3})" },
+        { "cache_item_invalidation", "Entity ({0}) with Id ({1}) was invalidated from the cache by thread (Id: {2} Name: {3})" },
+        { "cache_class_invalidation", "Entities based on class ({0}) was invalidated from the cache by thread (Id: {1} Name: {2})" },
+        { "cache_hit", "Cache hit for entity ({0}) with Id ({1})" },
+        { "cache_miss", "Cache miss for entity ({0}) with Id ({1})" },
         { "stack_of_visited_objects_that_refer_to_the_corrupt_object", "stack of visited objects that refer to the corrupt object: {0}" },
         { "corrupt_object_referenced_through_mapping", "corrupt object referenced through mapping: {0}" },
         { "corrupt_object", "corrupt object: {0}" },
@@ -101,6 +108,7 @@ public class TraceLocalizationResource extends ListResourceBundle {
         { "locked_object", "Locked Object : {0}" },
         { "depth", "Depth : {0}" },
         { "cachekey_released", "This thread is no longer holding the lock.  It must not be a blocking thread."},
+        { "cache_thread_info", "Cached entity ({0}) with Id ({1}) was prepared and stored into cache by another thread (id: {2} name: {3}), than current thread (id: {4} name: {5})" },
         { "deferred_locks", "Deferred lock on : {0}" },
         { "deferred_locks_released", "All deferred locks for thread \"{0}\" have been released." },
         { "acquiring_deferred_lock", "Thread \"{1}\" has acquired a deferred lock on object : {0} in order to avoid deadlock." },

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/sessions/IdentityMapAccessor.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/sessions/IdentityMapAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -791,6 +791,9 @@ public class IdentityMapAccessor implements org.eclipse.persistence.sessions.Ide
                 rcm.propagateCommand(command);
             }
         }
+        if (session.getProject().allowExtendedCacheLogging()) {
+            session.log(SessionLog.FINEST, SessionLog.CACHE, "cache_item_invalidation", new Object[] {theClass, primaryKey, Thread.currentThread().getId(), Thread.currentThread().getName()});
+        }
     }
 
     /**
@@ -890,6 +893,9 @@ public class IdentityMapAccessor implements org.eclipse.persistence.sessions.Ide
             }
         }
         invalidateQueryCache(myClass);
+        if (session.getProject().allowExtendedCacheLogging()) {
+            session.log(SessionLog.FINEST, SessionLog.CACHE, "cache_class_invalidation", new Object[] {myClass, Thread.currentThread().getId(), Thread.currentThread().getName()});
+        }
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
@@ -75,6 +75,7 @@ import org.eclipse.persistence.internal.descriptors.DescriptorIterator.CascadeCo
 import org.eclipse.persistence.internal.descriptors.ObjectBuilder;
 import org.eclipse.persistence.internal.descriptors.PersistenceEntity;
 import org.eclipse.persistence.internal.helper.ConcurrencyManager;
+import org.eclipse.persistence.internal.helper.ConcurrencyUtil;
 import org.eclipse.persistence.internal.helper.Helper;
 import org.eclipse.persistence.internal.helper.IdentityHashSet;
 import org.eclipse.persistence.internal.helper.IdentityWeakHashMap;
@@ -104,6 +105,7 @@ import org.eclipse.persistence.queries.ObjectLevelReadQuery;
 import org.eclipse.persistence.queries.ReadObjectQuery;
 import org.eclipse.persistence.queries.ReadQuery;
 import org.eclipse.persistence.sessions.DatabaseRecord;
+import org.eclipse.persistence.sessions.Session;
 import org.eclipse.persistence.sessions.SessionProfiler;
 import org.eclipse.persistence.sessions.coordination.MergeChangeSetCommand;
 

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
@@ -137,6 +137,12 @@ import org.eclipse.persistence.sessions.coordination.MergeChangeSetCommand;
  */
 public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persistence.sessions.UnitOfWork {
 
+    //These constants and variables are used in extended thread logging to compare UnitOfWork creation thread and thread which registering object in UnitOfWork
+    public final long CREATION_THREAD_ID = Thread.currentThread().getId();
+    public final String CREATION_THREAD_NAME = String.copyValueOf(Thread.currentThread().getName().toCharArray());
+    public final long CREATION_THREAD_HASHCODE = Thread.currentThread().hashCode();
+    private String creationThreadStackTrace;
+
     /** Fix made for weak caches to avoid garbage collection of the originals. **/
     /** As well as used as lookup in merge algorithm for aggregates and others **/
     protected transient Map<Object, Object> cloneToOriginals;
@@ -2980,6 +2986,19 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
      */
     @Override
     public Object internalExecuteQuery(DatabaseQuery query, AbstractRecord databaseRow) throws DatabaseException, QueryException {
+        if (project.allowExtendedThreadLogging()) {
+            Thread currentThread = Thread.currentThread();
+            if (this.CREATION_THREAD_HASHCODE != currentThread.hashCode()) {
+                log(SessionLog.SEVERE, SessionLog.THREAD, "unit_of_work_thread_info", new Object[]{this.getName(),
+                        this.CREATION_THREAD_ID, this.CREATION_THREAD_NAME,
+                        currentThread.getId(), currentThread.getName()});
+                if (project.allowExtendedThreadLoggingThreadDump()) {
+                    log(SessionLog.SEVERE, SessionLog.THREAD, "unit_of_work_thread_info_thread_dump", new Object[]{
+                            this.CREATION_THREAD_ID, this.CREATION_THREAD_NAME, this.creationThreadStackTrace,
+                            currentThread.getId(), currentThread.getName(), ConcurrencyUtil.SINGLETON.enrichGenerateThreadDumpForCurrentThread()});
+                }
+            }
+        }
         Object result = query.executeInUnitOfWork(this, databaseRow);
         executeDeferredEvents();
         return result;
@@ -4021,6 +4040,37 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
         if (descriptor.isDescriptorTypeAggregate()) {
             throw ValidationException.cannotRegisterAggregateObjectInUnitOfWork(objectToRegister.getClass());
         }
+        CacheKey cacheKey = null;
+        Object objectToRegisterId = null;
+        Thread currentThread = Thread.currentThread();
+        if (project.allowExtendedCacheLogging()) {
+            //Not null if objectToRegister exist in cache
+            Session rootSession = this.getRootSession(null).getParent() == null ? this.getRootSession(null) : this.getRootSession(null).getParent();
+            cacheKey = ((org.eclipse.persistence.internal.sessions.IdentityMapAccessor)rootSession.getIdentityMapAccessor()).getCacheKeyForObject(objectToRegister);
+            objectToRegisterId = this.getId(objectToRegister);
+            if (cacheKey != null) {
+                log(SessionLog.FINEST, SessionLog.CACHE, "cache_hit", new Object[] {objectToRegister.getClass(), objectToRegisterId});
+            } else {
+                log(SessionLog.FINEST, SessionLog.CACHE, "cache_miss", new Object[] {objectToRegister.getClass(), objectToRegisterId});
+            }
+            if (cacheKey != null && currentThread.hashCode() != cacheKey.CREATION_THREAD_HASHCODE) {
+                log(SessionLog.FINEST, SessionLog.CACHE, "cache_thread_info", new Object[]{objectToRegister.getClass(), objectToRegisterId,
+                        cacheKey.CREATION_THREAD_ID, cacheKey.CREATION_THREAD_NAME,
+                        currentThread.getId(), currentThread.getName()});
+            }
+        }
+        if (project.allowExtendedThreadLogging()) {
+            if (this.CREATION_THREAD_HASHCODE != currentThread.hashCode()) {
+                log(SessionLog.SEVERE, SessionLog.THREAD, "unit_of_work_thread_info", new Object[]{this.getName(),
+                        this.CREATION_THREAD_ID, this.CREATION_THREAD_NAME,
+                        currentThread.getId(), currentThread.getName()});
+                if (project.allowExtendedThreadLoggingThreadDump()) {
+                    log(SessionLog.SEVERE, SessionLog.THREAD, "unit_of_work_thread_info_thread_dump", new Object[]{
+                            this.CREATION_THREAD_ID, this.CREATION_THREAD_NAME, this.creationThreadStackTrace,
+                            currentThread.getId(), currentThread.getName(), ConcurrencyUtil.SINGLETON.enrichGenerateThreadDumpForCurrentThread()});
+                }
+            }
+        }
         //CR#2272
         logDebugMessage(objectToRegister, "register_existing");
         Object registeredObject;
@@ -4054,7 +4104,7 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
                     // check object for cachekey otherwise
                     // a new cache-key is used as there is no original to use for locking.
                     // It read time must be set to avoid it being invalidated.
-                    CacheKey cacheKey = null;
+                    cacheKey = null;
                     if (objectToRegister instanceof PersistenceEntity){
                         cacheKey = ((PersistenceEntity)objectToRegister)._persistence_getCacheKey();
                     }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/logging/LogCategory.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/logging/LogCategory.java
@@ -71,7 +71,7 @@ public enum LogCategory {
     SERVER(     (byte)0x13, SessionLog.SERVER),
     SQL(        (byte)0x14, SessionLog.SQL),
     TRANSACTION((byte)0x15, SessionLog.TRANSACTION),
-    WEAVER(     (byte)0x16, SessionLog.WEAVER);
+    WEAVER(     (byte)0x16, SessionLog.WEAVER),
     THREAD(     (byte)0x17, SessionLog.THREAD);
 
     /** Logging categories enumeration length. */

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/logging/LogCategory.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/logging/LogCategory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -43,6 +43,7 @@ import org.eclipse.persistence.config.PersistenceUnitProperties;
  * <tr><td>&nbsp;</td><td>SEQUENCING</td>     <td>&nbsp;</td><td>= "sequencing"</td></tr>
  * <tr><td>&nbsp;</td><td>SERVER</td>         <td>&nbsp;</td><td>= "server"</td></tr>
  * <tr><td>&nbsp;</td><td>SQL</td>            <td>&nbsp;</td><td>= "sql"</td></tr>
+ * <tr><td>&nbsp;</td><td>THREAD</td>         <td>&nbsp;</td><td>= "thread"</td></tr>
  * <tr><td>&nbsp;</td><td>TRANSACTION</td>    <td>&nbsp;</td><td>= "transaction"</td></tr>
  * <tr><td>&nbsp;</td><td>WEAVER</td>         <td>&nbsp;</td><td>= "weaver"</td></tr>
  * </table>
@@ -71,6 +72,7 @@ public enum LogCategory {
     SQL(        (byte)0x14, SessionLog.SQL),
     TRANSACTION((byte)0x15, SessionLog.TRANSACTION),
     WEAVER(     (byte)0x16, SessionLog.WEAVER);
+    THREAD(     (byte)0x17, SessionLog.THREAD);
 
     /** Logging categories enumeration length. */
     public static final int length = LogCategory.values().length;

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/logging/SessionLog.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/logging/SessionLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -60,6 +60,7 @@ import org.eclipse.persistence.sessions.Session;
  * <tr><td>&nbsp;</td><td>{@link #SEQUENCING}</td>    <td>&nbsp;</td><td>= {@value #SEQUENCING}</td></tr>
  * <tr><td>&nbsp;</td><td>{@link #SERVER}</td>        <td>&nbsp;</td><td>= {@value #SERVER}</td></tr>
  * <tr><td>&nbsp;</td><td>{@link #SQL}</td>           <td>&nbsp;</td><td>= {@value #SQL}</td></tr>
+ * <tr><td>&nbsp;</td><td>{@link #THREAD}</td>        <td>&nbsp;</td><td>= {@value #THREAD}</td></tr>
  * <tr><td>&nbsp;</td><td>{@link #TRANSACTION}</td>   <td>&nbsp;</td><td>= {@value #TRANSACTION}</td></tr>
  * <tr><td>&nbsp;</td><td>{@link #WEAVER}</td>        <td>&nbsp;</td><td>= {@value #WEAVER}</td></tr>
  * </table>
@@ -135,6 +136,7 @@ public interface SessionLog extends Cloneable {
     public static final String JPARS = "jpars";
     /** ModelGen logging name space. */
     public static final String PROCESSOR = "processor";
+    public static final String THREAD = "thread";
 
     public final String[] loggerCatagories = new String[] {
         SQL,
@@ -158,7 +160,8 @@ public interface SessionLog extends Cloneable {
         PROPERTIES,
         SERVER,
         DDL,
-        PROCESSOR
+        PROCESSOR,
+        THREAD
     };
 
     /**
@@ -313,6 +316,7 @@ public interface SessionLog extends Cloneable {
      * <tr><td>&nbsp;</td><td>{@link #SEQUENCING}</td>      <td>&nbsp;</td><td>= {@value #SEQUENCING}</td></tr>
      * <tr><td>&nbsp;</td><td>{@link #SERVER}</td>          <td>&nbsp;</td><td>= {@value #SERVER}</td></tr>
      * <tr><td>&nbsp;</td><td>{@link #SQL}</td>             <td>&nbsp;</td><td>= {@value #SQL}</td></tr>
+     * <tr><td>&nbsp;</td><td>{@link #THREAD}</td>          <td>&nbsp;</td><td>= {@value #THREAD}</td></tr>
      * <tr><td>&nbsp;</td><td>{@link #TRANSACTION}</td>     <td>&nbsp;</td><td>= {@value #TRANSACTION}</td></tr>
      * <tr><td>&nbsp;</td><td>{@link #WEAVER}</td>          <td>&nbsp;</td><td>= {@value #WEAVER}</td></tr>
      * </table>
@@ -375,6 +379,7 @@ public interface SessionLog extends Cloneable {
      * <tr><td>&nbsp;</td><td>{@link #SEQUENCING}</td>      <td>&nbsp;</td><td>= {@value #SEQUENCING}</td></tr>
      * <tr><td>&nbsp;</td><td>{@link #SERVER}</td>          <td>&nbsp;</td><td>= {@value #SERVER}</td></tr>
      * <tr><td>&nbsp;</td><td>{@link #SQL}</td>             <td>&nbsp;</td><td>= {@value #SQL}</td></tr>
+     * <tr><td>&nbsp;</td><td>{@link #THREAD}</td>          <td>&nbsp;</td><td>= {@value #THREAD}</td></tr>
      * <tr><td>&nbsp;</td><td>{@link #TRANSACTION}</td>     <td>&nbsp;</td><td>= {@value #TRANSACTION}</td></tr>
      * <tr><td>&nbsp;</td><td>{@link #WEAVER}</td>          <td>&nbsp;</td><td>= {@value #WEAVER}</td></tr>
      * </table>

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/sessions/Project.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/sessions/Project.java
@@ -153,6 +153,15 @@ public class Project extends CoreProject<ClassDescriptor, Login, DatabaseSession
     /** Flag that allows DDL generation of table per tenant multitenant descriptors */
     protected boolean allowTablePerMultitenantDDLGeneration = false;
 
+    /** Flag that allows extended logging of JPA L2 cache or not. */
+    protected boolean allowExtendedCacheLogging = false;
+
+    /** Flag that allows extended thread logging or not. */
+    protected boolean allowExtendedThreadLogging = false;
+
+    /** Flag that allows add to extended thread logging output thread stack trace or not.*/
+    protected boolean allowExtendedThreadLoggingThreadDump = false;
+
     /** Flag that allows call deferral to be disabled */
     protected boolean allowSQLDeferral = true;
 
@@ -1359,6 +1368,30 @@ public class Project extends CoreProject<ClassDescriptor, Login, DatabaseSession
     }
 
     /**
+     * INTERNAL:
+     * Return true if extended logging of JPA L2 cache usage is allowed on this project.
+     */
+    public boolean allowExtendedCacheLogging() {
+        return this.allowExtendedCacheLogging;
+    }
+
+    /**
+     * INTERNAL:
+     * Return true if extended thread logging is allowed on this project.
+     */
+    public boolean allowExtendedThreadLogging() {
+        return this.allowExtendedThreadLogging;
+    }
+
+    /**
+     * INTERNAL:
+     * Return true if thread dumps will be added to extended thread logging.
+     */
+    public boolean allowExtendedThreadLoggingThreadDump() {
+        return this.allowExtendedThreadLoggingThreadDump;
+    }
+
+    /**
      * PUBLIC:
      * Return the descriptor for  the alias
      */
@@ -1395,6 +1428,31 @@ public class Project extends CoreProject<ClassDescriptor, Login, DatabaseSession
      */
     public void setAllowNativeSQLQueries(boolean allowNativeSQLQueries) {
         this.allowNativeSQLQueries = allowNativeSQLQueries;
+    }
+
+
+    /**
+     * INTERNAL:
+     * Set whether extended logging of JPA L2 cache usage is allowed on this project.
+     */
+    public void setAllowExtendedCacheLogging(boolean allowExtendedCacheLogging) {
+        this.allowExtendedCacheLogging = allowExtendedCacheLogging;
+    }
+
+    /**
+     * INTERNAL:
+     * Set whether extended thread logging is allowed on this project.
+     */
+    public void setAllowExtendedThreadLogging(boolean allowExtendedThreadLogging) {
+        this.allowExtendedThreadLogging = allowExtendedThreadLogging;
+    }
+
+    /**
+     * INTERNAL:
+     * Set if thread dumps will be added to extended thread logging.
+     */
+    public void setAllowExtendedThreadLoggingThreadDump(boolean allowExtendedThreadLoggingThreadDump) {
+        this.allowExtendedThreadLoggingThreadDump = allowExtendedThreadLoggingThreadDump;
     }
 
     /**

--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
@@ -2844,6 +2844,9 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
             updateSQLCastSetting(m);
             updateUppercaseSetting(m);
             updateCacheStatementSettings(m);
+            updateAllowExtendedCacheLogging(m);
+            updateAllowExtendedThreadLogging(m);
+            updateAllowExtendedThreadLoggingThreadDump(m);
             updateTemporalMutableSetting(m);
             updateTableCreationSettings(m);
             updateIndexForeignKeys(m);
@@ -3899,6 +3902,60 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
             }
         } catch (NumberFormatException exception) {
             this.session.handleException(ValidationException.invalidValueForProperty(concurrencySemaphoreLogTimeout, PersistenceUnitProperties.CONCURRENCY_SEMAPHORE_LOG_TIMEOUT, exception));
+        }
+    }
+
+    /**
+     * Enable or disable extended logging of JPA L2 cache usage.
+     * The method needs to be called in deploy stage.
+     */
+    protected void updateAllowExtendedCacheLogging(Map m) {
+        String allowExtendedCacheLogging = EntityManagerFactoryProvider.getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.CACHE_EXTENDED_LOGGING, m, session);
+
+        if (allowExtendedCacheLogging != null) {
+            if (allowExtendedCacheLogging.equalsIgnoreCase("true")) {
+                session.getProject().setAllowExtendedCacheLogging(true);
+            } else if (allowExtendedCacheLogging.equalsIgnoreCase("false")) {
+                session.getProject().setAllowExtendedCacheLogging(false);
+            } else {
+                session.handleException(ValidationException.invalidBooleanValueForProperty(allowExtendedCacheLogging, PersistenceUnitProperties.CACHE_EXTENDED_LOGGING));
+            }
+        }
+    }
+
+    /**
+     * Enable or disable extended thread logging.
+     * The method needs to be called in deploy stage.
+     */
+    protected void updateAllowExtendedThreadLogging(Map m){
+        String allowExtendedThreadLogging = EntityManagerFactoryProvider.getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.THREAD_EXTENDED_LOGGING, m, session);
+
+        if (allowExtendedThreadLogging != null) {
+            if (allowExtendedThreadLogging.equalsIgnoreCase("true")) {
+                session.getProject().setAllowExtendedThreadLogging(true);
+            } else if (allowExtendedThreadLogging.equalsIgnoreCase("false")) {
+                session.getProject().setAllowExtendedThreadLogging(false);
+            } else {
+                session.handleException(ValidationException.invalidBooleanValueForProperty(allowExtendedThreadLogging, PersistenceUnitProperties.THREAD_EXTENDED_LOGGING));
+            }
+        }
+    }
+
+    /**
+     * Enable or disable thread dump addition to extended thread logging.
+     * The method needs to be called in deploy stage.
+     */
+    protected void updateAllowExtendedThreadLoggingThreadDump(Map m){
+        String allowExtendedThreadLoggingThreadDump = EntityManagerFactoryProvider.getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.THREAD_EXTENDED_LOGGING_THREADDUMP, m, session);
+
+        if (allowExtendedThreadLoggingThreadDump != null) {
+            if (allowExtendedThreadLoggingThreadDump.equalsIgnoreCase("true")) {
+                session.getProject().setAllowExtendedThreadLoggingThreadDump(true);
+            } else if (allowExtendedThreadLoggingThreadDump.equalsIgnoreCase("false")) {
+                session.getProject().setAllowExtendedThreadLoggingThreadDump(false);
+            } else {
+                session.handleException(ValidationException.invalidBooleanValueForProperty(allowExtendedThreadLoggingThreadDump, PersistenceUnitProperties.THREAD_EXTENDED_LOGGING_THREADDUMP));
+            }
         }
     }
 


### PR DESCRIPTION
This is backport from 2.6 PRs #1080, #1101, #1121 and master #1076.

This commit contains extension to logging code.
Main purpose is display info if cached entity is picked by another thread and WorkManager is called in different threads.
Log cached item lifecycle events (insert, refresh, remove, invalidate) from cache.
This logging is by default disabled and must be enabled by persistence properties
Major changes are:

- new thread log category specified in `org.eclipse.persistence.logging.LogCategory` and `org.eclipse.persistence.logging.SessionLog`
- three new persistence unit properties `eclipselink.cache.extended.logging` about cached item lifecycle, `eclipselink.thread.extended.logging` to enable this logging and `eclipselink.thread.extended.logging.threaddump` to add to the log output threads stack trace
- new log messages are called from `org.eclipse.persistence.internal.sessions.UnitOfWorkImpl`