### PR TITLE
[3.0] Maven/Nightly build fix - bundle names change

### DIFF
--- a/bundles/eclipselink/pom.xml
+++ b/bundles/eclipselink/pom.xml
@@ -412,41 +412,6 @@
 
     <build>
         <plugins>
-            <!--Initialize build.date and build.time buildNumber properties. Used to generate version.properties in org.eclipse.persistence:eclipselink module-->
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>buildnumber-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>build.date</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>create-timestamp</goal>
-                        </goals>
-                        <configuration>
-                            <timestampFormat>yyyyMMdd</timestampFormat>
-                            <timestampPropertyName>build.date</timestampPropertyName>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>build.time</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>create-timestamp</goal>
-                        </goals>
-                        <configuration>
-                            <timestampFormat>HHmm</timestampFormat>
-                            <timestampPropertyName>build.time</timestampPropertyName>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>create</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/bundles/nightly/pom.xml
+++ b/bundles/nightly/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <nightlyDir>/nightlybuild/${release.version}/${build.date}</nightlyDir>
-        <nightlyVersion>-${release.version}.v${build.date}-${buildNumber}</nightlyVersion>
+        <nightlyVersion>${release.version}.v${build.date}-${buildNumber}</nightlyVersion>
         <nightlyTestReportsDir>${project.build.directory}${nightlyDir}/Eclipse</nightlyTestReportsDir>
     </properties>
 
@@ -83,34 +83,6 @@
 
     <build>
         <plugins>
-            <!--Initialize build.date and build.time buildNumber properties. -->
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>buildnumber-maven-plugin</artifactId>
-                <configuration>
-                    <revisionOnScmFailure>false</revisionOnScmFailure>
-                    <shortRevisionLength>10</shortRevisionLength>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>build.date</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>create-timestamp</goal>
-                        </goals>
-                        <configuration>
-                            <timestampFormat>yyyyMMdd</timestampFormat>
-                            <timestampPropertyName>build.date</timestampPropertyName>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>create</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>com.coderplus.maven.plugins</groupId>
                 <artifactId>copy-rename-maven-plugin</artifactId>
@@ -128,7 +100,7 @@
                                         ../../foundation/eclipselink.core.test/target/${project.build.testReports.subdirectory}/${project.build.testReports.summaryFile}.html
                                     </sourceFile>
                                     <destinationFile>
-                                        ${project.build.directory}${nightlyDir}/Eclipse/eclipselink-core-lrg${nightlyVersion}.html
+                                        ${project.build.directory}${nightlyDir}/Eclipse/eclipselink-core-lrg-${nightlyVersion}.html
                                     </destinationFile>
                                 </fileSet>
                                 <fileSet>
@@ -136,7 +108,7 @@
                                         ../../dbws/org.eclipse.persistence.dbws/target/${project.build.testReports.subdirectory}/${project.build.testReports.summaryFile}.html
                                     </sourceFile>
                                     <destinationFile>
-                                        ${project.build.directory}${nightlyDir}/Eclipse/eclipselink-dbws-lrg${nightlyVersion}.html
+                                        ${project.build.directory}${nightlyDir}/Eclipse/eclipselink-dbws-lrg-${nightlyVersion}.html
                                     </destinationFile>
                                 </fileSet>
                                 <fileSet>
@@ -144,7 +116,7 @@
                                         ../../utils/org.eclipse.persistence.dbws.builder/target/${project.build.testReports.subdirectory}/${project.build.testReports.summaryFile}.html
                                     </sourceFile>
                                     <destinationFile>
-                                        ${project.build.directory}${nightlyDir}/Eclipse/eclipselink-dbws-util-lrg${nightlyVersion}.html
+                                        ${project.build.directory}${nightlyDir}/Eclipse/eclipselink-dbws-util-lrg-${nightlyVersion}.html
                                     </destinationFile>
                                 </fileSet>
                                 <fileSet>
@@ -152,7 +124,7 @@
                                         ../../moxy/org.eclipse.persistence.moxy/target/${project.build.testReports.subdirectory}/${project.build.testReports.summaryFile}.html
                                     </sourceFile>
                                     <destinationFile>
-                                        ${project.build.directory}${nightlyDir}/Eclipse/eclipselink-jaxb-lrg${nightlyVersion}.html
+                                        ${project.build.directory}${nightlyDir}/Eclipse/eclipselink-jaxb-lrg-${nightlyVersion}.html
                                     </destinationFile>
                                 </fileSet>
                                 <fileSet>
@@ -160,7 +132,7 @@
                                         ../../jpa/eclipselink.jpa.test/target/${project.build.testReports.subdirectory}/${project.build.testReports.summaryFile}.html
                                     </sourceFile>
                                     <destinationFile>
-                                        ${project.build.directory}${nightlyDir}/Eclipse/eclipselink-jpa-lrg${nightlyVersion}.html
+                                        ${project.build.directory}${nightlyDir}/Eclipse/eclipselink-jpa-lrg-${nightlyVersion}.html
                                     </destinationFile>
                                 </fileSet>
                                 <fileSet>
@@ -168,7 +140,7 @@
                                         ../../jpa/eclipselink.jpa.wdf.test/target/${project.build.testReports.subdirectory}/${project.build.testReports.summaryFile}.html
                                     </sourceFile>
                                     <destinationFile>
-                                        ${project.build.directory}${nightlyDir}/Eclipse/eclipselink-jpa-wdf-lrg${nightlyVersion}.html
+                                        ${project.build.directory}${nightlyDir}/Eclipse/eclipselink-jpa-wdf-lrg-${nightlyVersion}.html
                                     </destinationFile>
                                 </fileSet>
                                 <fileSet>
@@ -176,7 +148,7 @@
                                         ../../jpa/org.eclipse.persistence.jpars/target/${project.build.testReports.subdirectory}/${project.build.testReports.summaryFile}.html
                                     </sourceFile>
                                     <destinationFile>
-                                        ${project.build.directory}${nightlyDir}/Eclipse/eclipselink-jpars-lrg${nightlyVersion}.html
+                                        ${project.build.directory}${nightlyDir}/Eclipse/eclipselink-jpars-lrg-${nightlyVersion}.html
                                     </destinationFile>
                                 </fileSet>
                                 <fileSet>
@@ -184,7 +156,7 @@
                                         ../../moxy/org.eclipse.persistence.moxy/target/${project.build.testReports.subdirectory}/${project.build.testReports.summaryFile}.html
                                     </sourceFile>
                                     <destinationFile>
-                                        ${project.build.directory}${nightlyDir}/Eclipse/eclipselink-oxm-lrg${nightlyVersion}.html
+                                        ${project.build.directory}${nightlyDir}/Eclipse/eclipselink-oxm-lrg-${nightlyVersion}.html
                                     </destinationFile>
                                 </fileSet>
                                 <fileSet>
@@ -192,7 +164,7 @@
                                         ../../sdo/org.eclipse.persistence.sdo/target/${project.build.testReports.subdirectory}/${project.build.testReports.summaryFile}.html
                                     </sourceFile>
                                     <destinationFile>
-                                        ${project.build.directory}${nightlyDir}/Eclipse/eclipselink-sdo-lrg${nightlyVersion}.html
+                                        ${project.build.directory}${nightlyDir}/Eclipse/eclipselink-sdo-lrg-${nightlyVersion}.html
                                     </destinationFile>
                                 </fileSet>
                             </fileSets>
@@ -209,31 +181,31 @@
                                 <fileSet>
                                     <sourceFile>../eclipselink/target/eclipselink-${project.version}.zip</sourceFile>
                                     <destinationFile>
-                                        ${project.build.directory}${nightlyDir}/eclipselink${nightlyVersion}.zip
+                                        ${project.build.directory}${nightlyDir}/eclipselink-${nightlyVersion}.zip
                                     </destinationFile>
                                 </fileSet>
                                 <fileSet>
                                     <sourceFile>../others/target/eclipselink-plugins.zip</sourceFile>
                                     <destinationFile>
-                                        ${project.build.directory}${nightlyDir}/eclipselink-plugins${nightlyVersion}.zip
+                                        ${project.build.directory}${nightlyDir}/eclipselink-plugins-${nightlyVersion}.zip
                                     </destinationFile>
                                 </fileSet>
                                 <fileSet>
                                     <sourceFile>../others/target/eclipselink-plugins-nosql.zip</sourceFile>
                                     <destinationFile>
-                                        ${project.build.directory}${nightlyDir}/eclipselink-plugins-nosql${nightlyVersion}.zip
+                                        ${project.build.directory}${nightlyDir}/eclipselink-plugins-nosql-${nightlyVersion}.zip
                                     </destinationFile>
                                 </fileSet>
                                 <fileSet>
                                     <sourceFile>../others/target/eclipselink-test-jars.zip</sourceFile>
                                     <destinationFile>
-                                        ${project.build.directory}${nightlyDir}/eclipselink-test-jars${nightlyVersion}.zip
+                                        ${project.build.directory}${nightlyDir}/eclipselink-test-jars-${nightlyVersion}.zip
                                     </destinationFile>
                                 </fileSet>
                                 <fileSet>
                                     <sourceFile>../others/target/eclipselink-test-src.zip</sourceFile>
                                     <destinationFile>
-                                        ${project.build.directory}${nightlyDir}/eclipselink-test-src${nightlyVersion}.zip
+                                        ${project.build.directory}${nightlyDir}/eclipselink-test-src-${nightlyVersion}.zip
                                     </destinationFile>
                                 </fileSet>
                                 <fileSet>
@@ -248,7 +220,7 @@
                                         ../eclipselink/target//${eclipselink.unzip.subdir}/eclipselink/jlib/eclipselink-sources.jar
                                     </sourceFile>
                                     <destinationFile>
-                                        ${project.build.directory}${nightlyDir}/eclipselink-src${nightlyVersion}.zip
+                                        ${project.build.directory}${nightlyDir}/eclipselink-src-${nightlyVersion}.zip
                                     </destinationFile>
                                 </fileSet>
                             </fileSets>

--- a/bundles/nightly/pom.xml
+++ b/bundles/nightly/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <nightlyDir>/nightlybuild/${release.version}/${build.date}</nightlyDir>
-        <nightlyVersion>${release.version}.v${build.date}-${buildNumber}</nightlyVersion>
+        <nightlyVersion>${release.version}.v${build.date}${build.time}-${buildNumber}</nightlyVersion>
         <nightlyTestReportsDir>${project.build.directory}${nightlyDir}/Eclipse</nightlyTestReportsDir>
     </properties>
 

--- a/bundles/others/pom.xml
+++ b/bundles/others/pom.xml
@@ -33,7 +33,7 @@
     <properties>
         <archive.tmp.dir>archive-tmp</archive.tmp.dir>
         <test.jars.tmp.dir>eclipselink-test-jars</test.jars.tmp.dir>
-        <nightlyVersion>${release.version}.v${build.date}-${buildNumber}</nightlyVersion>
+        <nightlyVersion>${release.version}.v${build.date}${build.time}-${buildNumber}</nightlyVersion>
 
         <!--Javadoc properties-->
         <javadoc.prefixTitle>EclipseLink ${release.version}</javadoc.prefixTitle>

--- a/bundles/others/pom.xml
+++ b/bundles/others/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <archive.tmp.dir>archive-tmp</archive.tmp.dir>
         <test.jars.tmp.dir>eclipselink-test-jars</test.jars.tmp.dir>
+        <nightlyVersion>${release.version}.v${build.date}-${buildNumber}</nightlyVersion>
 
         <!--Javadoc properties-->
         <javadoc.prefixTitle>EclipseLink ${release.version}</javadoc.prefixTitle>

--- a/bundles/others/src/main/assembly/eclipselink-plugins.zip.xml
+++ b/bundles/others/src/main/assembly/eclipselink-plugins.zip.xml
@@ -26,7 +26,7 @@
     </componentDescriptors>
     <dependencySets>
         <dependencySet>
-            <outputFileNameMapping>${artifact.artifactId}_${release.version}.${build.qualifier}.${artifact.extension}</outputFileNameMapping>
+            <outputFileNameMapping>${artifact.artifactId}_${nightlyVersion}.${artifact.extension}</outputFileNameMapping>
             <includes>
                 <include>org.eclipse.persistence:*:*:*:${project.version}</include>
             </includes>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -40,50 +40,6 @@
         <module>tests</module>
     </modules>
 
-    <build>
-        <plugins>
-            <!--Initialize build.date and build.time buildNumber properties. Used to generate version.properties in org.eclipse.persistence:eclipselink module and artifacts in the bundles-->
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>buildnumber-maven-plugin</artifactId>
-                <configuration>
-                    <revisionOnScmFailure>false</revisionOnScmFailure>
-                    <shortRevisionLength>10</shortRevisionLength>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>build.date</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>create-timestamp</goal>
-                        </goals>
-                        <configuration>
-                            <timestampFormat>yyyyMMdd</timestampFormat>
-                            <timestampPropertyName>build.date</timestampPropertyName>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>build.time</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>create-timestamp</goal>
-                        </goals>
-                        <configuration>
-                            <timestampFormat>HHmm</timestampFormat>
-                            <timestampPropertyName>build.time</timestampPropertyName>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>create</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-
     <profiles>
         <profile>
             <id>test-lrg</id>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -40,6 +40,50 @@
         <module>tests</module>
     </modules>
 
+    <build>
+        <plugins>
+            <!--Initialize build.date and build.time buildNumber properties. Used to generate version.properties in org.eclipse.persistence:eclipselink module and artifacts in the bundles-->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>buildnumber-maven-plugin</artifactId>
+                <configuration>
+                    <revisionOnScmFailure>false</revisionOnScmFailure>
+                    <shortRevisionLength>10</shortRevisionLength>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>build.date</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>create-timestamp</goal>
+                        </goals>
+                        <configuration>
+                            <timestampFormat>yyyyMMdd</timestampFormat>
+                            <timestampPropertyName>build.date</timestampPropertyName>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>build.time</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>create-timestamp</goal>
+                        </goals>
+                        <configuration>
+                            <timestampFormat>HHmm</timestampFormat>
+                            <timestampPropertyName>build.time</timestampPropertyName>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>create</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <profiles>
         <profile>
             <id>test-lrg</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1200,6 +1200,45 @@
                     </execution>
                 </executions>
             </plugin>
+            <!--Initialize build.date and build.time buildNumber properties. Used to generate version.properties in org.eclipse.persistence:eclipselink module and artifacts in the bundles-->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>buildnumber-maven-plugin</artifactId>
+                <configuration>
+                    <revisionOnScmFailure>false</revisionOnScmFailure>
+                    <shortRevisionLength>10</shortRevisionLength>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>build.date</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>create-timestamp</goal>
+                        </goals>
+                        <configuration>
+                            <timestampFormat>yyyyMMdd</timestampFormat>
+                            <timestampPropertyName>build.date</timestampPropertyName>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>build.time</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>create-timestamp</goal>
+                        </goals>
+                        <configuration>
+                            <timestampFormat>HHmm</timestampFormat>
+                            <timestampPropertyName>build.time</timestampPropertyName>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>create</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
@@ -1293,7 +1332,10 @@
                     <niceManifest>true</niceManifest>
                     <instructions>
                         <_noextraheaders>true</_noextraheaders>
-                        <Bundle-Version>${release.version}</Bundle-Version>
+                        <Implementation-Version>${project.version}</Implementation-Version>
+                        <Implementation-SCM-Revision>${buildNumber}</Implementation-SCM-Revision>
+                        <Implementation-SCM-Branch>${scmBranch}</Implementation-SCM-Branch>
+                        <Bundle-Version>${release.version}.v${build.date}${build.time}</Bundle-Version>
                         <Automatic-Module-Name>${project.artifactId}</Automatic-Module-Name>
                         <HK2-Bundle-Name>${project.groupId}:${project.artifactId}</HK2-Bundle-Name>
                     </instructions>

--- a/pom.xml
+++ b/pom.xml
@@ -1292,7 +1292,8 @@
                 <configuration>
                     <niceManifest>true</niceManifest>
                     <instructions>
-                         <_noextraheaders>true</_noextraheaders>
+                        <_noextraheaders>true</_noextraheaders>
+                        <Bundle-Version>${release.version}</Bundle-Version>
                         <Automatic-Module-Name>${project.artifactId}</Automatic-Module-Name>
                         <HK2-Bundle-Name>${project.groupId}:${project.artifactId}</HK2-Bundle-Name>
                     </instructions>


### PR DESCRIPTION
This is fix for issue related with eclipselink-plugins.zip bundle.
Main purpose of this fix is to keep names of the `orc.eclipse.persistence` artifacts packed in `eclipselink-plugins.zip` bundle consistent with older versions of the EclipseLink.
EclipseLink artifacts in eclipselink-plugins-*.zip are named in the same way as in 2.6, 2.7 bundles
	e.g. `org.eclipse.persistence.core_2.7.9.v20210604-2c549e2208.jar`	x	`org.eclipse.persistence.core_3.0.2.v20210610-1fda5b4d4e.jar`
	`MANIFEST.MF` content is changed too.
	`Bundle-Version` contains `major.minor.micro.version.vYYYYMMDDHHmm` e.g. `Bundle-Version: 3.0.2.v202106101448`
	plus new additional properties e.g.

```
Implementation-Version: 3.0.2-SNAPSHOT
Implementation-SCM-Revision: 1fda5b4d4e
Implementation-SCM-Branch: 3.0
```


Some note about bundles at Eclipse.org lifecycle.
These bundles available at 
https://www.eclipse.org/eclipselink/downloads/nightly.php
https://www.eclipse.org/eclipselink/downloads/milestones.php
https://www.eclipse.org/eclipselink/downloads/
are build during a nightly build.
During promotion/release process are generated just Maven artifacts published at
https://jakarta.oss.sonatype.org/content/groups/staging/org/eclipse/persistence/eclipselink/2.7.9/
and later
in the Maven Central.
Bundles at Eclipse.org are just copied from Nightly to Milestones (e.g. RC1, MP1, ...) and Download (Final).
This is reason why timestamp stored in bundles at Eclipse.org is usually older, than timestamp in artifacts stored in Maven Central.


How to verify/test it without Jenkins environment (nightly build job):

- Build project `mvn clean install -DskipTests`
- Download test summary HTML report e.g. http://download.eclipse.org/rt/eclipselink/nightly/3.1.0/20210604/Eclipse/eclipselink-core-lrg-3.1.0.v20210604-b9aaac8bf9.html and store it in local machine
- Modify env variables `TEST_SUMMARY_SRC`, `ECLIPSELINK_PROJECT` in `populateTestResultsHTML.sh` and execute it to create required `test-summary.html` files. Without this step next one fails.
- Generate nightly build bundles: `mvn verify -pl :org.eclipse.persistence.nightly -P test-lrg`
- Check content in `<EL_PROJECT>/bundles/nightly/target`

[populateTestResultsHTML.tar.gz](https://github.com/eclipse-ee4j/eclipselink/files/6629330/populateTestResultsHTML.tar.gz)

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>