### PR TITLE
[2.6_WAS] Bug 485984: When object obtained thru em.getReference() is cached, and retrieved later in a txn

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/descriptors/ObjectBuilder.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/descriptors/ObjectBuilder.java
@@ -17,6 +17,8 @@
  *       - 356197: Add new VPD type to MultitenantType
  *     11/10/2011-2.4 Guy Pelletier 
  *       - 357474: Address primaryKey option from tenant discriminator column
+ *     01/15/2016-2.7 Mythily Parthasarathy
+ *       - 485984: Retrieve FetchGroup info along with getReference() from cache
  *     08/07/2016-2.6 Dalia Abo Sheasha 
  *       - 499335: Multiple embeddable fields can't reference same object
  *     02/14/2018-2.7 Will Dazey
@@ -2255,7 +2257,12 @@ public class ObjectBuilder extends CoreObjectBuilder<AbstractRecord, AbstractSes
             buildAttributesIntoWorkingCopyClone(workingClone, originalCacheKey, query, joinManager, databaseRow, unitOfWork, wasAClone);
             // Set fetch group after building object if not a refresh to avoid checking fetch during building.           
             if ((!isARefresh) && fetchGroupManager != null) {
-                fetchGroupManager.setObjectFetchGroup(workingClone, query.getExecutionFetchGroup(this.descriptor), unitOfWork);
+                if (wasAnOriginal) {
+                    //485984: Save the FetchGroup from the original
+                    fetchGroupManager.setObjectFetchGroup(workingClone, fetchGroupManager.getObjectFetchGroup(original), unitOfWork);
+                } else {
+                    fetchGroupManager.setObjectFetchGroup(workingClone, query.getExecutionFetchGroup(this.descriptor), unitOfWork);
+                }
             }
             Object backupClone = policy.buildBackupClone(workingClone, this, unitOfWork);
     

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/advanced/fetchgroup/AdvancedFetchGroupTableCreator.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/advanced/fetchgroup/AdvancedFetchGroupTableCreator.java
@@ -10,6 +10,8 @@
  * Contributors:
  *     01/19/2010-2.1 Guy Pelletier 
  *       - 211322: Add fetch-group(s) support to the EclipseLink-ORM.XML Schema
+ *     01/16/2016-2.7 Mythily Parthasarathy
+ *         485984: Added SHELF table and reference to SHELF in HELMET
  ******************************************************************************/  
 package org.eclipse.persistence.testing.models.jpa.advanced.fetchgroup;
 
@@ -25,6 +27,7 @@ public class AdvancedFetchGroupTableCreator extends TogglingFastTableCreator {
         addTableDefinition(buildCHESTPROTECTORTable());
         addTableDefinition(buildHELMETTable());
         addTableDefinition(buildHELMET_PROPERTIESTable());
+        addTableDefinition(buildSHELFTable());
     }
     
     public static TableDefinition buildHOCKEYGEARTable(){
@@ -191,6 +194,16 @@ public class AdvancedFetchGroupTableCreator extends TogglingFastTableCreator {
         fieldCOLOR.setUnique(false);
         fieldCOLOR.setIsIdentity(false);
         table.addField(fieldCOLOR);
+
+        FieldDefinition shelfFK = new FieldDefinition();
+        shelfFK.setName("SHELF_ID");
+        shelfFK.setTypeName("NUMERIC");
+        shelfFK.setSize(15);
+        shelfFK.setShouldAllowNull(true);
+        shelfFK.setIsPrimaryKey(false);
+        shelfFK.setUnique(false);
+        shelfFK.setIsIdentity(false);
+        table.addField(shelfFK);
         
         return table;
     }
@@ -231,6 +244,32 @@ public class AdvancedFetchGroupTableCreator extends TogglingFastTableCreator {
         
         return table;
     }
-    
+
+    public static TableDefinition buildSHELFTable() {
+        TableDefinition table = new TableDefinition();
+        table.setName("JPA_SHELF");
+
+        FieldDefinition fieldID = new FieldDefinition();
+        fieldID.setName("ID");
+        fieldID.setTypeName("NUMERIC");
+        fieldID.setSize(15);
+        fieldID.setShouldAllowNull(false);
+        fieldID.setIsPrimaryKey(true);
+        fieldID.setUnique(false);
+        fieldID.setIsIdentity(false);
+        table.addField(fieldID);
+
+        FieldDefinition fieldNAME = new FieldDefinition();
+        fieldNAME.setName("NAME");
+        fieldNAME.setTypeName("VARCHAR");
+        fieldNAME.setSize(42);
+        fieldNAME.setShouldAllowNull(true);
+        fieldNAME.setIsPrimaryKey(false);
+        fieldNAME.setUnique(false);
+        fieldNAME.setIsIdentity(false);
+        table.addField(fieldNAME);
+
+        return table;
+    }
 }
 

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/advanced/fetchgroup/Helmet.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/advanced/fetchgroup/Helmet.java
@@ -9,6 +9,8 @@
  *
  * Contributors:
  *     David Minsky - initial API and implementation
+ *     01/15/2016:2.7 Mythily Parthasarathy
+ *         - 485984-Added reference to Shelf entity
  ******************************************************************************/  
 package org.eclipse.persistence.testing.models.jpa.advanced.fetchgroup;
 
@@ -23,6 +25,7 @@ import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.MapKeyColumn;
 import javax.persistence.Table;
 
@@ -48,6 +51,10 @@ public class Helmet {
     @Column(name="PROPERTY_VALUE")
     @MapKeyColumn(name="PROPERTY_NAME")
     protected Map<String, String> properties;
+
+    @ManyToOne(targetEntity = Shelf.class)
+    @JoinColumn(name = "SHELF_ID", referencedColumnName = "ID")
+    private Shelf shelf;
 
     public Helmet() {
         super();
@@ -84,6 +91,14 @@ public class Helmet {
     
     public void removeProperty(String propertyName) {
         getProperties().remove(propertyName);
+    }
+
+    public void setShelf(Shelf shelf) {
+        this.shelf = shelf;
+    }
+
+    public Shelf getShelf() {
+        return this.shelf;
     }
 
 }

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/advanced/fetchgroup/Shelf.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/advanced/fetchgroup/Shelf.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 1998, 2016 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     01/15/2016-Mythily Parthasarathy
+ *       - 485984: initial API and implementation
+ ******************************************************************************/
+package org.eclipse.persistence.testing.models.jpa.advanced.fetchgroup;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.eclipse.persistence.annotations.Cache;
+import org.eclipse.persistence.config.CacheIsolationType;
+
+@Entity
+@Table(name="JPA_SHELF")
+@Cache(isolation = CacheIsolationType.PROTECTED)
+public class Shelf {
+    @Id
+    private Long id;
+
+    private String name;
+
+    public Long getId() {
+
+        return id;
+    }
+
+    public void setId(Long id) {
+
+        this.id = id;
+    }
+
+    public String getName() {
+
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+}

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/advanced/fetchgroup/AdvancedFetchGroupJunitTest.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/advanced/fetchgroup/AdvancedFetchGroupJunitTest.java
@@ -10,6 +10,8 @@
  * Contributors:
  *     01/19/2010-2.1 Guy Pelletier 
  *       - 211322: Add fetch-group(s) support to the EclipseLink-ORM.XML Schema
+ *     01/15/2016-2.7 Mythily Parthasarathy
+ *       - 485984: Add test for retrieval of cached getReference within a txn
  ******************************************************************************/  
 package org.eclipse.persistence.testing.tests.jpa.advanced.fetchgroup;
 
@@ -25,6 +27,8 @@ import org.eclipse.persistence.config.QueryHints;
 
 import org.eclipse.persistence.descriptors.ClassDescriptor;
 import org.eclipse.persistence.descriptors.FetchGroupManager;
+import org.eclipse.persistence.internal.jpa.EntityManagerImpl;
+import org.eclipse.persistence.sessions.UnitOfWork;
 import org.eclipse.persistence.testing.framework.junit.JUnitTestCase;
 
 import org.eclipse.persistence.testing.models.jpa.advanced.fetchgroup.AdvancedFetchGroupTableCreator;
@@ -32,6 +36,7 @@ import org.eclipse.persistence.testing.models.jpa.advanced.fetchgroup.ChestProte
 import org.eclipse.persistence.testing.models.jpa.advanced.fetchgroup.Helmet;
 import org.eclipse.persistence.testing.models.jpa.advanced.fetchgroup.HockeyGear;
 import org.eclipse.persistence.testing.models.jpa.advanced.fetchgroup.Pads;
+import org.eclipse.persistence.testing.models.jpa.advanced.fetchgroup.Shelf;
 import org.eclipse.persistence.testing.models.jpa.advanced.fetchgroup.GoalieGear.AgeGroup;
 
 public class AdvancedFetchGroupJunitTest extends JUnitTestCase { 
@@ -62,6 +67,8 @@ public class AdvancedFetchGroupJunitTest extends JUnitTestCase {
         suite.addTest(new AdvancedFetchGroupJunitTest("testFetchGroupOnPadsFromInheritanceParent"));
         // Bug 434120
         suite.addTest(new AdvancedFetchGroupJunitTest("testFetchGroupMergeMapAttribute"));
+        // Bug 485984
+        suite.addTest(new AdvancedFetchGroupJunitTest("testFetchGroupForCachedReference"));
         
         return suite;
     }
@@ -250,6 +257,66 @@ public class AdvancedFetchGroupJunitTest extends JUnitTestCase {
             commitTransaction(em);
             closeEntityManager(em);
         }
+    }
+
+    public void testFetchGroupForCachedReference() {
+        if (isWeavingEnabled()) {
+            EntityManager em = createEntityManager();
+            beginTransaction(em);
+
+            Shelf original = new Shelf();
+            original.setId(1L);
+            original.setName("original");
+            em.persist(original);
+
+            Shelf modified = new Shelf();
+            modified.setId(2L);
+            modified.setName("modified");
+            em.persist(modified);
+
+            Helmet helmet = new Helmet();
+            helmet.setId(3);
+            helmet.setShelf(original);
+            em.persist(helmet);
+
+            commitTransaction(em);
+            em.close();
+            clearCache();
+
+            em = createEntityManager();
+            //Create a changeset to ensure that the getReference() result is pushed to cache
+            UnitOfWork uw = UnitOfWork.class.cast(((EntityManagerImpl)em.getDelegate()).getActiveSession());
+            uw.beginEarlyTransaction();
+            helmet = em.find(Helmet.class,  helmet.getId());
+            modified = em.getReference(Shelf.class, modified.getId());
+            helmet.setShelf(modified);
+
+            uw.commit();
+            em.close();
+
+            try {
+                em = createEntityManager();
+                uw = UnitOfWork.class.cast(((EntityManagerImpl) em.getDelegate()).getActiveSession());
+                uw.beginEarlyTransaction();
+                modified = em.find(Shelf.class, modified.getId());
+                if (modified.getName() == null) {
+                    fail("find returned entity with missing attribute");
+                }
+            } finally {
+                uw.commit();
+                clearCache();
+                beginTransaction(em);
+                helmet = em.find(Helmet.class,  helmet.getId());
+                em.remove(helmet);
+                modified = em.find(Shelf.class,  modified.getId());
+                em.remove(modified);
+                original = em.find(Shelf.class,  original.getId());
+                em.remove(original);
+                commitTransaction(em);
+                closeEntityManager(em);
+            }
+        }
+
     }
     
     protected void verifyFetchedField(Field field, Object obj, Object value) {

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/advanced/fetchgroup/AdvancedFetchGroupJunitTest.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/advanced/fetchgroup/AdvancedFetchGroupJunitTest.java
@@ -28,6 +28,7 @@ import org.eclipse.persistence.config.QueryHints;
 import org.eclipse.persistence.descriptors.ClassDescriptor;
 import org.eclipse.persistence.descriptors.FetchGroupManager;
 import org.eclipse.persistence.internal.jpa.EntityManagerImpl;
+import org.eclipse.persistence.internal.sessions.UnitOfWorkImpl;
 import org.eclipse.persistence.sessions.UnitOfWork;
 import org.eclipse.persistence.testing.framework.junit.JUnitTestCase;
 
@@ -280,31 +281,32 @@ public class AdvancedFetchGroupJunitTest extends JUnitTestCase {
             em.persist(helmet);
 
             commitTransaction(em);
-            em.close();
+            closeEntityManager(em);
             clearCache();
 
             em = createEntityManager();
             //Create a changeset to ensure that the getReference() result is pushed to cache
-            UnitOfWork uw = UnitOfWork.class.cast(((EntityManagerImpl)em.getDelegate()).getActiveSession());
-            uw.beginEarlyTransaction();
+            beginTransaction(em);
+            em.unwrap(UnitOfWorkImpl.class).beginEarlyTransaction();
             helmet = em.find(Helmet.class,  helmet.getId());
             modified = em.getReference(Shelf.class, modified.getId());
             helmet.setShelf(modified);
 
-            uw.commit();
-            em.close();
+            commitTransaction(em);
+            closeEntityManager(em);
 
             try {
                 em = createEntityManager();
-                uw = UnitOfWork.class.cast(((EntityManagerImpl) em.getDelegate()).getActiveSession());
-                uw.beginEarlyTransaction();
+                beginTransaction(em);
+                em.unwrap(UnitOfWorkImpl.class).beginEarlyTransaction();
                 modified = em.find(Shelf.class, modified.getId());
                 if (modified.getName() == null) {
                     fail("find returned entity with missing attribute");
                 }
             } finally {
-                uw.commit();
-                clearCache();
+                if (isTransactionActive(em)){
+                    rollbackTransaction(em); 
+                }
                 beginTransaction(em);
                 helmet = em.find(Helmet.class,  helmet.getId());
                 em.remove(helmet);


### PR DESCRIPTION
Backport of https://bugs.eclipse.org/bugs/show_bug.cgi?id=485984 to 2.6_WAS