### PR TITLE
[master] Eclipselink 3.0 did not update ASM8 keyword to ASM9 in ClassWeaver and MethodWeaver: #1225

### DIFF
--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/weaving/ClassWeaver.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/weaving/ClassWeaver.java
@@ -215,7 +215,7 @@ public class ClassWeaver extends ClassVisitor implements Opcodes {
     }
 
     public ClassWeaver(ClassVisitor classWriter, ClassDetails classDetails) {
-        super(ASM8, classWriter);
+        super(ASM9, classWriter);
         this.classDetails = classDetails;
     }
 

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/weaving/MethodWeaver.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/weaving/MethodWeaver.java
@@ -44,7 +44,7 @@ public class MethodWeaver extends MethodVisitor implements Opcodes {
     protected boolean methodStarted = false;
 
     public MethodWeaver(ClassWeaver tcw, String methodName, String methodDescriptor, MethodVisitor mv) {
-        super(ASM8, mv);
+        super(ASM9, mv);
         this.tcw = tcw;
         this.methodName = methodName;
         this.methodDescriptor = methodDescriptor;


### PR DESCRIPTION
PR to change the ASM8 reference to ASM9 in ClassWeaver and MethodWeaver