### PR TITLE
[master] Minor JSE test failure fixes

### DIFF
--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/returninsert/TestReturnInsert.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/returninsert/TestReturnInsert.java
@@ -14,7 +14,8 @@
 //     Oracle - initial API and implementation
 package org.eclipse.persistence.jpa.returninsert;
 
-import java.time.Instant;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import jakarta.persistence.EntityManager;
@@ -305,7 +306,11 @@ public class TestReturnInsert {
     //Prepare primary key for ReturnInsertMaster
     private ReturnInsertMasterPK createReturnInsertMasterPK() {
         ReturnInsertMasterPK ReturnInsertMasterPK = new ReturnInsertMasterPK();
-        ReturnInsertMasterPK.setId(Date.from(Instant.ofEpochMilli(0)));
+        try {
+            DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S");
+            Date date = dateFormat.parse("1970-01-01 00:00:00.0");
+            ReturnInsertMasterPK.setId(date);
+        } catch (Exception e) { }
         ReturnInsertMasterPK.setCol1(1L);
         return ReturnInsertMasterPK;
     }
@@ -339,7 +344,11 @@ public class TestReturnInsert {
     //Prepare primary key for ReturnInsertDetail
     private ReturnInsertDetailPK createReturnInsertDetailPK() {
         ReturnInsertDetailPK returnInsertDetailPK = new ReturnInsertDetailPK();
-        returnInsertDetailPK.setId(Date.from(Instant.ofEpochMilli(0)));
+        try {
+            DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S");
+            Date date = dateFormat.parse("1970-01-01 00:00:00.0");
+            returnInsertDetailPK.setId(date);
+        } catch (Exception e) { }
         returnInsertDetailPK.setCol1(1L);
         returnInsertDetailPK.setCol2("abc");
         return returnInsertDetailPK;

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/cachedeadlock/CacheDeadLockDetectionTest.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/cachedeadlock/CacheDeadLockDetectionTest.java
@@ -128,8 +128,8 @@ public class CacheDeadLockDetectionTest {
             } catch (Exception ignore) {
             }
             try {
-                session.executeNonSelectingSQL("CREATE TABLE cachedeadlock_master (id integer PRIMARY KEY, name varchar(200))");
-                session.executeNonSelectingSQL("CREATE TABLE cachedeadlock_detail (id integer PRIMARY KEY, id_fk integer , name varchar(200))");
+                session.executeNonSelectingSQL("CREATE TABLE cachedeadlock_master (id integer NOT NULL, name varchar(200), PRIMARY KEY(id))");
+                session.executeNonSelectingSQL("CREATE TABLE cachedeadlock_detail (id integer NOT NULL, id_fk integer , name varchar(200), PRIMARY KEY(id))");
                 session.executeNonSelectingSQL("ALTER TABLE cachedeadlock_detail ADD CONSTRAINT fk_cachedeadlock_detail FOREIGN KEY ( id_fk ) REFERENCES cachedeadlock_master (ID)");
             } catch (Exception ignore) {
             }

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/conversion/TestJavaTimeTypeConverter.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/conversion/TestJavaTimeTypeConverter.java
@@ -17,6 +17,9 @@
 
 package org.eclipse.persistence.jpa.test.conversion;
 
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -26,8 +29,6 @@ import java.time.OffsetTime;
 import java.time.ZoneOffset;
 import java.util.Calendar;
 import java.util.Date;
-
-import java.util.TimeZone;
 
 import org.eclipse.persistence.exceptions.ConversionException;
 import org.eclipse.persistence.internal.helper.ClassConstants;
@@ -63,24 +64,21 @@ public class TestJavaTimeTypeConverter {
         Assert.assertEquals(1, ld.getDayOfMonth());
         Assert.assertEquals(2020,  ld.getYear());
     }
-    
-    @Test
-    public void timeConvertUtilDateToLocalDate() {
-        Calendar cal = Calendar.getInstance();
 
-        cal.setTimeZone(TimeZone.getTimeZone("UTC"));
-        cal.set(2020, 0, 1, 0, 0, 0);
-        Date date = cal.getTime();
+    @Test
+    public void timeConvertUtilDateToLocalDate() throws ParseException {
+        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+        Date date = dateFormat.parse("2020-01-01 24:00:00.000");
         Assert.assertEquals(2020 - 1900, date.getYear());
         Assert.assertEquals(0, date.getMonth());
-        Assert.assertEquals(1, date.getDate());
+        Assert.assertEquals(2, date.getDate());
 
         LocalDate ld = (LocalDate) cm.convertObject(date, ClassConstants.TIME_LDATE);
 
         Assert.assertNotNull(ld);
-        Assert.assertEquals(Month.JANUARY, ld.getMonth());
-        Assert.assertEquals(1, ld.getDayOfMonth());
         Assert.assertEquals(2020, ld.getYear());
+        Assert.assertEquals(Month.JANUARY, ld.getMonth());
+        Assert.assertEquals(2, ld.getDayOfMonth());
     }
 
     @Test

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/criteria/TestCoalesceFunction.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/criteria/TestCoalesceFunction.java
@@ -177,7 +177,7 @@ public class TestCoalesceFunction {
 
             Subquery<Date> countQuery = criteriaQuery.subquery(Date.class);
             Root<CoalesceEntity> countRoot = countQuery.from(CoalesceEntity.class);
-            countQuery.select(countRoot.get(CoalesceEntity_.date));
+            countQuery.select(countRoot.get(CoalesceEntity_.dateValue));
 
             // Pass the literal value directly
             Expression<Date> coalesceExp = builder.coalesce(countQuery, new Date());
@@ -206,7 +206,7 @@ public class TestCoalesceFunction {
 
             Subquery<Date> countQuery = criteriaQuery.subquery(Date.class);
             Root<CoalesceEntity> countRoot = countQuery.from(CoalesceEntity.class);
-            countQuery.select(countRoot.get(CoalesceEntity_.date));
+            countQuery.select(countRoot.get(CoalesceEntity_.dateValue));
 
             // create a ConstantExpression from the literal value
             Expression<Date> coalesceExp = builder.coalesce(countQuery, builder.literal(new Date()));

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/criteria/model/CoalesceEntity.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/criteria/model/CoalesceEntity.java
@@ -28,5 +28,5 @@ public class CoalesceEntity {
     private java.math.BigDecimal bigDecimal;
 
     @Temporal(TemporalType.DATE)
-    private java.util.Date date;
+    private java.util.Date dateValue;
 }

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/criteria/model/CoalesceEntity_.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/criteria/model/CoalesceEntity_.java
@@ -20,5 +20,5 @@ public class CoalesceEntity_ {
     public static volatile SingularAttribute<CoalesceEntity, Integer> id;
     public static volatile SingularAttribute<CoalesceEntity, String> description;
     public static volatile SingularAttribute<CoalesceEntity, java.math.BigDecimal> bigDecimal;
-    public static volatile SingularAttribute<CoalesceEntity, java.util.Date> date;
+    public static volatile SingularAttribute<CoalesceEntity, java.util.Date> dateValue;
 }

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/TestQueryHints.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/TestQueryHints.java
@@ -41,7 +41,6 @@ import org.eclipse.persistence.jpa.test.framework.DDLGen;
 import org.eclipse.persistence.jpa.test.framework.Emf;
 import org.eclipse.persistence.jpa.test.framework.EmfRunner;
 import org.eclipse.persistence.jpa.test.framework.PUPropertiesProvider;
-import org.eclipse.persistence.jpa.test.query.TestQueryProperties.PreparedStatementInvocationHandler;
 import org.eclipse.persistence.jpa.test.query.model.QueryEmployee;
 import org.eclipse.persistence.queries.ScrollableCursor;
 import org.eclipse.persistence.sessions.Connector;


### PR DESCRIPTION
1. CacheDeadLockDetectionTest - Failing on DB2
```
Internal Exception: com.ibm.db2.jcc.am.SqlSyntaxErrorException: DB2 SQL Error: SQLCODE=-542, SQLSTATE=42831, SQLERRMC=ID, DRIVER=3.72.24
Error Code: -542
Call: CREATE TABLE cachedeadlock_master (id integer PRIMARY KEY, name varchar(200))
```
This failure is because DB2 expects the "NOT NULL" clause for PRIMARY KEY columns: https://www.ibm.com/docs/en/db2-for-zos/11?topic=codes-542 

2. TestJavaTimeTypeConverter.timeConvertUtilDateToLocalDate - Failing depending on the JDK locale
```
<failure message="expected: '120' but was: '119'" type="junit.framework.AssertionFailedError">junit.framework.AssertionFailedError: expected: '120' but was: '119'
	at org.eclipse.persistence.jpa.test.conversion.TestJavaTimeTypeConverter.timeConvertUtilDateToLocalDate(TestJavaTimeTypeConverter.java:77)
	at org.eclipse.persistence.jpa.test.framework.EmfRunner.run(EmfRunner.java:43)
</failure>
```
What's happening here is that the `java.util.Calendar` is set to `Jan 1, 2020 00:00:00 UTC`, but when `java.util.Calendar.getTime()` is called, it creates a `java.util.Date` object. However, `java.util.Date` has no timezone, so it must be converted.

UTC (0000) gets translated into CST (1800); which is the local timezone for my JDK. But UTC (0000) is 6 hours ahead of CST, its really CST = ( Jan 1, 2020 00:00:00 UTC - 6 ) hours, making it Dec 31, 2019 18:00:00 CST. This conversion to causing the test to fail depending on the JDK locale the test is being run in.

3. TestCoalesceFunction - Failing on Oracle
```
    java.sql.SQLSyntaxErrorException: ORA-00904: : invalid identifier
Error Code: 904
Call: CREATE TABLE COALESCEENTITY (ID NUMBER(10) NOT NULL, BIGDECIMAL NUMBER(38) NULL, DATE DATE NULL, DESCRIPTION VARCHAR2(255) NULL, PRIMARY KEY (ID))
```
Using an attribute name of "date" causes Oracle to fail using a reserved word

4. TestReturnInsert - Failing on Oracle
```
<failure message="expected: '1' but was: '31'" type="junit.framework.AssertionFailedError">junit.framework.AssertionFailedError: expected: '1' but was: '31'
	at org.eclipse.persistence.jpa.returninsert.TestReturnInsert.testCreate(TestReturnInsert.java:153)
	at org.eclipse.persistence.jpa.returninsert.TestReturnInsert.test(TestReturnInsert.java:60)
</failure>
```
This is failing similar to TestJavaTimeTypeConverter. The test is expecting the date value of 1 (Jan 01 1970), but is getting 31 (Dec 31 1969) because the local locale of CST (non-UTC 0)