### PR TITLE
[3.0] Minor JSE test failure fixes

### DIFF
--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/returninsert/TestReturnInsert.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/returninsert/TestReturnInsert.java
@@ -14,6 +14,8 @@
 //     Oracle - initial API and implementation
 package org.eclipse.persistence.jpa.returninsert;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.util.Date;
 
@@ -305,7 +307,11 @@ public class TestReturnInsert {
     //Prepare primary key for ReturnInsertMaster
     private ReturnInsertMasterPK createReturnInsertMasterPK() {
         ReturnInsertMasterPK ReturnInsertMasterPK = new ReturnInsertMasterPK();
-        ReturnInsertMasterPK.setId(Date.from(Instant.ofEpochMilli(0)));
+        try {
+            DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S");
+            Date date = dateFormat.parse("1970-01-01 00:00:00.0");
+            ReturnInsertMasterPK.setId(date);
+        } catch (Exception e) { }
         ReturnInsertMasterPK.setCol1(1L);
         return ReturnInsertMasterPK;
     }
@@ -339,7 +345,11 @@ public class TestReturnInsert {
     //Prepare primary key for ReturnInsertDetail
     private ReturnInsertDetailPK createReturnInsertDetailPK() {
         ReturnInsertDetailPK returnInsertDetailPK = new ReturnInsertDetailPK();
-        returnInsertDetailPK.setId(Date.from(Instant.ofEpochMilli(0)));
+        try {
+            DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S");
+            Date date = dateFormat.parse("1970-01-01 00:00:00.0");
+            returnInsertDetailPK.setId(date);
+        } catch (Exception e) { }
         returnInsertDetailPK.setCol1(1L);
         returnInsertDetailPK.setCol2("abc");
         return returnInsertDetailPK;

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/cachedeadlock/CacheDeadLockDetectionTest.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/cachedeadlock/CacheDeadLockDetectionTest.java
@@ -128,8 +128,8 @@ public class CacheDeadLockDetectionTest {
             } catch (Exception ignore) {
             }
             try {
-                session.executeNonSelectingSQL("CREATE TABLE cachedeadlock_master (id integer PRIMARY KEY, name varchar(200))");
-                session.executeNonSelectingSQL("CREATE TABLE cachedeadlock_detail (id integer PRIMARY KEY, id_fk integer , name varchar(200))");
+                session.executeNonSelectingSQL("CREATE TABLE cachedeadlock_master (id integer NOT NULL, name varchar(200), PRIMARY KEY(id))");
+                session.executeNonSelectingSQL("CREATE TABLE cachedeadlock_detail (id integer NOT NULL, id_fk integer , name varchar(200), PRIMARY KEY(id))");
                 session.executeNonSelectingSQL("ALTER TABLE cachedeadlock_detail ADD CONSTRAINT fk_cachedeadlock_detail FOREIGN KEY ( id_fk ) REFERENCES cachedeadlock_master (ID)");
             } catch (Exception ignore) {
             }

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/conversion/TestJavaTimeTypeConverter.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/conversion/TestJavaTimeTypeConverter.java
@@ -17,6 +17,9 @@
 
 package org.eclipse.persistence.jpa.test.conversion;
 
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -26,8 +29,6 @@ import java.time.OffsetTime;
 import java.time.ZoneOffset;
 import java.util.Calendar;
 import java.util.Date;
-
-import java.util.TimeZone;
 
 import org.eclipse.persistence.exceptions.ConversionException;
 import org.eclipse.persistence.internal.helper.ClassConstants;
@@ -63,24 +64,21 @@ public class TestJavaTimeTypeConverter {
         Assert.assertEquals(1, ld.getDayOfMonth());
         Assert.assertEquals(2020,  ld.getYear());
     }
-    
-    @Test
-    public void timeConvertUtilDateToLocalDate() {
-        Calendar cal = Calendar.getInstance();
 
-        cal.setTimeZone(TimeZone.getTimeZone("UTC"));
-        cal.set(2020, 0, 1, 0, 0, 0);
-        Date date = cal.getTime();
+    @Test
+    public void timeConvertUtilDateToLocalDate() throws ParseException {
+        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+        Date date = dateFormat.parse("2020-01-01 24:00:00.000");
         Assert.assertEquals(2020 - 1900, date.getYear());
         Assert.assertEquals(0, date.getMonth());
-        Assert.assertEquals(1, date.getDate());
+        Assert.assertEquals(2, date.getDate());
 
         LocalDate ld = (LocalDate) cm.convertObject(date, ClassConstants.TIME_LDATE);
 
         Assert.assertNotNull(ld);
-        Assert.assertEquals(Month.JANUARY, ld.getMonth());
-        Assert.assertEquals(1, ld.getDayOfMonth());
         Assert.assertEquals(2020, ld.getYear());
+        Assert.assertEquals(Month.JANUARY, ld.getMonth());
+        Assert.assertEquals(2, ld.getDayOfMonth());
     }
 
     @Test

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/criteria/TestCoalesceFunction.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/criteria/TestCoalesceFunction.java
@@ -177,7 +177,7 @@ public class TestCoalesceFunction {
 
             Subquery<Date> countQuery = criteriaQuery.subquery(Date.class);
             Root<CoalesceEntity> countRoot = countQuery.from(CoalesceEntity.class);
-            countQuery.select(countRoot.get(CoalesceEntity_.date));
+            countQuery.select(countRoot.get(CoalesceEntity_.dateValue));
 
             // Pass the literal value directly
             Expression<Date> coalesceExp = builder.coalesce(countQuery, new Date());
@@ -206,7 +206,7 @@ public class TestCoalesceFunction {
 
             Subquery<Date> countQuery = criteriaQuery.subquery(Date.class);
             Root<CoalesceEntity> countRoot = countQuery.from(CoalesceEntity.class);
-            countQuery.select(countRoot.get(CoalesceEntity_.date));
+            countQuery.select(countRoot.get(CoalesceEntity_.dateValue));
 
             // create a ConstantExpression from the literal value
             Expression<Date> coalesceExp = builder.coalesce(countQuery, builder.literal(new Date()));

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/criteria/model/CoalesceEntity.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/criteria/model/CoalesceEntity.java
@@ -28,5 +28,5 @@ public class CoalesceEntity {
     private java.math.BigDecimal bigDecimal;
 
     @Temporal(TemporalType.DATE)
-    private java.util.Date date;
+    private java.util.Date dateValue;
 }

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/criteria/model/CoalesceEntity_.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/criteria/model/CoalesceEntity_.java
@@ -20,5 +20,5 @@ public class CoalesceEntity_ {
     public static volatile SingularAttribute<CoalesceEntity, Integer> id;
     public static volatile SingularAttribute<CoalesceEntity, String> description;
     public static volatile SingularAttribute<CoalesceEntity, java.math.BigDecimal> bigDecimal;
-    public static volatile SingularAttribute<CoalesceEntity, java.util.Date> date;
+    public static volatile SingularAttribute<CoalesceEntity, java.util.Date> dateValue;
 }

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/TestQueryHints.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/TestQueryHints.java
@@ -41,7 +41,6 @@ import org.eclipse.persistence.jpa.test.framework.DDLGen;
 import org.eclipse.persistence.jpa.test.framework.Emf;
 import org.eclipse.persistence.jpa.test.framework.EmfRunner;
 import org.eclipse.persistence.jpa.test.framework.PUPropertiesProvider;
-import org.eclipse.persistence.jpa.test.query.TestQueryProperties.PreparedStatementInvocationHandler;
 import org.eclipse.persistence.jpa.test.query.model.QueryEmployee;
 import org.eclipse.persistence.queries.ScrollableCursor;
 import org.eclipse.persistence.sessions.Connector;


### PR DESCRIPTION
5. TestQueryProperties / TestQueryHints - Failing on Oracle
```
Caused by: java.sql.SQLSyntaxErrorException: ORA-00955: name is already used by an existing object
	at oracle.jdbc.driver.T4CTTIoer.processError(T4CTTIoer.java:447)
	at oracle.jdbc.driver.T4CTTIoer.processError(T4CTTIoer.java:396)
	at oracle.jdbc.driver.T4C8Oall.processError(T4C8Oall.java:951)
```
Failing because drop/create was not used for all EMFs. Not sure why Oracle specifically had issues with this an no other database...

6. TestConvertResultToBoolean - Failing on DB2 & Oracle
On Oracle, the return type is BigDecimal and on DB2/Derby, the return type is Integer.

Signed-off-by: Will Dazey <dazeydev.3@gmail.com>