### PR TITLE
[2.6_WAS] Minor JSE test failure fixes

### DIFF
--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/criteria/TestCoalesceFunction.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/criteria/TestCoalesceFunction.java
@@ -177,7 +177,7 @@ public class TestCoalesceFunction {
 
             Subquery<Date> countQuery = criteriaQuery.subquery(Date.class);
             Root<CoalesceEntity> countRoot = countQuery.from(CoalesceEntity.class);
-            countQuery.select(countRoot.get(CoalesceEntity_.date));
+            countQuery.select(countRoot.get(CoalesceEntity_.dateValue));
 
             // Pass the literal value directly
             Expression<Date> coalesceExp = builder.coalesce(countQuery, new Date());
@@ -206,7 +206,7 @@ public class TestCoalesceFunction {
 
             Subquery<Date> countQuery = criteriaQuery.subquery(Date.class);
             Root<CoalesceEntity> countRoot = countQuery.from(CoalesceEntity.class);
-            countQuery.select(countRoot.get(CoalesceEntity_.date));
+            countQuery.select(countRoot.get(CoalesceEntity_.dateValue));
 
             // create a ConstantExpression from the literal value
             Expression<Date> coalesceExp = builder.coalesce(countQuery, builder.literal(new Date()));

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/criteria/model/CoalesceEntity.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/criteria/model/CoalesceEntity.java
@@ -28,5 +28,5 @@ public class CoalesceEntity {
     private java.math.BigDecimal bigDecimal;
 
     @Temporal(TemporalType.DATE)
-    private java.util.Date date;
+    private java.util.Date dateValue;
 }

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/criteria/model/CoalesceEntity_.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/criteria/model/CoalesceEntity_.java
@@ -20,5 +20,5 @@ public class CoalesceEntity_ {
     public static volatile SingularAttribute<CoalesceEntity, Integer> id;
     public static volatile SingularAttribute<CoalesceEntity, String> description;
     public static volatile SingularAttribute<CoalesceEntity, java.math.BigDecimal> bigDecimal;
-    public static volatile SingularAttribute<CoalesceEntity, java.util.Date> date;
+    public static volatile SingularAttribute<CoalesceEntity, java.util.Date> dateValue;
 }

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/property/TestConvertResultToBoolean.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/property/TestConvertResultToBoolean.java
@@ -19,11 +19,13 @@ import javax.persistence.EntityManagerFactory;
 import javax.persistence.Query;
 
 import org.eclipse.persistence.config.PersistenceUnitProperties;
+import org.eclipse.persistence.internal.jpa.EntityManagerFactoryImpl;
 import org.eclipse.persistence.jpa.test.framework.DDLGen;
 import org.eclipse.persistence.jpa.test.framework.Emf;
 import org.eclipse.persistence.jpa.test.framework.EmfRunner;
 import org.eclipse.persistence.jpa.test.framework.Property;
 import org.eclipse.persistence.jpa.test.property.model.GenericEntity;
+import org.eclipse.persistence.platform.database.DatabasePlatform;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -65,8 +67,18 @@ public class TestConvertResultToBoolean {
             List<?> intList = query.getResultList();
             assertNotNull(intList);
             assertEquals(2, intList.size());
-            assertEquals(new Long(1), intList.get(0));
-            assertEquals(new Long(0), intList.get(1));
+
+            DatabasePlatform platform = getPlatform(emf);
+            if(platform.isDB2() || platform.isDerby()) {
+                assertEquals(new Integer(1), intList.get(0));
+                assertEquals(new Integer(0), intList.get(1));
+            } else if(platform.isOracle()) {
+                assertEquals(new java.math.BigDecimal(1), intList.get(0));
+                assertEquals(new java.math.BigDecimal(0), intList.get(1));
+            } else {
+                assertEquals(new Long(1), intList.get(0));
+                assertEquals(new Long(0), intList.get(1));
+            }
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -105,5 +117,9 @@ public class TestConvertResultToBoolean {
                 em.close();
             }
         }
+    }
+
+    private DatabasePlatform getPlatform(EntityManagerFactory emf) {
+        return ((EntityManagerFactoryImpl)emf).getServerSession().getPlatform();
     }
 }

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQueryHints.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQueryHints.java
@@ -38,7 +38,6 @@ import org.eclipse.persistence.jpa.test.framework.DDLGen;
 import org.eclipse.persistence.jpa.test.framework.Emf;
 import org.eclipse.persistence.jpa.test.framework.EmfRunner;
 import org.eclipse.persistence.jpa.test.framework.PUPropertiesProvider;
-import org.eclipse.persistence.jpa.test.query.TestQueryProperties.PreparedStatementInvocationHandler;
 import org.eclipse.persistence.jpa.test.query.model.QueryEmployee;
 import org.eclipse.persistence.queries.ScrollableCursor;
 import org.eclipse.persistence.sessions.Connector;

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQueryProperties.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQueryProperties.java
@@ -60,7 +60,7 @@ public class TestQueryProperties implements PUPropertiesProvider {
             @Property(name = PersistenceUnitProperties.QUERY_TIMEOUT_UNIT, value = "SECONDS") })
     private EntityManagerFactory emfTimeoutSeconds;
 
-    @Emf(name = "timeoutWithUnitMintuesEMF", classes = { QueryEmployee.class }, properties = { 
+    @Emf(name = "timeoutWithUnitMintuesEMF", classes = { QueryEmployee.class }, createTables = DDLGen.DROP_CREATE, properties = { 
             @Property(name = PersistenceUnitProperties.QUERY_TIMEOUT, value = "" + TestQueryProperties.propertyTimeout),
             @Property(name = PersistenceUnitProperties.QUERY_TIMEOUT_UNIT, value = "MINUTES") })
     private EntityManagerFactory emfTimeoutMinutes;


### PR DESCRIPTION
1. CacheDeadLockDetectionTest - Failing on DB2
```
Internal Exception: com.ibm.db2.jcc.am.SqlSyntaxErrorException: DB2 SQL Error: SQLCODE=-542, SQLSTATE=42831, SQLERRMC=ID, DRIVER=3.72.24
Error Code: -542
Call: CREATE TABLE cachedeadlock_master (id integer PRIMARY KEY, name varchar(200))
```
This failure is because DB2 expects the "NOT NULL" clause for PRIMARY KEY columns: https://www.ibm.com/docs/en/db2-for-zos/11?topic=codes-542 

2. TestJavaTimeTypeConverter.timeConvertUtilDateToLocalDate - Failing depending on the JDK locale
```
<failure message="expected: '120' but was: '119'" type="junit.framework.AssertionFailedError">junit.framework.AssertionFailedError: expected: '120' but was: '119'
	at org.eclipse.persistence.jpa.test.conversion.TestJavaTimeTypeConverter.timeConvertUtilDateToLocalDate(TestJavaTimeTypeConverter.java:77)
	at org.eclipse.persistence.jpa.test.framework.EmfRunner.run(EmfRunner.java:43)
</failure>
```
What's happening here is that the `java.util.Calendar` is set to `Jan 1, 2020 00:00:00 UTC`, but when `java.util.Calendar.getTime()` is called, it creates a `java.util.Date` object. However, `java.util.Date` has no timezone, so it must be converted.

UTC (0000) gets translated into CST (1800); which is the local timezone for my JDK. But UTC (0000) is 6 hours ahead of CST, its really CST = ( Jan 1, 2020 00:00:00 UTC - 6 ) hours, making it Dec 31, 2019 18:00:00 CST. This conversion to causing the test to fail depending on the JDK locale the test is being run in.

3. TestCoalesceFunction - Failing on Oracle
```
    java.sql.SQLSyntaxErrorException: ORA-00904: : invalid identifier
Error Code: 904
Call: CREATE TABLE COALESCEENTITY (ID NUMBER(10) NOT NULL, BIGDECIMAL NUMBER(38) NULL, DATE DATE NULL, DESCRIPTION VARCHAR2(255) NULL, PRIMARY KEY (ID))
```
Using an attribute name of "date" causes Oracle to fail using a reserved word

4. TestReturnInsert - Failing on Oracle
```
<failure message="expected: '1' but was: '31'" type="junit.framework.AssertionFailedError">junit.framework.AssertionFailedError: expected: '1' but was: '31'
	at org.eclipse.persistence.jpa.returninsert.TestReturnInsert.testCreate(TestReturnInsert.java:153)
	at org.eclipse.persistence.jpa.returninsert.TestReturnInsert.test(TestReturnInsert.java:60)
</failure>
```
This is failing similar to TestJavaTimeTypeConverter. The test is expecting the date value of 1 (Jan 01 1970), but is getting 31 (Dec 31 1969) because the local locale of CST (non-UTC 0)


6. TestQueryProperties / TestQueryHints - Failing on Oracle

Caused by: java.sql.SQLSyntaxErrorException: ORA-00955: name is already used by an existing object
	at oracle.jdbc.driver.T4CTTIoer.processError(T4CTTIoer.java:447)
	at oracle.jdbc.driver.T4CTTIoer.processError(T4CTTIoer.java:396)
	at oracle.jdbc.driver.T4C8Oall.processError(T4C8Oall.java:951)

Failing because drop/create was not used for all EMFs. Not sure why Oracle specifically had issues with this an no other database...

7. TestConvertResultToBoolean - Failing on DB2 & Oracle
    On Oracle, the return type is BigDecimal and on DB2/Derby, the return type is Integer.


Signed-off-by: Will Dazey <dazeydev.3@gmail.com>