### PR TITLE
[Master] Update Eclipselink to use Eclipselink*Visitor types

### DIFF
--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/accessors/objects/MetadataAsmFactory.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/accessors/objects/MetadataAsmFactory.java
@@ -38,11 +38,15 @@ import org.eclipse.persistence.internal.helper.Helper;
 import org.eclipse.persistence.internal.jpa.metadata.MetadataDescriptor;
 import org.eclipse.persistence.internal.jpa.metadata.MetadataLogger;
 import org.eclipse.persistence.internal.libraries.asm.AnnotationVisitor;
+import org.eclipse.persistence.internal.libraries.asm.EclipseLinkAnnotationVisitor;
 import org.eclipse.persistence.internal.libraries.asm.Attribute;
 import org.eclipse.persistence.internal.libraries.asm.ClassReader;
 import org.eclipse.persistence.internal.libraries.asm.ClassVisitor;
+import org.eclipse.persistence.internal.libraries.asm.EclipseLinkClassVisitor;
+import org.eclipse.persistence.internal.libraries.asm.EclipseLinkFieldVisitor;
 import org.eclipse.persistence.internal.libraries.asm.EclipseLinkClassReader;
 import org.eclipse.persistence.internal.libraries.asm.FieldVisitor;
+import org.eclipse.persistence.internal.libraries.asm.EclipseLinkMethodVisitor;
 import org.eclipse.persistence.internal.libraries.asm.MethodVisitor;
 import org.eclipse.persistence.internal.libraries.asm.Opcodes;
 import org.eclipse.persistence.internal.libraries.asm.Type;
@@ -239,14 +243,14 @@ public class MetadataAsmFactory extends MetadataFactory {
     /**
      * Walk the class byte codes and collect the class info.
      */
-    public class ClassMetadataVisitor extends ClassVisitor {
+    public class ClassMetadataVisitor extends EclipseLinkClassVisitor {
 
         private boolean isLazy;
         private boolean processedMemeber;
         private MetadataClass classMetadata;
 
         ClassMetadataVisitor(MetadataClass metadataClass, boolean isLazy) {
-            super(Opcodes.ASM9);
+            super();
             this.isLazy = isLazy;
             this.classMetadata = metadataClass;
         }
@@ -331,7 +335,7 @@ public class MetadataAsmFactory extends MetadataFactory {
      *
      * @see MetadataAnnotationArrayVisitor for population of array attributes
      */
-    class MetadataAnnotationVisitor extends AnnotationVisitor {
+    class MetadataAnnotationVisitor extends EclipseLinkAnnotationVisitor {
 
         /**
          * Element the annotation is being applied to. If this is null the
@@ -350,7 +354,7 @@ public class MetadataAsmFactory extends MetadataFactory {
         }
 
         MetadataAnnotationVisitor(MetadataAnnotatedElement element, String name, boolean isRegular) {
-            super(Opcodes.ASM9);
+            super();
             this.element = element;
             this.annotation = new MetadataAnnotation();
             this.annotation.setName(processDescription(name, false).get(0));
@@ -358,7 +362,7 @@ public class MetadataAsmFactory extends MetadataFactory {
         }
 
         public MetadataAnnotationVisitor(MetadataAnnotation annotation) {
-            super(Opcodes.ASM9);
+            super();
             this.annotation = annotation;
         }
 
@@ -401,7 +405,7 @@ public class MetadataAsmFactory extends MetadataFactory {
      * Specialized visitor to handle the population of arrays of annotation
      * values.
      */
-    class MetadataAnnotationArrayVisitor extends AnnotationVisitor {
+    class MetadataAnnotationArrayVisitor extends EclipseLinkAnnotationVisitor {
 
         private MetadataAnnotation annotation;
 
@@ -410,7 +414,7 @@ public class MetadataAsmFactory extends MetadataFactory {
         private List<Object> values;
 
         public MetadataAnnotationArrayVisitor(MetadataAnnotation annotation, String name) {
-            super(Opcodes.ASM9);
+            super();
             this.annotation = annotation;
             this.attributeName = name;
             this.values = new ArrayList<Object>();
@@ -444,12 +448,12 @@ public class MetadataAsmFactory extends MetadataFactory {
      * Factory for the creation of {@link MetadataField} handling basic type,
      * generics, and annotations.
      */
-    class MetadataFieldVisitor extends FieldVisitor {
+    class MetadataFieldVisitor extends EclipseLinkFieldVisitor {
 
         private MetadataField field;
 
         public MetadataFieldVisitor(MetadataClass classMetadata, int access, String name, String desc, String signature, Object value) {
-            super(Opcodes.ASM9);
+            super();
             this.field = new MetadataField(classMetadata);
             this.field.setModifiers(access);
             this.field.setName(name);
@@ -479,12 +483,12 @@ public class MetadataAsmFactory extends MetadataFactory {
      */
     // Note: Subclassed EmptyListener to minimize signature requirements for
     // ignored MethodVisitor API
-    class MetadataMethodVisitor extends MethodVisitor {
+    class MetadataMethodVisitor extends EclipseLinkMethodVisitor {
 
         private MetadataMethod method;
 
         public MetadataMethodVisitor(MetadataClass classMetadata, int access, String name, String desc, String signature, String[] exceptions) {
-            super(Opcodes.ASM9);
+            super();
             this.method = new MetadataMethod(MetadataAsmFactory.this, classMetadata);
 
             this.method.setName(name);

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/weaving/ClassWeaver.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/weaving/ClassWeaver.java
@@ -25,6 +25,7 @@ import java.util.Iterator;
 
 import org.eclipse.persistence.internal.helper.Helper;
 import org.eclipse.persistence.internal.libraries.asm.ClassVisitor;
+import org.eclipse.persistence.internal.libraries.asm.EclipseLinkClassVisitor;
 import org.eclipse.persistence.internal.libraries.asm.FieldVisitor;
 import org.eclipse.persistence.internal.libraries.asm.Label;
 import org.eclipse.persistence.internal.libraries.asm.MethodVisitor;
@@ -41,7 +42,7 @@ import org.eclipse.persistence.internal.libraries.asm.Type;
  * @see org.eclipse.persistence.internal.jpa.weaving.MethodWeaver
  */
 
-public class ClassWeaver extends ClassVisitor implements Opcodes {
+public class ClassWeaver extends EclipseLinkClassVisitor implements Opcodes {
 
     // PersistenceWeaved
     public static final String PERSISTENCE_WEAVED_SHORT_SIGNATURE = "org/eclipse/persistence/internal/weaving/PersistenceWeaved";
@@ -215,7 +216,7 @@ public class ClassWeaver extends ClassVisitor implements Opcodes {
     }
 
     public ClassWeaver(ClassVisitor classWriter, ClassDetails classDetails) {
-        super(ASM9, classWriter);
+        super(classWriter);
         this.classDetails = classDetails;
     }
 

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/weaving/ClassWeaver.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/weaving/ClassWeaver.java
@@ -215,7 +215,7 @@ public class ClassWeaver extends ClassVisitor implements Opcodes {
     }
 
     public ClassWeaver(ClassVisitor classWriter, ClassDetails classDetails) {
-        super(ASM8, classWriter);
+        super(ASM9, classWriter);
         this.classDetails = classDetails;
     }
 

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/weaving/MethodWeaver.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/weaving/MethodWeaver.java
@@ -20,6 +20,7 @@
 import org.eclipse.persistence.internal.descriptors.VirtualAttributeMethodInfo;
 import org.eclipse.persistence.internal.libraries.asm.Attribute;
 import org.eclipse.persistence.internal.libraries.asm.Label;
+import org.eclipse.persistence.internal.libraries.asm.EclipseLinkMethodVisitor;
 import org.eclipse.persistence.internal.libraries.asm.MethodVisitor;
 import org.eclipse.persistence.internal.libraries.asm.Opcodes;
 import org.eclipse.persistence.internal.libraries.asm.Type;
@@ -34,7 +35,7 @@ import org.eclipse.persistence.internal.libraries.asm.Type;
  *
  */
 
-public class MethodWeaver extends MethodVisitor implements Opcodes {
+public class MethodWeaver extends EclipseLinkMethodVisitor implements Opcodes {
 
     protected ClassWeaver tcw;
     protected String methodName;
@@ -44,7 +45,7 @@ public class MethodWeaver extends MethodVisitor implements Opcodes {
     protected boolean methodStarted = false;
 
     public MethodWeaver(ClassWeaver tcw, String methodName, String methodDescriptor, MethodVisitor mv) {
-        super(ASM9, mv);
+        super(mv);
         this.tcw = tcw;
         this.methodName = methodName;
         this.methodDescriptor = methodDescriptor;

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/weaving/MethodWeaver.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/weaving/MethodWeaver.java
@@ -44,7 +44,7 @@ public class MethodWeaver extends MethodVisitor implements Opcodes {
     protected boolean methodStarted = false;
 
     public MethodWeaver(ClassWeaver tcw, String methodName, String methodDescriptor, MethodVisitor mv) {
-        super(ASM8, mv);
+        super(ASM9, mv);
         this.tcw = tcw;
         this.methodName = methodName;
         this.methodDescriptor = methodDescriptor;

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
         <test.xml.parser>org.eclipse.persistence.platform.xml.jaxp.JAXPParser</test.xml.parser>
 
         <!--Eclipse Dependencies version-->
-        <eclipselink.asm.version>9.1.0</eclipselink.asm.version>
+        <eclipselink.asm.version>9.1.1</eclipselink.asm.version>
         <activation.version>2.0.1</activation.version>
         <annotation.version>2.0.0</annotation.version>
         <cdi.version>3.0.0</cdi.version>


### PR DESCRIPTION
Eclipselink*Visitor types have been added to the Eclipselink ASM project, which moves the use of the ASM# constants out of the Eclipselink project and into the Eclipselink ASM project.  This should make it easier to avoid missing updating all of the constants when moving up to new major versions of ASM.