### PR TITLE
[2.7] Update Eclipselink to use Eclipselink*Visitor types

### DIFF
--- a/buildsystem/compdeps/pom.xml
+++ b/buildsystem/compdeps/pom.xml
@@ -62,7 +62,7 @@
         <eclipse.drop>2018-12</eclipse.drop>
 
         <!-- DEPENDENCY Versions -->
-        <eclipselink.asm.version>9.1.0</eclipselink.asm.version>
+        <eclipselink.asm.version>9.1.1</eclipselink.asm.version>
         <!-- CQ #21139, 21140 -->
         <ch.qos.logback.version>1.2.3</ch.qos.logback.version>
         <com.sun.xml.bind.version>2.3.3</com.sun.xml.bind.version>

--- a/dbws/org.eclipse.persistence.dbws/META-INF/MANIFEST.MF
+++ b/dbws/org.eclipse.persistence.dbws/META-INF/MANIFEST.MF
@@ -26,7 +26,7 @@ Created-By: 1.6.0_21 (Sun Microsystems Inc.)
 Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version>=1.8))"
 HK2-Bundle-Name: org.eclipse.persistence:org.eclipse.persistence.dbws
 Require-Bundle: org.eclipse.persistence.core;bundle-version="2.7.10",
- org.eclipse.persistence.asm;bundle-version="9.1",
+ org.eclipse.persistence.asm;bundle-version="9.1.1",
  org.eclipse.persistence.jpa;bundle-version="2.7.10",
  org.eclipse.persistence.moxy;bundle-version="2.7.10"
 Bundle-Vendor: Eclipse.org - EclipseLink Project

--- a/foundation/org.eclipse.persistence.core/META-INF/MANIFEST.MF
+++ b/foundation/org.eclipse.persistence.core/META-INF/MANIFEST.MF
@@ -175,7 +175,7 @@ Bundle-ClassPath: .
 HK2-Bundle-Name: org.eclipse.persistence:org.eclipse.persistence.core
 Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version>=1.8))"
 Require-Bundle: org.eclipse.persistence.antlr;bundle-version="3.5.2";resolution:=optional,
- org.eclipse.persistence.asm;bundle-version="9.1";resolution:=optional
+ org.eclipse.persistence.asm;bundle-version="9.1.1";resolution:=optional
 Bundle-SymbolicName: org.eclipse.persistence.core
 Eclipse-ExtensibleAPI: true
 Bundle-Name: EclipseLink Core
@@ -223,7 +223,7 @@ Import-Package: javax.activation;resolution:=optional,
  javax.xml.xpath;resolution:=optional,
  org.eclipse.persistence.internal.libraries.antlr.runtime;resolution:=optional,
  org.eclipse.persistence.internal.libraries.antlr.runtime.tree;resolution:=optional,
- org.eclipse.persistence.internal.libraries.asm;version="9.1";resolution:=optional,
+ org.eclipse.persistence.internal.libraries.asm;version="9.1.1";resolution:=optional,
  org.eclipse.persistence.jpa.jpql;version="[2.1,3.0)";resolution:=optional,
  org.eclipse.persistence.jpa.jpql.parser;version="[2.1,3.0)";resolution:=optional,
  org.eclipse.persistence.jpa.jpql.utility;version="[2.1,3.0)";resolution:=optional,

--- a/jpa/org.eclipse.persistence.jpa/META-INF/MANIFEST.MF
+++ b/jpa/org.eclipse.persistence.jpa/META-INF/MANIFEST.MF
@@ -41,7 +41,7 @@ Created-By: 1.6.0_21 (Sun Microsystems Inc.)
 HK2-Bundle-Name: org.eclipse.persistence:org.eclipse.persistence.jpa
 Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version>=1.8))"
 Require-Bundle: org.eclipse.persistence.core;bundle-version="2.7.10";visibility:=reexport,
- org.eclipse.persistence.asm;bundle-version="9.1";resolution:=optional
+ org.eclipse.persistence.asm;bundle-version="9.1.1";resolution:=optional
 Bundle-Vendor: Eclipse.org - EclipseLink Project
 Bundle-Version: 2.7.10.qualifier
 Bundle-ManifestVersion: 2
@@ -83,8 +83,8 @@ Import-Package: javax.naming;resolution:=optional,
  org.eclipse.persistence.internal.indirection;version="2.7.10",
  org.eclipse.persistence.internal.jpa.parsing;version="2.7.10",
  org.eclipse.persistence.internal.jpa.parsing.jpql;version="2.7.10",
- org.eclipse.persistence.internal.libraries.asm;version="9.1",
- org.eclipse.persistence.internal.libraries.asm.commons;version="9.1",
+ org.eclipse.persistence.internal.libraries.asm;version="9.1.1",
+ org.eclipse.persistence.internal.libraries.asm.commons;version="9.1.1",
  org.eclipse.persistence.internal.localization;version="2.7.10",
  org.eclipse.persistence.internal.mappings.converters;version="2.7.10",
  org.eclipse.persistence.internal.queries;version="2.7.10",

--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/metadata/accessors/objects/MetadataAsmFactory.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/metadata/accessors/objects/MetadataAsmFactory.java
@@ -41,7 +41,11 @@ import org.eclipse.persistence.internal.libraries.asm.AnnotationVisitor;
 import org.eclipse.persistence.internal.libraries.asm.Attribute;
 import org.eclipse.persistence.internal.libraries.asm.ClassReader;
 import org.eclipse.persistence.internal.libraries.asm.ClassVisitor;
+import org.eclipse.persistence.internal.libraries.asm.EclipseLinkAnnotationVisitor;
 import org.eclipse.persistence.internal.libraries.asm.EclipseLinkClassReader;
+import org.eclipse.persistence.internal.libraries.asm.EclipseLinkClassVisitor;
+import org.eclipse.persistence.internal.libraries.asm.EclipseLinkFieldVisitor;
+import org.eclipse.persistence.internal.libraries.asm.EclipseLinkMethodVisitor;
 import org.eclipse.persistence.internal.libraries.asm.FieldVisitor;
 import org.eclipse.persistence.internal.libraries.asm.MethodVisitor;
 import org.eclipse.persistence.internal.libraries.asm.Opcodes;
@@ -240,14 +244,14 @@ public class MetadataAsmFactory extends MetadataFactory {
     /**
      * Walk the class byte codes and collect the class info.
      */
-    public class ClassMetadataVisitor extends ClassVisitor {
+    public class ClassMetadataVisitor extends EclipseLinkClassVisitor {
 
         private boolean isLazy;
         private boolean processedMemeber;
         private MetadataClass classMetadata;
 
         ClassMetadataVisitor(MetadataClass metadataClass, boolean isLazy) {
-            super(Opcodes.ASM9);
+            super();
             this.isLazy = isLazy;
             this.classMetadata = metadataClass;
         }
@@ -324,7 +328,7 @@ public class MetadataAsmFactory extends MetadataFactory {
      *
      * @see MetadataAnnotationArrayVisitor for population of array attributes
      */
-    class MetadataAnnotationVisitor extends AnnotationVisitor {
+    class MetadataAnnotationVisitor extends EclipseLinkAnnotationVisitor {
 
         /**
          * Element the annotation is being applied to. If this is null the
@@ -343,7 +347,7 @@ public class MetadataAsmFactory extends MetadataFactory {
         }
 
         MetadataAnnotationVisitor(MetadataAnnotatedElement element, String name, boolean isRegular) {
-            super(Opcodes.ASM9);
+            super();
             this.element = element;
             this.annotation = new MetadataAnnotation();
             this.annotation.setName(processDescription(name, false).get(0));
@@ -351,7 +355,7 @@ public class MetadataAsmFactory extends MetadataFactory {
         }
 
         public MetadataAnnotationVisitor(MetadataAnnotation annotation) {
-            super(Opcodes.ASM9);
+            super();
             this.annotation = annotation;
         }
 
@@ -394,7 +398,7 @@ public class MetadataAsmFactory extends MetadataFactory {
      * Specialized visitor to handle the population of arrays of annotation
      * values.
      */
-    class MetadataAnnotationArrayVisitor extends AnnotationVisitor {
+    class MetadataAnnotationArrayVisitor extends EclipseLinkAnnotationVisitor {
 
         private MetadataAnnotation annotation;
 
@@ -403,7 +407,7 @@ public class MetadataAsmFactory extends MetadataFactory {
         private List<Object> values;
 
         public MetadataAnnotationArrayVisitor(MetadataAnnotation annotation, String name) {
-            super(Opcodes.ASM9);
+            super();
             this.annotation = annotation;
             this.attributeName = name;
             this.values = new ArrayList<Object>();
@@ -437,12 +441,12 @@ public class MetadataAsmFactory extends MetadataFactory {
      * Factory for the creation of {@link MetadataField} handling basic type,
      * generics, and annotations.
      */
-    class MetadataFieldVisitor extends FieldVisitor {
+    class MetadataFieldVisitor extends EclipseLinkFieldVisitor {
 
         private MetadataField field;
 
         public MetadataFieldVisitor(MetadataClass classMetadata, int access, String name, String desc, String signature, Object value) {
-            super(Opcodes.ASM9);
+            super();
             this.field = new MetadataField(classMetadata);
             this.field.setModifiers(access);
             this.field.setName(name);
@@ -471,12 +475,12 @@ public class MetadataAsmFactory extends MetadataFactory {
      */
     // Note: Subclassed EmptyListener to minimize signature requirements for
     // ignored MethodVisitor API
-    class MetadataMethodVisitor extends MethodVisitor {
+    class MetadataMethodVisitor extends EclipseLinkMethodVisitor {
 
         private MetadataMethod method;
 
         public MetadataMethodVisitor(MetadataClass classMetadata, int access, String name, String desc, String signature, String[] exceptions) {
-            super(Opcodes.ASM9);
+            super();
             this.method = new MetadataMethod(MetadataAsmFactory.this, classMetadata);
 
             this.method.setName(name);

--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/weaving/ClassWeaver.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/weaving/ClassWeaver.java
@@ -25,6 +25,7 @@ import java.util.Iterator;
 
 import org.eclipse.persistence.internal.helper.Helper;
 import org.eclipse.persistence.internal.libraries.asm.ClassVisitor;
+import org.eclipse.persistence.internal.libraries.asm.EclipseLinkClassVisitor;
 import org.eclipse.persistence.internal.libraries.asm.FieldVisitor;
 import org.eclipse.persistence.internal.libraries.asm.Label;
 import org.eclipse.persistence.internal.libraries.asm.MethodVisitor;
@@ -41,7 +42,7 @@ import org.eclipse.persistence.internal.libraries.asm.Type;
  * @see org.eclipse.persistence.internal.jpa.weaving.MethodWeaver
  */
 
-public class ClassWeaver extends ClassVisitor implements Opcodes {
+public class ClassWeaver extends EclipseLinkClassVisitor implements Opcodes {
 
     // PersistenceWeaved
     public static final String PERSISTENCE_WEAVED_SHORT_SIGNATURE = "org/eclipse/persistence/internal/weaving/PersistenceWeaved";
@@ -207,7 +208,7 @@ public class ClassWeaver extends ClassVisitor implements Opcodes {
     }
 
     public ClassWeaver(ClassVisitor classWriter, ClassDetails classDetails) {
-        super(ASM9, classWriter);
+        super(classWriter);
         this.classDetails = classDetails;
     }
 

--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/weaving/MethodWeaver.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/weaving/MethodWeaver.java
@@ -19,6 +19,7 @@
 //ASM imports
 import org.eclipse.persistence.internal.descriptors.VirtualAttributeMethodInfo;
 import org.eclipse.persistence.internal.libraries.asm.Attribute;
+import org.eclipse.persistence.internal.libraries.asm.EclipseLinkMethodVisitor;
 import org.eclipse.persistence.internal.libraries.asm.Label;
 import org.eclipse.persistence.internal.libraries.asm.MethodVisitor;
 import org.eclipse.persistence.internal.libraries.asm.Opcodes;
@@ -34,7 +35,7 @@ import org.eclipse.persistence.internal.libraries.asm.Type;
  *
  */
 
-public class MethodWeaver extends MethodVisitor implements Opcodes {
+public class MethodWeaver extends EclipseLinkMethodVisitor implements Opcodes {
 
     protected ClassWeaver tcw;
     protected String methodName;
@@ -44,7 +45,7 @@ public class MethodWeaver extends MethodVisitor implements Opcodes {
     protected boolean methodStarted = false;
 
     public MethodWeaver(ClassWeaver tcw, String methodName, String methodDescriptor, MethodVisitor mv) {
-        super(ASM9, mv);
+        super(mv);
         this.tcw = tcw;
         this.methodName = methodName;
         this.methodDescriptor = methodDescriptor;

--- a/moxy/org.eclipse.persistence.moxy/META-INF/MANIFEST.MF
+++ b/moxy/org.eclipse.persistence.moxy/META-INF/MANIFEST.MF
@@ -16,7 +16,7 @@ Bundle-Name: EclipseLink MOXy
 Created-By: 1.6.0_21 (Sun Microsystems Inc.)
 HK2-Bundle-Name: org.eclipse.persistence:org.eclipse.persistence.moxy
 Require-Bundle: org.eclipse.persistence.core;bundle-version="2.7.10";visibility:=reexport,
- org.eclipse.persistence.asm;bundle-version="9.1";resolution:=optional
+ org.eclipse.persistence.asm;bundle-version="9.1.1";resolution:=optional
 Bundle-Vendor: Eclipse.org - EclipseLink Project
 Bundle-Version: 2.7.10.qualifier
 Bundle-ManifestVersion: 2
@@ -63,7 +63,7 @@ Import-Package: com.sun.xml.bind;resolution:=optional,
  org.eclipse.persistence.internal.databaseaccess;version="2.7.10",
  org.eclipse.persistence.internal.descriptors;version="2.7.10",
  org.eclipse.persistence.internal.helper;version="2.7.10",
- org.eclipse.persistence.internal.libraries.asm;version="9.1";resolution:=optional,
+ org.eclipse.persistence.internal.libraries.asm;version="9.1.1";resolution:=optional,
  org.eclipse.persistence.internal.localization;version="2.7.10",
  org.eclipse.persistence.internal.oxm;version="2.7.10",
  org.eclipse.persistence.internal.oxm.record;version="2.7.10",

--- a/sdo/org.eclipse.persistence.sdo/META-INF/MANIFEST.MF
+++ b/sdo/org.eclipse.persistence.sdo/META-INF/MANIFEST.MF
@@ -14,7 +14,7 @@ Created-By: 1.6.0_21 (Sun Microsystems Inc.)
 HK2-Bundle-Name: org.eclipse.persistence:org.eclipse.persistence.sdo
 Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version>=1.8))"
 Require-Bundle: org.eclipse.persistence.core;bundle-version="2.7.10";visibility:=reexport,
- org.eclipse.persistence.asm;bundle-version="9.1";resolution:=optional,
+ org.eclipse.persistence.asm;bundle-version="9.1.1";resolution:=optional,
  org.eclipse.persistence.moxy;bundle-version="2.7.10";resolution:=optional,
  commonj.sdo;bundle-version="2.1.1"
 Bundle-Vendor: Eclipse.org - EclipseLink Project
@@ -34,7 +34,7 @@ Import-Package: javax.management;resolution:=optional,
  org.eclipse.persistence.internal.databaseaccess;version="2.7.10",
  org.eclipse.persistence.internal.descriptors;version="2.7.10",
  org.eclipse.persistence.internal.helper;version="2.7.10",
- org.eclipse.persistence.internal.libraries.asm;version="9.1";resolution:=optional,
+ org.eclipse.persistence.internal.libraries.asm;version="9.1.1";resolution:=optional,
  org.eclipse.persistence.internal.localization;version="2.7.10",
  org.eclipse.persistence.internal.oxm;version="2.7.10",
  org.eclipse.persistence.internal.oxm.record;version="2.7.10",


### PR DESCRIPTION
Eclipselink*Visitor types have been added to the Eclipselink ASM project, which moves the use of the ASM# constants out of the Eclipselink project and into the Eclipselink ASM project. This should make it easier to avoid missing updating all of the constants when moving up to new major versions of ASM.

(Updating to use Eclipselink ASM 9.1.1)