### PR TITLE
[3.0] Jenkins release job fix

### DIFF
--- a/etc/jenkins/release.groovy
+++ b/etc/jenkins/release.groovy
@@ -133,11 +133,13 @@ spec:
         // Build and release EclipseLink by release.sh script
         stage('Build and release EclipseLink') {
             steps {
-                container('el-build') {
-                    git branch: GIT_BRANCH_RELEASE, credentialsId: SSH_CREDENTIALS_ID, url: GIT_REPOSITORY_URL
-                    sh """
-                        etc/jenkins/release.sh "${RELEASE_VERSION}" "${NEXT_VERSION}" "${DRY_RUN}" "${OVERWRITE_GIT}" "${OVERWRITE_STAGING}"
-                    """
+                git branch: GIT_BRANCH_RELEASE, credentialsId: SSH_CREDENTIALS_ID, url: GIT_REPOSITORY_URL
+                sshagent([SSH_CREDENTIALS_ID]) {
+                    container('el-build') {
+                        sh """
+                            etc/jenkins/release.sh "${RELEASE_VERSION}" "${NEXT_VERSION}" "${DRY_RUN}" "${OVERWRITE_GIT}" "${OVERWRITE_STAGING}"
+                        """
+                    }
                 }
             }
         }


### PR DESCRIPTION
This is fix for `git push` call, which failed with `git@github.com: Permission denied (publickey).` error message. It's related with some Eclipse-CI infrastructure security settings. `release.sh` script must be called within `el-build` container and this container is wrapped by `sshagent([SSH_CREDENTIALS_ID]) {`.
Opposite nesting `sshagent([SSH_CREDENTIALS_ID]) {` inside `container('el-build') {` instruction leads into error.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>