### PR TITLE
Bugno33036242

### DIFF
--- a/foundation/eclipselink.core.test/src/test/java/org/eclipse/persistence/testing/tests/junit/sessionsxml/SessionManagerTest.java
+++ b/foundation/eclipselink.core.test/src/test/java/org/eclipse/persistence/testing/tests/junit/sessionsxml/SessionManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,6 +14,9 @@
 //     Oracle - initial API and implementation from Oracle TopLink
 package org.eclipse.persistence.testing.tests.junit.sessionsxml;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintWriter;
+import java.io.Writer;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -183,6 +186,25 @@ public class SessionManagerTest {
             Assert.assertTrue("invalid excpetion type: " + t, t instanceof ServerPlatformException);
         } finally {
             Platform.forceNPE = false;
+        }
+    }
+
+    @Test
+    public void testDestroyManager() {
+        reinitManager(true, true);
+        SessionManager m1 = SessionManager.getManager();
+        SessionLog logger = (SessionLog) getField(SessionManager.class, "LOG", null);
+        Writer orig = logger.getWriter();
+        ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+        Writer newWriter = new PrintWriter(outStream);
+        logger.setWriter(newWriter);
+        m1.destroy();
+        SessionManager m2 = SessionManager.getManager();
+        m2.destroy();
+        logger.setWriter(orig);
+        String message = outStream.toString();
+        if(message != null && message.contains("No partition instance associated with current SessionManager instance")){
+            Assert.fail("Test failed due to warning message " + message);
         }
     }
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/factories/SessionManager.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/factories/SessionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -179,7 +179,7 @@ public class SessionManager {
      */
     public void destroy() {
         if (supportPartitions) {
-            if (managers.remove(getPartitionID()) == null) {
+            if (!managers.isEmpty() && managers.remove(getPartitionID()) == null) {
                 //should not happen
                 LOG.log(SessionLog.WARNING, "session_manager_no_partition", new Object[0]);
            }


### PR DESCRIPTION
During undeploy of the application the method org.eclipse.persistence.sessions.factories.SessionManager.destroy is being called and when managers object is empty then it is resulting into the following exception
java.lang.NoClassDefFoundError: ch/qos/logback/core/status/WarnStatus

So in the fix I have added the check for empty managers object

Added testcase at eclipselink/foundation/eclipselink.core.test/src/test/java/org/eclipse/persistence/testing/tests/junit/sessionsxml/SessionManagerTest.java