### PR TITLE
[3.0] Jenkins build fix to reflect/use JDK specified in the Jenkins pipeline

### DIFF
--- a/etc/jenkins/build.sh
+++ b/etc/jenkins/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -13,5 +13,4 @@
 #  N/A
 
 echo '-[ EclipseLink Build ]-----------------------------------------------------------'
-. /etc/profile
-mvn install -DskipTests -Poss-release
+mvn -V -B install -DskipTests -Poss-release

--- a/etc/jenkins/publish_snapshots.sh
+++ b/etc/jenkins/publish_snapshots.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -16,7 +16,6 @@ if [ ${CONTINUOUS_BUILD} = "true" ]; then
     echo '-[ EclipseLink Publish to Jakarta Snapshots -> No publishing any artifacts]-----------------------------------------------------------'
 else
     echo '-[ EclipseLink Publish to Jakarta Snapshots ]-----------------------------------------------------------'
-    . /etc/profile
     mvn --no-transfer-progress -U -C -B -V \
       -Psnapshots -DskipTests \
       -Ddoclint=none -Ddeploy \

--- a/etc/jenkins/release.sh
+++ b/etc/jenkins/release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -20,7 +20,6 @@ HELP_PLUGIN='org.apache.maven.plugins:maven-help-plugin:3.1.0'
 # $5 -  OVERWRITE_STAGING           - Allows to overwrite existing version in OSSRH (Jakarta) staging repositories
 
 echo '-[ EclipseLink Release ]-----------------------------------------------------------'
-. /etc/profile
 
 ECLIPSELINK_VERSION="${1}"
 NEXT_ECLIPSELINK_VERSION="${2}"

--- a/etc/jenkins/test.sh
+++ b/etc/jenkins/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -13,15 +13,14 @@
 #  N/A
 
 echo '-[ EclipseLink Tests LRG ]-----------------------------------------------------------'
-. /etc/profile
 
 if [ ${CONTINUOUS_BUILD} = "true" ]; then
     echo '-[ EclipseLink SRG Tests ]-----------------------------------------------------------'
-    mvn verify
+    mvn -B -V verify
 else
     echo '-[ EclipseLink LRG Tests ]-----------------------------------------------------------'
     /opt/bin/mysql-start.sh
-    mvn verify -Pmysql,test-lrg
+    mvn -B -V verify -Pmysql,test-lrg
     /opt/bin/mysql-stop.sh
 fi
 

--- a/etc/jenkins/test_nosql.sh
+++ b/etc/jenkins/test_nosql.sh
@@ -13,7 +13,6 @@
 #  N/A
 
 echo '-[ EclipseLink Test NoSQL ]-----------------------------------------------------------'
-. /etc/profile
 /opt/bin/mongo-start.sh
-mvn verify -pl :org.eclipse.persistence.nosql -P mongodb
+mvn -B -V verify -pl :org.eclipse.persistence.nosql -P mongodb
 /opt/bin/mongo-stop.sh

--- a/etc/jenkins/test_server.sh
+++ b/etc/jenkins/test_server.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -16,10 +16,9 @@ if [ ${CONTINUOUS_BUILD} = "true" ]; then
     echo '-[ EclipseLink Continuous Build -> No server tests]-------------------------------'
 else
     echo '-[ EclipseLink Test Server ]-----------------------------------------------------------'
-    . /etc/profile
     echo '-[ INFO Server tests are temporary disabled until server with Jakarta packages will be available]-'
 #    /opt/bin/mysql-start.sh
-#    mvn --batch-mode verify -pl :org.eclipse.persistence.jpa.test -P server-test-jpa-lrg1,mysql
-#    mvn --batch-mode verify -pl :org.eclipse.persistence.jpa.test -P server-test-jpa-lrg2,mysql
+#    mvn -B -V -pl :org.eclipse.persistence.jpa.test -P server-test-jpa-lrg1,mysql
+#    mvn -B -V verify -pl :org.eclipse.persistence.jpa.test -P server-test-jpa-lrg2,mysql
 #    /opt/bin/mysql-stop.sh
 fi


### PR DESCRIPTION
This fix removes `. /etc/profile` call from scripts called by various Jenkins pipelines.
In `. /etc/profile` was hardcoded JDK 8 so Jenkins build/test didn't reflect JDK settings from pipeline.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>