### PR TITLE
fix: NullPointerException at CacheIndexMetadata.getField()

### DIFF
--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/accessors/classes/MappedSuperclassAccessor.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/accessors/classes/MappedSuperclassAccessor.java
@@ -1002,6 +1002,10 @@ public class MappedSuperclassAccessor extends ClassAccessor {
      * Process cache index information for the given metadata descriptor.
      */
     protected void processCacheIndexes() {
+        for (CacheIndexMetadata indexMetadata : m_cacheIndexes) {
+            indexMetadata.setProject(getDescriptor().getProject());
+        }
+
         // TODO: This method is adding annotation metadata to XML metadata. This
         // is wrong and does not follow the spec ideology. XML metadata should
         // override not merge with annotations.


### PR DESCRIPTION
PROBLEM
=======
NullPointerException raising at CacheIndexMetadata.getField() while EntityManager initialising.

CAUSE
=======
Entity metadata XML file contains tag <cache-index><column-name>SOMENAME</column-name></cache-index>.
XML Deserializer call CacheIndexMetadata default constructor. ORMetadata.m_project field stay none initialised.
Call of CacheIndexMetadata.getField() throw to exception.

SOLVING
=======
Set ORMetadata.m_project value after XML deserialization.

Signed-off-by: Vladimir Ivanov <ivvlev@ivvlev.com>
[Eclipselink3_Bug_CacheMetaIndexNPE.zip](https://github.com/eclipse-ee4j/eclipselink/files/7135432/Eclipselink3_Bug_CacheMetaIndexNPE.zip)
