### PR TITLE
[3.0] Bugfix: java.util.ConcurrentModificationException at IdentityMa…

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/identitymaps/IdentityMapManager.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/identitymaps/IdentityMapManager.java
@@ -488,8 +488,11 @@ public class IdentityMapManager implements Serializable, Cloneable {
         }
         Set invalidations = this.queryResultsInvalidationsByClass.get(classThatChanged);
         if (invalidations != null) {
-            for (Object queryKey : invalidations) {
-                this.queryResults.remove(queryKey);
+            synchronized (this.queryResults) {
+                for (Object queryKey : invalidations) {
+                    this.queryResults.remove(queryKey);
+                }
+                invalidations.clear();
             }
         }
         Class superClass = classThatChanged.getSuperclass();


### PR DESCRIPTION
…pManager.invalidateQueryCache

PROBLEM
=======
ConcurrentModificationException raising while evicting shared caches.

CAUSE
=======
Set 'invalidations' is changing in while we iterate over it.

SOLVING
=======
Add thread synchronization

Signed-off-by: Vladimir Ivanov <ivvlev@ivvlev.com>