### PR TITLE
#1298: Rename org.eclipse.persistence.session.Record to avoid collision with java.lang.Record

### DIFF
--- a/dbws/org.eclipse.persistence.dbws/src/main/java/org/eclipse/persistence/dbws/DBWSModelProject.java
+++ b/dbws/org.eclipse.persistence.dbws/src/main/java/org/eclipse/persistence/dbws/DBWSModelProject.java
@@ -62,8 +62,8 @@ import org.eclipse.persistence.oxm.mappings.XMLCompositeObjectMapping;
 import org.eclipse.persistence.oxm.mappings.XMLDirectMapping;
 import org.eclipse.persistence.oxm.mappings.XMLTransformationMapping;
 import org.eclipse.persistence.oxm.record.UnmarshalRecord;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Project;
-import org.eclipse.persistence.sessions.Record;
 import org.eclipse.persistence.sessions.Session;
 import org.xml.sax.Attributes;
 
@@ -308,9 +308,9 @@ public class DBWSModelProject extends Project {
         descriptor.getInheritancePolicy().setClassIndicatorField(isColl);
         descriptor.getInheritancePolicy().setClassExtractor(new ClassExtractor() {
             @Override
-            public Class<?> extractClassFromRow(Record record, Session session) {
+            public Class<?> extractClassFromRow(DataRecord dataRecord, Session session) {
                 Class<?> clz = Result.class;
-                UnmarshalRecord uRecord = (UnmarshalRecord)record;
+                UnmarshalRecord uRecord = (UnmarshalRecord) dataRecord;
                 Attributes attrs = uRecord.getAttributes();
                 if (attrs != null) {
                     for (int i = 0, l = attrs.getLength(); i < l; i++) {

--- a/dbws/org.eclipse.persistence.dbws/src/main/java/org/eclipse/persistence/internal/xr/QNameTransformer.java
+++ b/dbws/org.eclipse.persistence.dbws/src/main/java/org/eclipse/persistence/internal/xr/QNameTransformer.java
@@ -78,7 +78,7 @@ import org.eclipse.persistence.mappings.transformers.FieldTransformer;
 import org.eclipse.persistence.oxm.NamespaceResolver;
 import org.eclipse.persistence.oxm.XMLDescriptor;
 import org.eclipse.persistence.oxm.record.XMLRecord;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 
 public class QNameTransformer implements AttributeTransformer, FieldTransformer {
@@ -131,11 +131,11 @@ public class QNameTransformer implements AttributeTransformer, FieldTransformer 
   }
 
   @Override
-  public Object buildAttributeValue(Record record, Object object, Session session) {
-      if (null == record) {
+  public Object buildAttributeValue(DataRecord dataRecord, Object object, Session session) {
+      if (null == dataRecord) {
           return null;
       }
-      String value = (String)record.get(xPath);
+      String value = (String) dataRecord.get(xPath);
       if (null == value) {
           return null;
       }
@@ -144,7 +144,7 @@ public class QNameTransformer implements AttributeTransformer, FieldTransformer 
       if (index > -1) {
           String prefix = value.substring(0, index);
           String localName = value.substring(index + 1);
-          String namespaceURI = ((XMLRecord)record).resolveNamespacePrefix(prefix);
+          String namespaceURI = ((XMLRecord) dataRecord).resolveNamespacePrefix(prefix);
           // check for W3C_XML_SCHEMA_NS_URI - return TL_OX pre-built QName's
           if (W3C_XML_SCHEMA_NS_URI.equals(namespaceURI)) {
               qName = SCHEMA_QNAMES.get(localName);
@@ -160,7 +160,7 @@ public class QNameTransformer implements AttributeTransformer, FieldTransformer 
           return qName;
       }
       else {
-          String namespaceURI = ((XMLRecord)record)
+          String namespaceURI = ((XMLRecord) dataRecord)
               .resolveNamespacePrefix(DEFAULT_NAMESPACE_PREFIX);
           qName = new QName(namespaceURI, value);
       }

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/models/aggregate/Job.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/models/aggregate/Job.java
@@ -75,7 +75,7 @@ public class Job {
      * @return java.sql.Time[]
      * @param row org.eclipse.persistence.sessions.DatabaseRecord
      */
-    public Time[] getNormalHoursFromRow(org.eclipse.persistence.sessions.Record row) {
+    public Time[] getNormalHoursFromRow(DataRecord row) {
         Time[] hours = new Time[2];
         hours[0] = (Time)row.get("START_TIME");
         hours[1] = (Time)row.get("END_TIME");

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/models/employee/domain/Employee.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/models/employee/domain/Employee.java
@@ -178,7 +178,7 @@ public class Employee implements org.eclipse.persistence.testing.models.employee
      * IMPORTANT: This method builds the value but does not set it.
      * The mapping will set it using method or direct access as defined in the descriptor.
      */
-    public Time[] buildNormalHours(org.eclipse.persistence.sessions.Record row, Session session) {
+    public Time[] buildNormalHours(DataRecord row, Session session) {
         Time[] hours = new Time[2];
 
         /** This conversion allows for the database type not to match, i.e. may be a Timestamp or String. */

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/models/events/AboutToInsertEventAdapter.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/models/events/AboutToInsertEventAdapter.java
@@ -16,7 +16,7 @@ package org.eclipse.persistence.testing.models.events;
 
 import org.eclipse.persistence.descriptors.DescriptorEvent;
 import org.eclipse.persistence.descriptors.DescriptorEventAdapter;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.testing.framework.TestErrorException;
 
 /**
@@ -45,7 +45,7 @@ public class AboutToInsertEventAdapter extends DescriptorEventAdapter {
  */
     @Override
     public void aboutToInsert(DescriptorEvent event) {
-        Record row = event.getRecord();
+        DataRecord row = event.getRecord();
         Object value = row.get(newColumn);
         row.put(tableToAddTo + "." + columnToAdd, value);
         // Test that descriptor was set.

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/models/inheritance/Computer.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/models/inheritance/Computer.java
@@ -18,6 +18,7 @@ import java.io.*;
 import java.util.Enumeration;
 import org.eclipse.persistence.descriptors.*;
 import org.eclipse.persistence.mappings.*;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.tools.schemaframework.*;
 
 public class Computer implements Serializable {
@@ -114,7 +115,7 @@ public class Computer implements Serializable {
         return mainframe;
     }
 
-    public static Class getClassFromRow(org.eclipse.persistence.sessions.Record row) {
+    public static Class getClassFromRow(DataRecord row) {
         if (row.get("CTYPE").equals("PC")) {
             if (row.get("PCTYPE").equals("IBM")) {
                 return org.eclipse.persistence.testing.models.inheritance.IBMPC.class;

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/models/mapping/Address.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/models/mapping/Address.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -75,7 +75,7 @@ public class Address implements Serializable {
         return province;
     }
 
-    public String getProvinceFromRow(org.eclipse.persistence.sessions.Record row, Session session) {
+    public String getProvinceFromRow(DataRecord row, Session session) {
         String code = (String)row.get("PROVINCE");
         String provinceString = null;
 

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/models/mapping/Employee.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/models/mapping/Employee.java
@@ -491,7 +491,7 @@ public class Employee implements Serializable {
         return rank;
     }
 
-    public String getRankFromRow(org.eclipse.persistence.sessions.Record row, Session aSession) {
+    public String getRankFromRow(DataRecord row, Session aSession) {
         if (row.get("ERANK") == null) {
             return null;
         }
@@ -557,7 +557,7 @@ public class Employee implements Serializable {
         this.computer = computer;
     }
 
-    public java.util.Date setDateAndTime(org.eclipse.persistence.sessions.Record row, org.eclipse.persistence.sessions.Session session) {
+    public java.util.Date setDateAndTime(DataRecord row, org.eclipse.persistence.sessions.Session session) {
         java.sql.Date sqlDateOfBirth = ConversionManager.getDefaultManager().convertObject(row.get("BDAY"), java.sql.Date.class);
         java.sql.Time timeOfBirth = session.getLogin().getPlatform().convertObject(row.get("BTIME"), java.sql.Time.class);
         if ((timeOfBirth == null) || (sqlDateOfBirth == null)) {

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/models/transparentindirection/AbstractOrder.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/models/transparentindirection/AbstractOrder.java
@@ -153,13 +153,13 @@ public abstract class AbstractOrder implements Serializable {
         return (Integer) total.getValue();
     }
 
-    public int getTotalFromRow(org.eclipse.persistence.sessions.Record row, Session session) {
+    public int getTotalFromRow(DataRecord row, Session session) {
         int tens = ((Number)row.get("TOTT")).intValue();
         int ones = ((Number)row.get("TOTO")).intValue();
         return (tens * 10) + ones;
     }
 
-    public int getTotalFromRow2(org.eclipse.persistence.sessions.Record row, Session session) {
+    public int getTotalFromRow2(DataRecord row, Session session) {
         int tens = ((Number)row.get("TOTT2")).intValue();
         int ones = ((Number)row.get("TOTO2")).intValue();
         return (tens * 10) + ones;

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/feature/SequenceFieldRemovalForAcquireValueAfterInsertTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/feature/SequenceFieldRemovalForAcquireValueAfterInsertTest.java
@@ -144,7 +144,7 @@ public class SequenceFieldRemovalForAcquireValueAfterInsertTest extends TestCase
 
         @Override
         public void aboutToInsert(DescriptorEvent event) {
-            org.eclipse.persistence.sessions.Record modifyRow = event.getRecord();
+            DataRecord modifyRow = event.getRecord();
             Object[] keys = modifyRow.keySet().toArray();
             for (int i = 0; i < keys.length; i++) {
                 Object key = keys[i];

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/isolatedsession/IsolatedEmployee.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/isolatedsession/IsolatedEmployee.java
@@ -23,6 +23,7 @@ import java.math.BigDecimal;
 import java.sql.Time;
 
 import org.eclipse.persistence.indirection.*;
+import org.eclipse.persistence.sessions.DataRecord;
 
 /**
  * <p><b>Purpose</b>: Represent a employee of an organization.
@@ -174,7 +175,7 @@ public class IsolatedEmployee implements Serializable {
      *                        The mapping will set it using method or direct access
      *                        as defined in the descriptor.
      */
-    public Time[] buildNormalHours(org.eclipse.persistence.sessions.Record row, org.eclipse.persistence.sessions.Session session) {
+    public Time[] buildNormalHours(DataRecord row, org.eclipse.persistence.sessions.Session session) {
         Time[] hours = new Time[2];
 
         /** This conversion allows for the database type not to match, i.e. may be a Timestamp or String. */

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/nls/japanese/NLSEmployee.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/nls/japanese/NLSEmployee.java
@@ -127,7 +127,7 @@ public class NLSEmployee implements org.eclipse.persistence.testing.models.emplo
      * IMPORTANT: This method builds the value but does not set it.
      * The mapping will set it using method or direct access as defined in the descriptor.
      */
-    public Time[] buildNormalHours(org.eclipse.persistence.sessions.Record row, Session session) {
+    public Time[] buildNormalHours(DataRecord row, Session session) {
         Time[] hours = new Time[2];
 
         /** This conversion allows for the database type not to match, i.e. may be a Timestamp or String. */

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/ConformResultsRedirectorTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/ConformResultsRedirectorTest.java
@@ -18,6 +18,7 @@ import java.util.Vector;
 
 import org.eclipse.persistence.queries.*;
 import org.eclipse.persistence.queries.ReadAllQuery;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.UnitOfWork;
 import org.eclipse.persistence.sessions.Session;
 
@@ -66,7 +67,7 @@ ConformResultsRedirectorTest extends TestCase implements QueryRedirector {
     }
 
     @Override
-    public Object invokeQuery(DatabaseQuery query, org.eclipse.persistence.sessions.Record arguments, Session session) {
+    public Object invokeQuery(DatabaseQuery query, DataRecord arguments, Session session) {
         ReadAllQuery conformingQuery = new ReadAllQuery(Address.class);
         conformingQuery.conformResultsInUnitOfWork();
 

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/DataReadQueryTest1.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/DataReadQueryTest1.java
@@ -72,7 +72,7 @@ public class DataReadQueryTest1 extends AutoVerifyTestCase {
 
         stack = (Stack)getSession().executeQuery(query);
         // if we get here, we must not have generated a ClassCastException
-        org.eclipse.persistence.sessions.Record row = (org.eclipse.persistence.sessions.Record)stack.peek();
+        DataRecord row = (DataRecord)stack.peek();
         if (row.get("F_NAME") == null) {
             throw new TestErrorException("missing data");
         }

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/DoNotRedirectDefaultRedirectorTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/DoNotRedirectDefaultRedirectorTest.java
@@ -63,7 +63,7 @@ public class DoNotRedirectDefaultRedirectorTest extends TestCase {
      * Below are the methods called by the redirectors for various toplink queries
      */
 
-    public static Object readObject(DatabaseQuery query, org.eclipse.persistence.sessions.Record row, org.eclipse.persistence.sessions.Session session) {
+    public static Object readObject(DatabaseQuery query, DataRecord row, org.eclipse.persistence.sessions.Session session) {
         throw new TestErrorException("Query setting doNotRedirect was ignored");
     }
 

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/OrderingByExpressionTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/OrderingByExpressionTest.java
@@ -43,7 +43,7 @@ public class OrderingByExpressionTest extends OrderingTest {
     @Override
     protected void verify() {
         for (int i = 0; i < orderedQueryObjects.size(); i++) {
-            org.eclipse.persistence.sessions.Record row = (org.eclipse.persistence.sessions.Record)customSQLRows.elementAt(i);
+            DataRecord row = (DataRecord)customSQLRows.elementAt(i);
             Employee employee = (Employee)orderedQueryObjects.elementAt(i);
             String city = (String)row.get("CITY");
             String street = (String)row.get("STREET");

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/OrderingMutipleTableTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/OrderingMutipleTableTest.java
@@ -44,12 +44,12 @@ public class OrderingMutipleTableTest extends OrderingTest {
 
     @Override
     protected void verify() {
-        org.eclipse.persistence.sessions.Record row;
+        DataRecord row;
         org.eclipse.persistence.testing.models.employee.domain.Project project;
         String name;
 
         for (int i = 0; i < orderedQueryObjects.size(); i++) {
-            row = (org.eclipse.persistence.sessions.Record)customSQLRows.elementAt(i);
+            row = (DataRecord)customSQLRows.elementAt(i);
             project = (org.eclipse.persistence.testing.models.employee.domain.Project)orderedQueryObjects.elementAt(i);
             name = (String)row.get("PROJ_NAME");
 

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/OrderingTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/OrderingTest.java
@@ -49,13 +49,13 @@ public class OrderingTest extends TestCase {
 
     @Override
     protected void verify() {
-        org.eclipse.persistence.sessions.Record row;
+        DataRecord row;
         Employee employee;
         String firstName;
         String lastName;
 
         for (int i = 0; i < orderedQueryObjects.size(); i++) {
-            row = (org.eclipse.persistence.sessions.Record)customSQLRows.elementAt(i);
+            row = (DataRecord)customSQLRows.elementAt(i);
             employee = (Employee)orderedQueryObjects.elementAt(i);
             firstName = (String)row.get("F_NAME");
             lastName = (String)row.get("L_NAME");

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/OrderingWithAnyOfTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/OrderingWithAnyOfTest.java
@@ -45,7 +45,7 @@ public class OrderingWithAnyOfTest extends OrderingTest {
     @Override
     protected void verify() {
         for (int i = 0; i < orderedQueryObjects.size(); i++) {
-            org.eclipse.persistence.sessions.Record row = (org.eclipse.persistence.sessions.Record)customSQLRows.elementAt(i);
+            DataRecord row = (DataRecord)customSQLRows.elementAt(i);
             Employee employee = (Employee)orderedQueryObjects.elementAt(i);
             String city = (String)row.get("CITY");
             String name = (String)row.get("F_NAME");

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/QueryFrameworkTestSuite.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/QueryFrameworkTestSuite.java
@@ -22,7 +22,7 @@ import org.eclipse.persistence.testing.models.employee.domain.Project;
 import org.eclipse.persistence.sessions.*;
 import org.eclipse.persistence.expressions.*;
 import org.eclipse.persistence.queries.*;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.testing.framework.*;
 import org.eclipse.persistence.testing.tests.clientserver.*;
 import org.eclipse.persistence.tools.schemaframework.PopulationManager;
@@ -438,9 +438,9 @@ public class QueryFrameworkTestSuite extends TestSuite {
                 ExpressionBuilder builder = query.getExpressionBuilder();
                 query.setSelectionCriteria(builder.get("firstName").equal(builder.getParameter("name")));
                 query.addArgument("name");
-                Record record = new DatabaseRecord();
-                record.put("name", "Bob");
-                String sql = query.getTranslatedSQLString(getSession(), record);
+                DataRecord dataRecord = new DatabaseRecord();
+                dataRecord.put("name", "Bob");
+                String sql = query.getTranslatedSQLString(getSession(), dataRecord);
                 if (sql.indexOf("?") != -1) {
                     throwError("SQL was not translated.");
                 }
@@ -663,7 +663,7 @@ public class QueryFrameworkTestSuite extends TestSuite {
         query.addArgument("employee");
         query.setRedirector(new QueryRedirector() {
                 @Override
-                public Object invokeQuery(DatabaseQuery query, org.eclipse.persistence.sessions.Record arguments, org.eclipse.persistence.sessions.Session session) {
+                public Object invokeQuery(DatabaseQuery query, DataRecord arguments, org.eclipse.persistence.sessions.Session session) {
                     return arguments.get("employee");
                 }
             });

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/RedirectQueryOnUOWTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/RedirectQueryOnUOWTest.java
@@ -17,6 +17,7 @@ package org.eclipse.persistence.testing.tests.queries;
 import java.util.Vector;
 
 import org.eclipse.persistence.internal.sessions.AbstractSession;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 import org.eclipse.persistence.sessions.UnitOfWork;
 import org.eclipse.persistence.expressions.ExpressionBuilder;
@@ -89,7 +90,7 @@ RedirectQueryOnUOWTest extends TestCase {
 
 class StupidRedirector implements QueryRedirector {
     @Override
-    public Object invokeQuery(DatabaseQuery arg0, org.eclipse.persistence.sessions.Record arg1, Session arg2) {
+    public Object invokeQuery(DatabaseQuery arg0, DataRecord arg1, Session arg2) {
         // change code to do the correct class cast.
         // Also for this test case to be relevant a completely different query
         // must be executed.

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/RedirectorOnDescriptorTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/RedirectorOnDescriptorTest.java
@@ -163,27 +163,27 @@ public class RedirectorOnDescriptorTest extends TestCase {
      */
     public static
 
-    Object deleteObject(DatabaseQuery query, org.eclipse.persistence.sessions.Record row, org.eclipse.persistence.sessions.Session session) {
+    Object deleteObject(DatabaseQuery query, DataRecord row, org.eclipse.persistence.sessions.Session session) {
         redirectedDeleteObject = true;
         return null;
     }
 
-    public static Object insertObject(DatabaseQuery query, org.eclipse.persistence.sessions.Record row, org.eclipse.persistence.sessions.Session session) {
+    public static Object insertObject(DatabaseQuery query, DataRecord row, org.eclipse.persistence.sessions.Session session) {
         redirectedInsert = true;
         return null;
     }
 
-    public static Object readAll(DatabaseQuery query, org.eclipse.persistence.sessions.Record row, org.eclipse.persistence.sessions.Session session) {
+    public static Object readAll(DatabaseQuery query, DataRecord row, org.eclipse.persistence.sessions.Session session) {
         redirectedReadAll = true;
         return null;
     }
 
-    public static Object readObject(DatabaseQuery query, org.eclipse.persistence.sessions.Record row, org.eclipse.persistence.sessions.Session session) {
+    public static Object readObject(DatabaseQuery query, DataRecord row, org.eclipse.persistence.sessions.Session session) {
         redirectedReadObject = true;
         return null;
     }
 
-    public static Object updateObject(DatabaseQuery query, org.eclipse.persistence.sessions.Record row, org.eclipse.persistence.sessions.Session session) {
+    public static Object updateObject(DatabaseQuery query, DataRecord row, org.eclipse.persistence.sessions.Session session) {
         redirectedUpdate = true;
         return null;
     }

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/returning/model/AdapterForReturningProject.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/returning/model/AdapterForReturningProject.java
@@ -211,8 +211,8 @@ public class AdapterForReturningProject extends AdapterWithReturnObjectControl {
     }
 
     @Override
-    protected org.eclipse.persistence.sessions.Record getRowForInsert(org.eclipse.persistence.sessions.Record rowToInsert) {
-        org.eclipse.persistence.sessions.Record row = new DatabaseRecord();
+    protected DataRecord getRowForInsert(DataRecord rowToInsert) {
+        DataRecord row = new DatabaseRecord();
         Enumeration insertFields = insertInfos.keys();
         while (insertFields.hasMoreElements()) {
             DatabaseField field = (DatabaseField)insertFields.nextElement();
@@ -226,8 +226,8 @@ public class AdapterForReturningProject extends AdapterWithReturnObjectControl {
     }
 
     @Override
-    protected org.eclipse.persistence.sessions.Record getRowForUpdate(org.eclipse.persistence.sessions.Record rowChange) {
-        org.eclipse.persistence.sessions.Record row = new DatabaseRecord();
+    protected DataRecord getRowForUpdate(DataRecord rowChange) {
+        DataRecord row = new DatabaseRecord();
         Enumeration updateFields = updateInfos.keys();
         while (updateFields.hasMoreElements()) {
             DatabaseField field = (DatabaseField)updateFields.nextElement();

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/returning/model/AdapterWithReturnObjectControl.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/returning/model/AdapterWithReturnObjectControl.java
@@ -42,10 +42,10 @@ public abstract class AdapterWithReturnObjectControl implements ProjectAndDataba
     @Override
     public Object getObjectForInsert(Session session, Object objectToInsert) {
         ClassDescriptor desc = session.getClassDescriptor(objectToInsert);
-        org.eclipse.persistence.sessions.Record rowToInsert = desc.getObjectBuilder().buildRow(objectToInsert, (AbstractSession)session, WriteType.INSERT);
-        org.eclipse.persistence.sessions.Record rowReturn = getRowForInsert(rowToInsert);
+        DataRecord rowToInsert = desc.getObjectBuilder().buildRow(objectToInsert, (AbstractSession)session, WriteType.INSERT);
+        DataRecord rowReturn = getRowForInsert(rowToInsert);
         if (rowReturn != null && !rowReturn.isEmpty()) {
-            org.eclipse.persistence.sessions.Record row = new DatabaseRecord(rowToInsert.size());
+            DataRecord row = new DatabaseRecord(rowToInsert.size());
             row.putAll(rowToInsert);
             row.putAll(rowReturn);
             return readObjectFromRow(session, desc, row);
@@ -57,13 +57,13 @@ public abstract class AdapterWithReturnObjectControl implements ProjectAndDataba
     @Override
     public Object getObjectForUpdate(Session session, Object objectToUpdateBeforeChange, Object objectToUpdateAfterChange, boolean useUOW) {
         ClassDescriptor desc = session.getClassDescriptor(objectToUpdateBeforeChange);
-        org.eclipse.persistence.sessions.Record rowBeforeChange = desc.getObjectBuilder().buildRow(objectToUpdateBeforeChange, (AbstractSession)session, WriteType.UPDATE);
-        org.eclipse.persistence.sessions.Record rowAfterChange = desc.getObjectBuilder().buildRow(objectToUpdateAfterChange, (AbstractSession)session, WriteType.UPDATE);
-        org.eclipse.persistence.sessions.Record rowChange = new DatabaseRecord();
+        DataRecord rowBeforeChange = desc.getObjectBuilder().buildRow(objectToUpdateBeforeChange, (AbstractSession)session, WriteType.UPDATE);
+        DataRecord rowAfterChange = desc.getObjectBuilder().buildRow(objectToUpdateAfterChange, (AbstractSession)session, WriteType.UPDATE);
+        DataRecord rowChange = new DatabaseRecord();
         getChange(rowChange, session, objectToUpdateBeforeChange, objectToUpdateAfterChange, desc, useUOW, WriteType.UPDATE);
-        org.eclipse.persistence.sessions.Record rowReturn = getRowForUpdate(rowChange);
+        DataRecord rowReturn = getRowForUpdate(rowChange);
         if (rowReturn != null && !rowReturn.isEmpty()) {
-            org.eclipse.persistence.sessions.Record row = new DatabaseRecord(rowAfterChange.size());
+            DataRecord row = new DatabaseRecord(rowAfterChange.size());
             row.putAll(rowAfterChange);
             row.putAll(rowReturn);
             return readObjectFromRow(session, desc, row);
@@ -72,7 +72,7 @@ public abstract class AdapterWithReturnObjectControl implements ProjectAndDataba
         }
     }
 
-    public void getChange(org.eclipse.persistence.sessions.Record row, Session session, Object object1, Object object2, ClassDescriptor desc, boolean useUOW, WriteType writeType) {
+    public void getChange(DataRecord row, Session session, Object object1, Object object2, ClassDescriptor desc, boolean useUOW, WriteType writeType) {
         for (Enumeration<DatabaseMapping> mappings = desc.getMappings().elements(); mappings.hasMoreElements(); ) {
             DatabaseMapping mapping = mappings.nextElement();
             if (!mapping.isReadOnly()) {
@@ -81,7 +81,7 @@ public abstract class AdapterWithReturnObjectControl implements ProjectAndDataba
         }
     }
 
-    public void getChange(org.eclipse.persistence.sessions.Record row, DatabaseMapping mapping, Session session, Object object1, Object object2, boolean useUOW, WriteType writeType) {
+    public void getChange(DataRecord row, DatabaseMapping mapping, Session session, Object object1, Object object2, boolean useUOW, WriteType writeType) {
         if (mapping.isAggregateObjectMapping()) {
             Object aggregate1 = mapping.getAttributeValueFromObject(object1);
             Object aggregate2 = mapping.getAttributeValueFromObject(object2);
@@ -118,7 +118,7 @@ public abstract class AdapterWithReturnObjectControl implements ProjectAndDataba
         }
     }
 
-    protected Object readObjectFromRow(Session session, ClassDescriptor desc, org.eclipse.persistence.sessions.Record row) {
+    protected Object readObjectFromRow(Session session, ClassDescriptor desc, DataRecord row) {
         if (desc.hasInheritance()) {
             Class newClass = desc.getInheritancePolicy().classFromRow((DatabaseRecord)row, (AbstractSession)session);
             desc = session.getClassDescriptor(newClass);
@@ -133,11 +133,11 @@ public abstract class AdapterWithReturnObjectControl implements ProjectAndDataba
         return object;
     }
 
-    protected org.eclipse.persistence.sessions.Record getRowForInsert(org.eclipse.persistence.sessions.Record rowToInsert) {
+    protected DataRecord getRowForInsert(DataRecord rowToInsert) {
         return null;
     }
 
-    protected org.eclipse.persistence.sessions.Record getRowForUpdate(org.eclipse.persistence.sessions.Record rowChange) {
+    protected DataRecord getRowForUpdate(DataRecord rowChange) {
         return null;
     }
 }

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/returning/model/BaseClass.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/returning/model/BaseClass.java
@@ -78,7 +78,7 @@ public abstract class BaseClass implements Cloneable {
         }
     }
 
-    public BigDecimal[] build_a_plus_minus_b_BigDecimal(org.eclipse.persistence.sessions.Record row, Session session) {
+    public BigDecimal[] build_a_plus_minus_b_BigDecimal(DataRecord row, Session session) {
         BigDecimal[] a_plus_minus_b_BigDecimal = new BigDecimal[2];
         BigDecimal a = session.getDatasourcePlatform().convertObject(row.get(getFieldAName()), BigDecimal.class);
         BigDecimal b = session.getDatasourcePlatform().convertObject(row.get(getFieldBName()), BigDecimal.class);

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/security/SecurityOnInitializingAttributeMethodTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/security/SecurityOnInitializingAttributeMethodTest.java
@@ -20,7 +20,7 @@ import org.eclipse.persistence.exceptions.DescriptorException;
 import org.eclipse.persistence.exceptions.EclipseLinkException;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
 import org.eclipse.persistence.mappings.TransformationMapping;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 
 //Created by Ian Reid
@@ -68,21 +68,21 @@ public class SecurityOnInitializingAttributeMethodTest extends ExceptionTestSave
     }
 
     static class AttributeMethodOneArg extends AttributeMethod {
-        public Date buildNormalHours(Record record) {
+        public Date buildNormalHours(DataRecord dataRecord) {
             //do nothing security manager will cause error to occur
             return null;
         }
     }
 
     static class AttributeMethodAbstractSession extends AttributeMethod {
-        public Date buildNormalHours(Record record, AbstractSession session) {
+        public Date buildNormalHours(DataRecord dataRecord, AbstractSession session) {
             //do nothing security manager will cause error to occur
             return null;
         }
     }
 
     static class AttributeMethodSession extends AttributeMethod {
-        public Date buildNormalHours(Record record, Session s) {
+        public Date buildNormalHours(DataRecord dataRecord, Session s) {
             //do nothing security manager will cause error to occur
             return null;
         }

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/security/SecurityWhileInitializingClassExtractionMethodTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/security/SecurityWhileInitializingClassExtractionMethodTest.java
@@ -20,7 +20,7 @@ import org.eclipse.persistence.exceptions.DescriptorException;
 import org.eclipse.persistence.exceptions.EclipseLinkException;
 import org.eclipse.persistence.internal.sessions.AbstractRecord;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 
 //Created by Ian Reid
 //Date: April 25, 2k3
@@ -61,7 +61,7 @@ public class SecurityWhileInitializingClassExtractionMethodTest extends Exceptio
     }
 
     static class ExtractionRecord {
-        public static void dummy_Method(Record record) {
+        public static void dummy_Method(DataRecord dataRecord) {
         }
     }
 }

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/transparentindirection/RemoteDataReadQueryTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/transparentindirection/RemoteDataReadQueryTest.java
@@ -65,7 +65,7 @@ public class RemoteDataReadQueryTest extends AutoVerifyTestCase {
         int count = 0;
         while (stream.hasMoreElements()) {
             count++;
-            org.eclipse.persistence.sessions.Record row = (org.eclipse.persistence.sessions.Record)stream.nextElement();
+            DataRecord row = (DataRecord)stream.nextElement();
             if (row.get("CUSTNAME") == null) {
                 throw new TestErrorException("missing data");
             }
@@ -81,7 +81,7 @@ public class RemoteDataReadQueryTest extends AutoVerifyTestCase {
 
         stack = (Stack)getSession().executeQuery(query);
         // if we get here, we must not have generated a ClassCastException
-        org.eclipse.persistence.sessions.Record row = (org.eclipse.persistence.sessions.Record)stack.peek();
+        DataRecord row = (DataRecord)stack.peek();
         if (row.get("CUSTNAME") == null) {
             throw new TestErrorException("missing data");
         }

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/ConcurrentPerson.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/ConcurrentPerson.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -23,7 +23,7 @@ import org.eclipse.persistence.mappings.OneToManyMapping;
 import org.eclipse.persistence.mappings.OneToOneMapping;
 import org.eclipse.persistence.mappings.DirectToFieldMapping;
 import org.eclipse.persistence.mappings.TransformationMapping;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 import org.eclipse.persistence.tools.schemaframework.TableDefinition;
 
@@ -45,7 +45,7 @@ public class ConcurrentPerson implements java.io.Serializable {
         phoneNumbers = new ArrayList();
     }
 
-    public BigDecimal calculateLuckyNumber(Record row, Session session) {
+    public BigDecimal calculateLuckyNumber(DataRecord row, Session session) {
         Number code = (Number)row.get("ID");
         return new BigDecimal(code.doubleValue() * 2.435);
     }

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/Person.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/Person.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -21,7 +21,7 @@ import java.util.Vector;
 import org.eclipse.persistence.descriptors.RelationalDescriptor;
 import org.eclipse.persistence.mappings.OneToManyMapping;
 import org.eclipse.persistence.mappings.TransformationMapping;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 import org.eclipse.persistence.tools.schemaframework.TableDefinition;
 
@@ -32,7 +32,7 @@ public class Person implements java.io.Serializable {
     public BigDecimal id;
     public BigDecimal luckyNumber;
 
-    public BigDecimal calculateLuckyNumber(Record row, Session session) {
+    public BigDecimal calculateLuckyNumber(DataRecord row, Session session) {
         Number code = (Number)row.get("ID");
         return new BigDecimal(code.doubleValue() * 2.435);
     }

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/validation/EmployeeWithProblems.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/validation/EmployeeWithProblems.java
@@ -14,6 +14,8 @@
 //     Oracle - initial API and implementation from Oracle TopLink
 package org.eclipse.persistence.testing.tests.validation;
 
+import org.eclipse.persistence.sessions.DataRecord;
+
 import java.sql.Time;
 
 import java.util.Vector;
@@ -76,7 +78,7 @@ public class EmployeeWithProblems extends org.eclipse.persistence.testing.models
     }
     //this method returns void (instead of Time[]) to produce the error (TL-ERROR 81)
 
-    public void buildNormalHours2(org.eclipse.persistence.sessions.Record row, org.eclipse.persistence.sessions.Session session) { //used in test class org.eclipse.persistence.testing.tests.validation.ReturnTypeInGetAttributeAccessorTest
+    public void buildNormalHours2(DataRecord row, org.eclipse.persistence.sessions.Session session) { //used in test class org.eclipse.persistence.testing.tests.validation.ReturnTypeInGetAttributeAccessorTest
         Time[] hours = new Time[2];
 
         /** This conversion allows for the database type not to match, i.e. may be a Timestamp or String. */

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/validation/IllegalArgumentWhileInvokingAttributeMethodTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/validation/IllegalArgumentWhileInvokingAttributeMethodTest.java
@@ -21,7 +21,7 @@ import org.eclipse.persistence.exceptions.EclipseLinkException;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
 import org.eclipse.persistence.mappings.TransformationMapping;
 import org.eclipse.persistence.sessions.DatabaseRecord;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 
 
 //Created by Ian Reid
@@ -61,7 +61,7 @@ public class IllegalArgumentWhileInvokingAttributeMethodTest extends ExceptionTe
         }
     }
 
-    public String invalidMethod(Record row) {
+    public String invalidMethod(DataRecord row) {
         return "";
     }
 

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/validation/PersonWithValueHolder.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/validation/PersonWithValueHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -24,7 +24,7 @@ import java.util.Vector;
 import org.eclipse.persistence.exceptions.DescriptorException;
 import org.eclipse.persistence.indirection.ValueHolder;
 import org.eclipse.persistence.indirection.ValueHolderInterface;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 
 
@@ -90,14 +90,14 @@ public class PersonWithValueHolder {
         return phoneNumbers;
     }
 
-    public Time[] buildNormalHours(Record row) {
+    public Time[] buildNormalHours(DataRecord row) {
         Time[] hours = new Time[2];
         // hours[0] = (Time) session.getPlatform().convertObject(row.get("START_TIME"), java.sql.Time.class);
         //hours[1] = (Time) session.getPlatform().convertObject(row.get("END_TIME"), java.sql.Time.class);
         return hours;
     }
 
-    public Time[] buildNormalHoursAgain(Record row, Session session) throws DescriptorException {
+    public Time[] buildNormalHoursAgain(DataRecord row, Session session) throws DescriptorException {
         Time[] hours = new Time[2];
         // hours[0] = (Time) session.getPlatform().convertObject(row.get("START_TIME"), java.sql.Time.class);
         // hours[1] = (Time) session.getPlatform().convertObject(row.get("END_TIME"), java.sql.Time.class);

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/validation/TargetInvocationWhileInvokingAttributeMethodTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/validation/TargetInvocationWhileInvokingAttributeMethodTest.java
@@ -19,8 +19,8 @@ import org.eclipse.persistence.exceptions.DescriptorException;
 import org.eclipse.persistence.exceptions.EclipseLinkException;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
 import org.eclipse.persistence.mappings.TransformationMapping;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.DatabaseRecord;
-import org.eclipse.persistence.sessions.Record;
 
 
 //Created by Ian Reid
@@ -58,7 +58,7 @@ public class TargetInvocationWhileInvokingAttributeMethodTest extends ExceptionT
         }
     }
 
-    public String invalidMethod(Record row) throws java.lang.IllegalAccessException {
+    public String invalidMethod(DataRecord row) throws java.lang.IllegalAccessException {
         throw new IllegalAccessException();
     }
 

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/validation/TargetInvocationWhileInvokingRowExtractionMethodTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/validation/TargetInvocationWhileInvokingRowExtractionMethodTest.java
@@ -19,8 +19,8 @@ import org.eclipse.persistence.descriptors.RelationalDescriptor;
 import org.eclipse.persistence.exceptions.DescriptorException;
 import org.eclipse.persistence.exceptions.EclipseLinkException;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.DatabaseRecord;
-import org.eclipse.persistence.sessions.Record;
 
 
 //Created by Ian Reid
@@ -48,7 +48,7 @@ public class TargetInvocationWhileInvokingRowExtractionMethodTest extends Except
         policy.preInitialize((AbstractSession)getSession());
 
         row = new DatabaseRecord();
-        Class[] parmClasses = { Record.class };
+        Class[] parmClasses = { DataRecord.class };
 
 
         expectedException = DescriptorException.targetInvocationWhileInvokingRowExtractionMethod(row, TargetInvocationWhileInvokingRowExtractionMethodTest.class.getDeclaredMethod("invalidMethod", parmClasses), descriptor, new Exception());
@@ -63,7 +63,7 @@ public class TargetInvocationWhileInvokingRowExtractionMethodTest extends Except
         }
     }
 
-    public static void invalidMethod(Record row) throws java.lang.IllegalAccessException {
+    public static void invalidMethod(DataRecord row) throws java.lang.IllegalAccessException {
         throw new IllegalAccessException();
     }
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/QueryHints.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/QueryHints.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.eclipse.persistence.annotations.BatchFetch;
 import org.eclipse.persistence.annotations.BatchFetchType;
+import org.eclipse.persistence.sessions.DataRecord;
 
 /**
  * The class defines EclipseLink query hints.
@@ -839,7 +840,7 @@ public class QueryHints {
      * <p>It can also be used to return a single column, or single value.
      * Valid values are defined in ResultType.
      * @see ResultType
-     * @see org.eclipse.persistence.sessions.Record
+     * @see DataRecord
      * @see org.eclipse.persistence.sessions.DatabaseRecord
      * @see org.eclipse.persistence.queries.ReportQueryResult
      * @see org.eclipse.persistence.queries.ReportQuery#setReturnType(int)

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/ResultType.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/ResultType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,6 +13,8 @@
 // Contributors:
 //     James Sutherland - initial impl
 package org.eclipse.persistence.config;
+
+import org.eclipse.persistence.sessions.DataRecord;
 
 /**
  * Result type hint values.
@@ -35,7 +37,7 @@ package org.eclipse.persistence.config;
  * "" could be used instead of default value ResultType.Array.
  *
  * @see QueryHints#RESULT_TYPE
- * @see org.eclipse.persistence.sessions.Record
+ * @see DataRecord
  * @see org.eclipse.persistence.sessions.DatabaseRecord
  * @see org.eclipse.persistence.queries.ReportQueryResult
  * @see org.eclipse.persistence.queries.ReportQuery#setReturnType(int)

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/descriptors/ClassExtractor.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/descriptors/ClassExtractor.java
@@ -32,7 +32,7 @@ public abstract class ClassExtractor {
      * Map is used as the public interface to database row, the key is the field name,
      * the value is the database value.
      */
-    public abstract <T> Class<T> extractClassFromRow(org.eclipse.persistence.sessions.Record databaseRow, Session session);
+    public abstract <T> Class<T> extractClassFromRow(DataRecord databaseRow, Session session);
 
     /**
      * Allow for any initialization.

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/descriptors/DescriptorEvent.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/descriptors/DescriptorEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -21,7 +21,7 @@ import org.eclipse.persistence.core.descriptors.CoreDescriptorEvent;
 import org.eclipse.persistence.exceptions.ValidationException;
 import org.eclipse.persistence.exceptions.DescriptorException;
 import org.eclipse.persistence.queries.*;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.internal.sessions.*;
 
 /**
@@ -48,7 +48,7 @@ public class DescriptorEvent extends EventObject implements CoreDescriptorEvent 
     protected DatabaseQuery query;
 
     /** Optionally a database row may be provided on some events, (such as aboutToUpdate). */
-    protected Record record;
+    protected DataRecord dataRecord;
     protected ClassDescriptor descriptor;
 
     /**
@@ -195,8 +195,8 @@ public class DescriptorEvent extends EventObject implements CoreDescriptorEvent 
      * Return the record that is associated with some events,
      * such as postBuild, and aboutToUpdate.
      */
-    public Record getRecord() {
-        return record;
+    public DataRecord getRecord() {
+        return dataRecord;
     }
 
     /**
@@ -253,8 +253,8 @@ public class DescriptorEvent extends EventObject implements CoreDescriptorEvent 
      * INTERNAL:
      * Optionally a database row may be provided on some events, (such as aboutToUpdate).
      */
-    public void setRecord(Record record) {
-        this.record = record;
+    public void setRecord(DataRecord dataRecord) {
+        this.dataRecord = dataRecord;
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/descriptors/MethodClassExtractor.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/descriptors/MethodClassExtractor.java
@@ -21,8 +21,8 @@ import java.security.PrivilegedActionException;
 import org.eclipse.persistence.internal.helper.*;
 import org.eclipse.persistence.exceptions.*;
 import org.eclipse.persistence.internal.sessions.AbstractRecord;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
-import org.eclipse.persistence.sessions.Record;
 import org.eclipse.persistence.internal.security.*;
 
 /**
@@ -124,7 +124,7 @@ public class MethodClassExtractor extends ClassExtractor {
      */
     @Override
     @SuppressWarnings({"unchecked"})
-    public <T> Class<T> extractClassFromRow(Record row, org.eclipse.persistence.sessions.Session session) {
+    public <T> Class<T> extractClassFromRow(DataRecord row, org.eclipse.persistence.sessions.Session session) {
         Class<?> classForRow;
         try {
             Object[] arguments = new Object[1];

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/descriptors/copying/AbstractCopyPolicy.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/descriptors/copying/AbstractCopyPolicy.java
@@ -17,7 +17,7 @@ package org.eclipse.persistence.descriptors.copying;
 import org.eclipse.persistence.descriptors.ClassDescriptor;
 import org.eclipse.persistence.exceptions.DescriptorException;
 import org.eclipse.persistence.queries.ObjectBuildingQuery;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 import org.eclipse.persistence.sessions.UnitOfWork;
 
@@ -49,7 +49,7 @@ public abstract class AbstractCopyPolicy implements CopyPolicy {
      * By default create a new instance.
      */
     @Override
-    public Object buildWorkingCopyCloneFromRow(Record row, ObjectBuildingQuery query, Object primaryKey, UnitOfWork uow) throws DescriptorException {
+    public Object buildWorkingCopyCloneFromRow(DataRecord row, ObjectBuildingQuery query, Object primaryKey, UnitOfWork uow) throws DescriptorException {
         return this.descriptor.getObjectBuilder().buildNewInstance();
     }
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/descriptors/copying/CloneCopyPolicy.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/descriptors/copying/CloneCopyPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -122,7 +122,7 @@ public class CloneCopyPolicy extends AbstractCopyPolicy {
      * Create a new instance, unless a workingCopyClone method is specified, then build a new instance and clone it.
      */
     @Override
-    public Object buildWorkingCopyCloneFromRow(org.eclipse.persistence.sessions.Record row, ObjectBuildingQuery query, Object primaryKey, UnitOfWork uow) throws DescriptorException {
+    public Object buildWorkingCopyCloneFromRow(DataRecord row, ObjectBuildingQuery query, Object primaryKey, UnitOfWork uow) throws DescriptorException {
         // For now must preserve CMP code which builds heavy clones with a context.
         // Also preserve for clients who use the copy policy.
         ObjectBuilder builder = getDescriptor().getObjectBuilder();

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/descriptors/copying/CopyPolicy.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/descriptors/copying/CopyPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -51,7 +51,7 @@ public interface CopyPolicy extends Cloneable, Serializable {
     /**
      * Return an instance with the primary key set from the row, used for building a working copy during a unit of work transactional read.
      */
-    Object buildWorkingCopyCloneFromRow(org.eclipse.persistence.sessions.Record row, ObjectBuildingQuery query, Object primaryKey, UnitOfWork uow) throws DescriptorException;
+    Object buildWorkingCopyCloneFromRow(DataRecord row, ObjectBuildingQuery query, Object primaryKey, UnitOfWork uow) throws DescriptorException;
 
     /**
      * Clone the CopyPolicy.

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/exceptions/DatabaseException.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/exceptions/DatabaseException.java
@@ -21,7 +21,7 @@ import org.eclipse.persistence.internal.databaseaccess.*;
 import org.eclipse.persistence.internal.sessions.AbstractRecord;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
 import org.eclipse.persistence.exceptions.i18n.ExceptionMessageGenerator;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 
 /**
  * <P><B>Purpose</B>:
@@ -264,7 +264,7 @@ public class DatabaseException extends EclipseLinkException {
      * PUBLIC:
      * Return the query arguments used in the original query when exception is thrown
      */
-    public Record getQueryArgumentsRecord() {
+    public DataRecord getQueryArgumentsRecord() {
         return queryArguments;
     }
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/exceptions/QueryException.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/exceptions/QueryException.java
@@ -36,7 +36,7 @@ import org.eclipse.persistence.mappings.*;
 import org.eclipse.persistence.mappings.querykeys.ManyToManyQueryKey;
 import org.eclipse.persistence.internal.helper.*;
 import org.eclipse.persistence.exceptions.i18n.ExceptionMessageGenerator;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 
 /**
  * <p><b>Purpose</b>: This exception is used for any problem that is detected with a query.
@@ -562,7 +562,7 @@ public class QueryException extends ValidationException {
      * PUBLIC:
      * Return the query argements used in the original query when exception is thrown
      */
-    public Record getQueryArgumentsRecord() {
+    public DataRecord getQueryArgumentsRecord() {
         return queryArguments;
     }
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ClassConstants.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ClassConstants.java
@@ -57,6 +57,7 @@ import org.eclipse.persistence.queries.CursoredStream;
 import org.eclipse.persistence.queries.DatabaseQuery;
 import org.eclipse.persistence.queries.FetchGroupTracker;
 import org.eclipse.persistence.queries.ScrollableCursor;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.DirectConnector;
 import org.eclipse.persistence.sessions.Session;
 import org.eclipse.persistence.sessions.server.ServerSession;
@@ -114,7 +115,7 @@ public final class ClassConstants extends CoreClassConstants {
     public static final Class<AbstractSession> PublicInterfaceSession_Class = AbstractSession.class;
     public static final Class<QueryKey> QueryKey_Class = QueryKey.class;
     public static final Class<RelationExpression> RelationExpression_Class = RelationExpression.class;
-    public static final Class<org.eclipse.persistence.sessions.Record> Record_Class = org.eclipse.persistence.sessions.Record.class;
+    public static final Class<DataRecord> Record_Class = DataRecord.class;
     public static final Class<ServerSession> ServerSession_Class = ServerSession.class;
     public static final Class<Session> SessionsSession_Class = Session.class;
     public static final Class<ScrollableCursor> ScrollableCursor_Class = ScrollableCursor.class;

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/identitymaps/CacheKey.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/identitymaps/CacheKey.java
@@ -18,8 +18,8 @@ import org.eclipse.persistence.exceptions.ConcurrencyException;
 import org.eclipse.persistence.internal.helper.*;
 import org.eclipse.persistence.internal.sessions.AbstractRecord;
 import org.eclipse.persistence.queries.ObjectBuildingQuery;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.DatabaseRecord;
-import org.eclipse.persistence.sessions.Record;
 
 /**
  * <p><b>Purpose</b>: Container class for storing objects in an IdentityMap.
@@ -53,7 +53,7 @@ public class CacheKey extends ConcurrencyManager implements Cloneable {
     protected Object wrapper;
 
     /** This is used for Document Preservation to cache the record that this object was built from */
-    protected Record record;
+    protected DataRecord dataRecord;
 
     /** This attribute is the system time in milli seconds that the object was last refreshed on */
 
@@ -395,8 +395,8 @@ public class CacheKey extends ConcurrencyManager implements Cloneable {
         return readTime;
     }
 
-    public Record getRecord() {
-        return record;
+    public DataRecord getRecord() {
+        return dataRecord;
     }
 
     public Object getWrapper() {
@@ -558,8 +558,8 @@ public class CacheKey extends ConcurrencyManager implements Cloneable {
         invalidationState = CHECK_INVALIDATION_POLICY;
     }
 
-    public void setRecord(Record newRecord) {
-        this.record = newRecord;
+    public void setRecord(DataRecord newDataRecord) {
+        this.dataRecord = newDataRecord;
     }
 
     public void setWrapper(Object wrapper) {

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/identitymaps/IdentityMapManager.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/identitymaps/IdentityMapManager.java
@@ -65,7 +65,7 @@ import org.eclipse.persistence.logging.SessionLog;
 import org.eclipse.persistence.queries.InMemoryQueryIndirectionPolicy;
 import org.eclipse.persistence.queries.ObjectLevelReadQuery;
 import org.eclipse.persistence.queries.ReadQuery;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.SessionProfiler;
 import org.eclipse.persistence.sessions.interceptors.CacheInterceptor;
 
@@ -529,7 +529,7 @@ public class IdentityMapManager implements Serializable, Cloneable {
     /**
      * Query the cache in-memory.
      */
-    public Vector getAllFromIdentityMap(Expression selectionCriteria, Class theClass, Record translationRow, int valueHolderPolicy, boolean shouldReturnInvalidatedObjects) {
+    public Vector getAllFromIdentityMap(Expression selectionCriteria, Class theClass, DataRecord translationRow, int valueHolderPolicy, boolean shouldReturnInvalidatedObjects) {
         ClassDescriptor descriptor = this.session.getDescriptor(theClass);
         this.session.startOperationProfile(SessionProfiler.Caching);
         Vector objects = null;
@@ -623,7 +623,7 @@ public class IdentityMapManager implements Serializable, Cloneable {
     /**
      * Invalidate objects meeting selectionCriteria.
      */
-    public void invalidateObjects(Expression selectionCriteria, Class theClass, Record translationRow, boolean shouldInvalidateOnException) {
+    public void invalidateObjects(Expression selectionCriteria, Class theClass, DataRecord translationRow, boolean shouldInvalidateOnException) {
         ClassDescriptor descriptor = this.session.getDescriptor(theClass);
         this.session.startOperationProfile(SessionProfiler.Caching);
         try {
@@ -846,7 +846,7 @@ public class IdentityMapManager implements Serializable, Cloneable {
         return domainObject;
     }
 
-    public Object getFromIdentityMap(Expression selectionCriteria, Class theClass, Record translationRow, int valueHolderPolicy, boolean conforming, boolean shouldReturnInvalidatedObjects, ClassDescriptor descriptor) {
+    public Object getFromIdentityMap(Expression selectionCriteria, Class theClass, DataRecord translationRow, int valueHolderPolicy, boolean conforming, boolean shouldReturnInvalidatedObjects, ClassDescriptor descriptor) {
         UnitOfWorkImpl unitOfWork = (conforming) ? (UnitOfWorkImpl)this.session : null;
         this.session.startOperationProfile(SessionProfiler.Caching);
         try {

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/AbstractRecord.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/AbstractRecord.java
@@ -20,7 +20,7 @@ import java.util.*;
 import org.eclipse.persistence.internal.core.sessions.CoreAbstractRecord;
 import org.eclipse.persistence.internal.helper.*;
 import org.eclipse.persistence.exceptions.*;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.internal.helper.DatabaseField;
 
 /**
@@ -34,7 +34,7 @@ import org.eclipse.persistence.internal.helper.DatabaseField;
  * </ul>
  * @see DatabaseField
  */
-public abstract class AbstractRecord extends CoreAbstractRecord implements Record, Cloneable, Serializable, Map {
+public abstract class AbstractRecord extends CoreAbstractRecord implements DataRecord, Cloneable, Serializable, Map {
 
     /** Use vector to store the fields/values for optimal performance.*/
     protected Vector<DatabaseField> fields;

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/IdentityMapAccessor.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/IdentityMapAccessor.java
@@ -39,8 +39,8 @@ import org.eclipse.persistence.internal.identitymaps.IdentityMapManager;
 import org.eclipse.persistence.logging.SessionLog;
 import org.eclipse.persistence.queries.InMemoryQueryIndirectionPolicy;
 import org.eclipse.persistence.queries.ReadQuery;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.DatabaseRecord;
-import org.eclipse.persistence.sessions.Record;
 import org.eclipse.persistence.sessions.coordination.CommandManager;
 import org.eclipse.persistence.sessions.coordination.MergeChangeSetCommand;
 
@@ -228,7 +228,7 @@ public class IdentityMapAccessor implements org.eclipse.persistence.sessions.Ide
      * Return if their is an object for the row containing primary key and the class.
      */
     @Override
-    public boolean containsObjectInIdentityMap(Record rowContainingPrimaryKey, Class theClass) {
+    public boolean containsObjectInIdentityMap(DataRecord rowContainingPrimaryKey, Class theClass) {
         return containsObjectInIdentityMap(extractPrimaryKeyFromRow(rowContainingPrimaryKey, theClass), theClass);
     }
 
@@ -236,7 +236,7 @@ public class IdentityMapAccessor implements org.eclipse.persistence.sessions.Ide
      * INTERNAL:
      * Extract primary key from a row.
      */
-    protected Object extractPrimaryKeyFromRow(Record rowContainingPrimaryKey, Class theClass) {
+    protected Object extractPrimaryKeyFromRow(DataRecord rowContainingPrimaryKey, Class theClass) {
         return this.session.getDescriptor(theClass).getObjectBuilder().extractPrimaryKeyFromRow((AbstractRecord)rowContainingPrimaryKey, this.session);
     }
 
@@ -262,7 +262,7 @@ public class IdentityMapAccessor implements org.eclipse.persistence.sessions.Ide
      * Query the cache in-memory.
      * If the expression is too complex an exception will be thrown.
      */
-    public Vector getAllFromIdentityMap(Expression selectionCriteria, Class theClass, Record translationRow) throws QueryException {
+    public Vector getAllFromIdentityMap(Expression selectionCriteria, Class theClass, DataRecord translationRow) throws QueryException {
         return getAllFromIdentityMap(selectionCriteria, theClass, translationRow, InMemoryQueryIndirectionPolicy.SHOULD_THROW_INDIRECTION_EXCEPTION, true);
     }
 
@@ -272,7 +272,7 @@ public class IdentityMapAccessor implements org.eclipse.persistence.sessions.Ide
      * If the expression is too complex an exception will be thrown.
      */
     @Override
-    public Vector getAllFromIdentityMap(Expression selectionCriteria, Class theClass, Record translationRow, InMemoryQueryIndirectionPolicy valueHolderPolicy) throws QueryException {
+    public Vector getAllFromIdentityMap(Expression selectionCriteria, Class theClass, DataRecord translationRow, InMemoryQueryIndirectionPolicy valueHolderPolicy) throws QueryException {
         return getAllFromIdentityMap(selectionCriteria, theClass, translationRow, valueHolderPolicy, true);
     }
 
@@ -282,7 +282,7 @@ public class IdentityMapAccessor implements org.eclipse.persistence.sessions.Ide
      * If the expression is too complex an exception will be thrown.
      */
     @Override
-    public Vector getAllFromIdentityMap(Expression selectionCriteria, Class theClass, Record translationRow, int valueHolderPolicy) throws QueryException {
+    public Vector getAllFromIdentityMap(Expression selectionCriteria, Class theClass, DataRecord translationRow, int valueHolderPolicy) throws QueryException {
         return getAllFromIdentityMap(selectionCriteria, theClass, translationRow, valueHolderPolicy, true);
     }
 
@@ -293,7 +293,7 @@ public class IdentityMapAccessor implements org.eclipse.persistence.sessions.Ide
      * Only return objects that are invalid in the cache if specified.
      */
     @Override
-    public Vector getAllFromIdentityMap(Expression selectionCriteria, Class theClass, Record translationRow, InMemoryQueryIndirectionPolicy valueHolderPolicy, boolean shouldReturnInvalidatedObjects) throws QueryException {
+    public Vector getAllFromIdentityMap(Expression selectionCriteria, Class theClass, DataRecord translationRow, InMemoryQueryIndirectionPolicy valueHolderPolicy, boolean shouldReturnInvalidatedObjects) throws QueryException {
         int policy = 0;
         if (valueHolderPolicy != null) {
             policy = valueHolderPolicy.getPolicy();
@@ -308,7 +308,7 @@ public class IdentityMapAccessor implements org.eclipse.persistence.sessions.Ide
      * Only return objects that are invalid in the cache if specified.
      */
     @Override
-    public Vector getAllFromIdentityMap(Expression selectionCriteria, Class theClass, Record translationRow, int valueHolderPolicy, boolean shouldReturnInvalidatedObjects) throws QueryException {
+    public Vector getAllFromIdentityMap(Expression selectionCriteria, Class theClass, DataRecord translationRow, int valueHolderPolicy, boolean shouldReturnInvalidatedObjects) throws QueryException {
         return getIdentityMapManager().getAllFromIdentityMap(selectionCriteria, theClass, translationRow, valueHolderPolicy, shouldReturnInvalidatedObjects);
     }
 
@@ -433,7 +433,7 @@ public class IdentityMapAccessor implements org.eclipse.persistence.sessions.Ide
      * Return the object from the identity with the primary and class.
      */
     @Override
-    public Object getFromIdentityMap(Record rowContainingPrimaryKey, Class theClass) {
+    public Object getFromIdentityMap(DataRecord rowContainingPrimaryKey, Class theClass) {
         return getFromIdentityMap(extractPrimaryKeyFromRow(rowContainingPrimaryKey, theClass), theClass);
     }
 
@@ -443,7 +443,7 @@ public class IdentityMapAccessor implements org.eclipse.persistence.sessions.Ide
      * Only return invalidated objects if requested.
      */
     @Override
-    public Object getFromIdentityMap(Record rowContainingPrimaryKey, Class theClass, boolean shouldReturnInvalidatedObjects) {
+    public Object getFromIdentityMap(DataRecord rowContainingPrimaryKey, Class theClass, boolean shouldReturnInvalidatedObjects) {
         return getFromIdentityMap(extractPrimaryKeyFromRow(rowContainingPrimaryKey, theClass), theClass, shouldReturnInvalidatedObjects);
     }
 
@@ -454,7 +454,7 @@ public class IdentityMapAccessor implements org.eclipse.persistence.sessions.Ide
      * If the expression is too complex an exception will be thrown.
      */
     @Override
-    public Object getFromIdentityMap(Expression selectionCriteria, Class theClass, Record translationRow) throws QueryException {
+    public Object getFromIdentityMap(Expression selectionCriteria, Class theClass, DataRecord translationRow) throws QueryException {
         return getFromIdentityMap(selectionCriteria, theClass, translationRow, InMemoryQueryIndirectionPolicy.SHOULD_THROW_INDIRECTION_EXCEPTION);
     }
 
@@ -465,7 +465,7 @@ public class IdentityMapAccessor implements org.eclipse.persistence.sessions.Ide
      * If the expression is too complex an exception will be thrown.
      */
     @Override
-    public Object getFromIdentityMap(Expression selectionCriteria, Class theClass, Record translationRow, InMemoryQueryIndirectionPolicy valueHolderPolicy) throws QueryException {
+    public Object getFromIdentityMap(Expression selectionCriteria, Class theClass, DataRecord translationRow, InMemoryQueryIndirectionPolicy valueHolderPolicy) throws QueryException {
         int policy = 0;
         if (valueHolderPolicy != null) {
             policy = valueHolderPolicy.getPolicy();
@@ -480,7 +480,7 @@ public class IdentityMapAccessor implements org.eclipse.persistence.sessions.Ide
      * If the expression is too complex an exception will be thrown.
      */
     @Override
-    public Object getFromIdentityMap(Expression selectionCriteria, Class theClass, Record translationRow, int valueHolderPolicy) throws QueryException {
+    public Object getFromIdentityMap(Expression selectionCriteria, Class theClass, DataRecord translationRow, int valueHolderPolicy) throws QueryException {
         return getFromIdentityMap(selectionCriteria, theClass, translationRow, valueHolderPolicy, false);
     }
 
@@ -490,7 +490,7 @@ public class IdentityMapAccessor implements org.eclipse.persistence.sessions.Ide
      * If the object is not found null is returned.
      * If the expression is too complex an exception will be thrown.
      */
-    public Object getFromIdentityMap(Expression selectionCriteria, Class theClass, Record translationRow, int valueHolderPolicy, boolean conforming) {
+    public Object getFromIdentityMap(Expression selectionCriteria, Class theClass, DataRecord translationRow, int valueHolderPolicy, boolean conforming) {
         return getFromIdentityMap(selectionCriteria, theClass, translationRow, valueHolderPolicy, conforming, true, getSession().getDescriptor(theClass));
     }
 
@@ -500,7 +500,7 @@ public class IdentityMapAccessor implements org.eclipse.persistence.sessions.Ide
      * If the object is not found null is returned.
      * If the expression is too complex an exception will be thrown.
      */
-    public Object getFromIdentityMap(Expression selectionCriteria, Class theClass, Record translationRow, int valueHolderPolicy, boolean conforming, boolean shouldReturnInvalidatedObjects) {
+    public Object getFromIdentityMap(Expression selectionCriteria, Class theClass, DataRecord translationRow, int valueHolderPolicy, boolean conforming, boolean shouldReturnInvalidatedObjects) {
         return getFromIdentityMap(selectionCriteria, theClass, translationRow, valueHolderPolicy, conforming, shouldReturnInvalidatedObjects, getSession().getDescriptor(theClass));
     }
 
@@ -510,7 +510,7 @@ public class IdentityMapAccessor implements org.eclipse.persistence.sessions.Ide
      * If the object is not found null is returned.
      * If the expression is too complex an exception will be thrown.
      */
-    public Object getFromIdentityMap(Expression selectionCriteria, Class theClass, Record translationRow, int valueHolderPolicy, boolean conforming, boolean shouldReturnInvalidatedObjects, ClassDescriptor descriptor) {
+    public Object getFromIdentityMap(Expression selectionCriteria, Class theClass, DataRecord translationRow, int valueHolderPolicy, boolean conforming, boolean shouldReturnInvalidatedObjects, ClassDescriptor descriptor) {
         return getIdentityMapManager().getFromIdentityMap(selectionCriteria, theClass, translationRow, valueHolderPolicy, conforming, shouldReturnInvalidatedObjects, descriptor);
     }
 
@@ -767,7 +767,7 @@ public class IdentityMapAccessor implements org.eclipse.persistence.sessions.Ide
      * without any action.
      */
     @Override
-    public void invalidateObject(Record rowContainingPrimaryKey, Class theClass) {
+    public void invalidateObject(DataRecord rowContainingPrimaryKey, Class theClass) {
         invalidateObject(rowContainingPrimaryKey, theClass, false);
     }
 
@@ -777,7 +777,7 @@ public class IdentityMapAccessor implements org.eclipse.persistence.sessions.Ide
      * @param invalidateCluster if true the invalidation will be broadcast to each server in the cluster.
      */
     @Override
-    public void invalidateObject(Record rowContainingPrimaryKey, Class theClass, boolean invalidateCluster) {
+    public void invalidateObject(DataRecord rowContainingPrimaryKey, Class theClass, boolean invalidateCluster) {
         invalidateObject(extractPrimaryKeyFromRow(rowContainingPrimaryKey, theClass), theClass, invalidateCluster);
     }
 
@@ -800,7 +800,7 @@ public class IdentityMapAccessor implements org.eclipse.persistence.sessions.Ide
      * @param shouldInvalidateOnException boolean indicates weather to invalidate the object if conform threw exception.
      */
     @Override
-    public void invalidateObjects(Expression selectionCriteria, Class theClass, Record translationRow, boolean shouldInvalidateOnException) {
+    public void invalidateObjects(Expression selectionCriteria, Class theClass, DataRecord translationRow, boolean shouldInvalidateOnException) {
         getIdentityMapManager().invalidateObjects(selectionCriteria, theClass, translationRow, shouldInvalidateOnException);
     }
 
@@ -921,7 +921,7 @@ public class IdentityMapAccessor implements org.eclipse.persistence.sessions.Ide
      * Return if this object is valid in the cache.
      */
     @Override
-    public boolean isValid(Record rowContainingPrimaryKey, Class theClass) {
+    public boolean isValid(DataRecord rowContainingPrimaryKey, Class theClass) {
         return isValid(extractPrimaryKeyFromRow(rowContainingPrimaryKey, theClass), theClass);
     }
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/IsolatedClientSessionIdentityMapAccessor.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/IsolatedClientSessionIdentityMapAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -20,10 +20,9 @@ import org.eclipse.persistence.internal.identitymaps.*;
 import org.eclipse.persistence.queries.*;
 import org.eclipse.persistence.expressions.*;
 import org.eclipse.persistence.exceptions.*;
-import org.eclipse.persistence.internal.sessions.AbstractSession;
 import org.eclipse.persistence.descriptors.CacheIndex;
 import org.eclipse.persistence.descriptors.ClassDescriptor;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.logging.SessionLog;
 import org.eclipse.persistence.internal.descriptors.ObjectBuilder;
 import org.eclipse.persistence.internal.descriptors.PersistenceEntity;
@@ -185,7 +184,7 @@ public class IsolatedClientSessionIdentityMapAccessor extends org.eclipse.persis
      * Only return objects that are invalid in the cache if specified.
      */
     @Override
-    public Vector getAllFromIdentityMap(Expression selectionCriteria, Class theClass, Record translationRow, int valueHolderPolicy, boolean shouldReturnInvalidatedObjects) throws QueryException {
+    public Vector getAllFromIdentityMap(Expression selectionCriteria, Class theClass, DataRecord translationRow, int valueHolderPolicy, boolean shouldReturnInvalidatedObjects) throws QueryException {
         if (!session.getDescriptor(theClass).getCachePolicy().isSharedIsolation()) {
             return getIdentityMapManager().getAllFromIdentityMap(selectionCriteria, theClass, translationRow, valueHolderPolicy, shouldReturnInvalidatedObjects);
         } else {
@@ -380,7 +379,7 @@ public class IsolatedClientSessionIdentityMapAccessor extends org.eclipse.persis
      * If the expression is too complex an exception will be thrown.
      */
     @Override
-    public Object getFromIdentityMap(Expression selectionCriteria, Class theClass, Record translationRow, int valueHolderPolicy, boolean conforming, boolean shouldReturnInvalidatedObjects, ClassDescriptor descriptor) {
+    public Object getFromIdentityMap(Expression selectionCriteria, Class theClass, DataRecord translationRow, int valueHolderPolicy, boolean conforming, boolean shouldReturnInvalidatedObjects, ClassDescriptor descriptor) {
         if (!descriptor.getCachePolicy().isSharedIsolation()) {
             return getIdentityMapManager().getFromIdentityMap(selectionCriteria, theClass, translationRow, valueHolderPolicy, conforming, shouldReturnInvalidatedObjects, descriptor);
         } else {
@@ -662,7 +661,7 @@ public class IsolatedClientSessionIdentityMapAccessor extends org.eclipse.persis
      * @param shouldInvalidateOnException boolean indicates weather to invalidate the object if conform threw exception.
      */
     @Override
-    public void invalidateObjects(Expression selectionCriteria, Class theClass, Record translationRow, boolean shouldInvalidateOnException) {
+    public void invalidateObjects(Expression selectionCriteria, Class theClass, DataRecord translationRow, boolean shouldInvalidateOnException) {
         if (!session.getDescriptor(theClass).getCachePolicy().isSharedIsolation()) {
             getIdentityMapManager().invalidateObjects(selectionCriteria, theClass, translationRow, shouldInvalidateOnException);
         } else {

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/TransformationMappingChangeRecord.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/TransformationMappingChangeRecord.java
@@ -14,8 +14,8 @@
 //     Oracle - initial API and implementation from Oracle TopLink
 package org.eclipse.persistence.internal.sessions;
 
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.DatabaseRecord;
-import org.eclipse.persistence.sessions.Record;
 
 /**
  * <p>
@@ -47,7 +47,7 @@ public class TransformationMappingChangeRecord extends ChangeRecord implements o
      * This method is used to access the changes of the fields in a transformation mapping.
      */
     @Override
-    public Record getRecord() {
+    public DataRecord getRecord() {
         if (rowCollection == null) {
             this.rowCollection = new DatabaseRecord();
         }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkIdentityMapAccessor.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkIdentityMapAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -19,11 +19,10 @@ import java.util.*;
 import org.eclipse.persistence.descriptors.ClassDescriptor;
 import org.eclipse.persistence.internal.descriptors.PersistenceEntity;
 import org.eclipse.persistence.internal.identitymaps.*;
-import org.eclipse.persistence.internal.sessions.IdentityMapAccessor;
 import org.eclipse.persistence.expressions.*;
 import org.eclipse.persistence.exceptions.*;
 import org.eclipse.persistence.queries.*;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 
 /**
  * INTERNAL:
@@ -103,7 +102,7 @@ public class UnitOfWorkIdentityMapAccessor extends IdentityMapAccessor {
      * will always be returned from a UnitOfWork.
      */
     @Override
-    public Vector getAllFromIdentityMap(Expression selectionCriteria, Class theClass, Record translationRow, int valueHolderPolicy, boolean shouldReturnInvalidatedObjects) throws QueryException {
+    public Vector getAllFromIdentityMap(Expression selectionCriteria, Class theClass, DataRecord translationRow, int valueHolderPolicy, boolean shouldReturnInvalidatedObjects) throws QueryException {
         return super.getAllFromIdentityMap(selectionCriteria, theClass, translationRow, valueHolderPolicy, true);
     }
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/mappings/transformers/AttributeTransformer.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/mappings/transformers/AttributeTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,7 +16,7 @@ package org.eclipse.persistence.mappings.transformers;
 
 import java.io.*;
 import org.eclipse.persistence.sessions.Session;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.mappings.foundation.AbstractTransformationMapping;
 
 /**
@@ -36,10 +36,10 @@ public interface AttributeTransformer extends Serializable {
     void initialize(AbstractTransformationMapping mapping);
 
     /**
-     * @param record - The metadata being used to build the object.
+     * @param dataRecord - The metadata being used to build the object.
      * @param session - the current session
      * @param object - The current object that the attribute is being built for.
      * @return - The attribute value to be built into the object containing this mapping.
      */
-    Object buildAttributeValue(Record record, Object object, Session session);
+    Object buildAttributeValue(DataRecord dataRecord, Object object, Session session);
 }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/mappings/transformers/AttributeTransformerAdapter.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/mappings/transformers/AttributeTransformerAdapter.java
@@ -14,7 +14,7 @@
 //     Oracle - initial API and implementation from Oracle TopLink
 package org.eclipse.persistence.mappings.transformers;
 
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 import org.eclipse.persistence.mappings.foundation.AbstractTransformationMapping;
 
@@ -40,7 +40,7 @@ public class AttributeTransformerAdapter implements AttributeTransformer {
     }
 
     @Override
-    public Object buildAttributeValue(Record record, Object object, Session session) {
+    public Object buildAttributeValue(DataRecord dataRecord, Object object, Session session) {
         return null;
     }
 }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/mappings/transformers/MethodBasedAttributeTransformer.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/mappings/transformers/MethodBasedAttributeTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -26,7 +26,7 @@ import org.eclipse.persistence.internal.security.PrivilegedAccessHelper;
 import org.eclipse.persistence.internal.security.PrivilegedGetMethodParameterTypes;
 import org.eclipse.persistence.internal.security.PrivilegedMethodInvoker;
 import org.eclipse.persistence.mappings.foundation.AbstractTransformationMapping;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 
 /**
@@ -114,7 +114,7 @@ public class MethodBasedAttributeTransformer implements AttributeTransformer {
      * Build the attribute value by invoking the user's transformation method.
      */
     @Override
-    public Object buildAttributeValue(Record record, Object object, Session session) {
+    public Object buildAttributeValue(DataRecord dataRecord, Object object, Session session) {
         Class[] parameterTypes = null;
         if (PrivilegedAccessHelper.shouldUsePrivilegedAccess()){
             try{
@@ -126,7 +126,7 @@ public class MethodBasedAttributeTransformer implements AttributeTransformer {
             parameterTypes = PrivilegedAccessHelper.getMethodParameterTypes(attributeTransformationMethod);
         }
         Object[] parameters = new Object[parameterTypes.length];
-        parameters[0] = record;
+        parameters[0] = dataRecord;
         if (parameters.length == 2) {
             parameters[1] = session;
         }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/DatabaseQuery.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/DatabaseQuery.java
@@ -56,9 +56,9 @@ import org.eclipse.persistence.internal.sessions.AbstractRecord;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
 import org.eclipse.persistence.internal.sessions.UnitOfWorkImpl;
 import org.eclipse.persistence.mappings.DatabaseMapping;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.remote.*;
 import org.eclipse.persistence.sessions.DatabaseRecord;
-import org.eclipse.persistence.sessions.Record;
 import org.eclipse.persistence.sessions.SessionProfiler;
 
 /**
@@ -1073,7 +1073,7 @@ public abstract class DatabaseQuery implements Cloneable, Serializable {
      * ADVANCED: Return the call for this query. This call contains the SQL and
      * argument list.
      *
-     * @see #prepareCall(org.eclipse.persistence.sessions.Session, org.eclipse.persistence.sessions.Record) prepareCall(Session, Record)
+     * @see #prepareCall(org.eclipse.persistence.sessions.Session, DataRecord) prepareCall(Session, Record)
      */
     public Call getDatasourceCall() {
         Call call = null;
@@ -1095,7 +1095,7 @@ public abstract class DatabaseQuery implements Cloneable, Serializable {
      * ADVANCED: Return the calls for this query. This method can be called for
      * queries with multiple calls This call contains the SQL and argument list.
      *
-     * @see #prepareCall(org.eclipse.persistence.sessions.Session, org.eclipse.persistence.sessions.Record) prepareCall(Session, Record)
+     * @see #prepareCall(org.eclipse.persistence.sessions.Session, DataRecord) prepareCall(Session, Record)
      */
     public List getDatasourceCalls() {
         List calls = new Vector();
@@ -1433,7 +1433,7 @@ public abstract class DatabaseQuery implements Cloneable, Serializable {
      * queries. This can also be used for normal queries if they have been
      * prepared, (i.e. query.prepareCall()).
      *
-     * @see #prepareCall(org.eclipse.persistence.sessions.Session, org.eclipse.persistence.sessions.Record) prepareCall(Session, Record)
+     * @see #prepareCall(org.eclipse.persistence.sessions.Session, DataRecord) prepareCall(Session, Record)
      */
     public String getSQLString() {
         Call call = getDatasourceCall();
@@ -1453,7 +1453,7 @@ public abstract class DatabaseQuery implements Cloneable, Serializable {
      * for normal queries if they have been prepared, (i.e.
      * query.prepareCall()).
      *
-     * @see #prepareCall(org.eclipse.persistence.sessions.Session, org.eclipse.persistence.sessions.Record) prepareCall(Session, Record)
+     * @see #prepareCall(org.eclipse.persistence.sessions.Session, DataRecord) prepareCall(Session, Record)
      */
     public List getSQLStrings() {
         List calls = getDatasourceCalls();
@@ -1492,9 +1492,9 @@ public abstract class DatabaseQuery implements Cloneable, Serializable {
      * have been prepared, (i.e. query.prepareCall()). The Record argument is
      * one of (Record, XMLRecord) that contains the query arguments.
      *
-     * @see #prepareCall(org.eclipse.persistence.sessions.Session, Record)
+     * @see #prepareCall(org.eclipse.persistence.sessions.Session, DataRecord)
      */
-    public String getTranslatedSQLString(org.eclipse.persistence.sessions.Session session, Record translationRow) {
+    public String getTranslatedSQLString(org.eclipse.persistence.sessions.Session session, DataRecord translationRow) {
         prepareCall(session, translationRow);
         // CR#2859559 fix to use Session and Record interfaces not impl classes.
         CallQueryMechanism queryMechanism = (CallQueryMechanism) getQueryMechanism();
@@ -1512,9 +1512,9 @@ public abstract class DatabaseQuery implements Cloneable, Serializable {
      * have been prepared, (i.e. query.prepareCall()). This method can be used
      * for queries with multiple calls.
      *
-     * @see #prepareCall(org.eclipse.persistence.sessions.Session, org.eclipse.persistence.sessions.Record) prepareCall(Session, Record)
+     * @see #prepareCall(org.eclipse.persistence.sessions.Session, DataRecord) prepareCall(Session, Record)
      */
-    public List getTranslatedSQLStrings(org.eclipse.persistence.sessions.Session session, Record translationRow) {
+    public List getTranslatedSQLStrings(org.eclipse.persistence.sessions.Session session, DataRecord translationRow) {
         prepareCall(session, translationRow);
         CallQueryMechanism queryMechanism = (CallQueryMechanism) getQueryMechanism();
         if ((queryMechanism.getCalls() == null) || queryMechanism.getCalls().isEmpty()) {
@@ -1922,9 +1922,9 @@ public abstract class DatabaseQuery implements Cloneable, Serializable {
      * @see #getCall()
      * @see #getSQLString()
      * @see #getTranslatedSQLString(org.eclipse.persistence.sessions.Session,
-     *      Record)
+     *      DataRecord)
      */
-    public void prepareCall(org.eclipse.persistence.sessions.Session session, Record translationRow) throws QueryException {
+    public void prepareCall(org.eclipse.persistence.sessions.Session session, DataRecord translationRow) throws QueryException {
         // CR#2859559 fix to use Session and Record interfaces not impl classes.
         checkPrepare((AbstractSession) session, (AbstractRecord) translationRow, true);
     }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/MethodBaseQueryRedirector.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/MethodBaseQueryRedirector.java
@@ -197,7 +197,7 @@ public class MethodBaseQueryRedirector implements QueryRedirector {
      * Call the static method to execute the query.
      */
     @Override
-    public Object invokeQuery(DatabaseQuery query, org.eclipse.persistence.sessions.Record arguments, Session session) {
+    public Object invokeQuery(DatabaseQuery query, DataRecord arguments, Session session) {
         if (getMethod() == null) {
             initializeMethod(query);
         }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/QueryRedirector.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/QueryRedirector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -48,5 +48,5 @@ public interface QueryRedirector extends Serializable {
      * Perform the query.
      * This must execute the query base on the arguments and return a valid result for the query.
      */
-    Object invokeQuery(DatabaseQuery query, org.eclipse.persistence.sessions.Record arguments, Session session);
+    Object invokeQuery(DatabaseQuery query, DataRecord arguments, Session session);
 }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/QueryRedirectorHelper.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/QueryRedirectorHelper.java
@@ -16,7 +16,7 @@ package org.eclipse.persistence.queries;
 
 import org.eclipse.persistence.internal.sessions.AbstractRecord;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 
 /**
@@ -40,8 +40,8 @@ public class QueryRedirectorHelper {
      * in this case the cache check has also been redirected.  Through this method the redirector can have
      * EclipseLink check the cache in the normal manner.
      */
-    public static Object checkEclipseLinkCache(DatabaseQuery query, Record record, Session session){
-        return query.checkEarlyReturn((AbstractSession)session, (AbstractRecord)record);
+    public static Object checkEclipseLinkCache(DatabaseQuery query, DataRecord dataRecord, Session session){
+        return query.checkEarlyReturn((AbstractSession)session, (AbstractRecord) dataRecord);
     }
 
 }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sequencing/QuerySequence.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sequencing/QuerySequence.java
@@ -18,7 +18,8 @@ package org.eclipse.persistence.sequencing;
 
 import java.util.Vector;
 import java.math.BigDecimal;
-import org.eclipse.persistence.sessions.Record;
+
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.queries.*;
 import org.eclipse.persistence.internal.databaseaccess.Accessor;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
@@ -287,8 +288,8 @@ public class QuerySequence extends StandardSequence {
                     currentValue = BigDecimal.valueOf(((Number)result).longValue());
                 } else if (result instanceof String) {
                     currentValue = new BigDecimal((String)result);
-                } else if (result instanceof Record) {
-                    Object val = ((Record)result).get("text()");
+                } else if (result instanceof DataRecord) {
+                    Object val = ((DataRecord)result).get("text()");
                     currentValue = new BigDecimal((String)val);
                 } else {
                     // DatabaseException.errorPreallocatingSequenceNumbers() is thrown by the superclass

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/DataRecord.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/DataRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -24,6 +24,6 @@ import java.util.Map;
  * @author  mmacivor
  * @since   10.1.3
  */
-public interface Record extends Map {
+public interface DataRecord extends Map {
     // Uses Map API.
 }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/DatabaseRecord.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/DatabaseRecord.java
@@ -30,7 +30,7 @@ import org.eclipse.persistence.internal.sessions.AbstractRecord;
  *        <li> Allow get and put on the field or field name.
  * </ul>
  * @see DatabaseField
- * @see Record
+ * @see DataRecord
  * @see java.util.Map
  */
 public class DatabaseRecord extends AbstractRecord {

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/IdentityMapAccessor.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/IdentityMapAccessor.java
@@ -90,7 +90,7 @@ public interface IdentityMapAccessor {
      * Returns true if the identity map contains an Object with the same primary key
      * of the specified row (i.e. the database record) and Class type.
      */
-    boolean containsObjectInIdentityMap(Record rowContainingPrimaryKey, Class theClass);
+    boolean containsObjectInIdentityMap(DataRecord rowContainingPrimaryKey, Class theClass);
 
     /**
      * ADVANCED:
@@ -106,7 +106,7 @@ public interface IdentityMapAccessor {
      * @param shouldReturnInvalidatedObjects boolean - true if only invalid Objects should be returned
      * @return Vector of Objects
      */
-    Vector getAllFromIdentityMap(Expression selectionCriteria, Class theClass, Record translationRow, InMemoryQueryIndirectionPolicy valueHolderPolicy, boolean shouldReturnInvalidatedObjects) throws QueryException;
+    Vector getAllFromIdentityMap(Expression selectionCriteria, Class theClass, DataRecord translationRow, InMemoryQueryIndirectionPolicy valueHolderPolicy, boolean shouldReturnInvalidatedObjects) throws QueryException;
 
     /**
      * ADVANCED:
@@ -122,7 +122,7 @@ public interface IdentityMapAccessor {
      * @param shouldReturnInvalidatedObjects boolean - true if only invalid Objects should be returned
      * @return Vector of Objects
      */
-    Vector getAllFromIdentityMap(Expression selectionCriteria, Class theClass, Record translationRow, int valueHolderPolicy, boolean shouldReturnInvalidatedObjects) throws QueryException;
+    Vector getAllFromIdentityMap(Expression selectionCriteria, Class theClass, DataRecord translationRow, int valueHolderPolicy, boolean shouldReturnInvalidatedObjects) throws QueryException;
 
     /**
      * ADVANCED:
@@ -135,7 +135,7 @@ public interface IdentityMapAccessor {
      * {@link org.eclipse.persistence.queries.InMemoryQueryIndirectionPolicy InMemoryQueryIndirectionPolicy}
      * @return Vector of Objects with type theClass and matching the selectionCriteria
      */
-    Vector getAllFromIdentityMap(Expression selectionCriteria, Class theClass, Record translationRow, InMemoryQueryIndirectionPolicy valueHolderPolicy) throws QueryException;
+    Vector getAllFromIdentityMap(Expression selectionCriteria, Class theClass, DataRecord translationRow, InMemoryQueryIndirectionPolicy valueHolderPolicy) throws QueryException;
 
     /**
      * ADVANCED:
@@ -148,7 +148,7 @@ public interface IdentityMapAccessor {
      * {@link org.eclipse.persistence.queries.InMemoryQueryIndirectionPolicy InMemoryQueryIndirectionPolicy}
      * @return Vector of Objects with type theClass and matching the selectionCriteria
      */
-    Vector getAllFromIdentityMap(Expression selectionCriteria, Class theClass, Record translationRow, int valueHolderPolicy) throws QueryException;
+    Vector getAllFromIdentityMap(Expression selectionCriteria, Class theClass, DataRecord translationRow, int valueHolderPolicy) throws QueryException;
 
     /**
      * ADVANCED:
@@ -176,7 +176,7 @@ public interface IdentityMapAccessor {
      * @param theClass Class
      * @return Object from identity map, may be null.
      */
-    Object getFromIdentityMap(Record rowContainingPrimaryKey, Class theClass);
+    Object getFromIdentityMap(DataRecord rowContainingPrimaryKey, Class theClass);
 
     /**
      * ADVANCED:
@@ -197,7 +197,7 @@ public interface IdentityMapAccessor {
      * @param shouldReturnInvalidatedObjects boolean
      * @return Object from identity map, may be null.
      */
-    Object getFromIdentityMap(Record rowContainingPrimaryKey, Class theClass, boolean shouldReturnInvalidatedObjects);
+    Object getFromIdentityMap(DataRecord rowContainingPrimaryKey, Class theClass, boolean shouldReturnInvalidatedObjects);
 
     /**
      * ADVANCED:
@@ -209,7 +209,7 @@ public interface IdentityMapAccessor {
      * @param translationRow Record
      * @return Object from identity map, may be null
      */
-    Object getFromIdentityMap(Expression selectionCriteria, Class theClass, Record translationRow) throws QueryException;
+    Object getFromIdentityMap(Expression selectionCriteria, Class theClass, DataRecord translationRow) throws QueryException;
 
     /**
      * ADVANCED:
@@ -224,7 +224,7 @@ public interface IdentityMapAccessor {
      * see {@link org.eclipse.persistence.queries.InMemoryQueryIndirectionPolicy InMemoryQueryIndirectionPolicy}
      * @return Object from identity map, may be null
      */
-    Object getFromIdentityMap(Expression selectionCriteria, Class theClass, Record translationRow, InMemoryQueryIndirectionPolicy valueHolderPolicy) throws QueryException;
+    Object getFromIdentityMap(Expression selectionCriteria, Class theClass, DataRecord translationRow, InMemoryQueryIndirectionPolicy valueHolderPolicy) throws QueryException;
 
     /**
      * ADVANCED:
@@ -239,7 +239,7 @@ public interface IdentityMapAccessor {
      * see {@link org.eclipse.persistence.queries.InMemoryQueryIndirectionPolicy InMemoryQueryIndirectionPolicy}
      * @return Object from identity map, may be null
      */
-    Object getFromIdentityMap(Expression selectionCriteria, Class theClass, Record translationRow, int valueHolderPolicy) throws QueryException;
+    Object getFromIdentityMap(Expression selectionCriteria, Class theClass, DataRecord translationRow, int valueHolderPolicy) throws QueryException;
 
     /**
      * ADVANCED:
@@ -335,14 +335,14 @@ public interface IdentityMapAccessor {
      * be invalid in the cache. If the Object does not exist in the cache,
      * this method will return without any action.
      */
-    void invalidateObject(Record rowContainingPrimaryKey, Class theClass);
+    void invalidateObject(DataRecord rowContainingPrimaryKey, Class theClass);
 
     /**
      * ADVANCED:
      * Set an object to be invalid in the cache.
      * @param invalidateCluster if true the invalidation will be broadcast to each server in the cluster.
      */
-    void invalidateObject(Record rowContainingPrimaryKey, Class theClass, boolean invalidateCluster);
+    void invalidateObject(DataRecord rowContainingPrimaryKey, Class theClass, boolean invalidateCluster);
 
     /**
      * ADVANCED:
@@ -383,7 +383,7 @@ public interface IdentityMapAccessor {
      * @param translationRow Record
      * @param shouldInvalidateOnException boolean indicates weather to invalidate the object if conform threw exception.
      */
-    void invalidateObjects(Expression selectionCriteria, Class theClass, Record translationRow, boolean shouldInvalidateOnException);
+    void invalidateObjects(Expression selectionCriteria, Class theClass, DataRecord translationRow, boolean shouldInvalidateOnException);
 
     /**
      * ADVANCED:
@@ -428,7 +428,7 @@ public interface IdentityMapAccessor {
      * Returns true if this Object with the given primary key of the Row and Class type
      * given is valid in the cache.
      */
-    boolean isValid(Record rowContainingPrimaryKey, Class theClass);
+    boolean isValid(DataRecord rowContainingPrimaryKey, Class theClass);
 
     /**
      * PUBLIC:

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/SessionEventManager.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/SessionEventManager.java
@@ -23,7 +23,6 @@ import org.eclipse.persistence.internal.databaseaccess.*;
 import org.eclipse.persistence.internal.sessions.*;
 import org.eclipse.persistence.sessions.broker.SessionBroker;
 import org.eclipse.persistence.sessions.server.ClientSession;
-import org.eclipse.persistence.sessions.SessionProfiler;
 
 /**
  * <p><b>Purpose</b>: Used to support session events.
@@ -206,7 +205,7 @@ public class SessionEventManager extends CoreSessionEventManager<SessionEventLis
      * INTERNAL:
      * Raised for stored proc output parameters.
      */
-    public void outputParametersDetected(Record outputRow, DatasourceCall call) {
+    public void outputParametersDetected(DataRecord outputRow, DatasourceCall call) {
         if (!hasListeners()) {
             return;
         }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/SessionProfiler.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/SessionProfiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -99,7 +99,7 @@ public interface SessionProfiler {
      *
      * @return the execution result of the query.
      */
-    Object profileExecutionOfQuery(DatabaseQuery query, Record row, AbstractSession session);
+    Object profileExecutionOfQuery(DatabaseQuery query, DataRecord row, AbstractSession session);
 
     /**
      * INTERNAL:

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/SessionProfilerAdapter.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/SessionProfilerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -54,7 +54,7 @@ public abstract class SessionProfilerAdapter implements SessionProfiler {
      * @return the execution result of the query.
      */
     @Override
-    public Object profileExecutionOfQuery(DatabaseQuery query, Record row, AbstractSession session) {
+    public Object profileExecutionOfQuery(DatabaseQuery query, DataRecord row, AbstractSession session) {
         return session.internalExecuteQuery(query, (AbstractRecord)row);
     }
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/changesets/TransformationMappingChangeRecord.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/changesets/TransformationMappingChangeRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,7 +14,7 @@
 //     Oracle - initial API and implementation from Oracle TopLink
 package org.eclipse.persistence.sessions.changesets;
 
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 
 /**
  * <p>
@@ -29,5 +29,5 @@ public interface TransformationMappingChangeRecord extends ChangeRecord {
      * This method is used to access the changes of the fields in a transformation mapping.
      * @return org.eclipse.persistence.sessions.Record
      */
-    Record getRecord();
+    DataRecord getRecord();
 }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/interceptors/CacheKeyInterceptor.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/interceptors/CacheKeyInterceptor.java
@@ -17,7 +17,7 @@ package org.eclipse.persistence.sessions.interceptors;
 import org.eclipse.persistence.internal.identitymaps.AbstractIdentityMap;
 import org.eclipse.persistence.internal.identitymaps.CacheKey;
 import org.eclipse.persistence.internal.identitymaps.IdentityMap;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 
 /**
  * The CacheKeyInterceptor allows a Cache Interceptor implementation to wrap the EclipseLink CacheKey.
@@ -167,7 +167,7 @@ public class CacheKeyInterceptor extends CacheKey{
         }
 
         @Override
-        public Record getRecord() {
+        public DataRecord getRecord() {
             return wrappedKey.getRecord();
         }
 
@@ -269,8 +269,8 @@ public class CacheKeyInterceptor extends CacheKey{
         }
 
         @Override
-        public void setRecord(Record newRecord) {
-            wrappedKey.setRecord(newRecord);
+        public void setRecord(DataRecord newDataRecord) {
+            wrappedKey.setRecord(newDataRecord);
         }
 
         @Override

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/tools/profiler/PerformanceMonitor.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/tools/profiler/PerformanceMonitor.java
@@ -20,7 +20,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.io.*;
 
 import org.eclipse.persistence.queries.*;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.SessionProfiler;
 import org.eclipse.persistence.internal.sessions.AbstractRecord;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
@@ -192,7 +192,7 @@ public class PerformanceMonitor implements Serializable, Cloneable, SessionProfi
      * Monitoring is done on the endOperation only.
      */
     @Override
-    public Object profileExecutionOfQuery(DatabaseQuery query, Record row, AbstractSession session) {
+    public Object profileExecutionOfQuery(DatabaseQuery query, DataRecord row, AbstractSession session) {
         if (this.profileWeight < SessionProfiler.HEAVY) {
             return session.internalExecuteQuery(query, (AbstractRecord)row);
         }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/tools/profiler/PerformanceProfiler.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/tools/profiler/PerformanceProfiler.java
@@ -29,7 +29,7 @@ import org.eclipse.persistence.internal.localization.ToStringLocalization;
 import org.eclipse.persistence.internal.sessions.AbstractRecord;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
 import org.eclipse.persistence.queries.DatabaseQuery;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.SessionProfilerAdapter;
 
 /**
@@ -384,7 +384,7 @@ public class PerformanceProfiler extends SessionProfilerAdapter implements Seria
      */
     @Override
     @SuppressWarnings({"unchecked"})
-    public Object profileExecutionOfQuery(DatabaseQuery query, Record row, AbstractSession session) {
+    public Object profileExecutionOfQuery(DatabaseQuery query, DataRecord row, AbstractSession session) {
         long profileStartTime = System.nanoTime();
         long nestedProfileStartTime = getProfileTime();
         Profile profile = new Profile();

--- a/foundation/org.eclipse.persistence.nosql/src/it/java/org/eclipse/persistence/testing/models/employee/eis/xmlfile/NormalHoursNSTransformer.java
+++ b/foundation/org.eclipse.persistence.nosql/src/it/java/org/eclipse/persistence/testing/models/employee/eis/xmlfile/NormalHoursNSTransformer.java
@@ -25,7 +25,7 @@ import org.eclipse.persistence.mappings.transformers.AttributeTransformer;
 import org.eclipse.persistence.mappings.transformers.FieldTransformer;
 import org.eclipse.persistence.oxm.NamespaceResolver;
 import org.eclipse.persistence.oxm.XMLField;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 
 public class NormalHoursNSTransformer implements FieldTransformer, AttributeTransformer {
@@ -57,7 +57,7 @@ public class NormalHoursNSTransformer implements FieldTransformer, AttributeTran
     }
 
     @Override
-    public Object buildAttributeValue(Record row, Object object, Session session) {
+    public Object buildAttributeValue(DataRecord row, Object object, Session session) {
         Time[] hours = new Time[2];
 
         /**

--- a/foundation/org.eclipse.persistence.nosql/src/it/java/org/eclipse/persistence/testing/models/employee/eis/xmlfile/NormalHoursTransformer.java
+++ b/foundation/org.eclipse.persistence.nosql/src/it/java/org/eclipse/persistence/testing/models/employee/eis/xmlfile/NormalHoursTransformer.java
@@ -16,7 +16,7 @@ package org.eclipse.persistence.testing.models.employee.eis.xmlfile;
 
 import java.sql.Time;
 import org.eclipse.persistence.mappings.foundation.AbstractTransformationMapping;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 import org.eclipse.persistence.mappings.transformers.FieldTransformer;
 import org.eclipse.persistence.mappings.transformers.AttributeTransformer;
@@ -42,7 +42,7 @@ public class NormalHoursTransformer implements FieldTransformer, AttributeTransf
     }
 
     @Override
-    public Object buildAttributeValue(Record row, Object object, Session session) {
+    public Object buildAttributeValue(DataRecord row, Object object, Session session) {
         Time[] hours = new Time[2];
 
         /**

--- a/foundation/org.eclipse.persistence.nosql/src/it/java/org/eclipse/persistence/testing/tests/jpa/mongo/MongoDatabaseTestSuite.java
+++ b/foundation/org.eclipse.persistence.nosql/src/it/java/org/eclipse/persistence/testing/tests/jpa/mongo/MongoDatabaseTestSuite.java
@@ -42,7 +42,7 @@ import org.eclipse.persistence.jpa.JpaEntityManager;
 import org.eclipse.persistence.jpa.dynamic.JPADynamicHelper;
 import org.eclipse.persistence.nosql.adapters.mongo.Mongo3ConnectionSpec;
 import org.eclipse.persistence.nosql.adapters.mongo.MongoPlatform;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.testing.framework.junit.JUnitTestCase;
 import org.eclipse.persistence.testing.framework.junit.JUnitTestCaseHelper;
 import org.eclipse.persistence.testing.models.jpa.mongo.Address;
@@ -911,8 +911,8 @@ public class MongoDatabaseTestSuite extends JUnitTestCase {
         Query query = em.unwrap(JpaEntityManager.class).createQuery(interaction);
         List result = query.getResultList();
         if ((result.size() != 1)
-                || (!(result.get(0) instanceof Record))
-                || !(((Record)result.get(0)).get("_id").equals(existingOrder.id))) {
+                || (!(result.get(0) instanceof DataRecord))
+                || !(((DataRecord)result.get(0)).get("_id").equals(existingOrder.id))) {
             fail("Incorrect result: " + result);
         }
 

--- a/foundation/org.eclipse.persistence.nosql/src/it/java/org/eclipse/persistence/testing/tests/jpa/mongo/MongoTestSuite.java
+++ b/foundation/org.eclipse.persistence.nosql/src/it/java/org/eclipse/persistence/testing/tests/jpa/mongo/MongoTestSuite.java
@@ -41,7 +41,7 @@ import org.eclipse.persistence.internal.nosql.adapters.mongo.MongoOperation;
 import org.eclipse.persistence.jpa.JpaEntityManager;
 import org.eclipse.persistence.jpa.dynamic.JPADynamicHelper;
 import org.eclipse.persistence.nosql.adapters.mongo.MongoPlatform;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.testing.framework.junit.JUnitTestCase;
 import org.eclipse.persistence.testing.framework.junit.JUnitTestCaseHelper;
 import org.eclipse.persistence.testing.models.jpa.mongo.Address;
@@ -886,8 +886,8 @@ public class MongoTestSuite extends JUnitTestCase {
         Query query = em.unwrap(JpaEntityManager.class).createQuery(interaction);
         List result = query.getResultList();
         if ((result.size() != 1)
-                || (!(result.get(0) instanceof Record))
-                || !(((Record)result.get(0)).get("_id").equals(existingOrder.id))) {
+                || (!(result.get(0) instanceof DataRecord))
+                || !(((DataRecord)result.get(0)).get("_id").equals(existingOrder.id))) {
             fail("Incorrect result: " + result);
         }
 

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/eis/nosql/NoSQLSimpleTest.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/eis/nosql/NoSQLSimpleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -27,7 +27,7 @@ import org.eclipse.persistence.nosql.adapters.nosql.OracleNoSQLPlatform;
 import org.eclipse.persistence.queries.DataModifyQuery;
 import org.eclipse.persistence.queries.DataReadQuery;
 import org.eclipse.persistence.sessions.DatabaseSession;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.testing.framework.ReflectionHelper;
 import org.eclipse.persistence.testing.framework.junit.LogTestExecution;
 import org.eclipse.persistence.testing.tests.nosql.NoSQLURI;
@@ -138,7 +138,7 @@ public class NoSQLSimpleTest {
         readCall.addArgumentValue("Order/1234", "");
         final DataReadQuery read = new DataReadQuery(readCall);
         @SuppressWarnings("unchecked")
-        final List<Record> result = (List<Record>)session.executeQuery(read);
+        final List<DataRecord> result = (List<DataRecord>)session.executeQuery(read);
         final String value = new String((byte[])result.get(0).get("Order/1234"));
         assertEquals("foo expected: " + value, "foo", value);
     }

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/jpa/nosql/NoSQLJPAMappedTest.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/jpa/nosql/NoSQLJPAMappedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -30,7 +30,7 @@ import org.eclipse.persistence.eis.interactions.MappedInteraction;
 import org.eclipse.persistence.internal.nosql.adapters.nosql.OracleNoSQLOperation;
 import org.eclipse.persistence.jpa.JpaEntityManager;
 import org.eclipse.persistence.nosql.adapters.nosql.OracleNoSQLPlatform;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.testing.framework.junit.LogTestExecution;
 import org.eclipse.persistence.testing.models.jpa.nosql.mapped.Address;
 import org.eclipse.persistence.testing.models.jpa.nosql.mapped.Customer;
@@ -329,9 +329,9 @@ public class NoSQLJPAMappedTest {
         final List<Object> result1 = query1.getResultList();
         assertEquals(String.format("Expected result of size 1, got %d", result1.size()), 1, result1.size());
         assertTrue(String.format("Result is not instance of Record but %s", result1.get(0).getClass().getSimpleName()),
-                (result1.get(0) instanceof Record));
+                (result1.get(0) instanceof DataRecord));
         assertTrue(String.format("Incorrect result: %s", result1),
-                (((Record)result1.get(0)).containsKey("[Order-mapped," + existingOrder.id + "]")));
+                (((DataRecord)result1.get(0)).containsKey("[Order-mapped," + existingOrder.id + "]")));
 
         interaction = new MappedInteraction();
         interaction.setProperty(OracleNoSQLPlatform.OPERATION, OracleNoSQLOperation.GET.name());

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/jpa/nosql/NoSQLJPATest.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/jpa/nosql/NoSQLJPATest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -31,7 +31,7 @@ import org.eclipse.persistence.eis.interactions.XMLInteraction;
 import org.eclipse.persistence.internal.nosql.adapters.nosql.OracleNoSQLOperation;
 import org.eclipse.persistence.jpa.JpaEntityManager;
 import org.eclipse.persistence.nosql.adapters.nosql.OracleNoSQLPlatform;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.testing.framework.junit.LogTestExecution;
 import org.eclipse.persistence.testing.models.jpa.nosql.Address;
 import org.eclipse.persistence.testing.models.jpa.nosql.Customer;
@@ -313,9 +313,9 @@ public class NoSQLJPATest {
         final List<Object> result1 = query1.getResultList();
         assertEquals(String.format("Expected result of size 1, got %d", result1.size()), 1, result1.size());
         assertTrue(String.format("Result is not instance of Record but %s", result1.get(0).getClass().getSimpleName()),
-                (result1.get(0) instanceof Record));
+                (result1.get(0) instanceof DataRecord));
         assertTrue(String.format("Incorrect result: %s", result1),
-                (((Record)result1.get(0)).containsKey("[ORDER," + existingOrder.id + "]")));
+                (((DataRecord)result1.get(0)).containsKey("[ORDER," + existingOrder.id + "]")));
 
         interaction = new XMLInteraction();
         interaction.setProperty(OracleNoSQLPlatform.OPERATION, OracleNoSQLOperation.GET.name());

--- a/foundation/org.eclipse.persistence.oracle/src/main/java/org/eclipse/persistence/tools/profiler/oracle/DMSPerformanceProfiler.java
+++ b/foundation/org.eclipse.persistence.oracle/src/main/java/org/eclipse/persistence/tools/profiler/oracle/DMSPerformanceProfiler.java
@@ -26,7 +26,7 @@ import org.eclipse.persistence.internal.sessions.AbstractRecord;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
 import org.eclipse.persistence.logging.SessionLog;
 import org.eclipse.persistence.queries.DatabaseQuery;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 import org.eclipse.persistence.sessions.SessionProfiler;
 import org.eclipse.persistence.sessions.server.ServerSession;
@@ -753,7 +753,7 @@ public class DMSPerformanceProfiler implements Serializable, Cloneable, SessionP
     }
 
     @Override
-    public Object profileExecutionOfQuery(DatabaseQuery query, Record row, AbstractSession session) {
+    public Object profileExecutionOfQuery(DatabaseQuery query, DataRecord row, AbstractSession session) {
         //This is to profile the query execution and no operation name is given
         startOperationProfile(null, query, DMSConsole.HEAVY);
         Object result = null;

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/advanced/AdvancedReadTransformer.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/advanced/AdvancedReadTransformer.java
@@ -18,7 +18,7 @@ import java.sql.Time;
 
 import org.eclipse.persistence.mappings.foundation.AbstractTransformationMapping;
 import org.eclipse.persistence.mappings.transformers.AttributeTransformer;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 
 public class AdvancedReadTransformer implements AttributeTransformer {
@@ -38,18 +38,18 @@ public class AdvancedReadTransformer implements AttributeTransformer {
     }
 
     /**
-     * @param record - The metadata being used to build the object.
+     * @param dataRecord - The metadata being used to build the object.
      * @param session - the current session
      * @param object - The current object that the attribute is being built for.
      * @return - The attribute value to be built into the object containing this mapping.
      */
     @Override
-    public Object buildAttributeValue(Record record, Object object, Session session) {
+    public Object buildAttributeValue(DataRecord dataRecord, Object object, Session session) {
         if(attributeName.equals("overtimeHours")) {
             Time[] hours = new Time[2];
             /** This conversion allows for the database type not to match, i.e. may be a Timestamp or String. */
-            hours[0] = session.getDatasourcePlatform().convertObject(record.get("START_OVERTIME"), Time.class);
-            hours[1] = session.getDatasourcePlatform().convertObject(record.get("END_OVERTIME"), Time.class);
+            hours[0] = session.getDatasourcePlatform().convertObject(dataRecord.get("START_OVERTIME"), Time.class);
+            hours[1] = session.getDatasourcePlatform().convertObject(dataRecord.get("END_OVERTIME"), Time.class);
             return hours;
         } else {
             throw new RuntimeException("Unknown attribute");

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/advanced/Door.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/advanced/Door.java
@@ -32,7 +32,7 @@ import org.eclipse.persistence.annotations.Mutable;
 import org.eclipse.persistence.annotations.ReadTransformer;
 import org.eclipse.persistence.annotations.WriteTransformer;
 import org.eclipse.persistence.internal.helper.Helper;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 
 @Entity
@@ -114,7 +114,7 @@ public class Door implements Serializable, Cloneable {
         this.WarrantyDate = date;
     }
 
-    public Date calcWarrantyDate(Record row, Session session) {
+    public Date calcWarrantyDate(DataRecord row, Session session) {
         Date date = session.getDatasourcePlatform().convertObject(row.get("SALE_DATE"), Date.class );
         Calendar cal = Calendar.getInstance();
         cal.setTime(date);

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/advanced/Employee.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/advanced/Employee.java
@@ -95,7 +95,7 @@ import org.eclipse.persistence.annotations.WriteTransformers;
 import org.eclipse.persistence.config.CacheIsolationType;
 import org.eclipse.persistence.config.QueryHints;
 import org.eclipse.persistence.oxm.annotations.XmlPath;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 
 /**
@@ -391,7 +391,7 @@ public class Employee implements Serializable, Cloneable {
      * IMPORTANT: This method builds the value but does not set it.
      * The mapping will set it using method or direct access as defined in the descriptor.
      */
-    public Time[] buildNormalHours(Record row, Session session) {
+    public Time[] buildNormalHours(DataRecord row, Session session) {
         Time[] hours = new Time[2];
 
         /** This conversion allows for the database type not to match, i.e. may be a Timestamp or String. */

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/composite/advanced/member_2/AdvancedReadTransformer.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/composite/advanced/member_2/AdvancedReadTransformer.java
@@ -18,7 +18,7 @@ import java.sql.Time;
 
 import org.eclipse.persistence.mappings.foundation.AbstractTransformationMapping;
 import org.eclipse.persistence.mappings.transformers.AttributeTransformer;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 
 public class AdvancedReadTransformer implements AttributeTransformer {
@@ -38,18 +38,18 @@ public class AdvancedReadTransformer implements AttributeTransformer {
     }
 
     /**
-     * @param record - The metadata being used to build the object.
+     * @param dataRecord - The metadata being used to build the object.
      * @param session - the current session
      * @param object - The current object that the attribute is being built for.
      * @return - The attribute value to be built into the object containing this mapping.
      */
     @Override
-    public Object buildAttributeValue(Record record, Object object, Session session) {
+    public Object buildAttributeValue(DataRecord dataRecord, Object object, Session session) {
         if(attributeName.equals("overtimeHours")) {
             Time[] hours = new Time[2];
             /** This conversion allows for the database type not to match, i.e. may be a Timestamp or String. */
-            hours[0] = session.getDatasourcePlatform().convertObject(record.get("START_OVERTIME"), Time.class);
-            hours[1] = session.getDatasourcePlatform().convertObject(record.get("END_OVERTIME"), Time.class);
+            hours[0] = session.getDatasourcePlatform().convertObject(dataRecord.get("START_OVERTIME"), Time.class);
+            hours[1] = session.getDatasourcePlatform().convertObject(dataRecord.get("END_OVERTIME"), Time.class);
             return hours;
         } else {
             throw new RuntimeException("Unknown attribute");

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/composite/advanced/member_2/Employee.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/composite/advanced/member_2/Employee.java
@@ -28,8 +28,6 @@ import org.eclipse.persistence.annotations.ConversionValue;
 import org.eclipse.persistence.annotations.Customizer;
 import org.eclipse.persistence.annotations.ExistenceChecking;
 import org.eclipse.persistence.annotations.IdValidation;
-import org.eclipse.persistence.annotations.JoinFetch;
-import org.eclipse.persistence.annotations.JoinFetchType;
 import org.eclipse.persistence.annotations.Mutable;
 import org.eclipse.persistence.annotations.ObjectTypeConverter;
 import org.eclipse.persistence.annotations.OptimisticLocking;
@@ -43,7 +41,7 @@ import org.eclipse.persistence.annotations.WriteTransformer;
 import org.eclipse.persistence.annotations.WriteTransformers;
 import org.eclipse.persistence.config.CacheIsolationType;
 import org.eclipse.persistence.config.QueryHints;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 import org.eclipse.persistence.testing.models.jpa.composite.advanced.member_1.Address;
 import org.eclipse.persistence.testing.models.jpa.composite.advanced.member_1.Department;
@@ -313,7 +311,7 @@ public class Employee implements Serializable, Cloneable {
      * IMPORTANT: This method builds the value but does not set it.
      * The mapping will set it using method or direct access as defined in the descriptor.
      */
-    public Time[] buildNormalHours(Record row, Session session) {
+    public Time[] buildNormalHours(DataRecord row, Session session) {
         Time[] hours = new Time[2];
 
         /** This conversion allows for the database type not to match, i.e. may be a Timestamp or String. */

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/inheritance/AppleExtractor.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/inheritance/AppleExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -19,7 +19,7 @@ import org.eclipse.persistence.descriptors.ClassDescriptor;
 import org.eclipse.persistence.descriptors.ClassExtractor;
 import org.eclipse.persistence.exceptions.DescriptorException;
 import org.eclipse.persistence.expressions.ExpressionBuilder;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 
 public class AppleExtractor extends ClassExtractor {
@@ -30,7 +30,7 @@ public class AppleExtractor extends ClassExtractor {
      * field name, the value is the database value.
      */
     @Override
-    public Class extractClassFromRow(Record databaseRow, Session session) {
+    public Class extractClassFromRow(DataRecord databaseRow, Session session) {
         if (databaseRow.containsKey("JPA_MACBOOK_PRO.COLOR")) {
             return MacBookPro.class;
         } else if (databaseRow.containsKey("JPA_MACBOOK.RAM")) {

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/xml/advanced/AdvancedReadTransformer.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/xml/advanced/AdvancedReadTransformer.java
@@ -18,7 +18,7 @@ import java.sql.Time;
 
 import org.eclipse.persistence.mappings.foundation.AbstractTransformationMapping;
 import org.eclipse.persistence.mappings.transformers.AttributeTransformer;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 
 public class AdvancedReadTransformer implements AttributeTransformer {
@@ -38,18 +38,18 @@ public class AdvancedReadTransformer implements AttributeTransformer {
     }
 
     /**
-     * @param record - The metadata being used to build the object.
+     * @param dataRecord - The metadata being used to build the object.
      * @param session - the current session
      * @param object - The current object that the attribute is being built for.
      * @return - The attribute value to be built into the object containing this mapping.
      */
     @Override
-    public Object buildAttributeValue(Record record, Object object, Session session) {
+    public Object buildAttributeValue(DataRecord dataRecord, Object object, Session session) {
         if(attributeName.equals("overtimeHours")) {
             Time[] hours = new Time[2];
             /** This conversion allows for the database type not to match, i.e. may be a Timestamp or String. */
-            hours[0] = session.getDatasourcePlatform().convertObject(record.get("START_OVERTIME"), Time.class);
-            hours[1] = session.getDatasourcePlatform().convertObject(record.get("END_OVERTIME"), Time.class);
+            hours[0] = session.getDatasourcePlatform().convertObject(dataRecord.get("START_OVERTIME"), Time.class);
+            hours[1] = session.getDatasourcePlatform().convertObject(dataRecord.get("END_OVERTIME"), Time.class);
             return hours;
         } else {
             throw new RuntimeException("Unknown attribute");

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/xml/advanced/DoNotRedirect.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/xml/advanced/DoNotRedirect.java
@@ -19,13 +19,13 @@ import org.eclipse.persistence.internal.sessions.AbstractRecord;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
 import org.eclipse.persistence.queries.DatabaseQuery;
 import org.eclipse.persistence.queries.QueryRedirector;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 
 public class DoNotRedirect implements QueryRedirector {
 
     @Override
-    public Object invokeQuery(DatabaseQuery query, Record arguments, Session session) {
+    public Object invokeQuery(DatabaseQuery query, DataRecord arguments, Session session) {
         query.setDoNotRedirect(true);
         return ((AbstractSession)session).executeQuery(query, (AbstractRecord)arguments);
     }

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/xml/advanced/Employee.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/xml/advanced/Employee.java
@@ -28,7 +28,7 @@ import jakarta.persistence.Transient;
 
 import org.eclipse.persistence.annotations.Properties;
 import org.eclipse.persistence.annotations.Property;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 
 /**
@@ -183,7 +183,7 @@ public class Employee implements Serializable {
      * IMPORTANT: This method builds the value but does not set it.
      * The mapping will set it using method or direct access as defined in the descriptor.
      */
-    public Time[] buildNormalHours(Record row, Session session) {
+    public Time[] buildNormalHours(DataRecord row, Session session) {
         Time[] hours = new Time[2];
 
         /** This conversion allows for the database type not to match, i.e. may be a Timestamp or String. */

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/xml/composite/advanced/member_1/DoNotRedirect.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/xml/composite/advanced/member_1/DoNotRedirect.java
@@ -19,13 +19,13 @@ import org.eclipse.persistence.internal.sessions.AbstractRecord;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
 import org.eclipse.persistence.queries.DatabaseQuery;
 import org.eclipse.persistence.queries.QueryRedirector;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 
 public class DoNotRedirect implements QueryRedirector {
 
     @Override
-    public Object invokeQuery(DatabaseQuery query, Record arguments, Session session) {
+    public Object invokeQuery(DatabaseQuery query, DataRecord arguments, Session session) {
         query.setDoNotRedirect(true);
         return ((AbstractSession)session).executeQuery(query, (AbstractRecord)arguments);
     }

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/xml/composite/advanced/member_2/AdvancedReadTransformer.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/xml/composite/advanced/member_2/AdvancedReadTransformer.java
@@ -18,7 +18,7 @@ import java.sql.Time;
 
 import org.eclipse.persistence.mappings.foundation.AbstractTransformationMapping;
 import org.eclipse.persistence.mappings.transformers.AttributeTransformer;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 
 public class AdvancedReadTransformer implements AttributeTransformer {
@@ -38,18 +38,18 @@ public class AdvancedReadTransformer implements AttributeTransformer {
     }
 
     /**
-     * @param record - The metadata being used to build the object.
+     * @param dataRecord - The metadata being used to build the object.
      * @param session - the current session
      * @param object - The current object that the attribute is being built for.
      * @return - The attribute value to be built into the object containing this mapping.
      */
     @Override
-    public Object buildAttributeValue(Record record, Object object, Session session) {
+    public Object buildAttributeValue(DataRecord dataRecord, Object object, Session session) {
         if(attributeName.equals("overtimeHours")) {
             Time[] hours = new Time[2];
             /** This conversion allows for the database type not to match, i.e. may be a Timestamp or String. */
-            hours[0] = session.getDatasourcePlatform().convertObject(record.get("START_OVERTIME"), Time.class);
-            hours[1] = session.getDatasourcePlatform().convertObject(record.get("END_OVERTIME"), Time.class);
+            hours[0] = session.getDatasourcePlatform().convertObject(dataRecord.get("START_OVERTIME"), Time.class);
+            hours[1] = session.getDatasourcePlatform().convertObject(dataRecord.get("END_OVERTIME"), Time.class);
             return hours;
         } else {
             throw new RuntimeException("Unknown attribute");

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/xml/composite/advanced/member_2/Employee.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/xml/composite/advanced/member_2/Employee.java
@@ -28,7 +28,7 @@ import jakarta.persistence.Transient;
 
 import org.eclipse.persistence.annotations.Properties;
 import org.eclipse.persistence.annotations.Property;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 import org.eclipse.persistence.testing.models.jpa.xml.composite.advanced.member_1.Address;
 import org.eclipse.persistence.testing.models.jpa.xml.composite.advanced.member_3.Dealer;
@@ -185,7 +185,7 @@ public class Employee implements Serializable {
      * IMPORTANT: This method builds the value but does not set it.
      * The mapping will set it using method or direct access as defined in the descriptor.
      */
-    public Time[] buildNormalHours(Record row, Session session) {
+    public Time[] buildNormalHours(DataRecord row, Session session) {
         Time[] hours = new Time[2];
 
         /** This conversion allows for the database type not to match, i.e. may be a Timestamp or String. */

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/xml/inheritance/AppleExtractor.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa/xml/inheritance/AppleExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -19,7 +19,7 @@ import org.eclipse.persistence.descriptors.ClassDescriptor;
 import org.eclipse.persistence.descriptors.ClassExtractor;
 import org.eclipse.persistence.exceptions.DescriptorException;
 import org.eclipse.persistence.expressions.ExpressionBuilder;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 
 public class AppleExtractor extends ClassExtractor {
@@ -30,7 +30,7 @@ public class AppleExtractor extends ClassExtractor {
      * field name, the value is the database value.
      */
     @Override
-    public Class extractClassFromRow(Record databaseRow, Session session) {
+    public Class extractClassFromRow(DataRecord databaseRow, Session session) {
         if (databaseRow.containsKey("XML_MACBOOK_PRO.COLOR")) {
             return MacBookPro.class;
         } else if (databaseRow.containsKey("XML_MACBOOK.RAM")) {

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa21/advanced/Employee.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa21/advanced/Employee.java
@@ -27,7 +27,6 @@ package org.eclipse.persistence.testing.models.jpa21.advanced;
 import java.io.Serializable;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Vector;
 
 import jakarta.persistence.AttributeOverride;
@@ -56,13 +55,11 @@ import jakarta.persistence.NamedStoredProcedureQueries;
 import jakarta.persistence.NamedStoredProcedureQuery;
 import jakarta.persistence.NamedSubgraph;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.ParameterMode;
 import jakarta.persistence.PrimaryKeyJoinColumn;
 import jakarta.persistence.SecondaryTable;
 import jakarta.persistence.SqlResultSetMapping;
 import jakarta.persistence.SqlResultSetMappings;
 import jakarta.persistence.StoredProcedureParameter;
-import jakarta.persistence.StoredProcedureQuery;
 import jakarta.persistence.Table;
 import jakarta.persistence.TableGenerator;
 import jakarta.persistence.Version;
@@ -70,18 +67,11 @@ import jakarta.persistence.Version;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.ConversionValue;
 import org.eclipse.persistence.annotations.ObjectTypeConverter;
-import org.eclipse.persistence.annotations.TypeConverter;
-
-import org.eclipse.persistence.config.QueryHints;
-import org.eclipse.persistence.sessions.Record;
-import org.eclipse.persistence.sessions.Session;
 
 import static jakarta.persistence.CascadeType.*;
 import static jakarta.persistence.FetchType.*;
 import static jakarta.persistence.GenerationType.*;
 import static jakarta.persistence.ParameterMode.IN;
-import static jakarta.persistence.ParameterMode.INOUT;
-import static jakarta.persistence.ParameterMode.OUT;
 import static jakarta.persistence.ParameterMode.REF_CURSOR;
 
 @Entity

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa21/advanced/xml/Employee.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/models/jpa21/advanced/xml/Employee.java
@@ -17,17 +17,11 @@ package org.eclipse.persistence.testing.models.jpa21.advanced.xml;
 
 import java.io.Serializable;
 import java.util.Collection;
-import java.util.List;
 import java.util.Vector;
 
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.ConversionValue;
 import org.eclipse.persistence.annotations.ObjectTypeConverter;
-import org.eclipse.persistence.annotations.TypeConverter;
-
-import org.eclipse.persistence.config.QueryHints;
-import org.eclipse.persistence.sessions.Record;
-import org.eclipse.persistence.sessions.Session;
 
 @ObjectTypeConverter(
         name="sex",

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/config/DoNotRedirect.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/config/DoNotRedirect.java
@@ -18,7 +18,7 @@ import org.eclipse.persistence.internal.sessions.AbstractRecord;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
 import org.eclipse.persistence.queries.DatabaseQuery;
 import org.eclipse.persistence.queries.QueryRedirector;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 
 /**
@@ -30,7 +30,7 @@ import org.eclipse.persistence.sessions.Session;
 public class DoNotRedirect implements QueryRedirector {
 
     @Override
-    public Object invokeQuery(DatabaseQuery query, Record arguments, Session session) {
+    public Object invokeQuery(DatabaseQuery query, DataRecord arguments, Session session) {
         query.setDoNotRedirect(true);
         return ((AbstractSession) session).executeQuery(query, (AbstractRecord) arguments);
     }

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/jpql/ArrayQueryRedirector.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/jpql/ArrayQueryRedirector.java
@@ -18,12 +18,12 @@ import java.util.List;
 
 import org.eclipse.persistence.queries.DatabaseQuery;
 import org.eclipse.persistence.queries.QueryRedirector;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 
 public class ArrayQueryRedirector implements QueryRedirector {
     @Override
-    public Object invokeQuery(DatabaseQuery query, Record record, Session session) {
+    public Object invokeQuery(DatabaseQuery query, DataRecord dataRecord, Session session) {
         List result = (List)session.executeQuery(query);
         return result.toArray(new Object[result.size()]);
     }

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/annotations/xmlclassextractor/MyClassExtractor.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/annotations/xmlclassextractor/MyClassExtractor.java
@@ -15,12 +15,12 @@
 package org.eclipse.persistence.testing.jaxb.annotations.xmlclassextractor;
 
 import org.eclipse.persistence.descriptors.ClassExtractor;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 
 public class MyClassExtractor extends ClassExtractor {
     @Override
-    public Class extractClassFromRow(Record databaseRow, Session session) {
+    public Class extractClassFromRow(DataRecord databaseRow, Session session) {
         return Car.class;
     }
 }

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/annotations/xmlclassextractor/Vehicle.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/annotations/xmlclassextractor/Vehicle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -18,7 +18,7 @@ import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 
 import org.eclipse.persistence.oxm.annotations.XmlClassExtractor;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 
 @XmlClassExtractor(MyClassExtractor.class)
 @XmlRootElement(name="vehicle")
@@ -41,7 +41,7 @@ public class Vehicle {
         return false;
     }
 
-    public static Class getClassForRow(Record databaseRow) {
+    public static Class getClassForRow(DataRecord databaseRow) {
         return Car.class;
     }
 }

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/annotations/xmltransformation/AddressTransformer.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/annotations/xmltransformation/AddressTransformer.java
@@ -17,7 +17,7 @@ package org.eclipse.persistence.testing.jaxb.annotations.xmltransformation;
 import org.eclipse.persistence.mappings.foundation.AbstractTransformationMapping;
 import org.eclipse.persistence.mappings.transformers.AttributeTransformer;
 import org.eclipse.persistence.mappings.transformers.FieldTransformer;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 
 public class AddressTransformer implements FieldTransformer, AttributeTransformer {
@@ -46,9 +46,9 @@ public class AddressTransformer implements FieldTransformer, AttributeTransforme
     }
 
     @Override
-    public Object buildAttributeValue(Record record, Object object, Session session) {
-        String street = (String) record.get("address/street/text()");
-        String city =(String) record.get("address/city/text()");
+    public Object buildAttributeValue(DataRecord dataRecord, Object object, Session session) {
+        String street = (String) dataRecord.get("address/street/text()");
+        String city =(String) dataRecord.get("address/city/text()");
         return new AddressNoCtor(street, city);
     }
 

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/annotations/xmltransformation/EmployeeTransformationMethod.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/annotations/xmltransformation/EmployeeTransformationMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -21,7 +21,7 @@ import org.eclipse.persistence.oxm.annotations.XmlReadTransformer;
 import org.eclipse.persistence.oxm.annotations.XmlTransformation;
 import org.eclipse.persistence.oxm.annotations.XmlWriteTransformer;
 import org.eclipse.persistence.oxm.annotations.XmlWriteTransformers;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 
 @XmlRootElement(name="employee")
 public class EmployeeTransformationMethod {
@@ -56,9 +56,9 @@ public class EmployeeTransformationMethod {
 
     }
 
-    public String[] buildAttributeValue(Record record) {
-        String startTime = (String)record.get("normal-hours/start-time/text()");
-        String endTime = (String)record.get("normal-hours/end-time/text()");
+    public String[] buildAttributeValue(DataRecord dataRecord) {
+        String startTime = (String) dataRecord.get("normal-hours/start-time/text()");
+        String endTime = (String) dataRecord.get("normal-hours/end-time/text()");
 
         return new String[]{startTime, endTime};
     }

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/annotations/xmltransformation/NormalHoursTransformer.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/annotations/xmltransformation/NormalHoursTransformer.java
@@ -14,21 +14,17 @@
 // Oracle = 2.2 - Initial implementation
 package org.eclipse.persistence.testing.jaxb.annotations.xmltransformation;
 
-import java.sql.Time;
-import java.sql.Timestamp;
-
-import org.eclipse.persistence.internal.oxm.XMLConversionManager;
 import org.eclipse.persistence.mappings.foundation.AbstractTransformationMapping;
 import org.eclipse.persistence.mappings.transformers.AttributeTransformer;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 
 public class NormalHoursTransformer implements AttributeTransformer {
 
     @Override
-    public String[] buildAttributeValue(Record record, Object object, Session session) {
-        String startTime = (String)record.get("normal-hours/start-time/text()");
-        String endTime = (String)record.get("normal-hours/end-time/text()");
+    public String[] buildAttributeValue(DataRecord dataRecord, Object object, Session session) {
+        String startTime = (String) dataRecord.get("normal-hours/start-time/text()");
+        String endTime = (String) dataRecord.get("normal-hours/end-time/text()");
 
         return new String[]{startTime, endTime};
 

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/dynamic/util/AttributeTransformer.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/dynamic/util/AttributeTransformer.java
@@ -15,16 +15,16 @@
 package org.eclipse.persistence.testing.jaxb.dynamic.util;
 
 import org.eclipse.persistence.mappings.transformers.AttributeTransformerAdapter;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 
 public class AttributeTransformer extends AttributeTransformerAdapter {
 
     @Override
-    public Object buildAttributeValue(Record record, Object instance, Session session) {
+    public Object buildAttributeValue(DataRecord dataRecord, Object instance, Session session) {
         String[] objectValue = new String[2];
-        objectValue[0] = (String) record.get("transform/first-val/text()");
-        objectValue[1] = (String) record.get("transform/second-val/text()");
+        objectValue[0] = (String) dataRecord.get("transform/first-val/text()");
+        objectValue[1] = (String) dataRecord.get("transform/second-val/text()");
         return objectValue;
     }
 

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/dynamic/util/TestClassExtractor.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/dynamic/util/TestClassExtractor.java
@@ -15,13 +15,13 @@
 package org.eclipse.persistence.testing.jaxb.dynamic.util;
 
 import org.eclipse.persistence.descriptors.ClassExtractor;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 
 public class TestClassExtractor extends ClassExtractor {
 
     @Override
-    public Class extractClassFromRow(Record databaseRow, Session session) {
+    public Class extractClassFromRow(DataRecord databaseRow, Session session) {
         Class empClass = session.getProject().getDescriptorForAlias("Employee").getJavaClass();
         return empClass;
     }

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/dynamic/util/UnmarshalTransformer.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/dynamic/util/UnmarshalTransformer.java
@@ -15,16 +15,16 @@
 package org.eclipse.persistence.testing.jaxb.dynamic.util;
 
 import org.eclipse.persistence.mappings.transformers.AttributeTransformerAdapter;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 
 public class UnmarshalTransformer extends AttributeTransformerAdapter {
 
     @Override
-    public Object buildAttributeValue(Record record, Object instance, Session session) {
+    public Object buildAttributeValue(DataRecord dataRecord, Object instance, Session session) {
         String[] hours = new String[2];
-        hours[0] = (String) record.get("normal-hours/start-time/text()");
-        hours[1] = (String) record.get("normal-hours/end-time/text()");
+        hours[0] = (String) dataRecord.get("normal-hours/start-time/text()");
+        hours[1] = (String) dataRecord.get("normal-hours/end-time/text()");
         return hours;
     }
 

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/externalizedmetadata/mappings/xmltransformation/Employee.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/externalizedmetadata/mappings/xmltransformation/Employee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,7 +16,7 @@ package org.eclipse.persistence.testing.jaxb.externalizedmetadata.mappings.xmltr
 
 import jakarta.xml.bind.annotation.XmlTransient;
 
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 
 /**
  *  A simple class that contains a transformation mapping;
@@ -75,10 +75,10 @@ public class Employee {
     /**
      * Used for testing method name based attribute transformer.
      */
-    public String[] buildNormalHoursValue(Record record) {
+    public String[] buildNormalHoursValue(DataRecord dataRecord) {
         String[] hours = new String[2];
-        hours[0] = (String) record.get("normal-hours/start-time/text()");
-        hours[1] = (String) record.get("normal-hours/end-time/text()");
+        hours[0] = (String) dataRecord.get("normal-hours/start-time/text()");
+        hours[1] = (String) dataRecord.get("normal-hours/end-time/text()");
         return hours;
     }
 

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/externalizedmetadata/mappings/xmltransformation/NormalHoursAttributeTransformer.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/externalizedmetadata/mappings/xmltransformation/NormalHoursAttributeTransformer.java
@@ -16,7 +16,7 @@ package org.eclipse.persistence.testing.jaxb.externalizedmetadata.mappings.xmltr
 
 import org.eclipse.persistence.mappings.foundation.AbstractTransformationMapping;
 import org.eclipse.persistence.mappings.transformers.AttributeTransformer;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 
 public class NormalHoursAttributeTransformer implements AttributeTransformer {
@@ -24,10 +24,10 @@ public class NormalHoursAttributeTransformer implements AttributeTransformer {
     public void initialize(AbstractTransformationMapping mapping) {}
 
     @Override
-    public Object buildAttributeValue(Record record, Object instance, Session session) {
+    public Object buildAttributeValue(DataRecord dataRecord, Object instance, Session session) {
         String[] hours = new String[2];
-        hours[0] = (String) record.get("normal-hours/start-time/text()");
-        hours[1] = (String) record.get("normal-hours/end-time/text()");
+        hours[0] = (String) dataRecord.get("normal-hours/start-time/text()");
+        hours[1] = (String) dataRecord.get("normal-hours/end-time/text()");
         return hours;
     }
 }

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/externalizedmetadata/xmlclassextractor/MyClassExtractor.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/externalizedmetadata/xmlclassextractor/MyClassExtractor.java
@@ -15,12 +15,12 @@
 package org.eclipse.persistence.testing.jaxb.externalizedmetadata.xmlclassextractor;
 
 import org.eclipse.persistence.descriptors.ClassExtractor;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 
 public class MyClassExtractor extends ClassExtractor {
     @Override
-    public Class extractClassFromRow(Record databaseRow, Session session) {
+    public Class extractClassFromRow(DataRecord databaseRow, Session session) {
         return Car.class;
     }
 }

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/externalizedmetadata/xmlclassextractor/MyOtherClassExtractor.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/externalizedmetadata/xmlclassextractor/MyOtherClassExtractor.java
@@ -15,12 +15,12 @@
 package org.eclipse.persistence.testing.jaxb.externalizedmetadata.xmlclassextractor;
 
 import org.eclipse.persistence.descriptors.ClassExtractor;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 
 public class MyOtherClassExtractor extends ClassExtractor {
     @Override
-    public Class extractClassFromRow(Record databaseRow, Session session) {
+    public Class extractClassFromRow(DataRecord databaseRow, Session session) {
         return Vehicle.class;
     }
 }

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/externalizedmetadata/xmlclassextractor/Vehicle.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/externalizedmetadata/xmlclassextractor/Vehicle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,7 +15,7 @@
 package org.eclipse.persistence.testing.jaxb.externalizedmetadata.xmlclassextractor;
 
 import org.eclipse.persistence.oxm.annotations.XmlClassExtractor;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 
 @XmlClassExtractor(MyOtherClassExtractor.class)
 public class Vehicle {
@@ -36,7 +36,7 @@ public class Vehicle {
         return false;
     }
 
-    public static Class getClassForRow(Record databaseRow) {
+    public static Class getClassForRow(DataRecord databaseRow) {
         return Car.class;
     }
 }

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/oxm/inheritance/Vehicle.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/oxm/inheritance/Vehicle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,7 +13,7 @@
 // Contributors:
 //     Oracle - initial API and implementation from Oracle TopLink
 package org.eclipse.persistence.testing.oxm.inheritance;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 
 
 /**
@@ -39,7 +39,7 @@ public class Vehicle {
         return false;
     }
 
-    public static Class getClassForRow(Record databaseRow) {
+    public static Class getClassForRow(DataRecord databaseRow) {
         return Car.class;
     }
 }

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/oxm/mappings/compositeobject/self/plsqlcallmodel/PLSQLCallModelTestProject.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/oxm/mappings/compositeobject/self/plsqlcallmodel/PLSQLCallModelTestProject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -33,7 +33,7 @@ import org.eclipse.persistence.oxm.record.DOMRecord;
 import org.eclipse.persistence.oxm.record.UnmarshalRecord;
 //import org.eclipse.persistence.oxm.record.UnmarshalRecord;
 import org.eclipse.persistence.sessions.Project;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 import static org.eclipse.persistence.testing.oxm.mappings.compositeobject.self.plsqlcallmodel.PLSQLargument.IN;
 import static org.eclipse.persistence.testing.oxm.mappings.compositeobject.self.plsqlcallmodel.PLSQLargument.INOUT;
@@ -147,7 +147,7 @@ public class PLSQLCallModelTestProject extends Project {
         descriptor.setJavaClass(DatabaseTypeWrapper.class);
         descriptor.getInheritancePolicy().setClassExtractor(new ClassExtractor() {
             @Override
-            public Class<?> extractClassFromRow(Record databaseRow, Session session) {
+            public Class<?> extractClassFromRow(DataRecord databaseRow, Session session) {
                 if (databaseRow instanceof UnmarshalRecord) {
                     UnmarshalRecord unmarshalRecord = (UnmarshalRecord)databaseRow;
                     Attributes attributes = unmarshalRecord.getAttributes();

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/oxm/mappings/transformation/Employee.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/oxm/mappings/transformation/Employee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,8 +14,7 @@
 //     Oracle - initial API and implementation from Oracle TopLink
 package org.eclipse.persistence.testing.oxm.mappings.transformation;
 
-import java.util.Calendar;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 /**
  *  @version $Header: Employee.java 12-apr-2007.15:52:55 mmacivor Exp $
  *  @author  mmacivor
@@ -65,7 +64,7 @@ public class Employee
         name = newName;
     }
 
-    public Object buildNameAttribute(Record row)
+    public Object buildNameAttribute(DataRecord row)
     {
         return row.get("name/text()");
     }

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/oxm/mappings/transformation/NormalHoursAttributeTransformer.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/oxm/mappings/transformation/NormalHoursAttributeTransformer.java
@@ -14,9 +14,8 @@
 //     Oracle - initial API and implementation from Oracle TopLink
 package org.eclipse.persistence.testing.oxm.mappings.transformation;
 
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
-import org.eclipse.persistence.sessions.Record;
-import java.util.Calendar;
 import org.eclipse.persistence.mappings.transformers.*;
 /**
  *  @version $Header: NormalHoursAttributeTransformer.java 07-oct-2005.21:46:09 pkrogh Exp $
@@ -26,11 +25,11 @@ import org.eclipse.persistence.mappings.transformers.*;
 public class NormalHoursAttributeTransformer extends AttributeTransformerAdapter
 {
   @Override
-  public Object buildAttributeValue(Record record, Object instance, Session session)
+  public Object buildAttributeValue(DataRecord dataRecord, Object instance, Session session)
   {
     String[] hours = new String[2];
-    hours[0] = (String)record.get("normal-hours/start-time/text()");
-    hours[1] = (String)record.get("normal-hours/end-time/text()");
+    hours[0] = (String) dataRecord.get("normal-hours/start-time/text()");
+    hours[1] = (String) dataRecord.get("normal-hours/end-time/text()");
     return hours;
   }
 }

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/oxm/mappings/transformation/element/ElementNSTransformer.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/oxm/mappings/transformation/element/ElementNSTransformer.java
@@ -20,7 +20,7 @@ import org.eclipse.persistence.mappings.transformers.FieldTransformer;
 import org.eclipse.persistence.oxm.NamespaceResolver;
 import org.eclipse.persistence.oxm.XMLField;
 import org.eclipse.persistence.oxm.record.XMLRecord;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 
 public class ElementNSTransformer implements AttributeTransformer, FieldTransformer {
@@ -49,11 +49,11 @@ public class ElementNSTransformer implements AttributeTransformer, FieldTransfor
     }
 
     @Override
-    public Object buildAttributeValue(Record record, Object object, Session session) {
-        if(null == record) {
+    public Object buildAttributeValue(DataRecord dataRecord, Object object, Session session) {
+        if(null == dataRecord) {
             return null;
         }
-        XMLRecord xmlRecord = (XMLRecord) record;
+        XMLRecord xmlRecord = (XMLRecord) dataRecord;
 
         if(xmlRecord.getIndicatingNoEntry(startField) != null) {
             return XML_START;

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/oxm/mappings/transformation/element/ElementTransformer.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/oxm/mappings/transformation/element/ElementTransformer.java
@@ -18,7 +18,7 @@ import org.eclipse.persistence.mappings.foundation.AbstractTransformationMapping
 import org.eclipse.persistence.mappings.transformers.AttributeTransformer;
 import org.eclipse.persistence.mappings.transformers.FieldTransformer;
 import org.eclipse.persistence.oxm.record.XMLRecord;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 
 public class ElementTransformer implements AttributeTransformer, FieldTransformer {
@@ -32,11 +32,11 @@ public class ElementTransformer implements AttributeTransformer, FieldTransforme
     }
 
     @Override
-    public Object buildAttributeValue(Record record, Object object, Session session) {
-        if(null == record) {
+    public Object buildAttributeValue(DataRecord dataRecord, Object object, Session session) {
+        if(null == dataRecord) {
             return null;
         }
-        XMLRecord xmlRecord = (XMLRecord) record;
+        XMLRecord xmlRecord = (XMLRecord) dataRecord;
         if(xmlRecord.getIndicatingNoEntry(XML_START) != null) {
             return XML_START;
         } else if (xmlRecord.getIndicatingNoEntry(XML_INTERMEDIATE) != null) {

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/oxm/readonly/NormalHours2Transformer.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/oxm/readonly/NormalHours2Transformer.java
@@ -14,13 +14,12 @@
 //     Oracle - initial API and implementation from Oracle TopLink
 package org.eclipse.persistence.testing.oxm.readonly;
 
-import java.util.Calendar;
 import org.eclipse.persistence.mappings.foundation.AbstractTransformationMapping;
 import org.eclipse.persistence.sessions.Session;
 import org.eclipse.persistence.mappings.transformers.*;
 import java.util.Vector;
 
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 
 public class NormalHours2Transformer implements FieldTransformer, AttributeTransformer
 {
@@ -38,11 +37,11 @@ public class NormalHours2Transformer implements FieldTransformer, AttributeTrans
         return ((Employee)instance).normalHours2.elementAt(1);
   }
   @Override
-  public Object buildAttributeValue(Record record, Object instance, Session session)
+  public Object buildAttributeValue(DataRecord dataRecord, Object instance, Session session)
   {
     Vector normalHours = new Vector(2);
-    normalHours.addElement(record.get("normal-hours/start-time/text()"));
-    normalHours.addElement(record.get("normal-hours/end-time/text()"));
+    normalHours.addElement(dataRecord.get("normal-hours/start-time/text()"));
+    normalHours.addElement(dataRecord.get("normal-hours/end-time/text()"));
     return normalHours;
   }
 }

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/oxm/readonly/NormalHoursTransformer.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/oxm/readonly/NormalHoursTransformer.java
@@ -14,12 +14,11 @@
 //     Oracle - initial API and implementation from Oracle TopLink
 package org.eclipse.persistence.testing.oxm.readonly;
 
-import java.util.Calendar;
 import java.util.Vector;
 import org.eclipse.persistence.mappings.foundation.AbstractTransformationMapping;
 import org.eclipse.persistence.sessions.Session;
 import org.eclipse.persistence.mappings.transformers.*;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 
 public class NormalHoursTransformer implements AttributeTransformer, FieldTransformer
 {
@@ -37,11 +36,11 @@ public class NormalHoursTransformer implements AttributeTransformer, FieldTransf
         return ((Employee)instance).normalHours2.elementAt(1);
   }
   @Override
-  public Object buildAttributeValue(Record record, Object instance, Session session)
+  public Object buildAttributeValue(DataRecord dataRecord, Object instance, Session session)
   {
     Vector normalHours = new Vector(2);
-    normalHours.addElement(record.get("normal-hours/start-time"));
-    normalHours.addElement(record.get("normal-hours/end-time"));
+    normalHours.addElement(dataRecord.get("normal-hours/start-time"));
+    normalHours.addElement(dataRecord.get("normal-hours/end-time"));
     return normalHours;
   }
 }

--- a/sdo/org.eclipse.persistence.sdo/src/main/java/org/eclipse/persistence/sdo/helper/metadata/QNameTransformer.java
+++ b/sdo/org.eclipse.persistence.sdo/src/main/java/org/eclipse/persistence/sdo/helper/metadata/QNameTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -21,7 +21,7 @@ import org.eclipse.persistence.oxm.NamespaceResolver;
 import org.eclipse.persistence.oxm.XMLDescriptor;
 import org.eclipse.persistence.oxm.XMLField;
 import org.eclipse.persistence.oxm.record.XMLRecord;
-import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.Session;
 
 public class QNameTransformer implements AttributeTransformer, FieldTransformer {
@@ -49,12 +49,12 @@ public class QNameTransformer implements AttributeTransformer, FieldTransformer 
     }
 
     @Override
-    public Object buildAttributeValue(Record record, Object object, Session session) {
-        if (null == record) {
+    public Object buildAttributeValue(DataRecord dataRecord, Object object, Session session) {
+        if (null == dataRecord) {
             return null;
         }
 
-        String value = (String) record.get(xPath);
+        String value = (String) dataRecord.get(xPath);
         if (null == value) {
             return null;
         }
@@ -63,14 +63,14 @@ public class QNameTransformer implements AttributeTransformer, FieldTransformer 
         if (index > -1) {
             String prefix = value.substring(0, index);
             String localName = value.substring(index + 1);
-            String namespaceURI = ((XMLRecord) record).resolveNamespacePrefix(prefix);
+            String namespaceURI = ((XMLRecord) dataRecord).resolveNamespacePrefix(prefix);
             if (namespaceURI != null) {
                 return namespaceURI + HASH + localName;
             } else {
                 return localName;
             }
         } else {
-            String namespaceURI = ((XMLRecord) record).resolveNamespacePrefix(DEFAULT_NAMESPACE_PREFIX);
+            String namespaceURI = ((XMLRecord) dataRecord).resolveNamespacePrefix(DEFAULT_NAMESPACE_PREFIX);
             if (namespaceURI != null) {
                 return namespaceURI + HASH + value;
             } else {


### PR DESCRIPTION
Changes `org.eclipse.persistence.session.Record` to `org.eclipse.persistence.session.DataRecord`


Fixes #1298 

Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>