### PR TITLE
[master] SQL Struct with @Lob (BLOB, CLOB) used as stored procedure parameter type - fix 2.0

### DIFF
--- a/foundation/org.eclipse.persistence.oracle/src/main/java/org/eclipse/persistence/platform/database/oracle/Oracle12Platform.java
+++ b/foundation/org.eclipse.persistence.oracle/src/main/java/org/eclipse/persistence/platform/database/oracle/Oracle12Platform.java
@@ -183,6 +183,18 @@ public class Oracle12Platform extends Oracle11Platform {
                 attributes[index] = row.get(field);
             }
         }
-        return super.createStruct(structTypeName, attributes, session, connection);
+        return createStruct(structTypeName, attributes, connection);
+    }
+
+    /**
+     * Create java.sql.Struct from given parameters.
+     * @param structTypeName - the SQL type name of the SQL structured type that this Struct object maps to.
+     * @param attributes - the attributes that populate the returned object
+     * @param connection - DB connection
+     * @return Struct
+     */
+    @Override
+    public Struct createStruct(String structTypeName, Object[] attributes, Connection connection) throws SQLException {
+        return connection.createStruct(structTypeName, attributes);
     }
 }


### PR DESCRIPTION
Additional fix in `Oracle12Platform` class to use standard `java.sql.Connection.createStruct(....)` method instead of `org.eclipse.persistence.platform.database.oracleOracle8Platform.createStruct(...)` with deprecated `new oracle.sql.STRUCT(...)` call.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>