### PR TITLE
[2.7] Update ConcurrencyManager impl to be in sync with master

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/helper/ConcurrencyManager.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/helper/ConcurrencyManager.java
@@ -14,7 +14,8 @@
 //     Oracle - initial API and implementation from Oracle TopLink
 package org.eclipse.persistence.internal.helper;
 
-import java.io.*;
+import java.io.Serializable;
+import java.io.StringWriter;
 import java.security.AccessController;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -22,12 +23,14 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.eclipse.persistence.config.SystemProperties;
-import org.eclipse.persistence.exceptions.*;
-import org.eclipse.persistence.internal.localization.*;
+import org.eclipse.persistence.exceptions.ConcurrencyException;
 import org.eclipse.persistence.internal.identitymaps.CacheKey;
+import org.eclipse.persistence.internal.localization.ToStringLocalization;
+import org.eclipse.persistence.internal.localization.TraceLocalization;
 import org.eclipse.persistence.internal.security.PrivilegedAccessHelper;
 import org.eclipse.persistence.internal.security.PrivilegedGetSystemProperty;
-import org.eclipse.persistence.logging.*;
+import org.eclipse.persistence.logging.AbstractSessionLog;
+import org.eclipse.persistence.logging.SessionLog;
 
 /**
  * INTERNAL:
@@ -78,7 +81,7 @@ public class ConcurrencyManager implements Serializable {
     private static final Map<Thread, String> THREADS_TO_WAIT_ON_ACQUIRE_NAME_OF_METHOD_CREATING_TRACE = new ConcurrentHashMap<>();
     // Holds as a keys threads that needed to acquire one or more read locks on different cache keys.
     private static final Map<Thread, ReadLockManager> READ_LOCK_MANAGERS = new ConcurrentHashMap<>();
-    private static final Set<Thread> THREADS_WAITING_TO_RELEASE_DEFERRED_LOCKS = new HashSet<>();
+    private static final Set<Thread> THREADS_WAITING_TO_RELEASE_DEFERRED_LOCKS = ConcurrentHashMap.newKeySet();
     private static final Map<Thread, String> THREADS_WAITING_TO_RELEASE_DEFERRED_LOCKS_BUILD_OBJECT_COMPLETE_GOES_NOWHERE = new ConcurrentHashMap<>();
 
     /**
@@ -205,7 +208,8 @@ public class ConcurrencyManager implements Serializable {
             } finally {
                 removeThreadNoLongerWaitingToAcquireLockForWriting(currentThread);
             }
-            if ((this.activeThread == null && this.numberOfReaders.get() == 0) || (this.activeThread == currentThread)) {
+            if ((this.activeThread == null && this.numberOfReaders.get() == 0)
+                    || (this.activeThread == currentThread)) {
                 acquire(forMerge);
                 return true;
             }
@@ -373,7 +377,7 @@ public class ConcurrencyManager implements Serializable {
      * Return the deferred lock manager from the thread
      */
     public static DeferredLockManager getDeferredLockManager(Thread thread) {
-        return (thread == null) ? null : getDeferredLockManagers().get(thread);
+        return getDeferredLockManagers().get(thread);
     }
 
     /**
@@ -456,7 +460,8 @@ public class ConcurrencyManager implements Serializable {
         }
 
         Vector deferredLocks = lockManager.getDeferredLocks();
-        for (Enumeration deferredLocksEnum = deferredLocks.elements(); deferredLocksEnum.hasMoreElements();) {
+        for (Enumeration deferredLocksEnum = deferredLocks.elements();
+             deferredLocksEnum.hasMoreElements();) {
             ConcurrencyManager deferedLock = (ConcurrencyManager)deferredLocksEnum.nextElement();
             Thread activeThread = null;
             if (deferedLock.isAcquired()) {
@@ -806,6 +811,7 @@ public class ConcurrencyManager implements Serializable {
     /**
      * Print the nested depth.
      */
+    @Override
     public String toString() {
         Object[] args = { Integer.valueOf(getDepth()) };
         return Helper.getShortClassName(getClass()) + ToStringLocalization.buildMessage("nest_level", args);
@@ -850,7 +856,16 @@ public class ConcurrencyManager implements Serializable {
      *
      */
     public void putThreadAsWaitingToAcquireLockForWriting(Thread thread, String methodName) {
+        THREADS_TO_WAIT_ON_ACQUIRE.put(thread, this);
         THREADS_TO_WAIT_ON_ACQUIRE_NAME_OF_METHOD_CREATING_TRACE.put(thread, methodName);
+    }
+
+    /**
+     * The thread has acquired the lock for writing or decided to defer acquiring the lock putting this lock into its
+     * deferred lock list.
+     */
+    public void removeThreadNoLongerWaitingToAcquireLockForWriting(Thread thread) {
+        THREADS_TO_WAIT_ON_ACQUIRE.remove(thread);
         THREADS_TO_WAIT_ON_ACQUIRE_NAME_OF_METHOD_CREATING_TRACE.remove(thread);
     }
 
@@ -869,14 +884,6 @@ public class ConcurrencyManager implements Serializable {
     public void removeThreadNoLongerWaitingToAcquireLockForReading(Thread thread) {
         THREADS_TO_WAIT_ON_ACQUIRE_READ_LOCK.remove(thread);
         THREADS_TO_WAIT_ON_ACQUIRE_READ_LOCK_NAME_OF_METHOD_CREATING_TRACE.remove(thread);
-    }
-
-    /**
-     * The thread has acquired the lock for writing or decided to defer acquiring the lock putting this lock into its
-     * deferred lock list.
-     */
-    public void removeThreadNoLongerWaitingToAcquireLockForWriting(Thread thread) {
-        THREADS_TO_WAIT_ON_ACQUIRE.remove(thread);
     }
 
     /** Getter for {@link #concurrencyManagerId} */
@@ -980,10 +987,7 @@ public class ConcurrencyManager implements Serializable {
         Map<Thread, ReadLockManager> readLockManagers = getReadLockManagers();
         if (!readLockManagers.containsKey(thread)) {
             ReadLockManager  readLockManager = new ReadLockManager();
-            ReadLockManager value = readLockManagers.get(thread);
-            if (value == null) {
-                readLockManagers.put(thread, readLockManager);
-            }
+            readLockManagers.putIfAbsent(thread, readLockManager);
             return readLockManager;
         }
         return readLockManagers.get(thread);


### PR DESCRIPTION
Noticed differences between [3.0/master] ConcurrencyManager and [2.7] ConcurrencyManager... The code in 2.7 seems incorrect in comparison, so I created this PR to sync them up. 

Note that these changes seemed to diverge with [2.7] ConcurrencyManager in https://github.com/eclipse-ee4j/eclipselink/pull/1009/files and [master] ConcurrencyManager in https://github.com/eclipse-ee4j/eclipselink/pull/927/files

There may be more differences in these two PRs that need to be fixed, but I didnt go over them with a fine comb. 

Signed-off-by: Will Dazey <dazeydev.3@gmail.com>