### PR TITLE
[2.7] Update ECL 2.7 to use Eclipselink ASM 9.2.0.

### DIFF
--- a/buildsystem/compdeps/pom.xml
+++ b/buildsystem/compdeps/pom.xml
@@ -62,7 +62,7 @@
         <eclipse.drop>2018-12</eclipse.drop>
 
         <!-- DEPENDENCY Versions -->
-        <eclipselink.asm.version>9.1.1</eclipselink.asm.version>
+        <eclipselink.asm.version>9.2.0</eclipselink.asm.version>
         <!-- CQ #21139, 21140 -->
         <ch.qos.logback.version>1.2.3</ch.qos.logback.version>
         <com.sun.xml.bind.version>2.3.3</com.sun.xml.bind.version>

--- a/dbws/org.eclipse.persistence.dbws/META-INF/MANIFEST.MF
+++ b/dbws/org.eclipse.persistence.dbws/META-INF/MANIFEST.MF
@@ -26,7 +26,7 @@ Created-By: 1.6.0_21 (Sun Microsystems Inc.)
 Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version>=1.8))"
 HK2-Bundle-Name: org.eclipse.persistence:org.eclipse.persistence.dbws
 Require-Bundle: org.eclipse.persistence.core;bundle-version="2.7.10",
- org.eclipse.persistence.asm;bundle-version="9.1.1",
+ org.eclipse.persistence.asm;bundle-version="9.2.0",
  org.eclipse.persistence.jpa;bundle-version="2.7.10",
  org.eclipse.persistence.moxy;bundle-version="2.7.10"
 Bundle-Vendor: Eclipse.org - EclipseLink Project

--- a/foundation/org.eclipse.persistence.core/META-INF/MANIFEST.MF
+++ b/foundation/org.eclipse.persistence.core/META-INF/MANIFEST.MF
@@ -175,7 +175,7 @@ Bundle-ClassPath: .
 HK2-Bundle-Name: org.eclipse.persistence:org.eclipse.persistence.core
 Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version>=1.8))"
 Require-Bundle: org.eclipse.persistence.antlr;bundle-version="3.5.2";resolution:=optional,
- org.eclipse.persistence.asm;bundle-version="9.1.1";resolution:=optional
+ org.eclipse.persistence.asm;bundle-version="9.2.0";resolution:=optional
 Bundle-SymbolicName: org.eclipse.persistence.core
 Eclipse-ExtensibleAPI: true
 Bundle-Name: EclipseLink Core
@@ -223,7 +223,7 @@ Import-Package: javax.activation;resolution:=optional,
  javax.xml.xpath;resolution:=optional,
  org.eclipse.persistence.internal.libraries.antlr.runtime;resolution:=optional,
  org.eclipse.persistence.internal.libraries.antlr.runtime.tree;resolution:=optional,
- org.eclipse.persistence.internal.libraries.asm;version="9.1.1";resolution:=optional,
+ org.eclipse.persistence.internal.libraries.asm;version="9.2.0";resolution:=optional,
  org.eclipse.persistence.jpa.jpql;version="[2.1,3.0)";resolution:=optional,
  org.eclipse.persistence.jpa.jpql.parser;version="[2.1,3.0)";resolution:=optional,
  org.eclipse.persistence.jpa.jpql.utility;version="[2.1,3.0)";resolution:=optional,

--- a/jpa/org.eclipse.persistence.jpa/META-INF/MANIFEST.MF
+++ b/jpa/org.eclipse.persistence.jpa/META-INF/MANIFEST.MF
@@ -41,7 +41,7 @@ Created-By: 1.6.0_21 (Sun Microsystems Inc.)
 HK2-Bundle-Name: org.eclipse.persistence:org.eclipse.persistence.jpa
 Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version>=1.8))"
 Require-Bundle: org.eclipse.persistence.core;bundle-version="2.7.10";visibility:=reexport,
- org.eclipse.persistence.asm;bundle-version="9.1.1";resolution:=optional
+ org.eclipse.persistence.asm;bundle-version="9.2.0";resolution:=optional
 Bundle-Vendor: Eclipse.org - EclipseLink Project
 Bundle-Version: 2.7.10.qualifier
 Bundle-ManifestVersion: 2
@@ -83,8 +83,8 @@ Import-Package: javax.naming;resolution:=optional,
  org.eclipse.persistence.internal.indirection;version="2.7.10",
  org.eclipse.persistence.internal.jpa.parsing;version="2.7.10",
  org.eclipse.persistence.internal.jpa.parsing.jpql;version="2.7.10",
- org.eclipse.persistence.internal.libraries.asm;version="9.1.1",
- org.eclipse.persistence.internal.libraries.asm.commons;version="9.1.1",
+ org.eclipse.persistence.internal.libraries.asm;version="9.2.0",
+ org.eclipse.persistence.internal.libraries.asm.commons;version="9.2.0",
  org.eclipse.persistence.internal.localization;version="2.7.10",
  org.eclipse.persistence.internal.mappings.converters;version="2.7.10",
  org.eclipse.persistence.internal.queries;version="2.7.10",

--- a/moxy/org.eclipse.persistence.moxy/META-INF/MANIFEST.MF
+++ b/moxy/org.eclipse.persistence.moxy/META-INF/MANIFEST.MF
@@ -16,7 +16,7 @@ Bundle-Name: EclipseLink MOXy
 Created-By: 1.6.0_21 (Sun Microsystems Inc.)
 HK2-Bundle-Name: org.eclipse.persistence:org.eclipse.persistence.moxy
 Require-Bundle: org.eclipse.persistence.core;bundle-version="2.7.10";visibility:=reexport,
- org.eclipse.persistence.asm;bundle-version="9.1.1";resolution:=optional
+ org.eclipse.persistence.asm;bundle-version="9.2.0";resolution:=optional
 Bundle-Vendor: Eclipse.org - EclipseLink Project
 Bundle-Version: 2.7.10.qualifier
 Bundle-ManifestVersion: 2
@@ -63,7 +63,7 @@ Import-Package: com.sun.xml.bind;resolution:=optional,
  org.eclipse.persistence.internal.databaseaccess;version="2.7.10",
  org.eclipse.persistence.internal.descriptors;version="2.7.10",
  org.eclipse.persistence.internal.helper;version="2.7.10",
- org.eclipse.persistence.internal.libraries.asm;version="9.1.1";resolution:=optional,
+ org.eclipse.persistence.internal.libraries.asm;version="9.2.0";resolution:=optional,
  org.eclipse.persistence.internal.localization;version="2.7.10",
  org.eclipse.persistence.internal.oxm;version="2.7.10",
  org.eclipse.persistence.internal.oxm.record;version="2.7.10",

--- a/sdo/org.eclipse.persistence.sdo/META-INF/MANIFEST.MF
+++ b/sdo/org.eclipse.persistence.sdo/META-INF/MANIFEST.MF
@@ -14,7 +14,7 @@ Created-By: 1.6.0_21 (Sun Microsystems Inc.)
 HK2-Bundle-Name: org.eclipse.persistence:org.eclipse.persistence.sdo
 Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version>=1.8))"
 Require-Bundle: org.eclipse.persistence.core;bundle-version="2.7.10";visibility:=reexport,
- org.eclipse.persistence.asm;bundle-version="9.1.1";resolution:=optional,
+ org.eclipse.persistence.asm;bundle-version="9.2.0";resolution:=optional,
  org.eclipse.persistence.moxy;bundle-version="2.7.10";resolution:=optional,
  commonj.sdo;bundle-version="2.1.1"
 Bundle-Vendor: Eclipse.org - EclipseLink Project
@@ -34,7 +34,7 @@ Import-Package: javax.management;resolution:=optional,
  org.eclipse.persistence.internal.databaseaccess;version="2.7.10",
  org.eclipse.persistence.internal.descriptors;version="2.7.10",
  org.eclipse.persistence.internal.helper;version="2.7.10",
- org.eclipse.persistence.internal.libraries.asm;version="9.1.1";resolution:=optional,
+ org.eclipse.persistence.internal.libraries.asm;version="9.2.0";resolution:=optional,
  org.eclipse.persistence.internal.localization;version="2.7.10",
  org.eclipse.persistence.internal.oxm;version="2.7.10",
  org.eclipse.persistence.internal.oxm.record;version="2.7.10",


### PR DESCRIPTION
Update Eclipselink 2.7 to use Eclipselink ASM 9.2.0.