### PR TITLE
[3.0] Update Eclipselink 3.0 to use Eclipselink ASM 9.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
         <test.xml.parser>org.eclipse.persistence.platform.xml.jaxp.JAXPParser</test.xml.parser>
 
         <!--Eclipse Dependencies version-->
-        <eclipselink.asm.version>9.1.1</eclipselink.asm.version>
+        <eclipselink.asm.version>9.2.0</eclipselink.asm.version>
         <activation.version>2.0.1</activation.version>
         <annotation.version>2.0.0</annotation.version>
         <cdi.version>3.0.0</cdi.version>


### PR DESCRIPTION
As per the title.