### PR TITLE
[3.0] problems with session customizer when upgrading to 2.7.9 - bugfix + unit test (#1364) - backport from master

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/queries/ExpressionQueryMechanism.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/queries/ExpressionQueryMechanism.java
@@ -837,12 +837,12 @@ public class ExpressionQueryMechanism extends StatementQueryMechanism {
         if (getDescriptor().hasReturningPolicies() && getDescriptor().getReturnFieldsToGenerateUpdate() != null) {
             // In case of RelationalDescriptor only return fields for current table must be used.
             List<DatabaseField> returnFieldsForTable = new ArrayList<>();
-            for (DatabaseField item: getDescriptor().getReturnFieldsToGenerateInsert()) {
+            for (DatabaseField item: getDescriptor().getReturnFieldsToGenerateUpdate()) {
                 if (table.equals(item.getTable())) {
                     returnFieldsForTable.add(item);
                 }
                 if (!returnFieldsForTable.isEmpty()) {
-                    updateStatement.setReturnFields(getDescriptor().getReturnFieldsToGenerateInsert());
+                    updateStatement.setReturnFields(getDescriptor().getReturnFieldsToGenerateUpdate());
                 }
             }
         }

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/returninsert/TestReturnInsert.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/returninsert/TestReturnInsert.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertNotNull;
+import static org.junit.Assert.fail;
 
 /**
  * TestSuite to test entities, that has a @ReturnInsert and @ReturnUpdate annotations.
@@ -107,7 +108,9 @@ public class TestReturnInsert {
                         "    COL4     VARCHAR (15) NOT NULL," +
                         "    COL4_VIRTUAL VARCHAR (100) AS ( COL4 || '_col4' ) VIRTUAL," +
                         "    COL5     VARCHAR (15) NOT NULL," +
-                        "    COL5_VIRTUAL VARCHAR (100) AS ( COL5 || '_col5' ) VIRTUAL)");
+                        "    COL5_VIRTUAL VARCHAR (100) AS ( COL5 || '_col5' ) VIRTUAL," +
+                        "    COL6     VARCHAR (15) NOT NULL," +
+                        "    COL6_VIRTUAL VARCHAR (100) AS ( COL6 || '_col6' ) VIRTUAL)");
                 session.executeNonSelectingSQL("ALTER TABLE JPA22_RETURNINSERT_DETAIL ADD CONSTRAINT PKJPA22_RETURNINSERT_DETAIL PRIMARY KEY ( ID_VIRTUAL, ID, COL1, COL2 )");
                 session.executeNonSelectingSQL("ALTER TABLE JPA22_RETURNINSERT_DETAIL ADD CONSTRAINT FKJPA22_RETURNINSERT_MASTER_DETAIL FOREIGN KEY ( ID_VIRTUAL, ID, COL1 ) REFERENCES JPA22_RETURNINSERT_MASTER ( ID_VIRTUAL, ID, COL1 ) NOT DEFERRABLE");
                 session.executeNonSelectingSQL("CREATE TABLE JPA22_RETURNINSERT_MASTER_JOINED  (" +
@@ -143,6 +146,8 @@ public class TestReturnInsert {
             returnInsertDetail = insertReturnInsertDetail(em, returnInsertMaster);
 
         em.getTransaction().commit();
+        } catch (Exception e) {
+            fail(e.getMessage());
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -171,6 +176,8 @@ public class TestReturnInsert {
             returnInsertDetailJoined = em.merge(returnInsertDetailJoined);
 
             em.getTransaction().commit();
+        } catch (Exception e) {
+            fail(e.getMessage());
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -196,6 +203,8 @@ public class TestReturnInsert {
             returnInsertDetailJoined = em.merge(returnInsertDetailJoined);
 
             em.getTransaction().commit();
+        } catch (Exception e) {
+            fail(e.getMessage());
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -220,6 +229,8 @@ public class TestReturnInsert {
             returnInsertDetailJoined = em.merge(returnInsertDetailJoined);
 
             em.getTransaction().commit();
+        } catch (Exception e) {
+            fail(e.getMessage());
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -252,9 +263,12 @@ public class TestReturnInsert {
             assertEquals("abc_col2", returnInsertDetailFindResult.getReturnInsertDetailEmbedded().getCol2Virtual());
             //Test update
             returnInsertDetailFindResult.getReturnInsertDetailEmbedded().setCol3("ijk");
+            returnInsertDetailFindResult.setCol6("rst");
             returnInsertDetailMerge = em.merge(returnInsertDetailFindResult);
 
             em.getTransaction().commit();
+        } catch (Exception e) {
+            fail(e.getMessage());
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -264,6 +278,7 @@ public class TestReturnInsert {
             }
         }
         assertEquals("ijk_col3", returnInsertDetailMerge.getReturnInsertDetailEmbedded().getCol3Virtual());
+        assertEquals("rst_col6", returnInsertDetailMerge.getCol6Virtual());
     }
 
     private void testQuery() {
@@ -278,6 +293,8 @@ public class TestReturnInsert {
             Query query  = em.createQuery("select t from ReturnInsertDetail t where t.id = :returnInsertDetailId");
             query.setParameter("returnInsertDetailId", returnInsertDetailPK);
             returnInsertDetailQueryResult = (ReturnInsertDetail) query.getSingleResult();
+        } catch (Exception e) {
+            fail(e.getMessage());
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -311,7 +328,9 @@ public class TestReturnInsert {
             DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S");
             Date date = dateFormat.parse("1970-01-01 00:00:00.0");
             ReturnInsertMasterPK.setId(date);
-        } catch (Exception e) { }
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
         ReturnInsertMasterPK.setCol1(1L);
         return ReturnInsertMasterPK;
     }
@@ -338,6 +357,8 @@ public class TestReturnInsert {
         //Inherited field
         returnInsertDetail.setCol4("opq");
 
+        returnInsertDetail.setCol6("rst");
+
         em.persist(returnInsertDetail);
         return returnInsertDetail;
     }
@@ -349,7 +370,9 @@ public class TestReturnInsert {
             DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S");
             Date date = dateFormat.parse("1970-01-01 00:00:00.0");
             returnInsertDetailPK.setId(date);
-        } catch (Exception e) { }
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
         returnInsertDetailPK.setCol1(1L);
         returnInsertDetailPK.setCol2("abc");
         return returnInsertDetailPK;

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/returninsert/model/ReturnInsertDetail.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/returninsert/model/ReturnInsertDetail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -17,6 +17,8 @@ package org.eclipse.persistence.jpa.returninsert.model;
 import org.eclipse.persistence.annotations.ReturnInsert;
 
 import jakarta.persistence.*;
+import org.eclipse.persistence.annotations.ReturnUpdate;
+
 import java.io.Serializable;
 
 /**
@@ -42,6 +44,13 @@ public class ReturnInsertDetail extends ReturnInsertDetailParent implements Seri
 
 	@Embedded
 	private ReturnInsertDetailEmbedded returnInsertDetailEmbedded;
+
+	@Column(name = "COL6")
+	private String col6;
+
+	@ReturnUpdate
+	@Column(name = "COL6_VIRTUAL", insertable = false)
+	private String col6Virtual;
 
 	@OneToOne(cascade = { CascadeType.MERGE, CascadeType.PERSIST })
 	@JoinColumns({
@@ -76,6 +85,22 @@ public class ReturnInsertDetail extends ReturnInsertDetailParent implements Seri
 
 	public void setReturnInsertDetailEmbedded(ReturnInsertDetailEmbedded returnInsertDetailEmbedded) {
 		this.returnInsertDetailEmbedded = returnInsertDetailEmbedded;
+	}
+
+	public String getCol6() {
+		return col6;
+	}
+
+	public void setCol6(String col6) {
+		this.col6 = col6;
+	}
+
+	public String getCol6Virtual() {
+		return col6Virtual;
+	}
+
+	public void setCol6Virtual(String col6Virtual) {
+		this.col6Virtual = col6Virtual;
 	}
 
 	public ReturnInsertMaster getReturnInsertMaster() {


### PR DESCRIPTION
Standalone usage ReturnUpdate annotation was broken in PR #1016.
fixes #1363

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>
(cherry picked from commit fb1cc69d09a70bf74935132181a105ddd37e07d6)