### PR TITLE
[master] Oracle dependencies update (JDBC Driver, XMLParser, DMS) to 21c

### DIFF
--- a/bundles/eclipselink/pom.xml
+++ b/bundles/eclipselink/pom.xml
@@ -160,31 +160,31 @@
         </dependency>
 
         <dependency>
-            <groupId>com.oracle.ojdbc</groupId>
+            <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc8</artifactId>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>com.oracle.ojdbc</groupId>
+            <groupId>com.oracle.database.xml</groupId>
             <artifactId>xmlparserv2</artifactId>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>com.oracle.ojdbc</groupId>
+            <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ucp</artifactId>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>com.oracle.ojdbc</groupId>
+            <groupId>com.oracle.database.xml</groupId>
             <artifactId>xdb</artifactId>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>com.oracle.ojdbc</groupId>
+            <groupId>com.oracle.database.observability</groupId>
             <artifactId>dms</artifactId>
             <scope>provided</scope>
             <optional>true</optional>

--- a/bundles/eclipselink/pom.xml
+++ b/bundles/eclipselink/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at

--- a/dbws/eclipselink.dbws.test.oracle/pom.xml
+++ b/dbws/eclipselink.dbws.test.oracle/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at

--- a/dbws/eclipselink.dbws.test.oracle/pom.xml
+++ b/dbws/eclipselink.dbws.test.oracle/pom.xml
@@ -75,7 +75,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.oracle.ojdbc</groupId>
+            <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc8</artifactId>
             <scope>test</scope>
         </dependency>

--- a/foundation/eclipselink.extension.oracle.spatial.test/pom.xml
+++ b/foundation/eclipselink.extension.oracle.spatial.test/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at

--- a/foundation/eclipselink.extension.oracle.spatial.test/pom.xml
+++ b/foundation/eclipselink.extension.oracle.spatial.test/pom.xml
@@ -55,7 +55,7 @@
         <!--Oracle proprietary dependencies-->
         <!--JDBC driver dependencies-->
         <dependency>
-            <groupId>com.oracle.ojdbc</groupId>
+            <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc8</artifactId>
             <scope>test</scope>
         </dependency>

--- a/foundation/org.eclipse.persistence.oracle.nosql/pom.xml
+++ b/foundation/org.eclipse.persistence.oracle.nosql/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at

--- a/foundation/org.eclipse.persistence.oracle.nosql/pom.xml
+++ b/foundation/org.eclipse.persistence.oracle.nosql/pom.xml
@@ -82,7 +82,7 @@
         </dependency>
         <!--JDBC driver dependencies-->
         <dependency>
-            <groupId>com.oracle.ojdbc</groupId>
+            <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc8</artifactId>
             <scope>test</scope>
         </dependency>

--- a/foundation/org.eclipse.persistence.oracle.test/pom.xml
+++ b/foundation/org.eclipse.persistence.oracle.test/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at

--- a/foundation/org.eclipse.persistence.oracle.test/pom.xml
+++ b/foundation/org.eclipse.persistence.oracle.test/pom.xml
@@ -60,27 +60,27 @@
         <!--Oracle proprietary dependencies-->
         <!--JDBC driver dependencies-->
         <dependency>
-            <groupId>com.oracle.ojdbc</groupId>
+            <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc8</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.oracle.ojdbc</groupId>
+            <groupId>com.oracle.database.xml</groupId>
             <artifactId>xmlparserv2</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.oracle.ojdbc</groupId>
+            <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ucp</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.oracle.ojdbc</groupId>
+            <groupId>com.oracle.database.xml</groupId>
             <artifactId>xdb</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.oracle.ojdbc</groupId>
+            <groupId>com.oracle.database.observability</groupId>
             <artifactId>dms</artifactId>
             <scope>test</scope>
         </dependency>

--- a/foundation/org.eclipse.persistence.oracle.test/src/it/java/org/eclipse/persistence/testing/framework/oracle/SessionExchanger.java
+++ b/foundation/org.eclipse.persistence.oracle.test/src/it/java/org/eclipse/persistence/testing/framework/oracle/SessionExchanger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/foundation/org.eclipse.persistence.oracle.test/src/it/java/org/eclipse/persistence/testing/framework/oracle/SessionExchanger.java
+++ b/foundation/org.eclipse.persistence.oracle.test/src/it/java/org/eclipse/persistence/testing/framework/oracle/SessionExchanger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -19,7 +19,8 @@ import java.sql.SQLException;
 import java.util.Map;
 import java.util.Properties;
 
-import oracle.jdbc.pool.OracleDataSource;
+import oracle.ucp.jdbc.PoolDataSource;
+import oracle.ucp.jdbc.PoolDataSourceFactory;
 
 import org.eclipse.persistence.sessions.JNDIConnector;
 import org.eclipse.persistence.sessions.DatabaseLogin;
@@ -52,7 +53,7 @@ public class SessionExchanger {
     DatabaseSession originalSession;
     DatabaseSession newSession;
     boolean hasLoggedOutOriginalSession;
-    OracleDataSource dataSource;
+    PoolDataSource dataSource;
 
     // pass the original session and params for the new one:
     //   useDatabaseSession - "true" means new session is DatabaseSession; "false" - ServerSession;
@@ -157,13 +158,7 @@ public class SessionExchanger {
         } finally {
             newSession = null;
             if(dataSource != null) {
-                try {
-                    dataSource.close();
-                } catch (SQLException ex) {
-                    throw new TestProblemException("Exception thrown while closing OracleDataSource:\n", ex);
-                } finally {
-                    dataSource = null;
-                }
+                dataSource = null;
             }
         }
     }
@@ -190,21 +185,19 @@ public class SessionExchanger {
     // create a data source using the supplied connection string
     void createDataSource(String connectionString, int minConnections, int maxConnections) {
         try {
-            dataSource = new OracleDataSource();
+            dataSource = PoolDataSourceFactory.getPoolDataSource();
+            dataSource.setConnectionFactoryClassName("oracle.jdbc.pool.OracleDataSource");
             Properties props = new Properties();
             if(minConnections >= 0) {
-                props.setProperty("MinLimit", Integer.toString(minConnections));
-                props.setProperty("InitialLimit", Integer.toString(minConnections));
+                dataSource.setMinPoolSize(minConnections);
+                dataSource.setInitialPoolSize(minConnections);
             }
             if(maxConnections >= 0) {
-                props.setProperty("MaxLimit", Integer.toString(maxConnections));
+                dataSource.setMaxPoolSize(maxConnections);
             }
-            if(!props.isEmpty()) {
-                dataSource.setConnectionCacheProperties(props);
-            }
+            dataSource.setURL(connectionString);
         } catch (SQLException ex) {
             throw new TestProblemException("Failed to create OracleDataSource with " + connectionString + ".\n", ex);
         }
-        dataSource.setURL(connectionString);
     }
 }

--- a/foundation/org.eclipse.persistence.oracle.test/src/it/java/org/eclipse/persistence/testing/tests/distributedservers/rcm/jms/JMSSetupHelper.java
+++ b/foundation/org.eclipse.persistence.oracle.test/src/it/java/org/eclipse/persistence/testing/tests/distributedservers/rcm/jms/JMSSetupHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/foundation/org.eclipse.persistence.oracle.test/src/it/java/org/eclipse/persistence/testing/tests/distributedservers/rcm/jms/JMSSetupHelper.java
+++ b/foundation/org.eclipse.persistence.oracle.test/src/it/java/org/eclipse/persistence/testing/tests/distributedservers/rcm/jms/JMSSetupHelper.java
@@ -105,13 +105,6 @@ public class JMSSetupHelper extends BroadcastSetupHelper {
     @Override
     protected Object[] internalCreateFactory() throws Exception {
         updateDbSettings();
-        if (oracleDataSource != null) {
-            try {
-                oracleDataSource.close();
-            } catch (java.sql.SQLException ex) {
-                // ignore
-            }
-        }
         createInDb();
 
         oracleDataSource = new oracle.jdbc.pool.OracleDataSource();
@@ -146,12 +139,7 @@ public class JMSSetupHelper extends BroadcastSetupHelper {
             destroyInDb();
         } catch (java.sql.SQLException ex) {
         } finally {
-            try {
-                oracleDataSource.close();
-            } catch (java.sql.SQLException ex) {
-            } finally {
-                oracleDataSource = null;
-            }
+            oracleDataSource = null;
         }
     }
 

--- a/foundation/org.eclipse.persistence.oracle.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/proxyauthentication/ProxyAuthenticationTestSuite.java
+++ b/foundation/org.eclipse.persistence.oracle.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/proxyauthentication/ProxyAuthenticationTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/foundation/org.eclipse.persistence.oracle.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/proxyauthentication/ProxyAuthenticationTestSuite.java
+++ b/foundation/org.eclipse.persistence.oracle.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/proxyauthentication/ProxyAuthenticationTestSuite.java
@@ -27,8 +27,9 @@ import junit.framework.Test;
 import junit.framework.TestSuite;
 
 import oracle.jdbc.OracleConnection;
-import oracle.jdbc.pool.OracleDataSource;
 
+import oracle.ucp.jdbc.PoolDataSource;
+import oracle.ucp.jdbc.PoolDataSourceFactory;
 import org.eclipse.persistence.config.PersistenceUnitProperties;
 import org.eclipse.persistence.config.ExclusiveConnectionMode;
 import org.eclipse.persistence.internal.sessions.ExclusiveIsolatedClientSession;
@@ -61,7 +62,7 @@ public class ProxyAuthenticationTestSuite extends JUnitTestCase {
     // indicates whether EclusiveIsolatedClientSession should be used.
     boolean shoulUseExclusiveIsolatedSession;
     // datasource created in external connection pooling case.
-    OracleDataSource dataSource;
+    PoolDataSource dataSource;
 
     // writeUser is set by an event risen by ModifyQuery.
     private static String writeUser;
@@ -171,27 +172,17 @@ public class ProxyAuthenticationTestSuite extends JUnitTestCase {
         // the test has customized the factory - it should be closed.
         closeEntityManagerFactory();
         // close the data source if it has been created
-        if(dataSource != null) {
-            try {
-                dataSource.close();
-            } catch (SQLException ex) {
-                throw new RuntimeException("Exception thrown while closing OracleDataSource:\n", ex);
-            } finally {
-                dataSource = null;
-            }
-        }
+        dataSource = null;
     }
 
     // create a data source using the supplied connection string
     void createDataSource(String connectionString) {
         try {
-            dataSource = new OracleDataSource();
-            Properties props = new Properties();
-            // the pool using just one connection would cause deadlock in case of a connection leak - good for the test.
-            props.setProperty("MinLimit", "1");
-            props.setProperty("MaxLimit", "1");
-            props.setProperty("InitialLimit", "1");
-            dataSource.setConnectionCacheProperties(props);
+            dataSource = PoolDataSourceFactory.getPoolDataSource();
+            dataSource.setConnectionFactoryClassName("oracle.jdbc.pool.OracleDataSource");
+            dataSource.setMinPoolSize(1);
+            dataSource.setMaxPoolSize(1);
+            dataSource.setInitialPoolSize(1);
             dataSource.setURL(connectionString);
         } catch (SQLException ex) {
             throw new RuntimeException("Failed to create OracleDataSource with " + connectionString + ".\n", ex);

--- a/foundation/org.eclipse.persistence.oracle.test/src/it/java/org/eclipse/persistence/testing/tests/proxyauthentication/oci/ProxyTestHelper.java
+++ b/foundation/org.eclipse.persistence.oracle.test/src/it/java/org/eclipse/persistence/testing/tests/proxyauthentication/oci/ProxyTestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/foundation/org.eclipse.persistence.oracle.test/src/it/java/org/eclipse/persistence/testing/tests/proxyauthentication/oci/ProxyTestHelper.java
+++ b/foundation/org.eclipse.persistence.oracle.test/src/it/java/org/eclipse/persistence/testing/tests/proxyauthentication/oci/ProxyTestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -49,7 +49,6 @@ public abstract class ProxyTestHelper {
 
     public void close() throws SQLException {
         if (oracleDataSource != null) {
-            oracleDataSource.close();
             oracleDataSource = null;
         }
     }

--- a/foundation/org.eclipse.persistence.oracle/pom.xml
+++ b/foundation/org.eclipse.persistence.oracle/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at

--- a/foundation/org.eclipse.persistence.oracle/pom.xml
+++ b/foundation/org.eclipse.persistence.oracle/pom.xml
@@ -40,31 +40,31 @@
         <!--Oracle proprietary dependencies-->
         <!--JDBC driver dependencies-->
         <dependency>
-            <groupId>com.oracle.ojdbc</groupId>
+            <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc8</artifactId>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>com.oracle.ojdbc</groupId>
+            <groupId>com.oracle.database.xml</groupId>
             <artifactId>xmlparserv2</artifactId>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>com.oracle.ojdbc</groupId>
+            <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ucp</artifactId>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>com.oracle.ojdbc</groupId>
+            <groupId>com.oracle.database.xml</groupId>
             <artifactId>xdb</artifactId>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>com.oracle.ojdbc</groupId>
+            <groupId>com.oracle.database.observability</groupId>
             <artifactId>dms</artifactId>
             <scope>provided</scope>
             <optional>true</optional>

--- a/jpa/eclipselink.jpa.oracle.test/pom.xml
+++ b/jpa/eclipselink.jpa.oracle.test/pom.xml
@@ -180,17 +180,17 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.oracle.ojdbc</groupId>
+            <groupId>com.oracle.database.xml</groupId>
             <artifactId>xmlparserv2</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.oracle.ojdbc</groupId>
+            <groupId>com.oracle.database.xml</groupId>
             <artifactId>xdb</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.oracle.ojdbc</groupId>
+            <groupId>com.oracle.database.nls</groupId>
             <artifactId>orai18n</artifactId>
             <scope>test</scope>
         </dependency>

--- a/jpa/eclipselink.jpa.oracle.test/pom.xml
+++ b/jpa/eclipselink.jpa.oracle.test/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at

--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
         <pgsql.version>42.2.18</pgsql.version>
         <!-- CQ #21139, 21140 -->
         <logback.version>1.3.0-alpha5</logback.version>
-        <oracle.jdbc.version>19.3.0.0</oracle.jdbc.version>
+        <oracle.jdbc.version>21.3.0.0</oracle.jdbc.version>
         <!-- CQ #2437 -->
         <oracle.aqapi.version>19.3.0.0</oracle.aqapi.version>
         <oracle.fmw.version>12.2.1-2-0</oracle.fmw.version>
@@ -804,37 +804,37 @@
             </dependency>
             <!-- All files as a Oracle JDBC driver CQ #21154 -->
             <dependency>
-                <groupId>com.oracle.ojdbc</groupId>
+                <groupId>com.oracle.database.jdbc</groupId>
                 <artifactId>ojdbc8</artifactId>
                 <version>${oracle.jdbc.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.oracle.ojdbc</groupId>
+                <groupId>com.oracle.database.xml</groupId>
                 <artifactId>xmlparserv2</artifactId>
                 <version>${oracle.jdbc.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.oracle.ojdbc</groupId>
+                <groupId>com.oracle.database.jdbc</groupId>
                 <artifactId>ucp</artifactId>
                 <version>${oracle.jdbc.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.oracle.ojdbc</groupId>
+                <groupId>com.oracle.database.xml</groupId>
                 <artifactId>xdb</artifactId>
                 <version>${oracle.jdbc.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.oracle.ojdbc</groupId>
+                <groupId>com.oracle.database.observability</groupId>
                 <artifactId>dms</artifactId>
                 <version>${oracle.jdbc.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.oracle.ojdbc</groupId>
+                <groupId>com.oracle.database.ha</groupId>
                 <artifactId>simplefan</artifactId>
                 <version>${oracle.jdbc.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.oracle.ojdbc</groupId>
+                <groupId>com.oracle.database.ha</groupId>
                 <artifactId>ons</artifactId>
                 <version>${oracle.jdbc.version}</version>
             </dependency>
@@ -846,7 +846,7 @@
                                 </dependency>
             -->
             <dependency>
-                <groupId>com.oracle.ojdbc</groupId>
+                <groupId>com.oracle.database.nls</groupId>
                 <artifactId>orai18n</artifactId>
                 <version>${oracle.jdbc.version}</version>
             </dependency>
@@ -1714,7 +1714,7 @@
                 <test.properties.file>${user.home}/${test.oracle.properties.file}</test.properties.file>
                 <test.properties.fileName>${test.oracle.properties.file}</test.properties.fileName>
                 <!--Used by sql-maven-plugin-->
-                <db.driver.groupId>com.oracle.ojdbc</db.driver.groupId>
+                <db.driver.groupId>com.oracle.database.jdbc</db.driver.groupId>
                 <db.driver.artifactId>ojdbc8</db.driver.artifactId>
                 <db.driver.version>${oracle.jdbc.version}</db.driver.version>
                 <test.skip.in-memory.db>true</test.skip.in-memory.db>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at

--- a/utils/eclipselink.dbws.builder.test.oracle/pom.xml
+++ b/utils/eclipselink.dbws.builder.test.oracle/pom.xml
@@ -84,12 +84,12 @@
         </dependency>
         <!--Oracle proprietary dependencies-->
         <dependency>
-            <groupId>com.oracle.ojdbc</groupId>
+            <groupId>com.oracle.database.xml</groupId>
             <artifactId>xmlparserv2</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.oracle.ojdbc</groupId>
+            <groupId>com.oracle.database.xml</groupId>
             <artifactId>xdb</artifactId>
             <scope>test</scope>
         </dependency>

--- a/utils/eclipselink.dbws.builder.test.oracle/pom.xml
+++ b/utils/eclipselink.dbws.builder.test.oracle/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at


### PR DESCRIPTION
In 21.3.0.0 are some changes in:

1. Maven artifacts naming (groupId)
2. Some deprecated methods in 19.3.0.0 were removed in 21.3.0.0 (e.g. close(), DataSources with connection pooling has to be created by Oracle Universal Connection Pool API)

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>