### PR TITLE
[3.0] Bug in the PersistenceUnitProcessor.findPersistenceArchives(ClassLoader loader, String descriptorPath) - bugfix - backport from master

### DIFF
--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/advanced/PersistenceUnitProcessorTest.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/advanced/PersistenceUnitProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -79,6 +79,21 @@ public class PersistenceUnitProcessorTest extends JUnitTestCase {
         );
     }
 
+    private static void checkPURootCustomWithCustomDescriptorLocation(
+            String inputScheme,
+            String inputFile,
+            String expectedOutput,
+            String descriptorLocation
+    ) throws Exception {
+        assertEquals(
+                expectedOutput,
+                PersistenceUnitProcessor.computePURootURL(
+                        new URL(inputScheme, "", -1, inputFile, dummyHandler),
+                        descriptorLocation
+                ).toString()
+        );
+    }
+
     private static void checkPURootFailsCustom(
         String inputScheme,
         String inputFile
@@ -117,6 +132,15 @@ public class PersistenceUnitProcessorTest extends JUnitTestCase {
         checkPURootCustom(
             "zip", "/foo/bar.war!/WEB-INF/classes/META-INF/persistence.xml",
             "jar:file:/foo/bar.war!/WEB-INF/classes/"
+        );
+
+        // WAR files have a special location available.
+        // Simulate event when custom persistence descriptor file name is used and specified e.g.
+        // System.setProperty(PersistenceUnitProperties.ECLIPSELINK_PERSISTENCE_XML, "WEB-INF/classes/META-INF/my-persistence.xml");
+        checkPURootCustomWithCustomDescriptorLocation(
+                "zip", "/foo/bar.war!/WEB-INF/classes/META-INF/my-persistence.xml",
+                "file:/foo/bar.war",
+                "WEB-INF/classes/META-INF/my-persistence.xml"
         );
 
         // Same as the previous one, but not a WAR!

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/deployment/PersistenceUnitProcessor.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/deployment/PersistenceUnitProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2018 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -756,7 +756,7 @@ public class PersistenceUnitProcessor {
             // archive, and file is the URL of that archive. Since
             // the innermost archive has to be a JAR (according to JPA Spec),
             // this case is handled by the previous branch.
-            return rootEntry.equals(WEBINF_CLASSES_STR);
+            return rootEntry.equals(WEBINF_CLASSES_STR) || rootEntry.isEmpty();
         } else {
             return false;
         }


### PR DESCRIPTION
This small fix allows using/loading persistence.xml from WAR file from `.../WEB-INF/classes/META-INF/persistence.xml` location in JSE environment.
It is still required to point EclipseLink (EntityManagerFactory) to this location in JSE environment by:
``
  System.setProperty(PersistenceUnitProperties.ECLIPSELINK_PERSISTENCE_XML, "WEB-INF/classes/META-INF/persistence.xml");
``
or
``
  Properties persistenceUnitProperties = new Properties();
  persistenceUnitProperties.setProperty(PersistenceUnitProperties.ECLIPSELINK_PERSISTENCE_XML, "WEB-INF/classes/META-INF/persistence.xml");
  EntityManagerFactory entityManagerFactory = Persistence.createEntityManagerFactory("test-jpa-pu2", persistenceUnitProperties);
``
Before this fix ValidationException
e.g.
``
Internal Exception: Exception [EclipseLink-7357] (Eclipse Persistence Services - 4.0.0.v202112161344): org.eclipse.persistence.exceptions.ValidationException
Exception Description: URL [jar:file:/tmp/test1348.war!/WEB-INF/classes/META-INF/persistence.xml] for resource [WEB-INF/classes/META-INF/persistence.xml] does not belong to a valid persistence root (as per JPA Specification)
``
was thrown

Fixes #1348

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>
(cherry picked from commit 9417d470363c01c92e689f58f85b0f899fd1f69c)