### PR TITLE
[master] Fix/new feature for Bug 404069 - MOXy should not append .0 to time info for dateTime and time formats + unit test

### DIFF
--- a/foundation/org.eclipse.persistence.core/pom.xml
+++ b/foundation/org.eclipse.persistence.core/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -368,6 +368,10 @@
                             <includes>
                                 <include>org.eclipse.persistence.testing.oxm.OXMSRGTestSuite</include>
                             </includes>
+                            <excludes>
+                                <exclude>org.eclipse.persistence.testing.oxm.systemproperties.OXMSystemPropertiesNonDefaultTestCases</exclude>
+                                <exclude>org.eclipse.persistence.testing.oxm.systemproperties.DateAndTimeNonDefaultTestCases</exclude>
+                            </excludes>
                         </configuration>
                     </execution>
                     <execution>
@@ -394,6 +398,7 @@
                                 <include>*.MappingClassLoaderTestCases</include>
                                 <include>org.eclipse.persistence.testing.oxm.mappings.directcollection.nillable.DirectCollectionMappingNillableTestSuite</include>
                                 <include>org.eclipse.persistence.testing.oxm.mappings.keybased.multipletargets.compositekey.CompositeKeyTestCases</include>
+                                <include>org.eclipse.persistence.testing.oxm.systemproperties.OXMSystemPropertiesTestCases</include>
                             </includes>
                             <excludes>
                                 <exclude>*.MappingTestSuite</exclude>
@@ -402,6 +407,8 @@
                                 <exclude>org.eclipse.persistence.testing.oxm.mappings.DocPresMappingTestSuite</exclude>
                                 <exclude>org.eclipse.persistence.testing.oxm.mappings.anyobjectandanycollection.XMLAnyObjectAndAnyCollectionMappingTestSuite</exclude>
                                 <exclude>*.SAXMappingTestSuite</exclude>
+                                <exclude>org.eclipse.persistence.testing.oxm.systemproperties.OXMSystemPropertiesNonDefaultTestCases</exclude>
+                                <exclude>org.eclipse.persistence.testing.oxm.systemproperties.DateAndTimeNonDefaultTestCases</exclude>
                             </excludes>
                         </configuration>
                     </execution>
@@ -436,6 +443,8 @@
                                 <exclude>org.eclipse.persistence.testing.oxm.mappings.anyobjectandanycollection.XMLAnyObjectAndAnyCollectionMappingTestSuite</exclude>
                                 <exclude>org.eclipse.persistence.testing.oxm.mappings.keybased.compositekeyclass.CompositeKeyClassMappingTestSuite</exclude>
                                 <exclude>org.eclipse.persistence.testing.oxm.mappings.sequenced.SequencedMappingTestSuite</exclude>
+                                <exclude>org.eclipse.persistence.testing.oxm.systemproperties.OXMSystemPropertiesNonDefaultTestCases</exclude>
+                                <exclude>org.eclipse.persistence.testing.oxm.systemproperties.DateAndTimeNonDefaultTestCases</exclude>
                             </excludes>
                         </configuration>
                     </execution>
@@ -482,6 +491,8 @@
                                 <exclude>org.eclipse.persistence.testing.oxm.mappings.compositeobject.self.converter.CompositeObjectSelfConverterTestSuite</exclude>
                                 <exclude>org.eclipse.persistence.testing.oxm.mappings.keybased.compositekeyclass.CompositeKeyClassMappingTestSuite</exclude>
                                 <exclude>org.eclipse.persistence.testing.oxm.mappings.containeracessor.ContainerAccessorTestSuite</exclude>
+                                <exclude>org.eclipse.persistence.testing.oxm.systemproperties.OXMSystemPropertiesNonDefaultTestCases</exclude>
+                                <exclude>org.eclipse.persistence.testing.oxm.systemproperties.DateAndTimeNonDefaultTestCases</exclude>
                             </excludes>
                         </configuration>
                     </execution>
@@ -529,6 +540,8 @@
                                 <exclude>org.eclipse.persistence.testing.oxm.mappings.compositeobject.self.converter.CompositeObjectSelfConverterTestSuite</exclude>
                                 <exclude>org.eclipse.persistence.testing.oxm.mappings.keybased.compositekeyclass.CompositeKeyClassMappingTestSuite</exclude>
                                 <exclude>org.eclipse.persistence.testing.oxm.mappings.containeracessor.ContainerAccessorTestSuite</exclude>
+                                <exclude>org.eclipse.persistence.testing.oxm.systemproperties.OXMSystemPropertiesNonDefaultTestCases</exclude>
+                                <exclude>org.eclipse.persistence.testing.oxm.systemproperties.DateAndTimeNonDefaultTestCases</exclude>
                             </excludes>
                         </configuration>
                     </execution>
@@ -565,7 +578,32 @@
                                 <exclude>org.eclipse.persistence.testing.oxm.mappings.keybased.KeyBasedMappingTestSuite</exclude>
                                 <exclude>org.eclipse.persistence.testing.oxm.mappings.keybased.compositekeyclass.CompositeKeyClassMappingTestSuite</exclude>
                                 <exclude>org.eclipse.persistence.testing.oxm.mappings.sequenced.SequencedMappingTestSuite</exclude>
+                                <exclude>org.eclipse.persistence.testing.oxm.systemproperties.OXMSystemPropertiesNonDefaultTestCases</exclude>
+                                <exclude>org.eclipse.persistence.testing.oxm.systemproperties.DateAndTimeNonDefaultTestCases</exclude>
                             </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-oxm-non-default-system-properties</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <skipTests>${test-skip-oxm}</skipTests>
+                            <reportNameSuffix>test-oxm-non-default-system-properties</reportNameSuffix>
+                            <forkCount>1</forkCount>
+                            <reuseForks>false</reuseForks>
+                            <systemPropertyVariables>
+                                <org.eclipse.persistence.json.type-compatibility>true</org.eclipse.persistence.json.type-compatibility>
+                                <org.eclipse.persistence.json.use-xsd-types-prefix>true</org.eclipse.persistence.json.use-xsd-types-prefix>
+                                <org.eclipse.persistence.json.type-attribute-name>jsonTestType</org.eclipse.persistence.json.type-attribute-name>
+                                <org.eclipse.persistence.json.disable-nested-array-name>true</org.eclipse.persistence.json.disable-nested-array-name>
+                                <org.eclipse.persistence.xml.time.suffix>.0</org.eclipse.persistence.xml.time.suffix>
+                            </systemPropertyVariables>
+                            <includes>
+                                <include>org.eclipse.persistence.testing.oxm.systemproperties.OXMSystemPropertiesNonDefaultTestCases</include>
+                                <include>org.eclipse.persistence.testing.oxm.systemproperties.DateAndTimeNonDefaultTestCases</include>
+                            </includes>
                         </configuration>
                     </execution>
                 </executions>

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/oxm/OXMSystemProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/oxm/OXMSystemProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -54,6 +54,20 @@ public final class OXMSystemProperties {
 
     public static final String DISABLE_SECURE_PROCESSING = "eclipselink.disableXmlSecurity";
 
+    /**
+     * Add suffix/decimal part to time part/seconds in case of conversion from supported date/time formats into String.
+     * It happens only if source time doesn't contain fraction of seconds and for XML, JSON conversion. E.g.:
+     * For -Dorg.eclipse.persistence.xml.time.suffix=.0
+     * <ul>
+     * <li>Source value: 2003-08-29T03:00:00-04:00  -&gt; Output string: 2003-08-29T03:00:00.0-04:00</li>
+     * <li>Source value: 1975-02-21T07:47:15  -&gt; Output string: 1975-02-21T07:47:15.0</li>
+     * </ul>
+     * @since 2.7.11
+     */
+    public static final String XML_CONVERSION_TIME_SUFFIX = "org.eclipse.persistence.xml.time.suffix";
+
+    public static final String DEFAULT_XML_CONVERSION_TIME_SUFFIX = "";
+
     public static final Boolean jsonTypeCompatiblity = PrivilegedAccessHelper.getSystemPropertyBoolean(JSON_TYPE_COMPATIBILITY, false);
 
     public static final Boolean jsonUseXsdTypesPrefix = PrivilegedAccessHelper.getSystemPropertyBoolean(JSON_USE_XSD_TYPES_PREFIX, false);
@@ -61,6 +75,8 @@ public final class OXMSystemProperties {
     public static final String jsonTypeAttributeName = PrivilegedAccessHelper.getSystemProperty(JSON_TYPE_ATTRIBUTE_NAME, Constants.SCHEMA_TYPE_ATTRIBUTE);
 
     public static final Boolean jsonDisableNestedArrayName = PrivilegedAccessHelper.getSystemPropertyBoolean(JSON_DISABLE_NESTED_ARRAY_NAME, false);
+
+    public static final String xmlConversionTimeSuffix = PrivilegedAccessHelper.getSystemProperty(XML_CONVERSION_TIME_SUFFIX, DEFAULT_XML_CONVERSION_TIME_SUFFIX);
 
     private OXMSystemProperties() {}
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/oxm/XMLConversionManager.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/oxm/XMLConversionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -1166,7 +1166,7 @@ public class XMLConversionManager extends ConversionManager implements org.eclip
                 milliStr = '.' + milliStr;
                 result = pre + milliStr + post;
             } else {
-                result = pre + post;
+                result = pre + OXMSystemProperties.xmlConversionTimeSuffix + post;
             }
         }
         return result;
@@ -1873,7 +1873,7 @@ public class XMLConversionManager extends ConversionManager implements org.eclip
     private String appendNanos(String string, Timestamp ts) {
         StringBuilder strBldr = new StringBuilder(string);
         int nanos = ts.getNanos();
-        strBldr.append(nanos==0 ? "" : '.' + Helper.buildZeroPrefixAndTruncTrailZeros(nanos, TOTAL_NS_DIGITS));
+        strBldr.append(nanos==0 ? OXMSystemProperties.xmlConversionTimeSuffix : '.' + Helper.buildZeroPrefixAndTruncTrailZeros(nanos, TOTAL_NS_DIGITS));
         return strBldr.toString();
     }
 
@@ -1889,7 +1889,7 @@ public class XMLConversionManager extends ConversionManager implements org.eclip
             // adjust for negative time values, i.e. before Epoch
             msns = msns + 1000;
         }
-        strBldr.append(msns==0 ? "" : '.' + Helper.buildZeroPrefixAndTruncTrailZeros(msns, TOTAL_MS_DIGITS));
+        strBldr.append(msns==0 ? OXMSystemProperties.xmlConversionTimeSuffix : '.' + Helper.buildZeroPrefixAndTruncTrailZeros(msns, TOTAL_MS_DIGITS));
         return strBldr.toString();
     }
 

--- a/foundation/org.eclipse.persistence.core/src/test/java/org/eclipse/persistence/testing/oxm/systemproperties/DateAndTimeNonDefaultTestCases.java
+++ b/foundation/org.eclipse.persistence.core/src/test/java/org/eclipse/persistence/testing/oxm/systemproperties/DateAndTimeNonDefaultTestCases.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation from Oracle TopLink
+package org.eclipse.persistence.testing.oxm.systemproperties;
+
+
+import org.eclipse.persistence.testing.oxm.xmlconversionmanager.DateAndTimeTestCases;
+
+public class DateAndTimeNonDefaultTestCases extends DateAndTimeTestCases {
+
+    public DateAndTimeNonDefaultTestCases(String name) {
+        super(name);
+        super.controlXmlConversionTimeSuffix = ".0";
+    }
+
+}

--- a/foundation/org.eclipse.persistence.core/src/test/java/org/eclipse/persistence/testing/oxm/systemproperties/OXMSystemPropertiesNonDefaultTestCases.java
+++ b/foundation/org.eclipse.persistence.core/src/test/java/org/eclipse/persistence/testing/oxm/systemproperties/OXMSystemPropertiesNonDefaultTestCases.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.testing.oxm.systemproperties;
+
+import org.eclipse.persistence.internal.oxm.OXMSystemProperties;
+import org.eclipse.persistence.internal.oxm.XMLConversionManager;
+import org.eclipse.persistence.oxm.XMLConstants;
+import org.junit.Test;
+
+import java.sql.Timestamp;
+import java.util.TimeZone;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests OXMSystemProperties class. With default non-values. It requires to be isolated JVM to avoid impact to others tests or it should be executed with other tests with same system properties.
+ */
+public class OXMSystemPropertiesNonDefaultTestCases {
+
+    static {
+        System.setProperty(OXMSystemProperties.JSON_TYPE_COMPATIBILITY, "true");
+        System.setProperty(OXMSystemProperties.JSON_USE_XSD_TYPES_PREFIX, "true");
+        System.setProperty(OXMSystemProperties.JSON_TYPE_ATTRIBUTE_NAME, "jsonTestType");
+        System.setProperty(OXMSystemProperties.JSON_DISABLE_NESTED_ARRAY_NAME, "true");
+        System.setProperty(OXMSystemProperties.XML_CONVERSION_TIME_SUFFIX, ".0");
+    }
+
+
+    @Test
+    public void testNonDefaultProperties() {
+        assertTrue(OXMSystemProperties.jsonTypeCompatiblity);
+        assertTrue(OXMSystemProperties.jsonUseXsdTypesPrefix);
+        assertEquals("jsonTestType", OXMSystemProperties.jsonTypeAttributeName);
+        assertTrue(OXMSystemProperties.jsonDisableNestedArrayName);
+        assertEquals(".0", OXMSystemProperties.xmlConversionTimeSuffix);
+    }
+}

--- a/foundation/org.eclipse.persistence.core/src/test/java/org/eclipse/persistence/testing/oxm/systemproperties/OXMSystemPropertiesTestCases.java
+++ b/foundation/org.eclipse.persistence.core/src/test/java/org/eclipse/persistence/testing/oxm/systemproperties/OXMSystemPropertiesTestCases.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.testing.oxm.systemproperties;
+
+import org.eclipse.persistence.internal.oxm.OXMSystemProperties;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Tests OXMSystemProperties class. With default values.
+ */
+public class OXMSystemPropertiesTestCases {
+
+    @Test
+    public void testProperties() {
+        assertFalse(OXMSystemProperties.jsonTypeCompatiblity);
+        assertFalse(OXMSystemProperties.jsonUseXsdTypesPrefix);
+        assertEquals("type", OXMSystemProperties.jsonTypeAttributeName);
+        assertFalse(OXMSystemProperties.jsonDisableNestedArrayName);
+        assertEquals("", OXMSystemProperties.xmlConversionTimeSuffix);
+    }
+}

--- a/foundation/org.eclipse.persistence.core/src/test/java/org/eclipse/persistence/testing/oxm/xmlconversionmanager/DateAndTimeTestCases.java
+++ b/foundation/org.eclipse.persistence.core/src/test/java/org/eclipse/persistence/testing/oxm/xmlconversionmanager/DateAndTimeTestCases.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -83,6 +83,7 @@ public class DateAndTimeTestCases extends OXTestCase {
 
     // XML Conversion Manager
     private XMLConversionManager xcm;
+    protected String controlXmlConversionTimeSuffix = "";
 
     public DateAndTimeTestCases(String name) {
         super(name);
@@ -150,7 +151,7 @@ public class DateAndTimeTestCases extends OXTestCase {
 
     public void testUtilDateToString_default_0ms() {
         java.util.Date utilDate = new java.util.Date(CONTROL_DATE_TIME_0MS);
-        String control = "1975-02-21T07:47:15"+TIMEZONE_OFFSET;
+        String control = "1975-02-21T07:47:15" + controlXmlConversionTimeSuffix + TIMEZONE_OFFSET;
         String test = xcm.convertObject(utilDate, String.class);
         assertEquals(control, test);
     }
@@ -239,7 +240,7 @@ public class DateAndTimeTestCases extends OXTestCase {
 
     public void testUtilDateToString_dateTime_0ms() {
         java.util.Date utilDate = new java.util.Date(CONTROL_DATE_TIME_0MS);
-        String control = "1975-02-21T07:47:15"+TIMEZONE_OFFSET;
+        String control = "1975-02-21T07:47:15" + controlXmlConversionTimeSuffix + TIMEZONE_OFFSET;
         String test = xcm.convertObject(utilDate, String.class, XMLConstants.DATE_TIME_QNAME);
         assertEquals(control, test);
     }
@@ -274,7 +275,7 @@ public class DateAndTimeTestCases extends OXTestCase {
 
     public void testUtilDateToString_time_0ms() {
         java.util.Date utilDate = new java.util.Date(CONTROL_DATE_TIME_0MS);
-        String control = "07:47:15"+TIMEZONE_OFFSET;
+        String control = "07:47:15" + controlXmlConversionTimeSuffix + TIMEZONE_OFFSET;
         String test = xcm.convertObject(utilDate, String.class, XMLConstants.TIME_QNAME);
         assertEquals(control, test);
     }
@@ -376,7 +377,7 @@ public class DateAndTimeTestCases extends OXTestCase {
         xmlConversionManager.setTimeZoneQualified(true);
         java.util.Date utilDate = xmlConversionManager.convertObject(CONTROL_DST_INPUT_DATE_TIME, java.util.Date.class);
         String testString = xmlConversionManager.convertObject(utilDate, String.class);
-        assertEquals("2003-08-29T03:00:00-04:00", testString);
+        assertEquals("2003-08-29T03:00:00" + controlXmlConversionTimeSuffix + "-04:00", testString);
     }
 
     public void testUtilDateToString_dateTime_dstTimeZone() {
@@ -385,7 +386,7 @@ public class DateAndTimeTestCases extends OXTestCase {
         xmlConversionManager.setTimeZoneQualified(true);
         java.util.Date utilDate = xmlConversionManager.convertObject(CONTROL_DST_INPUT_DATE_TIME, java.util.Date.class);
         String testString = xmlConversionManager.convertObject(utilDate, String.class, XMLConstants.DATE_TIME_QNAME);
-        assertEquals("2003-08-29T03:00:00-04:00", testString);
+        assertEquals("2003-08-29T03:00:00" + controlXmlConversionTimeSuffix + "-04:00", testString);
     }
 
     public void testUtilDateToString_time_dstTimeZone() {
@@ -394,7 +395,7 @@ public class DateAndTimeTestCases extends OXTestCase {
         xmlConversionManager.setTimeZoneQualified(true);
         java.util.Date utilDate = xmlConversionManager.convertObject(CONTROL_DST_INPUT_DATE_TIME, java.util.Date.class);
         String testString = xmlConversionManager.convertObject(utilDate, String.class, XMLConstants.TIME_QNAME);
-        assertEquals("03:00:00-04:00", testString);
+        assertEquals("03:00:00" + controlXmlConversionTimeSuffix + "-04:00", testString);
     }
 
     public void testStringToUtilDate_default_null() {
@@ -880,7 +881,7 @@ public class DateAndTimeTestCases extends OXTestCase {
 
     public void testSqlDateToString_dateTime_0ms() {
         java.sql.Date sqlDate = new java.sql.Date(CONTROL_DATE_TIME_0MS);
-        String control = "1975-02-21T07:47:15"+TIMEZONE_OFFSET;
+        String control = "1975-02-21T07:47:15" + controlXmlConversionTimeSuffix + TIMEZONE_OFFSET;
         String test = xcm.convertObject(sqlDate, String.class, XMLConstants.DATE_TIME_QNAME);
         assertEquals(control, test);
     }
@@ -915,7 +916,7 @@ public class DateAndTimeTestCases extends OXTestCase {
 
     public void testSqlDateToString_time_0ms() {
         java.sql.Date sqlDate = new java.sql.Date(CONTROL_DATE_TIME_0MS);
-        String control = "07:47:15"+TIMEZONE_OFFSET;
+        String control = "07:47:15" + controlXmlConversionTimeSuffix + TIMEZONE_OFFSET;
         String test = xcm.convertObject(sqlDate, String.class, XMLConstants.TIME_QNAME);
         assertEquals(control, test);
     }
@@ -1017,7 +1018,7 @@ public class DateAndTimeTestCases extends OXTestCase {
         xmlConversionManager.setTimeZoneQualified(true);
         java.sql.Date sqlDate = xmlConversionManager.convertObject(CONTROL_DST_INPUT_DATE_TIME, java.sql.Date.class, XMLConstants.DATE_TIME_QNAME);
         String testString = xmlConversionManager.convertObject(sqlDate, String.class, XMLConstants.DATE_TIME_QNAME);
-        assertEquals("2003-08-29T03:00:00-04:00", testString);
+        assertEquals("2003-08-29T03:00:00" + controlXmlConversionTimeSuffix + "-04:00", testString);
     }
 
     public void testSqlDateToString_time_dstTimeZone() {
@@ -1026,7 +1027,7 @@ public class DateAndTimeTestCases extends OXTestCase {
         xmlConversionManager.setTimeZoneQualified(true);
         java.sql.Date sqlDate = xmlConversionManager.convertObject(CONTROL_DST_INPUT_DATE_TIME, java.sql.Date.class, XMLConstants.DATE_TIME_QNAME);
         String testString = xmlConversionManager.convertObject(sqlDate, String.class, XMLConstants.TIME_QNAME);
-        assertEquals("03:00:00-04:00", testString);
+        assertEquals("03:00:00" + controlXmlConversionTimeSuffix + "-04:00", testString);
     }
 
     public void testStringToSqlDate_default_null() {
@@ -1417,7 +1418,7 @@ public class DateAndTimeTestCases extends OXTestCase {
 
     public void testSqlTimeToString_default() {
         java.sql.Time sqlTime = new java.sql.Time(CONTROL_TIME_0MS);
-        String control = "07:47:15"+TIMEZONE_OFFSET;
+        String control = "07:47:15" + controlXmlConversionTimeSuffix + TIMEZONE_OFFSET;
         String test = xcm.convertObject(sqlTime, String.class);
         boolean passed = control.equals(test) || control.equals(test.replace("+01:00", "Z"));
         assertTrue(passed);
@@ -1425,7 +1426,7 @@ public class DateAndTimeTestCases extends OXTestCase {
 
     public void testSqlTimeToString_default_0ms() {
         java.sql.Time sqlTime = new java.sql.Time(CONTROL_TIME_0MS);
-        String control = "07:47:15"+TIMEZONE_OFFSET;
+        String control = "07:47:15" + controlXmlConversionTimeSuffix + TIMEZONE_OFFSET;
         String test = xcm.convertObject(sqlTime, String.class);
         assertEquals(control, test);
     }
@@ -1483,14 +1484,14 @@ public class DateAndTimeTestCases extends OXTestCase {
 
     public void testSqlTimeToString_dateTime() {
         java.sql.Time sqlTime = new java.sql.Time(CONTROL_DATE_TIME_0MS);
-        String control = "1975-02-21T07:47:15"+TIMEZONE_OFFSET;
+        String control = "1975-02-21T07:47:15" + controlXmlConversionTimeSuffix + TIMEZONE_OFFSET;
         String test = xcm.convertObject(sqlTime, String.class, XMLConstants.DATE_TIME_QNAME);
         assertEquals(control, test);
     }
 
     public void testSqlTimeToString_dateTime_0ms() {
         java.sql.Time sqlTime = new java.sql.Time(CONTROL_DATE_TIME_0MS);
-        String control = "1975-02-21T07:47:15"+TIMEZONE_OFFSET;
+        String control = "1975-02-21T07:47:15" + controlXmlConversionTimeSuffix + TIMEZONE_OFFSET;
         String test = xcm.convertObject(sqlTime, String.class, XMLConstants.DATE_TIME_QNAME);
         assertEquals(control, test);
     }
@@ -1525,14 +1526,14 @@ public class DateAndTimeTestCases extends OXTestCase {
 
     public void testSqlTimeToString_time() {
         java.sql.Time sqlTime = new java.sql.Time(CONTROL_DATE_TIME_0MS);
-        String control = "07:47:15"+TIMEZONE_OFFSET;
+        String control = "07:47:15" + controlXmlConversionTimeSuffix + TIMEZONE_OFFSET;
         String test = xcm.convertObject(sqlTime, String.class, XMLConstants.TIME_QNAME);
         assertEquals(control, test);
     }
 
     public void testSqlTimeToString_time_0ms() {
         java.sql.Time sqlTime = new java.sql.Time(CONTROL_DATE_TIME_0MS);
-        String control = "07:47:15"+TIMEZONE_OFFSET;
+        String control = "07:47:15" + controlXmlConversionTimeSuffix + TIMEZONE_OFFSET;
         String test = xcm.convertObject(sqlTime, String.class, XMLConstants.TIME_QNAME);
         assertEquals(control, test);
     }
@@ -1634,7 +1635,7 @@ public class DateAndTimeTestCases extends OXTestCase {
         xmlConversionManager.setTimeZoneQualified(true);
         java.sql.Time sqlTime = xmlConversionManager.convertObject(CONTROL_DST_INPUT_DATE_TIME, Time.class, XMLConstants.DATE_TIME_QNAME);
         String testString = xmlConversionManager.convertObject(sqlTime, String.class);
-        assertEquals("03:00:00-04:00", testString);
+        assertEquals("03:00:00" + controlXmlConversionTimeSuffix + "-04:00", testString);
     }
 
     public void testSqlTimeToString_dateTime_dstTimeZone() {
@@ -1643,7 +1644,7 @@ public class DateAndTimeTestCases extends OXTestCase {
         xmlConversionManager.setTimeZoneQualified(true);
         java.sql.Time sqlTime = xmlConversionManager.convertObject(CONTROL_DST_INPUT_DATE_TIME, Time.class, XMLConstants.DATE_TIME_QNAME);
         String testString = xmlConversionManager.convertObject(sqlTime, String.class, XMLConstants.DATE_TIME_QNAME);
-        assertEquals("2003-08-29T03:00:00-04:00", testString);
+        assertEquals("2003-08-29T03:00:00" + controlXmlConversionTimeSuffix + "-04:00", testString);
     }
 
     public void testSqlTimeToString_time_dstTimeZone() {
@@ -1652,7 +1653,7 @@ public class DateAndTimeTestCases extends OXTestCase {
         xmlConversionManager.setTimeZoneQualified(true);
         java.sql.Time sqlTime = xmlConversionManager.convertObject(CONTROL_DST_INPUT_DATE_TIME, Time.class, XMLConstants.DATE_TIME_QNAME);
         String testString = xmlConversionManager.convertObject(sqlTime, String.class, XMLConstants.TIME_QNAME);
-        assertEquals("03:00:00-04:00", testString);
+        assertEquals("03:00:00" + controlXmlConversionTimeSuffix + "-04:00", testString);
     }
 
     public void testStringToSqlTime_default_null() {
@@ -2071,7 +2072,7 @@ public class DateAndTimeTestCases extends OXTestCase {
 
     public void testTimestampToString_default_0ms() {
         java.sql.Timestamp timestamp = new java.sql.Timestamp(CONTROL_DATE_TIME_0MS);
-        String control = "1975-02-21T07:47:15"+TIMEZONE_OFFSET;
+        String control = "1975-02-21T07:47:15" + controlXmlConversionTimeSuffix + TIMEZONE_OFFSET;
         String test = xcm.convertObject(timestamp, String.class);
         assertEquals(control, test);
     }
@@ -2128,7 +2129,7 @@ public class DateAndTimeTestCases extends OXTestCase {
 
     public void testTimestampToString_dateTime_0ms() {
         java.sql.Timestamp timestamp = new java.sql.Timestamp(CONTROL_DATE_TIME_0MS);
-        String control = "1975-02-21T07:47:15"+TIMEZONE_OFFSET;
+        String control = "1975-02-21T07:47:15" + controlXmlConversionTimeSuffix + TIMEZONE_OFFSET;
         String test = xcm.convertObject(timestamp, String.class, XMLConstants.DATE_TIME_QNAME);
         assertEquals(control, test);
     }
@@ -2215,7 +2216,7 @@ public class DateAndTimeTestCases extends OXTestCase {
 
     public void testTimestampToString_time_0ms() {
         java.sql.Timestamp timestamp = new java.sql.Timestamp(CONTROL_DATE_TIME_0MS);
-        String control = "07:47:15"+TIMEZONE_OFFSET;
+        String control = "07:47:15" + controlXmlConversionTimeSuffix + TIMEZONE_OFFSET;
         String test = xcm.convertObject(timestamp, String.class, XMLConstants.TIME_QNAME);
         assertEquals(control, test);
     }
@@ -2325,7 +2326,7 @@ public class DateAndTimeTestCases extends OXTestCase {
         xmlConversionManager.setTimeZoneQualified(true);
         java.sql.Timestamp sqlTimestamp = xmlConversionManager.convertObject(CONTROL_DST_INPUT_DATE_TIME, Timestamp.class, XMLConstants.DATE_TIME_QNAME);
         String testString = xmlConversionManager.convertObject(sqlTimestamp, String.class);
-        assertEquals("2003-08-29T03:00:00-04:00", testString);
+        assertEquals("2003-08-29T03:00:00" + controlXmlConversionTimeSuffix + "-04:00", testString);
     }
 
     public void testSqlTimestampToString_dateTime_dstTimeZone() {
@@ -2334,7 +2335,7 @@ public class DateAndTimeTestCases extends OXTestCase {
         xmlConversionManager.setTimeZoneQualified(true);
         java.sql.Timestamp sqlTimestamp = xmlConversionManager.convertObject(CONTROL_DST_INPUT_DATE_TIME, Timestamp.class, XMLConstants.DATE_TIME_QNAME);
         String testString = xmlConversionManager.convertObject(sqlTimestamp, String.class, XMLConstants.DATE_TIME_QNAME);
-        assertEquals("2003-08-29T03:00:00-04:00", testString);
+        assertEquals("2003-08-29T03:00:00" + controlXmlConversionTimeSuffix + "-04:00", testString);
     }
 
     public void testSqlTimestampToString_time_dstTimeZone() {
@@ -2343,7 +2344,7 @@ public class DateAndTimeTestCases extends OXTestCase {
         xmlConversionManager.setTimeZoneQualified(true);
         java.sql.Timestamp sqlTimestamp = xmlConversionManager.convertObject(CONTROL_DST_INPUT_DATE_TIME, Timestamp.class, XMLConstants.DATE_TIME_QNAME);
         String testString = xmlConversionManager.convertObject(sqlTimestamp, String.class, XMLConstants.TIME_QNAME);
-        assertEquals("03:00:00-04:00", testString);
+        assertEquals("03:00:00" + controlXmlConversionTimeSuffix + "-04:00", testString);
     }
 
     public void testStringToTimestamp_default_null() {
@@ -3682,7 +3683,7 @@ public class DateAndTimeTestCases extends OXTestCase {
     }
     
     public void testPostADDateToSQLDate_DateTime() {
-        String control = "0001-01-01T00:00:00" + TIMEZONE_OFFSET;
+        String control = "0001-01-01T00:00:00" + controlXmlConversionTimeSuffix + TIMEZONE_OFFSET;
         String input = "0001-01-01";
         java.sql.Date sqlDate = java.sql.Date.valueOf(input);
         String test = xcm.convertObject(sqlDate, String.class, XMLConstants.DATE_TIME_QNAME);
@@ -3691,7 +3692,7 @@ public class DateAndTimeTestCases extends OXTestCase {
     
     // java.sql.Timestamp -> String tests
     public void testPostADDateTimeToSQLTimestamp() {
-        String control = "0001-01-01T01:01:01" + TIMEZONE_OFFSET;
+        String control = "0001-01-01T01:01:01" + controlXmlConversionTimeSuffix + TIMEZONE_OFFSET;
         String input = "0001-01-01 01:01:01";
         java.sql.Timestamp sqlTimestamp = java.sql.Timestamp.valueOf(input);
         String test = xcm.convertObject(sqlTimestamp, String.class);
@@ -3764,7 +3765,7 @@ public class DateAndTimeTestCases extends OXTestCase {
     
     // java.util.Date -> String tests
     public void testPostADDateTimeToUtilDate() {
-        String control = "0001-01-01T00:00:00" + TIMEZONE_OFFSET;
+        String control = "0001-01-01T00:00:00" + controlXmlConversionTimeSuffix + TIMEZONE_OFFSET;
         
         Calendar cal = Calendar.getInstance();
         cal.clear();
@@ -3830,7 +3831,7 @@ public class DateAndTimeTestCases extends OXTestCase {
     // java.sql.Time -> String tests
     public void testTimeToSQLTime() {
         String input = "00:00:00";
-        String control = input + TIMEZONE_OFFSET;
+        String control = input + controlXmlConversionTimeSuffix + TIMEZONE_OFFSET;
         
         java.sql.Time sqlTime = java.sql.Time.valueOf(input);
         
@@ -3840,7 +3841,7 @@ public class DateAndTimeTestCases extends OXTestCase {
     
     public void testTimeToSQLTime_TIME() {
         String input = "00:00:00";
-        String control = input + TIMEZONE_OFFSET;
+        String control = input + controlXmlConversionTimeSuffix + TIMEZONE_OFFSET;
         
         java.sql.Time sqlTime = java.sql.Time.valueOf(input);
         


### PR DESCRIPTION
This new feature optionally add suffix/decimal part to time part/seconds in case of conversion from supported date/time formats into String. This suffix is controlled by new `org.eclipse.persistence.xml.time.suffix` system property.
It happens only if source time doesn't contain fraction of seconds and for XML, JSON conversion. E.g.:
For `-Dorg.eclipse.persistence.xml.time.suffix=.0`
Source value: 2003-08-29T03:00:00-04:00  -> Output string: 2003-08-29T03:00:00.0-04:00
Source value: 1975-02-21T07:47:15  -> Output string: 1975-02-21T07:47:15.0

It simplifies migration from WebLogic Server 11g to 12c.

Origin bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=404069

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>