### PR TITLE
[2.6] Fix/new feature for Bug 404069 - MOXy should not append .0 to time info for dateTime and time formats + unit test - backport from master

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/OXMSystemProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/OXMSystemProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2016 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -41,8 +41,23 @@ public final class OXMSystemProperties {
 
     public static final String DISABLE_SECURE_PROCESSING = "eclipselink.disableXmlSecurity";
 
+    /**
+     * Add suffix/decimal part to time part/seconds in case of conversion from supported date/time formats into String.
+     * It happens only if source time doesn't contain fraction of seconds and for XML, JSON conversion. E.g.:
+     * For -Dorg.eclipse.persistence.xml.time.suffix=.0
+     * <ul>
+     * <li>Source value: 2003-08-29T03:00:00-04:00  -&gt; Output string: 2003-08-29T03:00:00.0-04:00</li>
+     * <li>Source value: 1975-02-21T07:47:15  -&gt; Output string: 1975-02-21T07:47:15.0</li>
+     * </ul>
+     * @since 2.7.11
+     */
+    public static final String XML_CONVERSION_TIME_SUFFIX = "org.eclipse.persistence.xml.time.suffix";
+
+    public static final String DEFAULT_XML_CONVERSION_TIME_SUFFIX = "";
+
     public static final Boolean jsonTypeCompatiblity = PrivilegedAccessHelper.getSystemPropertyBoolean(JSON_TYPE_COMPATIBILITY, false);
 
     public static final Boolean jsonUseXsdTypesPrefix = PrivilegedAccessHelper.getSystemPropertyBoolean(JSON_USE_XSD_TYPES_PREFIX, false);
 
+    public static final String xmlConversionTimeSuffix = PrivilegedAccessHelper.getSystemProperty(XML_CONVERSION_TIME_SUFFIX, DEFAULT_XML_CONVERSION_TIME_SUFFIX);
 }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLConversionManager.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/oxm/XMLConversionManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2014 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -1156,7 +1156,7 @@ public class XMLConversionManager extends ConversionManager implements org.eclip
                 milliStr = '.' + milliStr;
                 result = pre + milliStr + post;
             } else {
-                result = pre + post;
+                result = pre + OXMSystemProperties.xmlConversionTimeSuffix + post;
             }
         }
         return result;
@@ -1886,7 +1886,7 @@ public class XMLConversionManager extends ConversionManager implements org.eclip
     private String appendNanos(String string, Timestamp ts) {
         StringBuilder strBldr = new StringBuilder(string);
         int nanos = ts.getNanos();
-        strBldr.append(nanos==0 ? "" : '.' + Helper.buildZeroPrefixAndTruncTrailZeros(nanos, TOTAL_NS_DIGITS)).toString();
+        strBldr.append(nanos==0 ? OXMSystemProperties.xmlConversionTimeSuffix : '.' + Helper.buildZeroPrefixAndTruncTrailZeros(nanos, TOTAL_NS_DIGITS));
         return strBldr.toString();
     }
 
@@ -1905,7 +1905,7 @@ public class XMLConversionManager extends ConversionManager implements org.eclip
             // adjust for negative time values, i.e. before Epoch
             msns = msns + 1000;
         }
-        strBldr.append(msns==0 ? "" : '.' + Helper.buildZeroPrefixAndTruncTrailZeros(msns, TOTAL_MS_DIGITS)).toString();
+        strBldr.append(msns==0 ? OXMSystemProperties.xmlConversionTimeSuffix : '.' + Helper.buildZeroPrefixAndTruncTrailZeros(msns, TOTAL_MS_DIGITS));
         return strBldr.toString();
     }
 

--- a/moxy/eclipselink.moxy.test/antbuild.xml
+++ b/moxy/eclipselink.moxy.test/antbuild.xml
@@ -315,6 +315,7 @@
         <run_oxm_dom_tests runpathref="oxm.run.path"/>
         <run_oxm_deploymentxml_tests runpathref="oxm.run.path"/>
         <run_oxm_docpres_tests runpathref="oxm.run.path"/>
+        <run_oxm_non_default_system_properties runpathref="oxm.run.path"/>
     </target>
     <target name="compile-and-run-jaxb-tests" depends="compile-tests" description="build and run moxy (oxm) tests">
         <run_jaxb_tests runpathref="jaxb.run.path"/>
@@ -324,6 +325,7 @@
         <run_oxm_dom_tests runpathref="oxm.run.path"/>
         <run_oxm_deploymentxml_tests runpathref="oxm.run.path"/>
         <run_oxm_docpres_tests runpathref="oxm.run.path"/>
+        <run_oxm_non_default_system_properties runpathref="oxm.run.path"/>
     </target>
     <target name="compile-and-run-oxm-deploymentxml-tl-tests" depends="compile-tests" description="build and run moxy (oxm) tl deployment xml tests">
         <run_oxm_deploymentxml_tl_tests runpathref="oxm.run.path"/>
@@ -400,6 +402,7 @@
         <run_oxm_dom_tests runpathref="oxm.run.against.jar.path"/>
         <run_oxm_deploymentxml_tests runpathref="oxm.run.against.jar.path"/>
         <run_oxm_docpres_tests runpathref="oxm.run.against.jar.path"/>
+        <run_oxm_non_default_system_properties runpathref="oxm.run.against.jar.path"/>
     </target>
     <target name="compile-and-run-srg-tests-against-jar" depends="compile-tests-against-jar" description="build and run moxy srg tests against eclipselink.jar">
         <run_jaxb_srg_tests runpathref="jaxb.run.against.jar.path"/>
@@ -413,6 +416,7 @@
         <run_oxm_dom_tests runpathref="oxm.run.against.jar.path"/>
         <run_oxm_deploymentxml_tests runpathref="oxm.run.against.jar.path"/>
         <run_oxm_docpres_tests runpathref="oxm.run.against.jar.path"/>
+        <run_oxm_non_default_system_properties runpathref="oxm.run.against.jar.path"/>
     </target>
 
     <!-- JUnit report targets -->
@@ -612,6 +616,8 @@
                 <batchtest todir="${report.dir}/srg/oxm/default">
                     <fileset dir="${src.dir}">
                         <include name="org/eclipse/persistence/testing/oxm/OXMSRGTestSuite.java"/>
+                        <exclude name="org/eclipse/persistence/testing/oxm/systemproperties/OXMSystemPropertiesNonDefaultTestCases.java"/>
+                        <exclude name="org/eclipse/persistence/testing/oxm/systemproperties/DateAndTimeNonDefaultTestCases.java"/>
                     </fileset>
                     <formatter type="xml"/>
                 </batchtest>
@@ -660,6 +666,9 @@
                         <exclude name="org/eclipse/persistence/testing/oxm/mappings/DocPresMappingTestSuite.java"/>
                         <exclude name="org/eclipse/persistence/testing/oxm/mappings/anyobjectandanycollection/XMLAnyObjectAndAnyCollectionMappingTestSuite.java"/>
                         <exclude name="**/SAXMappingTestSuite.java"/>
+                        <exclude name="org/eclipse/persistence/testing/oxm/systemproperties/OXMSystemPropertiesNonDefaultTestCases.java"/>
+                        <exclude name="org/eclipse/persistence/testing/oxm/systemproperties/DateAndTimeNonDefaultTestCases.java"/>
+                        <include name="org/eclipse/persistence/testing/oxm/systemproperties/OXMSystemPropertiesTestCases.java"/>
                         <include name="org/eclipse/persistence/testing/oxm/mappings/directcollection/nillable/DirectCollectionMappingNillableTestSuite.java"/>
                         <include name="org/eclipse/persistence/testing/oxm/mappings/keybased/multipletargets/compositekey/CompositeKeyTestCases.java"/>
                     </fileset>
@@ -713,6 +722,8 @@
                         <exclude name="org/eclipse/persistence/testing/oxm/mappings/choicecollection/XMLChoiceCollectionMappingTestSuite.java"/>
                         -->
                         <exclude name="org/eclipse/persistence/testing/oxm/mappings/sequenced/SequencedMappingTestSuite.java"/>
+                        <exclude name="org/eclipse/persistence/testing/oxm/systemproperties/OXMSystemPropertiesNonDefaultTestCases.java"/>
+                        <exclude name="org/eclipse/persistence/testing/oxm/systemproperties/DateAndTimeNonDefaultTestCases.java"/>
                     </fileset>
                     <formatter type="xml"/>
                 </batchtest>
@@ -776,6 +787,8 @@
                         <exclude name="org/eclipse/persistence/testing/oxm/mappings/compositeobject/self/converter/CompositeObjectSelfConverterTestSuite.java"/>
                         <exclude name="org/eclipse/persistence/testing/oxm/mappings/keybased/compositekeyclass/CompositeKeyClassMappingTestSuite.java"/>
                         <exclude name="org/eclipse/persistence/testing/oxm/mappings/containeracessor/ContainerAccessorTestSuite.java"/>
+                        <exclude name="org/eclipse/persistence/testing/oxm/systemproperties/OXMSystemPropertiesNonDefaultTestCases.java"/>
+                        <exclude name="org/eclipse/persistence/testing/oxm/systemproperties/DateAndTimeNonDefaultTestCases.java"/>
                     </fileset>
                     <formatter type="xml"/>
                 </batchtest>
@@ -835,6 +848,8 @@
                         <exclude name="org/eclipse/persistence/testing/oxm/mappings/compositeobject/self/converter/CompositeObjectSelfConverterTestSuite.java"/>
                         <exclude name="org/eclipse/persistence/testing/oxm/mappings/keybased/compositekeyclass/CompositeKeyClassMappingTestSuite.java"/>
                         <exclude name="org/eclipse/persistence/testing/oxm/mappings/containeracessor/ContainerAccessorTestSuite.java"/>
+                        <exclude name="org/eclipse/persistence/testing/oxm/systemproperties/OXMSystemPropertiesNonDefaultTestCases.java"/>
+                        <exclude name="org/eclipse/persistence/testing/oxm/systemproperties/DateAndTimeNonDefaultTestCases.java"/>
                     </fileset>
                     <formatter type="xml"/>
                 </batchtest>
@@ -888,6 +903,8 @@
                         <exclude name="org/eclipse/persistence/testing/oxm/mappings/choicecollection/XMLChoiceCollectionMappingTestSuite.java"/>
                         -->
                         <exclude name="org/eclipse/persistence/testing/oxm/mappings/sequenced/SequencedMappingTestSuite.java"/>
+                        <exclude name="org/eclipse/persistence/testing/oxm/systemproperties/OXMSystemPropertiesNonDefaultTestCases.java"/>
+                        <exclude name="org/eclipse/persistence/testing/oxm/systemproperties/DateAndTimeNonDefaultTestCases.java"/>
                     </fileset>
                     <formatter type="xml"/>
                 </batchtest>
@@ -899,6 +916,41 @@
                 <condition>
                     <and>
                         <isset property="junit.failed.oxm_docpres"/>
+                        <istrue value="${test.fail.fast}"/>
+                    </and>
+                </condition>
+            </fail>
+        </sequential>
+    </macrodef>
+    <macrodef name="run_oxm_non_default_system_properties">
+        <attribute name="runpathref"/>
+        <sequential>
+            <delete dir="${report.dir}/oxm/nondefault" includeEmptyDirs="true" failonerror="false"/>
+            <mkdir dir="${report.dir}/oxm/nondefault"/>
+            <junit failureproperty="junit.failed.oxm_nondefault" printsummary="yes" fork="true" dir="${resource.dir}" showoutput="yes" maxmemory="512m">
+                <jvmarg value="-ea"/>
+                <sysproperty key="useLogging" value="false"/>
+                <sysproperty key="eclipselink.xml.platform" value="${xml.platform}"/>
+                <sysproperty key="org.eclipse.persistence.json.type-compatibility" value="true"/>
+                <sysproperty key="org.eclipse.persistence.json.use-xsd-types-prefix" value="true"/>
+                <sysproperty key="org.eclipse.persistence.xml.time.suffix" value=".0"/>
+                <sysproperty key="parser" value="${parser}"/>
+                <syspropertyset refid="parser.properties"/>
+                <batchtest todir="${report.dir}/oxm/nondefault">
+                    <fileset dir="${src.dir}">
+                        <include name="org/eclipse/persistence/testing/oxm/systemproperties/OXMSystemPropertiesNonDefaultTestCases.java"/>
+                        <include name="org/eclipse/persistence/testing/oxm/systemproperties/DateAndTimeNonDefaultTestCases.java"/>
+                    </fileset>
+                    <formatter type="xml"/>
+                </batchtest>
+                <classpath>
+                    <path refid="@{runpathref}"/>
+                </classpath>
+            </junit>
+            <fail message="TESTS FAILED !">
+                <condition>
+                    <and>
+                        <isset property="junit.failed.nondefault"/>
                         <istrue value="${test.fail.fast}"/>
                     </and>
                 </condition>

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/oxm/systemproperties/DateAndTimeNonDefaultTestCases.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/oxm/systemproperties/DateAndTimeNonDefaultTestCases.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     Oracle - initial API and implementation from Oracle TopLink
+ ******************************************************************************/
+package org.eclipse.persistence.testing.oxm.systemproperties;
+
+
+import org.eclipse.persistence.testing.oxm.xmlconversionmanager.DateAndTimeTestCases;
+
+public class DateAndTimeNonDefaultTestCases extends DateAndTimeTestCases {
+
+    public DateAndTimeNonDefaultTestCases(String name) {
+        super(name);
+        super.controlXmlConversionTimeSuffix = ".0";
+    }
+
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/oxm/systemproperties/OXMSystemPropertiesNonDefaultTestCases.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/oxm/systemproperties/OXMSystemPropertiesNonDefaultTestCases.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     Oracle - initial API and implementation from Oracle TopLink
+ ******************************************************************************/
+package org.eclipse.persistence.testing.oxm.systemproperties;
+
+import org.eclipse.persistence.internal.oxm.OXMSystemProperties;
+import org.eclipse.persistence.internal.oxm.XMLConversionManager;
+import org.eclipse.persistence.oxm.XMLConstants;
+import org.junit.Test;
+
+import java.sql.Timestamp;
+import java.util.TimeZone;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests OXMSystemProperties class. With default non-values. It requires to be isolated JVM to avoid impact to others tests or it should be executed with other tests with same system properties.
+ */
+public class OXMSystemPropertiesNonDefaultTestCases {
+
+    static {
+        System.setProperty(OXMSystemProperties.JSON_TYPE_COMPATIBILITY, "true");
+        System.setProperty(OXMSystemProperties.JSON_USE_XSD_TYPES_PREFIX, "true");
+        System.setProperty(OXMSystemProperties.XML_CONVERSION_TIME_SUFFIX, ".0");
+    }
+
+
+    @Test
+    public void testNonDefaultProperties() {
+        assertTrue(OXMSystemProperties.jsonTypeCompatiblity);
+        assertTrue(OXMSystemProperties.jsonUseXsdTypesPrefix);
+        assertEquals(".0", OXMSystemProperties.xmlConversionTimeSuffix);
+    }
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/oxm/systemproperties/OXMSystemPropertiesTestCases.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/oxm/systemproperties/OXMSystemPropertiesTestCases.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     Oracle - initial API and implementation from Oracle TopLink
+ ******************************************************************************/
+package org.eclipse.persistence.testing.oxm.systemproperties;
+
+import org.eclipse.persistence.internal.oxm.OXMSystemProperties;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Tests OXMSystemProperties class. With default values.
+ */
+public class OXMSystemPropertiesTestCases {
+
+    @Test
+    public void testProperties() {
+        assertFalse(OXMSystemProperties.jsonTypeCompatiblity);
+        assertFalse(OXMSystemProperties.jsonUseXsdTypesPrefix);
+        assertEquals("", OXMSystemProperties.xmlConversionTimeSuffix);
+    }
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/oxm/xmlconversionmanager/DateAndTimeTestCases.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/oxm/xmlconversionmanager/DateAndTimeTestCases.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2014 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -80,6 +80,7 @@ public class DateAndTimeTestCases extends OXTestCase {
 
     // XML Conversion Manager
     private XMLConversionManager xcm;
+    protected String controlXmlConversionTimeSuffix = "";
 
     public DateAndTimeTestCases(String name) {
         super(name);
@@ -146,7 +147,7 @@ public class DateAndTimeTestCases extends OXTestCase {
 
     public void testUtilDateToString_default_0ms() {
         java.util.Date utilDate = new java.util.Date(CONTROL_DATE_TIME_0MS);
-        String control = "1975-02-21T07:47:15"+TIMEZONE_OFFSET;
+        String control = "1975-02-21T07:47:15" + controlXmlConversionTimeSuffix + TIMEZONE_OFFSET;
         String test = (String)xcm.convertObject(utilDate, String.class);
         this.assertEquals(control, test);
     }
@@ -235,7 +236,7 @@ public class DateAndTimeTestCases extends OXTestCase {
 
     public void testUtilDateToString_dateTime_0ms() {
         java.util.Date utilDate = new java.util.Date(CONTROL_DATE_TIME_0MS);
-        String control = "1975-02-21T07:47:15"+TIMEZONE_OFFSET;
+        String control = "1975-02-21T07:47:15" + controlXmlConversionTimeSuffix + TIMEZONE_OFFSET;
         String test = (String)xcm.convertObject(utilDate, String.class, XMLConstants.DATE_TIME_QNAME);
         this.assertEquals(control, test);
     }
@@ -270,7 +271,7 @@ public class DateAndTimeTestCases extends OXTestCase {
 
     public void testUtilDateToString_time_0ms() {
         java.util.Date utilDate = new java.util.Date(CONTROL_DATE_TIME_0MS);
-        String control = "07:47:15"+TIMEZONE_OFFSET;
+        String control = "07:47:15" + controlXmlConversionTimeSuffix + TIMEZONE_OFFSET;
         String test = (String)xcm.convertObject(utilDate, String.class, XMLConstants.TIME_QNAME);
         this.assertEquals(control, test);
     }
@@ -372,7 +373,7 @@ public class DateAndTimeTestCases extends OXTestCase {
         xmlConversionManager.setTimeZoneQualified(true);
         java.util.Date utilDate = (java.util.Date) xmlConversionManager.convertObject(CONTROL_DST_INPUT_DATE_TIME, java.util.Date.class);
         String testString = (String) xmlConversionManager.convertObject(utilDate, String.class);
-        this.assertEquals("2003-08-29T03:00:00-04:00", testString);
+        assertEquals("2003-08-29T03:00:00" + controlXmlConversionTimeSuffix + "-04:00", testString);
     }
 
     public void testUtilDateToString_dateTime_dstTimeZone() {
@@ -381,7 +382,7 @@ public class DateAndTimeTestCases extends OXTestCase {
         xmlConversionManager.setTimeZoneQualified(true);
         java.util.Date utilDate = (java.util.Date) xmlConversionManager.convertObject(CONTROL_DST_INPUT_DATE_TIME, java.util.Date.class);
         String testString = (String) xmlConversionManager.convertObject(utilDate, String.class, XMLConstants.DATE_TIME_QNAME);
-        this.assertEquals("2003-08-29T03:00:00-04:00", testString);
+        assertEquals("2003-08-29T03:00:00" + controlXmlConversionTimeSuffix + "-04:00", testString);
     }
 
     public void testUtilDateToString_time_dstTimeZone() {
@@ -390,7 +391,7 @@ public class DateAndTimeTestCases extends OXTestCase {
         xmlConversionManager.setTimeZoneQualified(true);
         java.util.Date utilDate = (java.util.Date) xmlConversionManager.convertObject(CONTROL_DST_INPUT_DATE_TIME, java.util.Date.class);
         String testString = (String) xmlConversionManager.convertObject(utilDate, String.class, XMLConstants.TIME_QNAME);
-        this.assertEquals("03:00:00-04:00", testString);
+        assertEquals("03:00:00" + controlXmlConversionTimeSuffix + "-04:00", testString);
     }
 
     public void testStringToUtilDate_default_null() {
@@ -876,7 +877,7 @@ public class DateAndTimeTestCases extends OXTestCase {
 
     public void testSqlDateToString_dateTime_0ms() {
         java.sql.Date sqlDate = new java.sql.Date(CONTROL_DATE_TIME_0MS);
-        String control = "1975-02-21T07:47:15"+TIMEZONE_OFFSET;
+        String control = "1975-02-21T07:47:15" + controlXmlConversionTimeSuffix + TIMEZONE_OFFSET;
         String test = (String)xcm.convertObject(sqlDate, String.class, XMLConstants.DATE_TIME_QNAME);
         this.assertEquals(control, test);
     }
@@ -911,7 +912,7 @@ public class DateAndTimeTestCases extends OXTestCase {
 
     public void testSqlDateToString_time_0ms() {
         java.sql.Date sqlDate = new java.sql.Date(CONTROL_DATE_TIME_0MS);
-        String control = "07:47:15"+TIMEZONE_OFFSET;
+        String control = "07:47:15" + controlXmlConversionTimeSuffix + TIMEZONE_OFFSET;
         String test = (String)xcm.convertObject(sqlDate, String.class, XMLConstants.TIME_QNAME);
         this.assertEquals(control, test);
     }
@@ -1013,7 +1014,7 @@ public class DateAndTimeTestCases extends OXTestCase {
         xmlConversionManager.setTimeZoneQualified(true);
         java.sql.Date sqlDate = (java.sql.Date) xmlConversionManager.convertObject(CONTROL_DST_INPUT_DATE_TIME, java.sql.Date.class, XMLConstants.DATE_TIME_QNAME);
         String testString = (String) xmlConversionManager.convertObject(sqlDate, String.class, XMLConstants.DATE_TIME_QNAME);
-        this.assertEquals("2003-08-29T03:00:00-04:00", testString);
+        assertEquals("2003-08-29T03:00:00" + controlXmlConversionTimeSuffix + "-04:00", testString);
     }
 
     public void testSqlDateToString_time_dstTimeZone() {
@@ -1022,7 +1023,7 @@ public class DateAndTimeTestCases extends OXTestCase {
         xmlConversionManager.setTimeZoneQualified(true);
         java.sql.Date sqlDate = (java.sql.Date) xmlConversionManager.convertObject(CONTROL_DST_INPUT_DATE_TIME, java.sql.Date.class, XMLConstants.DATE_TIME_QNAME);
         String testString = (String) xmlConversionManager.convertObject(sqlDate, String.class, XMLConstants.TIME_QNAME);
-        this.assertEquals("03:00:00-04:00", testString);
+        assertEquals("03:00:00" + controlXmlConversionTimeSuffix + "-04:00", testString);
     }
 
     public void testStringToSqlDate_default_null() {
@@ -1413,7 +1414,7 @@ public class DateAndTimeTestCases extends OXTestCase {
 
     public void testSqlTimeToString_default() {
         java.sql.Time sqlTime = new java.sql.Time(CONTROL_TIME_0MS);
-        String control = "07:47:15"+TIMEZONE_OFFSET;
+        String control = "07:47:15" + controlXmlConversionTimeSuffix + TIMEZONE_OFFSET;
         String test = (String)xcm.convertObject(sqlTime, String.class);
         boolean passed = control.equals(test) || control.equals(test.replace("+01:00", "Z"));
         this.assertTrue(passed);
@@ -1421,7 +1422,7 @@ public class DateAndTimeTestCases extends OXTestCase {
 
     public void testSqlTimeToString_default_0ms() {
         java.sql.Time sqlTime = new java.sql.Time(CONTROL_TIME_0MS);
-        String control = "07:47:15"+TIMEZONE_OFFSET;
+        String control = "07:47:15" + controlXmlConversionTimeSuffix + TIMEZONE_OFFSET;
         String test = (String)xcm.convertObject(sqlTime, String.class);
         this.assertEquals(control, test);
     }
@@ -1479,14 +1480,14 @@ public class DateAndTimeTestCases extends OXTestCase {
 
     public void testSqlTimeToString_dateTime() {
         java.sql.Time sqlTime = new java.sql.Time(CONTROL_DATE_TIME_0MS);
-        String control = "1975-02-21T07:47:15"+TIMEZONE_OFFSET;
+        String control = "1975-02-21T07:47:15" + controlXmlConversionTimeSuffix + TIMEZONE_OFFSET;
         String test = (String)xcm.convertObject(sqlTime, String.class, XMLConstants.DATE_TIME_QNAME);
         this.assertEquals(control, test);
     }
 
     public void testSqlTimeToString_dateTime_0ms() {
         java.sql.Time sqlTime = new java.sql.Time(CONTROL_DATE_TIME_0MS);
-        String control = "1975-02-21T07:47:15"+TIMEZONE_OFFSET;
+        String control = "1975-02-21T07:47:15" + controlXmlConversionTimeSuffix + TIMEZONE_OFFSET;
         String test = (String)xcm.convertObject(sqlTime, String.class, XMLConstants.DATE_TIME_QNAME);
         this.assertEquals(control, test);
     }
@@ -1521,14 +1522,14 @@ public class DateAndTimeTestCases extends OXTestCase {
 
     public void testSqlTimeToString_time() {
         java.sql.Time sqlTime = new java.sql.Time(CONTROL_DATE_TIME_0MS);
-        String control = "07:47:15"+TIMEZONE_OFFSET;
+        String control = "07:47:15" + controlXmlConversionTimeSuffix + TIMEZONE_OFFSET;
         String test = (String)xcm.convertObject(sqlTime, String.class, XMLConstants.TIME_QNAME);
         this.assertEquals(control, test);
     }
 
     public void testSqlTimeToString_time_0ms() {
         java.sql.Time sqlTime = new java.sql.Time(CONTROL_DATE_TIME_0MS);
-        String control = "07:47:15"+TIMEZONE_OFFSET;
+        String control = "07:47:15" + controlXmlConversionTimeSuffix + TIMEZONE_OFFSET;
         String test = (String)xcm.convertObject(sqlTime, String.class, XMLConstants.TIME_QNAME);
         this.assertEquals(control, test);
     }
@@ -1630,7 +1631,7 @@ public class DateAndTimeTestCases extends OXTestCase {
         xmlConversionManager.setTimeZoneQualified(true);
         java.sql.Time sqlTime = (java.sql.Time) xmlConversionManager.convertObject(CONTROL_DST_INPUT_DATE_TIME, java.sql.Time.class, XMLConstants.DATE_TIME_QNAME);
         String testString = (String) xmlConversionManager.convertObject(sqlTime, String.class);
-        this.assertEquals("03:00:00-04:00", testString);
+        assertEquals("03:00:00" + controlXmlConversionTimeSuffix + "-04:00", testString);
     }
 
     public void testSqlTimeToString_dateTime_dstTimeZone() {
@@ -1639,7 +1640,7 @@ public class DateAndTimeTestCases extends OXTestCase {
         xmlConversionManager.setTimeZoneQualified(true);
         java.sql.Time sqlTime = (java.sql.Time) xmlConversionManager.convertObject(CONTROL_DST_INPUT_DATE_TIME, java.sql.Time.class, XMLConstants.DATE_TIME_QNAME);
         String testString = (String) xmlConversionManager.convertObject(sqlTime, String.class, XMLConstants.DATE_TIME_QNAME);
-        this.assertEquals("2003-08-29T03:00:00-04:00", testString);
+        assertEquals("2003-08-29T03:00:00" + controlXmlConversionTimeSuffix + "-04:00", testString);
     }
 
     public void testSqlTimeToString_time_dstTimeZone() {
@@ -1648,7 +1649,7 @@ public class DateAndTimeTestCases extends OXTestCase {
         xmlConversionManager.setTimeZoneQualified(true);
         java.sql.Time sqlTime = (java.sql.Time) xmlConversionManager.convertObject(CONTROL_DST_INPUT_DATE_TIME, java.sql.Time.class, XMLConstants.DATE_TIME_QNAME);
         String testString = (String) xmlConversionManager.convertObject(sqlTime, String.class, XMLConstants.TIME_QNAME);
-        this.assertEquals("03:00:00-04:00", testString);
+        assertEquals("03:00:00" + controlXmlConversionTimeSuffix + "-04:00", testString);
     }
 
     public void testStringToSqlTime_default_null() {
@@ -2067,7 +2068,7 @@ public class DateAndTimeTestCases extends OXTestCase {
 
     public void testTimestampToString_default_0ms() {
         java.sql.Timestamp timestamp = new java.sql.Timestamp(CONTROL_DATE_TIME_0MS);
-        String control = "1975-02-21T07:47:15"+TIMEZONE_OFFSET;
+        String control = "1975-02-21T07:47:15" + controlXmlConversionTimeSuffix + TIMEZONE_OFFSET;
         String test = (String)xcm.convertObject(timestamp, String.class);
         this.assertEquals(control, test);
     }
@@ -2124,7 +2125,7 @@ public class DateAndTimeTestCases extends OXTestCase {
 
     public void testTimestampToString_dateTime_0ms() {
         java.sql.Timestamp timestamp = new java.sql.Timestamp(CONTROL_DATE_TIME_0MS);
-        String control = "1975-02-21T07:47:15"+TIMEZONE_OFFSET;
+        String control = "1975-02-21T07:47:15" + controlXmlConversionTimeSuffix + TIMEZONE_OFFSET;
         String test = (String)xcm.convertObject(timestamp, String.class, XMLConstants.DATE_TIME_QNAME);
         this.assertEquals(control, test);
     }
@@ -2212,7 +2213,7 @@ public class DateAndTimeTestCases extends OXTestCase {
 
     public void testTimestampToString_time_0ms() {
         java.sql.Timestamp timestamp = new java.sql.Timestamp(CONTROL_DATE_TIME_0MS);
-        String control = "07:47:15"+TIMEZONE_OFFSET;
+        String control = "07:47:15" + controlXmlConversionTimeSuffix + TIMEZONE_OFFSET;
         String test = (String)xcm.convertObject(timestamp, String.class, XMLConstants.TIME_QNAME);
         this.assertEquals(control, test);
     }
@@ -2322,7 +2323,7 @@ public class DateAndTimeTestCases extends OXTestCase {
         xmlConversionManager.setTimeZoneQualified(true);
         java.sql.Timestamp sqlTimestamp = (java.sql.Timestamp) xmlConversionManager.convertObject(CONTROL_DST_INPUT_DATE_TIME, java.sql.Timestamp.class, XMLConstants.DATE_TIME_QNAME);
         String testString = (String) xmlConversionManager.convertObject(sqlTimestamp, String.class);
-        this.assertEquals("2003-08-29T03:00:00-04:00", testString);
+        assertEquals("2003-08-29T03:00:00" + controlXmlConversionTimeSuffix + "-04:00", testString);
     }
 
     public void testSqlTimestampToString_dateTime_dstTimeZone() {
@@ -2331,7 +2332,7 @@ public class DateAndTimeTestCases extends OXTestCase {
         xmlConversionManager.setTimeZoneQualified(true);
         java.sql.Timestamp sqlTimestamp = (java.sql.Timestamp) xmlConversionManager.convertObject(CONTROL_DST_INPUT_DATE_TIME, java.sql.Timestamp.class, XMLConstants.DATE_TIME_QNAME);
         String testString = (String) xmlConversionManager.convertObject(sqlTimestamp, String.class, XMLConstants.DATE_TIME_QNAME);
-        this.assertEquals("2003-08-29T03:00:00-04:00", testString);
+        assertEquals("2003-08-29T03:00:00" + controlXmlConversionTimeSuffix + "-04:00", testString);
     }
 
     public void testSqlTimestampToString_time_dstTimeZone() {
@@ -2340,7 +2341,7 @@ public class DateAndTimeTestCases extends OXTestCase {
         xmlConversionManager.setTimeZoneQualified(true);
         java.sql.Timestamp sqlTimestamp = (java.sql.Timestamp) xmlConversionManager.convertObject(CONTROL_DST_INPUT_DATE_TIME, java.sql.Timestamp.class, XMLConstants.DATE_TIME_QNAME);
         String testString = (String) xmlConversionManager.convertObject(sqlTimestamp, String.class, XMLConstants.TIME_QNAME);
-        this.assertEquals("03:00:00-04:00", testString);
+        assertEquals("03:00:00" + controlXmlConversionTimeSuffix + "-04:00", testString);
     }
 
     public void testStringToTimestamp_default_null() {


### PR DESCRIPTION
This new feature optionally add suffix/decimal part to time part/seconds in case of conversion from supported date/time formats into String. This suffix is controlled by new `org.eclipse.persistence.xml.time.suffix` system property.
It happens only if source time doesn't contain fraction of seconds and for XML, JSON conversion. E.g.:
For `-Dorg.eclipse.persistence.xml.time.suffix=.0`
Source value: 2003-08-29T03:00:00-04:00  -> Output string: 2003-08-29T03:00:00.0-04:00
Source value: 1975-02-21T07:47:15  -> Output string: 1975-02-21T07:47:15.0

It simplifies migration from WebLogic Server 11g to 12c.

Origin bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=404069

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>