### PR TITLE
[master] fix #1408 SQL statement is printed in exceptions despite eclipselink.logging.level.sql is OFF

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/exceptions/DatabaseException.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/exceptions/DatabaseException.java
@@ -17,6 +17,7 @@ package org.eclipse.persistence.exceptions;
 import org.eclipse.persistence.exceptions.i18n.ExceptionMessageGenerator;
 import org.eclipse.persistence.internal.databaseaccess.Accessor;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
+import org.eclipse.persistence.logging.SessionLog;
 import org.eclipse.persistence.queries.Call;
 import org.eclipse.persistence.queries.DatabaseQuery;
 import org.eclipse.persistence.sessions.DataRecord;
@@ -211,7 +212,7 @@ public class DatabaseException extends EclipseLinkException {
             } else {
                 writer.write("000");
             }
-            if (getCall() != null) {
+            if (getCall() != null && session.shouldLog(SessionLog.FINE, SessionLog.SQL)) {
                 writer.write(cr());
                 writer.write(getIndentationString());
                 writer.write(ExceptionMessageGenerator.getHeader("CallHeader"));

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/AbstractSession.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/AbstractSession.java
@@ -1880,6 +1880,10 @@ public abstract class AbstractSession extends CoreAbstractSession<ClassDescripto
                 if (queryException.getSession() == null) {
                     queryException.setSession(this);
                 }
+                if (queryException.getQuery().getSession() == null) {
+                    queryException.getQuery().setSession(this);
+                }
+                queryException.getQuery().setOccurException(true);
             } else if (exception instanceof DatabaseException databaseException) {
                 if (databaseException.getQuery() == null) {
                     databaseException.setQuery(query);
@@ -1890,6 +1894,10 @@ public abstract class AbstractSession extends CoreAbstractSession<ClassDescripto
                 if (databaseException.getSession() == null) {
                     databaseException.setSession(this);
                 }
+                if (databaseException.getQuery().getSession() == null) {
+                    databaseException.getQuery().setSession(this);
+                }
+                databaseException.getQuery().setOccurException(true);
                 //if this query is a read query outside of a transaction then we may be able to retry the query
                 if (!isInTransaction() && query.isReadQuery() && getDatasourceLogin() instanceof DatabaseLogin) {
                     final int count = getLogin().getQueryRetryAttemptCount();

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/DatabaseQuery.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/DatabaseQuery.java
@@ -65,6 +65,7 @@ import org.eclipse.persistence.internal.sessions.AbstractSession;
 import org.eclipse.persistence.internal.sessions.UnitOfWorkImpl;
 import org.eclipse.persistence.internal.sessions.remote.RemoteSessionController;
 import org.eclipse.persistence.internal.sessions.remote.Transporter;
+import org.eclipse.persistence.logging.SessionLog;
 import org.eclipse.persistence.mappings.DatabaseMapping;
 import org.eclipse.persistence.sessions.DataRecord;
 import org.eclipse.persistence.sessions.DatabaseRecord;
@@ -358,6 +359,9 @@ public abstract class DatabaseQuery implements Cloneable, Serializable {
 
     /** Allow the reserved pound char used to delimit bind parameters to be overridden */
     protected String parameterDelimiter;
+
+    /** Flag to control the sql log */
+    protected boolean occurException = false;
 
     /**
      * PUBLIC: Initialize the state of the query
@@ -2757,6 +2761,20 @@ public abstract class DatabaseQuery implements Cloneable, Serializable {
         setShouldStoreBypassCache(true);
     }
 
+    /**
+     * Return true if exception has occured.
+     */
+    public boolean isOccurException() {
+        return occurException;
+    }
+
+    /**
+     * Set if exception has occurd.
+     */
+    public void setOccurException(boolean occurException) {
+        this.occurException = occurException;
+    }
+
     @Override
     public String toString() {
         String referenceClassString = "";
@@ -2768,10 +2786,13 @@ public abstract class DatabaseQuery implements Cloneable, Serializable {
         if ((getName() != null) && (!getName().isEmpty())) {
             nameString = "name=\"" + getName() + "\" ";
         }
-        if (isSQLCallQuery()) {
-            queryString = "sql=\"" + getSQLString() + "\"";
-        } else if (isJPQLCallQuery()) {
-            queryString = "jpql=\"" + getJPQLString() + "\"";
+
+        if (isOccurException() && session.shouldLog(SessionLog.FINE, SessionLog.SQL)) {
+            if (isSQLCallQuery()) {
+                queryString = "sql=\"" + getSQLString() + "\"";
+            } else if (isJPQLCallQuery()) {
+                queryString = "jpql=\"" + getJPQLString() + "\"";
+            }
         }
         return getClass().getSimpleName() + "(" + nameString + referenceClassString + queryString + ")";
     }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/DatabaseQuery.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/DatabaseQuery.java
@@ -2786,13 +2786,13 @@ public abstract class DatabaseQuery implements Cloneable, Serializable {
         if ((getName() != null) && (!getName().isEmpty())) {
             nameString = "name=\"" + getName() + "\" ";
         }
-
-        if (isOccurException() && session.shouldLog(SessionLog.FINE, SessionLog.SQL)) {
-            if (isSQLCallQuery()) {
-                queryString = "sql=\"" + getSQLString() + "\"";
-            } else if (isJPQLCallQuery()) {
-                queryString = "jpql=\"" + getJPQLString() + "\"";
-            }
+        if (isOccurException() && !session.shouldLog(SessionLog.FINE, SessionLog.SQL)) {
+            return getClass().getSimpleName() + "(" + nameString + referenceClassString + ")";
+        }
+        if (isSQLCallQuery()) {
+            queryString = "sql=\"" + getSQLString() + "\"";
+        } else if (isJPQLCallQuery()) {
+            queryString = "jpql=\"" + getJPQLString() + "\"";
         }
         return getClass().getSimpleName() + "(" + nameString + referenceClassString + queryString + ")";
     }


### PR DESCRIPTION
* Fixes #1408

EclipseLink can print SQL statement sent to the database and control logging by the persistence unit property eclipselink.logging.level.sql(log level).  
On the otherhand, EclipseLink throws exception when failed to execute SQL statement.  
According to the following document, the SQL statement be only logged for log level < CONFIG in exceptions.  
https://wiki.eclipse.org/EclipseLink/Examples/JPA/Logging#Log_Level_Configuration
```
This property will also control how parameters are logged in exceptions. By default parameters are only logged for log level < CONFIG.
```
However, when exception is thrown, SQL statement is always logged in exceptions regardless of log level.  
It should be only logged for log level < CONFIG.

Signed-off-by: Ryosuke Okada <ryosuke.okada@fujitsu.com>