### PR TITLE
[3.0] org.eclipse.persistence.jpa.jse.test test fixes against Oracle DB - backport from master

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatasourcePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatasourcePlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, 2020 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -1064,7 +1064,7 @@ public class DatasourcePlatform implements Platform {
      * Override this method if the platform needs to use a custom function based on the DatabaseField
      * @return An expression for the given field set equal to a parameter matching the field
      */
-    public Expression createExpressionFor(DatabaseField field, Expression builder) {
+    public Expression createExpressionFor(DatabaseField field, Expression builder, String fieldClassificationClassName) {
         Expression subExp1 = builder.getField(field);
         Expression subExp2 = builder.getParameter(field);
         return subExp1.equal(subExp2);

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/descriptors/ObjectBuilder.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/descriptors/ObjectBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2021 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -3029,12 +3029,16 @@ public class ObjectBuilder extends CoreObjectBuilder<AbstractRecord, AbstractSes
         Expression subExp1;
         Expression subExp2;
         Expression subExpression;
-        List primaryKeyFields = this.descriptor.getPrimaryKeyFields();
+        List<DatabaseField> primaryKeyFields = this.descriptor.getPrimaryKeyFields();
 
         if(null != primaryKeyFields) {
             for (int index = 0; index < primaryKeyFields.size(); index++) {
-                DatabaseField primaryKeyField = (DatabaseField)primaryKeyFields.get(index);
-                subExpression = ((DatasourcePlatform)session.getDatasourcePlatform()).createExpressionFor(primaryKeyField, builder);
+                DatabaseField primaryKeyField = primaryKeyFields.get(index);
+                String fieldClassificationClassName = null;
+                if (this.getBaseMappingForField(primaryKeyField) instanceof AbstractDirectMapping) {
+                    fieldClassificationClassName = ((AbstractDirectMapping)this.getBaseMappingForField(primaryKeyField)).getFieldClassificationClassName();
+                }
+                subExpression = ((DatasourcePlatform)session.getDatasourcePlatform()).createExpressionFor(primaryKeyField, builder, fieldClassificationClassName);
 
                 if (expression == null) {
                     expression = subExpression;

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/mappings/foundation/AbstractDirectMapping.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/mappings/foundation/AbstractDirectMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2020 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -1362,5 +1362,13 @@ public abstract class AbstractDirectMapping extends AbstractColumnMapping implem
         if (isUpdatable() && ! isReadOnly()) {
             databaseRow.add(getField(), null);
         }
+    }
+
+    /**
+     * INTERNAL:
+     * Get fieldClassificationClassName. Value usually exist for fields with some kind of embedded converter like <code>@Lob</code> or <code>@Temporal</code>.
+     */
+    public String getFieldClassificationClassName() {
+        return this.fieldClassificationClassName;
     }
 }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/OraclePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/OraclePlatform.java
@@ -1213,15 +1213,17 @@ public class OraclePlatform extends org.eclipse.persistence.platform.database.Da
     }
 
     @Override
-    public Expression createExpressionFor(DatabaseField field, Expression builder) {
+    public Expression createExpressionFor(DatabaseField field, Expression builder, String fieldClassificationClassName) {
         if (field.getType() == java.sql.Clob.class || 
-                field.getType() == java.sql.Blob.class) {
+                field.getType() == java.sql.Blob.class ||
+                "java.sql.Clob".equals(fieldClassificationClassName) ||
+                "java.sql.Blob".equals(fieldClassificationClassName)) {
             Expression subExp1 = builder.getField(field);
             Expression subExp2 = builder.getParameter(field);
             subExp1 = subExp1.getFunction("dbms_lob.compare", subExp2);
             return subExp1.equal(0);
         }
-        return super.createExpressionFor(field, builder);
+        return super.createExpressionFor(field, builder, fieldClassificationClassName);
     }
 
     // Value of shouldCheckResultTableExistsQuery must be true.

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/embeddable/model/ElementCollectionEmbeddableTemporal.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/embeddable/model/ElementCollectionEmbeddableTemporal.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 IBM Corporation. All rights reserved.
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,6 +14,7 @@ package org.eclipse.persistence.jpa.embeddable.model;
 
 import java.util.Date;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
@@ -21,6 +23,7 @@ import jakarta.persistence.TemporalType;
 public class ElementCollectionEmbeddableTemporal {
 
     @Temporal(value = TemporalType.DATE)
+    @Column(name = "TEMPORALVALUE", columnDefinition = "DATE")
     private Date temporalValue;
 
     public ElementCollectionEmbeddableTemporal() { }

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/lob/TestLobMerge.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/lob/TestLobMerge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, 2019 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -41,12 +41,6 @@ public class TestLobMerge {
     @Emf(createTables = DDLGen.DROP_CREATE, classes = { CollectedEntity.class, ParentEntity.class })
     private EntityManagerFactory emf;
 
-    /**
-     * Merging ElementCollections on Oracle fails when EclipseLink generates 
-     * a DELETE SQL statement with a WHERE clause containing a CLOB.
-     * 
-     * @throws Exception
-     */
     @Test
     public void testLobMerge() throws Exception {
         //Test for Oracle only
@@ -59,10 +53,10 @@ public class TestLobMerge {
         EntityManager em = emf.createEntityManager();
         try {
             final Set<CollectedEntity> col1 = new HashSet<CollectedEntity>(
-                    Arrays.asList(new CollectedEntity[] { 
+                    Arrays.asList(new CollectedEntity[] {
                             new CollectedEntity("label1", "content1"),
                             new CollectedEntity("label2", "content2"),
-                            new CollectedEntity("label3", "content3") }));
+                            new CollectedEntity("label3", "content3")));
 
             final ParentEntity pdo = new ParentEntity(9, Collections.unmodifiableSet(col1));
             em.getTransaction().begin();
@@ -70,7 +64,7 @@ public class TestLobMerge {
             em.getTransaction().commit();
 
             final Set<CollectedEntity> col2 = new HashSet<CollectedEntity>(
-                    Arrays.asList(new CollectedEntity[] { 
+                    Arrays.asList(new CollectedEntity[] {
                             new CollectedEntity("label1", "content1"),
                             new CollectedEntity("label2", "content2") }));
             final ParentEntity newEntity = new ParentEntity(pdo.getId(), col2);

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/lob/TestLobMerge.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/lob/TestLobMerge.java
@@ -56,7 +56,7 @@ public class TestLobMerge {
                     Arrays.asList(new CollectedEntity[] {
                             new CollectedEntity("label1", "content1"),
                             new CollectedEntity("label2", "content2"),
-                            new CollectedEntity("label3", "content3")));
+                            new CollectedEntity("label3", "content3") }));
 
             final ParentEntity pdo = new ParentEntity(9, Collections.unmodifiableSet(col1));
             em.getTransaction().begin();

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/mapping/TestMultitenantOneToMany.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/mapping/TestMultitenantOneToMany.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,6 +15,7 @@ package org.eclipse.persistence.jpa.test.mapping;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import org.eclipse.persistence.config.PersistenceUnitProperties;
+import org.eclipse.persistence.internal.jpa.EntityManagerImpl;
 import org.eclipse.persistence.jpa.test.framework.DDLGen;
 import org.eclipse.persistence.jpa.test.framework.Emf;
 import org.eclipse.persistence.jpa.test.framework.EmfRunner;
@@ -51,67 +52,77 @@ public class TestMultitenantOneToMany {
     )
     private EntityManagerFactory emf;
 
+    private boolean supportedPlatform = false;
+
     @Before
     public void setup() {
         EntityManager em = emf.createEntityManager();
-        try {
-            em.getTransaction().begin();
-            em.createNativeQuery("CREATE SCHEMA tenant_1").executeUpdate();
-            em.createNativeQuery("CREATE SCHEMA tenant_2").executeUpdate();
-            em.createNativeQuery("CREATE TABLE tenant_1.parent(id bigint primary key)").executeUpdate();
-            em.createNativeQuery("CREATE TABLE tenant_2.parent(id bigint primary key)").executeUpdate();
-            em.createNativeQuery("CREATE TABLE tenant_1.children(id bigint NOT NULL, parent_id bigint, PRIMARY KEY " +
-                    "(id), CONSTRAINT parent_fkey FOREIGN KEY (parent_id) REFERENCES tenant_1.parent (id))")
-                    .executeUpdate();
-            em.createNativeQuery("CREATE TABLE tenant_2.children(id bigint NOT NULL, parent_id bigint, PRIMARY KEY " +
-                    "(id), CONSTRAINT parent_fkey FOREIGN KEY (parent_id) REFERENCES tenant_2.parent (id))")
-                    .executeUpdate();
-            em.createNativeQuery("INSERT INTO tenant_1.parent(id) VALUES(1)").executeUpdate();
-            em.createNativeQuery("INSERT INTO tenant_2.parent(id) VALUES(2)").executeUpdate();
-            em.createNativeQuery("INSERT INTO tenant_1.children(id, parent_id) VALUES(10, 1)").executeUpdate();
-            em.createNativeQuery("INSERT INTO tenant_2.children(id, parent_id) VALUES(11, 2)").executeUpdate();
-            em.getTransaction().commit();
-        } finally {
-            if (em.getTransaction().isActive()) {
-                em.getTransaction().rollback();
-            }
-            if (em.isOpen()) {
-                em.close();
+        //MySQL only due permissions for CREATE SCHEMA command.
+        if (((EntityManagerImpl)em).getDatabaseSession().getPlatform().isMySQL()) {
+            supportedPlatform = true;
+            try {
+                em.getTransaction().begin();
+                em.createNativeQuery("DROP SCHEMA IF EXISTS tenant_1").executeUpdate();
+                em.createNativeQuery("DROP SCHEMA IF EXISTS tenant_2").executeUpdate();
+                em.createNativeQuery("CREATE SCHEMA tenant_1").executeUpdate();
+                em.createNativeQuery("CREATE SCHEMA tenant_2").executeUpdate();
+                em.createNativeQuery("CREATE TABLE tenant_1.parent(id bigint primary key)").executeUpdate();
+                em.createNativeQuery("CREATE TABLE tenant_2.parent(id bigint primary key)").executeUpdate();
+                em.createNativeQuery("CREATE TABLE tenant_1.children(id bigint NOT NULL, parent_id bigint, PRIMARY KEY " +
+                                "(id), CONSTRAINT parent_fkey FOREIGN KEY (parent_id) REFERENCES tenant_1.parent (id))")
+                        .executeUpdate();
+                em.createNativeQuery("CREATE TABLE tenant_2.children(id bigint NOT NULL, parent_id bigint, PRIMARY KEY " +
+                                "(id), CONSTRAINT parent_fkey FOREIGN KEY (parent_id) REFERENCES tenant_2.parent (id))")
+                        .executeUpdate();
+                em.createNativeQuery("INSERT INTO tenant_1.parent(id) VALUES(1)").executeUpdate();
+                em.createNativeQuery("INSERT INTO tenant_2.parent(id) VALUES(2)").executeUpdate();
+                em.createNativeQuery("INSERT INTO tenant_1.children(id, parent_id) VALUES(10, 1)").executeUpdate();
+                em.createNativeQuery("INSERT INTO tenant_2.children(id, parent_id) VALUES(11, 2)").executeUpdate();
+                em.getTransaction().commit();
+            } finally {
+                if (em.getTransaction().isActive()) {
+                    em.getTransaction().rollback();
+                }
+                if (em.isOpen()) {
+                    em.close();
+                }
             }
         }
     }
 
     @Test
     public void testMultitenancySchemaDescriminatorWithOneToMany() {
-        boolean awaitTermination = false;
-        List<Future<ParentMultitenant>> parent1Results = new ArrayList<>();
-        List<Future<ParentMultitenant>> parent2Results = new ArrayList<>();
-        try {
-            ExecutorService es = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
-            for (int i = 1; i <= 10000; i++) {
-                parent1Results.add(es.submit(() -> load("tenant_1", 1L)));
-                parent2Results.add(es.submit(() -> load("tenant_2", 2L)));
+        if (supportedPlatform) {
+            boolean awaitTermination = false;
+            List<Future<ParentMultitenant>> parent1Results = new ArrayList<>();
+            List<Future<ParentMultitenant>> parent2Results = new ArrayList<>();
+            try {
+                ExecutorService es = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
+                for (int i = 1; i <= 10000; i++) {
+                    parent1Results.add(es.submit(() -> load("tenant_1", 1L)));
+                    parent2Results.add(es.submit(() -> load("tenant_2", 2L)));
+                }
+                es.shutdown();
+                awaitTermination = es.awaitTermination(10, TimeUnit.MINUTES);
+                for (Future<ParentMultitenant> parentFuture : parent1Results) {
+                    ParentMultitenant parent = parentFuture.get();
+                    assertEquals(1L, (long) parent.getId());
+                    assertEquals(10L, (long) parent.getChildren().get(0).getId());
+                }
+                for (Future<ParentMultitenant> parentFuture : parent2Results) {
+                    ParentMultitenant parent = parentFuture.get();
+                    assertEquals(2L, (long) parent.getId());
+                    assertEquals(11L, (long) parent.getChildren().get(0).getId());
+                }
+            } catch (Exception e) {
+                StringWriter sw = new StringWriter();
+                PrintWriter pw = new PrintWriter(sw);
+                e.printStackTrace(pw);
+                fail("Exception was caught: " + sw.toString());
             }
-            es.shutdown();
-            awaitTermination = es.awaitTermination(10, TimeUnit.MINUTES);
-            for (Future<ParentMultitenant> parentFuture : parent1Results) {
-                ParentMultitenant parent = parentFuture.get();
-                assertEquals(1L, (long) parent.getId());
-                assertEquals(10L, (long) parent.getChildren().get(0).getId());
+            if (!awaitTermination) {
+                fail("timeout elapsed before termination of the threads");
             }
-            for (Future<ParentMultitenant> parentFuture : parent2Results) {
-                ParentMultitenant parent = parentFuture.get();
-                assertEquals(2L, (long) parent.getId());
-                assertEquals(11L, (long) parent.getChildren().get(0).getId());
-            }
-        } catch (Exception e) {
-            StringWriter sw = new StringWriter();
-            PrintWriter pw = new PrintWriter(sw);
-            e.printStackTrace(pw);
-            fail("Exception was caught: " + sw.toString());
-        }
-        if (!awaitTermination) {
-            fail("timeout elapsed before termination of the threads");
         }
     }
 


### PR DESCRIPTION
This PR contains fixes for following test errors if JPA JSE tests are executed against Oracle DB:

1. org.eclipse.persistence.jpa.embeddable.TestCollectionTableEmbeddable

```
[ERROR] Tests run: 2, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 2.281 s <<< FAILURE! - in org.eclipse.persistence.jpa.embeddable.TestCollectionTableEmbeddable
[ERROR] org.eclipse.persistence.jpa.embeddable.TestCollectionTableEmbeddable.mergeTest  Time elapsed: 0.325 s  <<< ERROR!
org.eclipse.persistence.exceptions.ConversionException: 

Exception Description: The object [04-DEC-21 03.56.45.937000000 AM], of class [class java.lang.String], from mapping [org.eclipse.persistence.mappings.DirectToFieldMapping[temporalValue-->EntMapDateTemporal.TEMPORALVALUE]] with descriptor [RelationalDescriptor(org.eclipse.persistence.jpa.embeddable.model.ElementCollectionEmbeddableTemporal --> [DatabaseTable(EntMapDateTemporal)])], could not be converted to [class java.sql.Timestamp].
	at org.eclipse.persistence.jpa.embeddable.TestCollectionTableEmbeddable.mergeTest(TestCollectionTableEmbeddable.java:73)
```
In entity `org.eclipse.persistence.jpa.embeddable.model.ElementCollectionEmbeddableTemporal` is specified DB column type. Without this is VARCHAR2 used. VARCHAR2 is problematic in case of read operation (conversion) back into `java.util.Date`.

2. org.eclipse.persistence.jpa.test.lob.TestLobMerge

```
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 1.646 s <<< FAILURE! - in org.eclipse.persistence.jpa.test.lob.TestLobMerge
[ERROR] org.eclipse.persistence.jpa.test.lob.TestLobMerge.testLobMerge  Time elapsed: 1.543 s  <<< ERROR!
jakarta.persistence.RollbackException: 
Exception [EclipseLink-4002] (Eclipse Persistence Services - 4.0.0.v202112030849): org.eclipse.persistence.exceptions.DatabaseException
Internal Exception: java.sql.SQLSyntaxErrorException: ORA-00932: inconsistent datatypes: expected - got CLOB

Error Code: 932
Call: DELETE FROM ParentEntity_SUBS WHERE (((content = ?) AND (label = ?)) AND (parent_id = ?))
	bind => [3 parameters bound]
Query: DeleteObjectQuery(org.eclipse.persistence.jpa.test.lob.model.CollectedEntity@9bffba99)
	at org.eclipse.persistence.jpa.test.lob.TestLobMerge.testLobMerge(TestLobMerge.java:78)
Caused by: org.eclipse.persistence.exceptions.DatabaseException: 

Internal Exception: java.sql.SQLSyntaxErrorException: ORA-00932: inconsistent datatypes: expected - got CLOB
```
It leads into EclipseLink fix in some `*Platform` classes, `org.eclipse.persistence.internal.descriptors.ObjectBuilder` and `org.eclipse.persistence.mappings.foundation.AbstractDirectMapping`.

3.	org.eclipse.persistence.jpa.test.mapping.TestMultitenantOneToMany

```
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.106 s <<< FAILURE! - in org.eclipse.persistence.jpa.test.mapping.TestMultitenantOneToMany
[ERROR] org.eclipse.persistence.jpa.test.mapping.TestMultitenantOneToMany.testMultitenancySchemaDescriminatorWithOneToMany  Time elapsed: 0.1 s  <<< ERROR!
jakarta.persistence.PersistenceException: 
Exception [EclipseLink-4002] (Eclipse Persistence Services - 4.0.0.v202112070752): org.eclipse.persistence.exceptions.DatabaseException
Internal Exception: java.sql.SQLSyntaxErrorException: ORA-02420: missing schema authorization clause

Error Code: 2420
Call: CREATE SCHEMA tenant_1
Query: DataModifyQuery(sql="CREATE SCHEMA tenant_1")
	at org.eclipse.persistence.jpa.test.mapping.TestMultitenantOneToMany.setup(TestMultitenantOneToMany.java:59)
Caused by: org.eclipse.persistence.exceptions.DatabaseException: 

Internal Exception: java.sql.SQLSyntaxErrorException: ORA-02420: missing schema authorization clause
```
Test change to use prefix based multitenancy.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>