### PR TITLE
[master] JPA 3.1 (ORM 3.1 implementation)

### DIFF
--- a/jpa/org.eclipse.persistence.jpa.modelgen/src/main/java/org/eclipse/persistence/internal/jpa/modelgen/objects/PersistenceUnit.java
+++ b/jpa/org.eclipse.persistence.jpa.modelgen/src/main/java/org/eclipse/persistence/internal/jpa/modelgen/objects/PersistenceUnit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -27,6 +27,8 @@
 //       - 494610: Session Properties map should be Map<String, Object>
 //     10/09/2017-2.7 Lukas Jungmann
 //       - 521954: Eclipselink 2.7 is not able to parse ORM XML files using the 2.2 schema
+//     02/10/2022-4.0 Oracle
+//       - JPA 3.1 UUID Support
 package org.eclipse.persistence.internal.jpa.modelgen.objects;
 
 import static org.eclipse.persistence.internal.jpa.metadata.MetadataConstants.JPA_EMBEDDABLE;
@@ -281,23 +283,28 @@ public class PersistenceUnit {
             addXMLEntityMappings(mappingFile, XMLEntityMappingsReader.getEclipseLinkOrmProject());
         } catch (XMLMarshalException e) {
             try {
-                // Try Persistence 3.0 project
-                addXMLEntityMappings(mappingFile, XMLEntityMappingsReader.getOrm3_0Project());
-            } catch (XMLMarshalException xe) {
+                // Try Persistence 3.1 project
+                addXMLEntityMappings(mappingFile, XMLEntityMappingsReader.getOrm3_1Project());
+            } catch (XMLMarshalException e31) {
                 try {
-                    // Try JPA 2.2 project
-                    addXMLEntityMappings(mappingFile, XMLEntityMappingsReader.getOrm2_2Project());
-                } catch (XMLMarshalException xme) {
+                    // Try Persistence 3.0 project
+                    addXMLEntityMappings(mappingFile, XMLEntityMappingsReader.getOrm3_0Project());
+                } catch (XMLMarshalException e30) {
                     try {
-                        // Try JPA 2.1 project
-                        addXMLEntityMappings(mappingFile, XMLEntityMappingsReader.getOrm2_1Project());
-                    } catch (XMLMarshalException ee) {
+                        // Try JPA 2.2 project
+                        addXMLEntityMappings(mappingFile, XMLEntityMappingsReader.getOrm2_2Project());
+                    } catch (XMLMarshalException e22) {
                         try {
-                            // Try JPA 2.0 project
-                            addXMLEntityMappings(mappingFile, XMLEntityMappingsReader.getOrm2_0Project());
-                        } catch (XMLMarshalException eee) {
-                            // Try JPA 1.0 project (don't catch exceptions at this point)
-                            addXMLEntityMappings(mappingFile, XMLEntityMappingsReader.getOrm1_0Project());
+                            // Try JPA 2.1 project
+                            addXMLEntityMappings(mappingFile, XMLEntityMappingsReader.getOrm2_1Project());
+                        } catch (XMLMarshalException e21) {
+                            try {
+                                // Try JPA 2.0 project
+                                addXMLEntityMappings(mappingFile, XMLEntityMappingsReader.getOrm2_0Project());
+                            } catch (XMLMarshalException e20) {
+                                // Try JPA 1.0 project (don't catch exceptions at this point)
+                                addXMLEntityMappings(mappingFile, XMLEntityMappingsReader.getOrm1_0Project());
+                            }
                         }
                     }
                 }

--- a/jpa/org.eclipse.persistence.jpa.modelgen/src/test/java/org/eclipse/persistence/jpa/test/modelgen/TestProcessor.java
+++ b/jpa/org.eclipse.persistence.jpa.modelgen/src/test/java/org/eclipse/persistence/jpa/test/modelgen/TestProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -325,8 +325,8 @@ public class TestProcessor {
     private static final String PXML = "<persistence xmlns=\"https://jakarta.ee/xml/ns/persistence\"\n" +
             "  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
             "  xsi:schemaLocation=\"https://jakarta.ee/xml/ns/persistence\n" +
-            "    https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd\"\n" +
-            "  version=\"3.0\">\n" +
+            "    https://jakarta.ee/xml/ns/persistence/persistence_3_1.xsd\"\n" +
+            "  version=\"3.1\">\n" +
             "     <persistence-unit name=\"sample-pu\" transaction-type=\"RESOURCE_LOCAL\">\n" +
             "          <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>\n" +
             "          <exclude-unlisted-classes>false</exclude-unlisted-classes>\n" +
@@ -337,8 +337,8 @@ public class TestProcessor {
 
     private static final String OXML = "<entity-mappings xmlns=\"https://jakarta.ee/xml/ns/persistence/orm\"\n" +
 "             xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
-"             xsi:schemaLocation=\"https://jakarta.ee/xml/ns/persistence/orm https://jakarta.ee/xml/ns/persistence/orm/orm_3_0.xsd\"\n" +
-"             version=\"3.0\">" +
+"             xsi:schemaLocation=\"https://jakarta.ee/xml/ns/persistence/orm https://jakarta.ee/xml/ns/persistence/orm/orm_3_1.xsd\"\n" +
+"             version=\"3.1\">" +
             "</entity-mappings>";
 
     private static final String PXML_LOG_BEG =

--- a/jpa/org.eclipse.persistence.jpa.modelgen/src/test/java/org/eclipse/persistence/jpa/test/modelgen/TestProcessor.java
+++ b/jpa/org.eclipse.persistence.jpa.modelgen/src/test/java/org/eclipse/persistence/jpa/test/modelgen/TestProcessor.java
@@ -64,88 +64,37 @@ public class TestProcessor {
 
     @Test
     public void testProc() throws Exception {
-        TestFO entity = new TestFO("org.Sample",
-                "package org; import jakarta.persistence.Entity; @Entity public class Sample { public  Sample() {} public int getX() {return 1;} interface A {}}");
-        TestFO nonSC = new TestFO("some.IF",
-                "package some; public class IF { public IF() {}}");
-        TestFO nonAnn = new TestFO("custom.Ann",
-                "package custom; public @interface Ann { }");
-        TestFO nonExt = new TestFO("external.Cls",
-                "package external; public class Cls { public Cls(){}}");
-        TestFO nonEntity = new TestFO("org.NotE",
-                "package org; import jakarta.persistence.Entity; public class NotE extends some.IF { public  NotE() {} @custom.Ann public external.Cls getW() {return new Object();}}");
-        TestFO generated8 = new TestFO("org.Gen8",
-                "package org; import jakarta.annotation.Generated; @Generated(\"com.example.Generator\") public class Gen8 { public  Gen8() {} public int getY() {return 42;}}");
-        TestFO generated9 = new TestFO("org.Gen9",
-                "package org; @javax.annotation.processing.Generated(\"com.example.Generator\") public class Gen9 { public  Gen9() {} public int getZ() {return 9*42;}}");
-
-        Result result = runProject("testProc",
-                getJavacOptions("-Aeclipselink.logging.level.processor=OFF"),
-                Arrays.asList(entity, nonSC, nonAnn, nonExt, nonEntity, generated8, generated9));
-
-        File outputFile = new File(result.srcOut, "org/Sample_.java");
-        Assert.assertTrue("Model file not generated", outputFile.exists());
-        Assert.assertTrue(Files.lines(outputFile.toPath()).anyMatch(s -> s.contains("@StaticMetamodel(Sample.class)")));
+        testProc("testProc3030", PXML30, OXML30);
+        testProc("testProc3031", PXML30, OXML31);
     }
 
     @Test
     public void testGenerateComment() throws Exception {
-        TestFO entity = new TestFO("org.Sample",
-                "package org; import jakarta.persistence.Entity; @Entity public class Sample { public  Sample() {} public int getX() {return 1;} interface A {}}");
-
-        Result result = runProject("testGenerateComment",
-            getJavacOptions("-A" + CanonicalModelProperties.CANONICAL_MODEL_GENERATE_COMMENTS + "=false",
-                    "-Aeclipselink.logging.level.processor=OFF"),
-            Arrays.asList(entity));
-
-        File outputFile = new File(result.srcOut, "org/Sample_.java");
-        Assert.assertTrue("Model file not generated", outputFile.exists());
-        Assert.assertTrue(Files.lines(outputFile.toPath()).noneMatch(s -> s.contains("comments=")));
-        Assert.assertTrue("Compilation failed", result.success);
+        testGenerateComment("testGenerateComment3030", PXML30, OXML30);
+        testGenerateComment("testGenerateComment3031", PXML30, OXML31);
     }
 
     @Test
     public void testGenerate() throws Exception {
-        TestFO entity = new TestFO("org.Sample",
-                "package org; import jakarta.persistence.Entity; @Entity public class Sample { public  Sample() {} public int getX() {return 1;} interface A {}}");
-
-        Result result = runProject("testGenerate",
-            getJavacOptions("-A" + CanonicalModelProperties.CANONICAL_MODEL_GENERATE_GENERATED + "=false",
-                    "-Aeclipselink.logging.level.processor=OFF"),
-            Arrays.asList(entity));
-
-        File outputFile = new File(result.srcOut, "org/Sample_.java");
-        Assert.assertTrue("Model file not generated", outputFile.exists());
-        Assert.assertTrue(Files.lines(outputFile.toPath()).noneMatch(s -> s.contains("Generated")));
-        Assert.assertTrue("Compilation failed", result.success);
+        testGenerate("testGenerate3030", PXML30, OXML30);
+        testGenerate("testGenerate3031", PXML30, OXML31);
     }
 
     @Test
     public void testTypeUse() throws Exception {
-        TestFO entity = new TestFO("org.Ent",
-                "package org; @jakarta.persistence.Entity public class Ent { @org.ann.NotNull private byte[] bytes;}");
-        TestFO ann = new TestFO("org.ann.NotNull",
-                "package org.ann; @java.lang.annotation.Target(java.lang.annotation.ElementType.TYPE_USE) public @interface NotNull {}");
-
-        Result result = runProject("testTypeUse",
-            getJavacOptions("-Aeclipselink.logging.level.processor=OFF"),
-            Arrays.asList(entity, ann));
-
-        File outputFile = new File(result.srcOut, "org/Ent_.java");
-        Assert.assertTrue("Model file not generated", outputFile.exists());
-        Assert.assertTrue(Files.lines(outputFile.toPath()).noneMatch(s -> s.contains("NotNull")));
-        Assert.assertTrue("Compilation failed", result.success);
+        testTypeUse("testTypeUse3030", PXML30, OXML30);
+        testTypeUse("testTypeUse3031", PXML30, OXML31);
     }
 
     @Test
     public void testProcessorLoggingOffFromCmdLine() throws Exception {
-        verifyLogging("testProcessorLoggingOffFromCmdLine", PXML, false,
+        verifyLogging("testProcessorLoggingOffFromCmdLine", PXML30, false,
                 "-Aeclipselink.logging.level.processor=OFF");
     }
 
     @Test
     public void testGlobalLoggingOffFromCmdLine() throws Exception {
-        verifyLogging("testGlobalLoggingOffFromCmdLine", PXML, false,
+        verifyLogging("testGlobalLoggingOffFromCmdLine", PXML30, false,
                 "-Aeclipselink.logging.level=OFF");
     }
 
@@ -167,13 +116,13 @@ public class TestProcessor {
 
     @Test
     public void testProcessorLoggingFinestFromCmdLine() throws Exception {
-        verifyLogging("testProcessorLoggingFinestFromCmdLine", PXML, true,
+        verifyLogging("testProcessorLoggingFinestFromCmdLine", PXML30, true,
                 "-Aeclipselink.logging.level.processor=FINEST");
     }
 
     @Test
     public void testGlobalLoggingFinestFromCmdLine() throws Exception {
-        verifyLogging("testGlobalLoggingFinestFromCmdLine", PXML, true,
+        verifyLogging("testGlobalLoggingFinestFromCmdLine", PXML30, true,
                 "-Aeclipselink.logging.level=FINEST");
     }
 
@@ -189,6 +138,77 @@ public class TestProcessor {
         final String pu = buildPU("testGlobalLoggingFinestFromPU",
                 new Property("eclipselink.logging.level", "FINEST"));
         verifyLogging("testGlobalLoggingFinestFromPU", pu, true);
+    }
+
+    private void testProc(String name, String pxml, String oxml) throws Exception {
+        TestFO entity = new TestFO("org.Sample",
+                "package org; import jakarta.persistence.Entity; @Entity public class Sample { public  Sample() {} public int getX() {return 1;} interface A {}}");
+        TestFO nonSC = new TestFO("some.IF",
+                "package some; public class IF { public IF() {}}");
+        TestFO nonAnn = new TestFO("custom.Ann",
+                "package custom; public @interface Ann { }");
+        TestFO nonExt = new TestFO("external.Cls",
+                "package external; public class Cls { public Cls(){}}");
+        TestFO nonEntity = new TestFO("org.NotE",
+                "package org; import jakarta.persistence.Entity; public class NotE extends some.IF { public  NotE() {} @custom.Ann public external.Cls getW() {return new Object();}}");
+        TestFO generated8 = new TestFO("org.Gen8",
+                "package org; import jakarta.annotation.Generated; @Generated(\"com.example.Generator\") public class Gen8 { public  Gen8() {} public int getY() {return 42;}}");
+        TestFO generated9 = new TestFO("org.Gen9",
+                "package org; @javax.annotation.processing.Generated(\"com.example.Generator\") public class Gen9 { public  Gen9() {} public int getZ() {return 9*42;}}");
+
+        Result result = runProject(name,
+                getJavacOptions("-Aeclipselink.logging.level.processor=OFF"),
+                Arrays.asList(entity, nonSC, nonAnn, nonExt, nonEntity, generated8, generated9), pxml, oxml);
+
+        File outputFile = new File(result.srcOut, "org/Sample_.java");
+        Assert.assertTrue("Model file not generated", outputFile.exists());
+        Assert.assertTrue(Files.lines(outputFile.toPath()).anyMatch(s -> s.contains("@StaticMetamodel(Sample.class)")));
+    }
+
+    private void testGenerateComment(String name, String pxml, String oxml) throws Exception {
+        TestFO entity = new TestFO("org.Sample",
+                "package org; import jakarta.persistence.Entity; @Entity public class Sample { public  Sample() {} public int getX() {return 1;} interface A {}}");
+
+        Result result = runProject(name,
+                getJavacOptions("-A" + CanonicalModelProperties.CANONICAL_MODEL_GENERATE_COMMENTS + "=false",
+                        "-Aeclipselink.logging.level.processor=OFF"),
+                Arrays.asList(entity), pxml, oxml);
+
+        File outputFile = new File(result.srcOut, "org/Sample_.java");
+        Assert.assertTrue("Model file not generated", outputFile.exists());
+        Assert.assertTrue(Files.lines(outputFile.toPath()).noneMatch(s -> s.contains("comments=")));
+        Assert.assertTrue("Compilation failed", result.success);
+    }
+
+    private void testGenerate(String name, String pxml, String oxml) throws Exception {
+        TestFO entity = new TestFO("org.Sample",
+                "package org; import jakarta.persistence.Entity; @Entity public class Sample { public  Sample() {} public int getX() {return 1;} interface A {}}");
+
+        Result result = runProject(name,
+                getJavacOptions("-A" + CanonicalModelProperties.CANONICAL_MODEL_GENERATE_GENERATED + "=false",
+                        "-Aeclipselink.logging.level.processor=OFF"),
+                Arrays.asList(entity), pxml, oxml);
+
+        File outputFile = new File(result.srcOut, "org/Sample_.java");
+        Assert.assertTrue("Model file not generated", outputFile.exists());
+        Assert.assertTrue(Files.lines(outputFile.toPath()).noneMatch(s -> s.contains("Generated")));
+        Assert.assertTrue("Compilation failed", result.success);
+    }
+
+    public void testTypeUse(String name, String pxml, String oxml) throws Exception {
+        TestFO entity = new TestFO("org.Ent",
+                "package org; @jakarta.persistence.Entity public class Ent { @org.ann.NotNull private byte[] bytes;}");
+        TestFO ann = new TestFO("org.ann.NotNull",
+                "package org.ann; @java.lang.annotation.Target(java.lang.annotation.ElementType.TYPE_USE) public @interface NotNull {}");
+
+        Result result = runProject(name,
+                getJavacOptions("-Aeclipselink.logging.level.processor=OFF"),
+                Arrays.asList(entity, ann), pxml, oxml);
+
+        File outputFile = new File(result.srcOut, "org/Ent_.java");
+        Assert.assertTrue("Model file not generated", outputFile.exists());
+        Assert.assertTrue(Files.lines(outputFile.toPath()).noneMatch(s -> s.contains("NotNull")));
+        Assert.assertTrue("Compilation failed", result.success);
     }
 
     private List<String> getJavacOptions(String... opts) {
@@ -253,7 +273,7 @@ public class TestProcessor {
         }
     }
 
-    private Result runProject(String name, List<String> options, List<JavaFileObject> sources) throws Exception {
+    private Result runProject(String name, List<String> options, List<JavaFileObject> sources, String pxmlStr, String oxmlStr) throws Exception {
                 File runDir = new File(System.getProperty("run.dir"), name);
         File srcOut = new File(runDir, "src");
         srcOut.mkdirs();
@@ -262,13 +282,13 @@ public class TestProcessor {
         File pxml = new File(cpDir, "META-INF/persistence.xml");
         pxml.getParentFile().mkdirs();
         try (BufferedWriter writer = Files.newBufferedWriter(pxml.toPath(), StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE)) {
-            writer.write(PXML, 0, PXML.length());
+            writer.write(pxmlStr, 0, pxmlStr.length());
         } catch (IOException x) {
             throw x;
         }
         File oxml = new File(cpDir, "META-INF/orm.xml");
         try (BufferedWriter writer = Files.newBufferedWriter(oxml.toPath(), StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE)) {
-            writer.write(OXML, 0, OXML.length());
+            writer.write(oxmlStr, 0, oxmlStr.length());
         } catch (IOException x) {
             throw x;
         }
@@ -322,11 +342,11 @@ public class TestProcessor {
         }
     }
 
-    private static final String PXML = "<persistence xmlns=\"https://jakarta.ee/xml/ns/persistence\"\n" +
+    private static final String PXML30 = "<persistence xmlns=\"https://jakarta.ee/xml/ns/persistence\"\n" +
             "  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
             "  xsi:schemaLocation=\"https://jakarta.ee/xml/ns/persistence\n" +
-            "    https://jakarta.ee/xml/ns/persistence/persistence_3_1.xsd\"\n" +
-            "  version=\"3.1\">\n" +
+            "    https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd\"\n" +
+            "  version=\"3.0\">\n" +
             "     <persistence-unit name=\"sample-pu\" transaction-type=\"RESOURCE_LOCAL\">\n" +
             "          <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>\n" +
             "          <exclude-unlisted-classes>false</exclude-unlisted-classes>\n" +
@@ -335,10 +355,16 @@ public class TestProcessor {
             "     </persistence-unit>\n" +
             "</persistence>";
 
-    private static final String OXML = "<entity-mappings xmlns=\"https://jakarta.ee/xml/ns/persistence/orm\"\n" +
+    private static final String OXML30 = "<entity-mappings xmlns=\"https://jakarta.ee/xml/ns/persistence/orm\"\n" +
 "             xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
-"             xsi:schemaLocation=\"https://jakarta.ee/xml/ns/persistence/orm https://jakarta.ee/xml/ns/persistence/orm/orm_3_1.xsd\"\n" +
-"             version=\"3.1\">" +
+"             xsi:schemaLocation=\"https://jakarta.ee/xml/ns/persistence/orm https://jakarta.ee/xml/ns/persistence/orm/orm_3_0.xsd\"\n" +
+"             version=\"3.0\">" +
+            "</entity-mappings>";
+
+    private static final String OXML31 = "<entity-mappings xmlns=\"https://jakarta.ee/xml/ns/persistence/orm\"\n" +
+            "             xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+            "             xsi:schemaLocation=\"https://jakarta.ee/xml/ns/persistence/orm https://jakarta.ee/xml/ns/persistence/orm/orm_3_1.xsd\"\n" +
+            "             version=\"3.1\">" +
             "</entity-mappings>";
 
     private static final String PXML_LOG_BEG =

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/xml/XMLEntityMappingsReader.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/xml/XMLEntityMappingsReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2018 IBM and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -27,6 +27,9 @@
 //       - 338610: JPA 2.1 Functionality for Java EE 7 (JSR-338)
 //     09/06/2017-2.7 Jody Grassel
 //       - 521954: Eclipselink is not able to parse ORM XML files using the 2.2 schema
+//     02/10/2022-4.0 Oracle
+//       - JPA 3.1 UUID Support
+
 package org.eclipse.persistence.internal.jpa.metadata.xml;
 
 import java.io.IOException;
@@ -75,6 +78,8 @@ public class XMLEntityMappingsReader {
     public static final String ORM_2_2_NAMESPACE = "http://xmlns.jcp.org/xml/ns/persistence/orm";
     public static final String ORM_3_0_XSD = "org/eclipse/persistence/jpa/orm_3_0.xsd";
     public static final String ORM_3_0_NAMESPACE = "https://jakarta.ee/xml/ns/persistence/orm";
+    public static final String ORM_3_1_XSD = "org/eclipse/persistence/jpa/orm_3_1.xsd";
+    public static final String ORM_3_1_NAMESPACE = "https://jakarta.ee/xml/ns/persistence/orm";
     public static final String ECLIPSELINK_ORM_XSD = "org/eclipse/persistence/jpa/eclipselink_orm_2_5.xsd";
     public static final String ECLIPSELINK_ORM_NAMESPACE = "http://www.eclipse.org/eclipselink/xsds/persistence/orm";
 
@@ -83,6 +88,7 @@ public class XMLEntityMappingsReader {
     private static XMLContext m_orm2_1Project;
     private static XMLContext m_orm2_2Project;
     private static XMLContext m_orm3_0Project;
+    private static XMLContext m_orm3_1Project;
     private static XMLContext m_eclipseLinkOrmProject;
 
     private static Schema m_orm1_0Schema;
@@ -90,6 +96,7 @@ public class XMLEntityMappingsReader {
     private static Schema m_orm2_1Schema;
     private static Schema m_orm2_2Schema;
     private static Schema m_orm3_0Schema;
+    private static Schema m_orm3_1Schema;
     private static Schema m_eclipseLinkOrmSchema;
 
     private XMLEntityMappingsReader() {
@@ -146,10 +153,15 @@ public class XMLEntityMappingsReader {
                 if (validateSchema) {
                     context[1] = getOrm2_2Schema();
                 }
-            } else {
+            } else if (contentHandler.getVersion().contains("3.0")) {
                 context[0] = getOrm3_0Project();
                 if (validateSchema) {
                     context[1] = getOrm3_0Schema();
+                }
+            } else {
+                context[0] = getOrm3_1Project();
+                if (validateSchema) {
+                    context[1] = getOrm3_1Schema();
                 }
             }
         }
@@ -300,6 +312,28 @@ public class XMLEntityMappingsReader {
     }
 
     /**
+     * @return the JPA 3.1 orm project.
+     */
+    public static XMLContext getOrm3_1Project() {
+        if (m_orm3_1Project == null) {
+            m_orm3_1Project = new XMLContext(new XMLEntityMappingsMappingProject(ORM_3_1_NAMESPACE, ORM_3_1_XSD));
+        }
+
+        return m_orm3_1Project;
+    }
+
+    /**
+     * @return the JPA 3.1 orm schema.
+     */
+    public static Schema getOrm3_1Schema() throws IOException, SAXException {
+        if (m_orm3_1Schema == null) {
+            m_orm3_1Schema = loadLocalSchema(ORM_3_1_XSD);
+        }
+
+        return m_orm3_1Schema;
+    }
+
+    /**
      * Free the project and schema objects to avoid holding onto the memory.
      * This can be done post-deployment to conserve memory.
      */
@@ -309,6 +343,7 @@ public class XMLEntityMappingsReader {
         m_orm2_1Project = null;
         m_orm2_2Project = null;
         m_orm3_0Project = null;
+        m_orm3_1Project = null;
         m_eclipseLinkOrmProject = null;
 
         m_orm1_0Schema = null;
@@ -316,6 +351,7 @@ public class XMLEntityMappingsReader {
         m_orm2_1Schema = null;
         m_orm2_2Schema = null;
         m_orm3_0Schema = null;
+        m_orm3_1Schema = null;
         m_eclipseLinkOrmSchema = null;
     }
 

--- a/jpa/org.eclipse.persistence.jpa/src/main/resources/org/eclipse/persistence/jpa/eclipselink_orm_3_1.xsd
+++ b/jpa/org.eclipse.persistence.jpa/src/main/resources/org/eclipse/persistence/jpa/eclipselink_orm_3_1.xsd
@@ -87,6 +87,7 @@ Contributors:
   <xsd:simpleType name="supported-versions-type">
     <xsd:restriction base="orm:versionType">
       <xsd:enumeration value="3.0"/>
+      <xsd:enumeration value="3.1"/>
     </xsd:restriction>
   </xsd:simpleType>
 
@@ -740,7 +741,7 @@ Contributors:
             <xsd:element name="embeddable" type="orm:embeddable"/>
       </xsd:choice>
       </xsd:sequence>
-      <xsd:attribute name="version" type="orm:supported-versions-type" default="3.0" use="optional"/>
+      <xsd:attribute name="version" type="orm:supported-versions-type" default="3.1" use="optional"/>
     </xsd:complexType>
   </xsd:element>
 

--- a/jpa/org.eclipse.persistence.jpa/src/main/resources/org/eclipse/persistence/jpa/eclipselink_orm_3_1.xsd
+++ b/jpa/org.eclipse.persistence.jpa/src/main/resources/org/eclipse/persistence/jpa/eclipselink_orm_3_1.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -31,6 +31,8 @@ Contributors:
       - 337323: Multi-tenant with shared schema support (part 1)
     02/13/2013-2.5 Guy Pelletier
       - 397772: JPA 2.1 Entity Graph Support (XML support)
+    02/10/2022-4.0 Oracle
+      - JPA 3.1 UUID Support
 -->
 
 <!-- Java Persistence API object-relational mapping file schema -->
@@ -39,11 +41,11 @@ Contributors:
   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
   elementFormDefault="qualified"
   attributeFormDefault="unqualified"
-  version="3.0">
+  version="3.1">
 
   <xsd:annotation>
     <xsd:documentation>
-      @(#)eclipselink_orm_3_0.xsd 3.0  ##DATE##
+      @(#)eclipselink_orm_3_1.xsd 3.1  ##DATE##
     </xsd:documentation>
   </xsd:annotation>
 
@@ -64,8 +66,8 @@ Contributors:
        <entity-mappings xmlns="http://www.eclipse.org/eclipselink/xsds/persistence/orm"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.eclipse.org/eclipselink/xsds/persistence/orm
-       eclipselink_orm_3_0.xsd
-       version="3.0">
+       eclipselink_orm_3_1.xsd
+       version="3.1">
        ...
        </entity-mappings>
 
@@ -2769,7 +2771,7 @@ Contributors:
     <xsd:annotation>
       <xsd:documentation>
 
-        public enum GenerationType { TABLE, SEQUENCE, IDENTITY, AUTO };
+        public enum GenerationType { TABLE, SEQUENCE, IDENTITY, UUID, AUTO };
 
       </xsd:documentation>
     </xsd:annotation>
@@ -2777,6 +2779,7 @@ Contributors:
       <xsd:enumeration value="TABLE"/>
       <xsd:enumeration value="SEQUENCE"/>
       <xsd:enumeration value="IDENTITY"/>
+      <xsd:enumeration value="UUID"/>
       <xsd:enumeration value="AUTO"/>
     </xsd:restriction>
   </xsd:simpleType>

--- a/jpa/org.eclipse.persistence.jpa/src/main/resources/org/eclipse/persistence/jpa/orm_3_1.xsd
+++ b/jpa/org.eclipse.persistence.jpa/src/main/resources/org/eclipse/persistence/jpa/orm_3_1.xsd
@@ -1,0 +1,2325 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0,
+    or the Eclipse Distribution License v. 1.0 which is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+
+    SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+-->
+
+<!-- Jakarta Persistence API object/relational mapping file schema -->
+<xsd:schema targetNamespace="https://jakarta.ee/xml/ns/persistence/orm" 
+  xmlns:orm="https://jakarta.ee/xml/ns/persistence/orm" 
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+  elementFormDefault="qualified" 
+  attributeFormDefault="unqualified" 
+  version="3.1">
+
+  <xsd:annotation>
+     <xsd:documentation><![CDATA[
+
+       This is the XML Schema for the persistence object/relational 
+       mapping file.
+       The file may be named "META-INF/orm.xml" in the persistence 
+       archive or it may be named some other name which would be 
+       used to locate the file as resource on the classpath.
+
+       Object/relational mapping files must indicate the object/relational
+       mapping file schema by using the persistence namespace:
+
+       https://jakarta.ee/xml/ns/persistence/orm
+
+       and indicate the version of the schema by
+       using the version element as shown below:
+
+      <entity-mappings xmlns="https://jakarta.ee/xml/ns/persistence/orm"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence/orm
+          https://jakarta.ee/xml/ns/persistence/orm/orm_3_1.xsd"
+        version="3.1">
+          ...
+      </entity-mappings>
+
+
+     ]]></xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:complexType name="emptyType"/>
+
+  <xsd:simpleType name="versionType">
+    <xsd:restriction base="xsd:token">
+      <xsd:pattern value="[0-9]+(\.[0-9]+)*"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <!-- **************************************************** -->
+
+  <xsd:element name="entity-mappings">
+    <xsd:complexType>
+      <xsd:annotation>
+        <xsd:documentation>
+
+        The entity-mappings element is the root element of a mapping
+        file. It contains the following four types of elements:
+
+        1. The persistence-unit-metadata element contains metadata
+        for the entire persistence unit. It is undefined if this element
+        occurs in multiple mapping files within the same persistence unit.
+        
+        2. The package, schema, catalog and access elements apply to all of
+        the entity, mapped-superclass and embeddable elements defined in
+        the same file in which they occur.
+
+        3. The sequence-generator, table-generator, converter, named-query,
+        named-native-query, named-stored-procedure-query, and 
+        sql-result-set-mapping elements are global to the persistence
+        unit. It is undefined to have more than one sequence-generator
+        or table-generator of the same name in the same or different
+        mapping files in a persistence unit. It is undefined to have
+        more than one named-query, named-native-query, sql-result-set-mapping,
+        or named-stored-procedure-query of the same name in the same 
+        or different mapping files in a persistence unit.  It is also
+        undefined to have more than one converter for the same target
+        type in the same or different mapping files in a persistence unit.
+
+        4. The entity, mapped-superclass and embeddable elements each define
+        the mapping information for a managed persistent class. The mapping
+        information contained in these elements may be complete or it may
+        be partial.
+
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+        <xsd:element name="description" type="xsd:string"
+                     minOccurs="0"/>
+        <xsd:element name="persistence-unit-metadata" 
+                     type="orm:persistence-unit-metadata"
+                     minOccurs="0"/>
+        <xsd:element name="package" type="xsd:string"
+                     minOccurs="0"/>
+        <xsd:element name="schema" type="xsd:string"
+                     minOccurs="0"/>
+        <xsd:element name="catalog" type="xsd:string"
+                     minOccurs="0"/>
+        <xsd:element name="access" type="orm:access-type"
+                     minOccurs="0"/>
+        <xsd:element name="sequence-generator" type="orm:sequence-generator"
+                     minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element name="table-generator" type="orm:table-generator" 
+                     minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element name="named-query" type="orm:named-query" 
+                     minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element name="named-native-query" type="orm:named-native-query"
+                     minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element name="named-stored-procedure-query" 
+                     type="orm:named-stored-procedure-query"
+                     minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element name="sql-result-set-mapping" 
+                     type="orm:sql-result-set-mapping" 
+                     minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element name="mapped-superclass" type="orm:mapped-superclass" 
+                     minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element name="entity" type="orm:entity" 
+                     minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element name="embeddable" type="orm:embeddable" 
+                     minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element name="converter" type="orm:converter" 
+                     minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="version" type="orm:versionType" 
+                     fixed="3.1" use="required"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="persistence-unit-metadata">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Metadata that applies to the persistence unit and not just to 
+        the mapping file in which it is contained. 
+
+        If the xml-mapping-metadata-complete element is specified,
+        the complete set of mapping metadata for the persistence unit 
+        is contained in the XML mapping files for the persistence unit.
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="xml-mapping-metadata-complete" type="orm:emptyType"
+                   minOccurs="0"/>
+      <xsd:element name="persistence-unit-defaults" 
+                   type="orm:persistence-unit-defaults"
+                   minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="persistence-unit-defaults">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        These defaults are applied to the persistence unit as a whole 
+        unless they are overridden by local annotation or XML 
+        element settings. 
+        
+        schema - Used as the schema for all tables, secondary tables, join
+            tables, collection tables, sequence generators, and table 
+            generators that apply to the persistence unit
+        catalog - Used as the catalog for all tables, secondary tables, join
+            tables, collection tables, sequence generators, and table 
+            generators that apply to the persistence unit
+        delimited-identifiers - Used to treat database identifiers as
+            delimited identifiers.
+        access - Used as the access type for all managed classes in
+            the persistence unit
+        cascade-persist - Adds cascade-persist to the set of cascade options
+            in all entity relationships of the persistence unit
+        entity-listeners - List of default entity listeners to be invoked 
+            on each entity in the persistence unit. 
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+        <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+        <xsd:element name="schema" type="xsd:string"
+                     minOccurs="0"/>
+        <xsd:element name="catalog" type="xsd:string"
+                     minOccurs="0"/>
+        <xsd:element name="delimited-identifiers" type="orm:emptyType" 
+                     minOccurs="0"/>
+        <xsd:element name="access" type="orm:access-type"
+                     minOccurs="0"/>
+        <xsd:element name="cascade-persist" type="orm:emptyType" 
+                     minOccurs="0"/>
+        <xsd:element name="entity-listeners" type="orm:entity-listeners"
+                     minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="entity">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Defines the settings and mappings for an entity. Is allowed to be
+        sparsely populated and used in conjunction with the annotations.
+        Alternatively, the metadata-complete attribute can be used to 
+        indicate that no annotations on the entity class (and its fields
+        or properties) are to be processed. If this is the case then 
+        the defaulting rules for the entity and its subelements will 
+        be recursively applied.
+
+        @Target(TYPE) @Retention(RUNTIME)
+          public @interface Entity {
+          String name() default "";
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="table" type="orm:table" 
+                   minOccurs="0"/>
+      <xsd:element name="secondary-table" type="orm:secondary-table" 
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:sequence>
+        <xsd:element name="primary-key-join-column" 
+                     type="orm:primary-key-join-column" 
+                     minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element name="primary-key-foreign-key" 
+                     type="orm:foreign-key" 
+                     minOccurs="0"/>
+      </xsd:sequence>
+      <xsd:element name="id-class" type="orm:id-class" minOccurs="0"/>
+      <xsd:element name="inheritance" type="orm:inheritance" minOccurs="0"/>
+      <xsd:element name="discriminator-value" type="orm:discriminator-value" 
+                   minOccurs="0"/>
+      <xsd:element name="discriminator-column" 
+                   type="orm:discriminator-column" 
+                   minOccurs="0"/>
+      <xsd:element name="sequence-generator" type="orm:sequence-generator" 
+                   minOccurs="0"/>
+      <xsd:element name="table-generator" type="orm:table-generator" 
+                   minOccurs="0"/>
+      <xsd:element name="named-query" type="orm:named-query" 
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="named-native-query" type="orm:named-native-query" 
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="named-stored-procedure-query"
+                   type="orm:named-stored-procedure-query" 
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="sql-result-set-mapping" 
+                   type="orm:sql-result-set-mapping" 
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="exclude-default-listeners" type="orm:emptyType" 
+                   minOccurs="0"/>
+      <xsd:element name="exclude-superclass-listeners" type="orm:emptyType" 
+                   minOccurs="0"/>
+      <xsd:element name="entity-listeners" type="orm:entity-listeners" 
+                   minOccurs="0"/>
+      <xsd:element name="pre-persist" type="orm:pre-persist" minOccurs="0"/>
+      <xsd:element name="post-persist" type="orm:post-persist" 
+                   minOccurs="0"/>
+      <xsd:element name="pre-remove" type="orm:pre-remove" minOccurs="0"/>
+      <xsd:element name="post-remove" type="orm:post-remove" minOccurs="0"/>
+      <xsd:element name="pre-update" type="orm:pre-update" minOccurs="0"/>
+      <xsd:element name="post-update" type="orm:post-update" minOccurs="0"/>
+      <xsd:element name="post-load" type="orm:post-load" minOccurs="0"/>
+      <xsd:element name="attribute-override" type="orm:attribute-override" 
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="association-override" 
+                   type="orm:association-override"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="convert" type="orm:convert"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="named-entity-graph" type="orm:named-entity-graph"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="attributes" type="orm:attributes" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="class" type="xsd:string" use="required"/>
+    <xsd:attribute name="access" type="orm:access-type"/>
+    <xsd:attribute name="cacheable" type="xsd:boolean"/>
+    <xsd:attribute name="metadata-complete" type="xsd:boolean"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:simpleType name="access-type">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This element determines how the persistence provider accesses the
+        state of an entity or embedded object.
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="PROPERTY"/>
+      <xsd:enumeration value="FIELD"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="association-override">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({TYPE, METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface AssociationOverride {
+          String name();
+          JoinColumn[] joinColumns() default{};
+          JoinTable joinTable() default @JoinTable;
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+      <xsd:choice>
+        <xsd:sequence>
+          <xsd:element name="join-column" type="orm:join-column"
+                       minOccurs="0" maxOccurs="unbounded"/>
+          <xsd:element name="foreign-key" type="orm:foreign-key" 
+                       minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:element name="join-table" type="orm:join-table"
+                     minOccurs="0"/>
+      </xsd:choice>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="attribute-override">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({TYPE, METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface AttributeOverride {
+          String name();
+          Column column();
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="column" type="orm:column"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="attributes">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This element contains the entity field or property mappings.
+        It may be sparsely populated to include only a subset of the
+        fields or properties. If metadata-complete for the entity is true
+        then the remainder of the attributes will be defaulted according
+        to the default rules.
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+      <xsd:choice>
+        <xsd:element name="id" type="orm:id" 
+                     minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element name="embedded-id" type="orm:embedded-id" 
+                     minOccurs="0"/>
+      </xsd:choice>
+      <xsd:element name="basic" type="orm:basic"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="version" type="orm:version"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="many-to-one" type="orm:many-to-one"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="one-to-many" type="orm:one-to-many"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="one-to-one" type="orm:one-to-one"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="many-to-many" type="orm:many-to-many" 
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="element-collection" type="orm:element-collection" 
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="embedded" type="orm:embedded"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="transient" type="orm:transient"
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="basic">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface Basic {
+          FetchType fetch() default EAGER;
+          boolean optional() default true;
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="column" type="orm:column" minOccurs="0"/>
+      <xsd:choice>
+        <xsd:element name="lob" type="orm:lob" minOccurs="0"/>
+        <xsd:element name="temporal" type="orm:temporal" minOccurs="0"/>
+        <xsd:element name="enumerated" type="orm:enumerated" minOccurs="0"/>
+        <xsd:element name="convert" type="orm:convert" minOccurs="0"/>
+      </xsd:choice>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="fetch" type="orm:fetch-type"/>
+    <xsd:attribute name="optional" type="xsd:boolean"/>
+    <xsd:attribute name="access" type="orm:access-type"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="cascade-type">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        public enum CascadeType { ALL, PERSIST, MERGE, REMOVE, REFRESH, DETACH};
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="cascade-all" type="orm:emptyType"
+                   minOccurs="0"/>
+      <xsd:element name="cascade-persist" type="orm:emptyType"
+                   minOccurs="0"/>
+      <xsd:element name="cascade-merge" type="orm:emptyType"
+                   minOccurs="0"/>
+      <xsd:element name="cascade-remove" type="orm:emptyType"
+                   minOccurs="0"/>
+      <xsd:element name="cascade-refresh" type="orm:emptyType"
+                   minOccurs="0"/>
+      <xsd:element name="cascade-detach" type="orm:emptyType"
+                   minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="collection-table">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface CollectionTable {
+          String name() default "";
+          String catalog() default "";
+          String schema() default "";
+          JoinColumn[] joinColumns() default {};
+          UniqueConstraint[] uniqueConstraints() default {};
+          Index[] indexes() default {};
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:sequence>
+        <xsd:element name="join-column" type="orm:join-column" 
+                     minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element name="foreign-key" type="orm:foreign-key" 
+                     minOccurs="0"/>
+      </xsd:sequence>
+      <xsd:element name="unique-constraint" type="orm:unique-constraint" 
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="index" type="orm:index" 
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="catalog" type="xsd:string"/>
+    <xsd:attribute name="schema" type="xsd:string"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="column">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface Column {
+          String name() default "";
+          boolean unique() default false;
+          boolean nullable() default true;
+          boolean insertable() default true;
+          boolean updatable() default true;
+          String columnDefinition() default "";
+          String table() default "";
+          int length() default 255;
+          int precision() default 0; // decimal precision
+          int scale() default 0; // decimal scale
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="unique" type="xsd:boolean"/>
+    <xsd:attribute name="nullable" type="xsd:boolean"/>
+    <xsd:attribute name="insertable" type="xsd:boolean"/>
+    <xsd:attribute name="updatable" type="xsd:boolean"/>
+    <xsd:attribute name="column-definition" type="xsd:string"/>
+    <xsd:attribute name="table" type="xsd:string"/>
+    <xsd:attribute name="length" type="xsd:int"/>
+    <xsd:attribute name="precision" type="xsd:int"/>
+    <xsd:attribute name="scale" type="xsd:int"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="column-result">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({}) @Retention(RUNTIME)
+        public @interface ColumnResult {
+          String name();
+          Class type() default void.class;
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="class" type="xsd:string"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:simpleType name="constraint-mode">
+    <xsd:annotation>
+      <xsd:documentation>
+
+       public enum ConstraintMode {CONSTRAINT, NO_CONSTRAINT, PROVIDER_DEFAULT};
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="CONSTRAINT"/>
+      <xsd:enumeration value="NO_CONSTRAINT"/>
+      <xsd:enumeration value="PROVIDER_DEFAULT"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+<!-- **************************************************** -->
+
+
+  <xsd:complexType name="constructor-result">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({}) @Retention(RUNTIME)
+        public @interface ConstructorResult {
+          Class targetClass();
+          ColumnResult[] columns();
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="column" type="orm:column-result" 
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="target-class" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="convert">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({TYPE, METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface Convert {
+          Class converter() default void.class;
+          String attributeName() default "";
+          boolean disableConversion() default false;
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="converter" type="xsd:string"/>
+    <xsd:attribute name="attribute-name" type="xsd:string"/>
+    <xsd:attribute name="disable-conversion" type="xsd:boolean"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="converter">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({TYPE, METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface Converter {
+          boolean autoApply() default false;
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="class" type="xsd:string" use="required"/>
+    <xsd:attribute name="auto-apply" type="xsd:boolean"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="discriminator-column">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({TYPE}) @Retention(RUNTIME)
+        public @interface DiscriminatorColumn {
+          String name() default "DTYPE";
+          DiscriminatorType discriminatorType() default STRING;
+          String columnDefinition() default "";
+          int length() default 31;
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="discriminator-type" type="orm:discriminator-type"/>
+    <xsd:attribute name="column-definition" type="xsd:string"/>
+    <xsd:attribute name="length" type="xsd:int"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:simpleType name="discriminator-type">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        public enum DiscriminatorType { STRING, CHAR, INTEGER };
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="STRING"/>
+      <xsd:enumeration value="CHAR"/>
+      <xsd:enumeration value="INTEGER"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+<!-- **************************************************** -->
+
+  <xsd:simpleType name="discriminator-value">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({TYPE}) @Retention(RUNTIME)
+        public @interface DiscriminatorValue {
+          String value();
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string"/>
+  </xsd:simpleType>
+
+<!-- **************************************************** -->
+
+ <xsd:complexType name="element-collection">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface ElementCollection {
+          Class targetClass() default void.class;
+          FetchType fetch() default LAZY;
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:choice>
+        <xsd:element name="order-by" type="orm:order-by"
+                     minOccurs="0"/>
+        <xsd:element name="order-column" type="orm:order-column"
+                     minOccurs="0"/>
+      </xsd:choice>
+      <xsd:choice>
+        <xsd:element name="map-key" type="orm:map-key"
+                     minOccurs="0"/>
+        <xsd:sequence>
+          <xsd:element name="map-key-class" type="orm:map-key-class"
+                       minOccurs="0"/>
+          <xsd:choice>
+            <xsd:element name="map-key-temporal"
+                         type="orm:temporal"
+                         minOccurs="0"/>
+            <xsd:element name="map-key-enumerated"
+                         type="orm:enumerated"
+                         minOccurs="0"/>
+            <xsd:sequence>
+               <xsd:element name="map-key-attribute-override"
+                            type="orm:attribute-override"
+                            minOccurs="0" maxOccurs="unbounded"/>
+               <xsd:element name="map-key-convert" type="orm:convert"
+                            minOccurs="0" maxOccurs="unbounded"/>
+            </xsd:sequence>
+          </xsd:choice>
+          <xsd:choice>
+            <xsd:element name="map-key-column"
+                         type="orm:map-key-column"
+                         minOccurs="0"/>
+            <xsd:sequence>
+              <xsd:element name="map-key-join-column"
+                           type="orm:map-key-join-column"
+                           minOccurs="0" maxOccurs="unbounded"/>
+              <xsd:element name="map-key-foreign-key" 
+                           type="orm:foreign-key" 
+                           minOccurs="0"/>
+            </xsd:sequence>
+          </xsd:choice>
+        </xsd:sequence>
+      </xsd:choice>
+      <xsd:choice>
+        <xsd:sequence>
+          <xsd:element name="column" type="orm:column" minOccurs="0"/>
+          <xsd:choice>
+            <xsd:element name="temporal"
+                         type="orm:temporal"
+                         minOccurs="0"/>
+            <xsd:element name="enumerated"
+                         type="orm:enumerated"
+                         minOccurs="0"/>
+            <xsd:element name="lob"
+                         type="orm:lob"
+                         minOccurs="0"/>
+          </xsd:choice>
+        </xsd:sequence>
+        <xsd:sequence>
+          <xsd:element name="attribute-override"
+                       type="orm:attribute-override"
+                       minOccurs="0" maxOccurs="unbounded"/>
+          <xsd:element name="association-override"
+                       type="orm:association-override"
+                       minOccurs="0" maxOccurs="unbounded"/>
+          <xsd:element name="convert" type="orm:convert"
+                       minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
+      </xsd:choice>
+      <xsd:element name="collection-table" type="orm:collection-table"
+                     minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="target-class" type="xsd:string"/>
+    <xsd:attribute name="fetch" type="orm:fetch-type"/>
+    <xsd:attribute name="access" type="orm:access-type"/>
+</xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="embeddable">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Defines the settings and mappings for embeddable objects. Is 
+        allowed to be sparsely populated and used in conjunction with 
+        the annotations. Alternatively, the metadata-complete attribute 
+        can be used to indicate that no annotations are to be processed 
+        in the class. If this is the case then the defaulting rules will 
+        be recursively applied.
+
+        @Target({TYPE}) @Retention(RUNTIME)
+        public @interface Embeddable {}
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="attributes" type="orm:embeddable-attributes" 
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="class" type="xsd:string" use="required"/>
+    <xsd:attribute name="access" type="orm:access-type"/>
+    <xsd:attribute name="metadata-complete" type="xsd:boolean"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="embeddable-attributes">
+    <xsd:sequence>
+      <xsd:element name="basic" type="orm:basic" 
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="many-to-one" type="orm:many-to-one"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="one-to-many" type="orm:one-to-many"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="one-to-one" type="orm:one-to-one"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="many-to-many" type="orm:many-to-many" 
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="element-collection" type="orm:element-collection" 
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="embedded" type="orm:embedded"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="transient" type="orm:transient" 
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="embedded">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface Embedded {}
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="attribute-override" type="orm:attribute-override" 
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="association-override" 
+                   type="orm:association-override"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="convert" type="orm:convert"
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="access" type="orm:access-type"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="embedded-id">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface EmbeddedId {}
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="attribute-override" type="orm:attribute-override" 
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="access" type="orm:access-type"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="entity-listener">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Defines an entity listener to be invoked at lifecycle events
+        for the entities that list this listener.
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="pre-persist" type="orm:pre-persist" minOccurs="0"/>
+      <xsd:element name="post-persist" type="orm:post-persist" 
+                   minOccurs="0"/>
+      <xsd:element name="pre-remove" type="orm:pre-remove" minOccurs="0"/>
+      <xsd:element name="post-remove" type="orm:post-remove" minOccurs="0"/>
+      <xsd:element name="pre-update" type="orm:pre-update" minOccurs="0"/>
+      <xsd:element name="post-update" type="orm:post-update" minOccurs="0"/>
+      <xsd:element name="post-load" type="orm:post-load" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="class" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="entity-listeners">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({TYPE}) @Retention(RUNTIME)
+        public @interface EntityListeners {
+          Class[] value();
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="entity-listener" type="orm:entity-listener" 
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="entity-result">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({}) @Retention(RUNTIME)
+        public @interface EntityResult {
+          Class entityClass();
+          FieldResult[] fields() default {};
+          String discriminatorColumn() default "";
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="field-result" type="orm:field-result" 
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="entity-class" type="xsd:string" use="required"/>
+    <xsd:attribute name="discriminator-column" type="xsd:string"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:simpleType name="enum-type">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        public enum EnumType {
+          ORDINAL,
+          STRING
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="ORDINAL"/>
+      <xsd:enumeration value="STRING"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+<!-- **************************************************** -->
+
+  <xsd:simpleType name="enumerated">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface Enumerated {
+          EnumType value() default ORDINAL;
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="orm:enum-type"/>
+  </xsd:simpleType>
+
+<!-- **************************************************** -->
+
+  <xsd:simpleType name="fetch-type">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        public enum FetchType { LAZY, EAGER };
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="LAZY"/>
+      <xsd:enumeration value="EAGER"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="field-result">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({}) @Retention(RUNTIME)
+        public @interface FieldResult {
+          String name();
+          String column();
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="column" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="foreign-key">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({}) @Retention(RUNTIME)
+        public @interface ForeignKey {
+          String name() default "";
+	  ConstraintMode value() default CONSTRAINT;
+          String foreign-key-definition() default "";
+
+        Note that the elements that embed the use of the annotation
+        default this use as @ForeignKey(PROVIDER_DEFAULT).
+
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="constraint-mode" type="orm:constraint-mode"/>
+    <xsd:attribute name="foreign-key-definition" type="xsd:string"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="generated-value">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface GeneratedValue {
+          GenerationType strategy() default AUTO;
+          String generator() default "";
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="strategy" type="orm:generation-type"/>
+    <xsd:attribute name="generator" type="xsd:string"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:simpleType name="generation-type">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        public enum GenerationType { TABLE, SEQUENCE, IDENTITY, UUID, AUTO };
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="TABLE"/>
+      <xsd:enumeration value="SEQUENCE"/>
+      <xsd:enumeration value="IDENTITY"/>
+      <xsd:enumeration value="UUID"/>
+      <xsd:enumeration value="AUTO"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="id">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface Id {}
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="column" type="orm:column" 
+                   minOccurs="0"/>
+      <xsd:element name="generated-value" type="orm:generated-value"
+                   minOccurs="0"/>
+      <xsd:element name="temporal" type="orm:temporal" 
+                   minOccurs="0"/>
+      <xsd:element name="table-generator" type="orm:table-generator" 
+                   minOccurs="0"/>
+      <xsd:element name="sequence-generator" type="orm:sequence-generator"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="access" type="orm:access-type"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="id-class">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({TYPE}) @Retention(RUNTIME)
+        public @interface IdClass {
+          Class value();
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="class" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="index">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({}) @Retention(RUNTIME)
+        public @interface Index {
+          String name() default "";
+          String columnList();
+          boolean unique() default false;
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="column-list" type="xsd:string" use="required"/>
+    <xsd:attribute name="unique" type="xsd:boolean"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="inheritance">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({TYPE}) @Retention(RUNTIME)
+        public @interface Inheritance {
+          InheritanceType strategy() default SINGLE_TABLE;
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="strategy" type="orm:inheritance-type"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:simpleType name="inheritance-type">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        public enum InheritanceType
+          { SINGLE_TABLE, JOINED, TABLE_PER_CLASS};
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="SINGLE_TABLE"/>
+      <xsd:enumeration value="JOINED"/>
+      <xsd:enumeration value="TABLE_PER_CLASS"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="join-column">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface JoinColumn {
+          String name() default "";
+          String referencedColumnName() default "";
+          boolean unique() default false;
+          boolean nullable() default true;
+          boolean insertable() default true;
+          boolean updatable() default true;
+          String columnDefinition() default "";
+          String table() default "";
+          ForeignKey foreignKey() default @ForeignKey();
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="referenced-column-name" type="xsd:string"/>
+    <xsd:attribute name="unique" type="xsd:boolean"/>
+    <xsd:attribute name="nullable" type="xsd:boolean"/>
+    <xsd:attribute name="insertable" type="xsd:boolean"/>
+    <xsd:attribute name="updatable" type="xsd:boolean"/>
+    <xsd:attribute name="column-definition" type="xsd:string"/>
+    <xsd:attribute name="table" type="xsd:string"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="join-table">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface JoinTable {
+          String name() default "";
+          String catalog() default "";
+          String schema() default "";
+          JoinColumn[] joinColumns() default {};
+          JoinColumn[] inverseJoinColumns() default {};
+          UniqueConstraint[] uniqueConstraints() default {};
+          Index[] indexes() default {};
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:sequence>
+        <xsd:element name="join-column" type="orm:join-column" 
+                     minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element name="foreign-key" type="orm:foreign-key" 
+                     minOccurs="0"/>
+      </xsd:sequence>
+      <xsd:sequence>
+        <xsd:element name="inverse-join-column" type="orm:join-column" 
+                     minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element name="inverse-foreign-key" type="orm:foreign-key" 
+                     minOccurs="0"/>
+      </xsd:sequence>
+      <xsd:element name="unique-constraint" type="orm:unique-constraint" 
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="index" type="orm:index" 
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="catalog" type="xsd:string"/>
+    <xsd:attribute name="schema" type="xsd:string"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="lob">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface Lob {}
+
+      </xsd:documentation>
+    </xsd:annotation>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:simpleType name="lock-mode-type">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        public enum LockModeType { READ, WRITE, OPTIMISTIC, OPTIMISTIC_FORCE_INCREMENT, PESSIMISTIC_READ, PESSIMISTIC_WRITE, PESSIMISTIC_FORCE_INCREMENT, NONE};
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="READ"/>
+      <xsd:enumeration value="WRITE"/>
+      <xsd:enumeration value="OPTIMISTIC"/>
+      <xsd:enumeration value="OPTIMISTIC_FORCE_INCREMENT"/>
+      <xsd:enumeration value="PESSIMISTIC_READ"/>
+      <xsd:enumeration value="PESSIMISTIC_WRITE"/>
+      <xsd:enumeration value="PESSIMISTIC_FORCE_INCREMENT"/>
+      <xsd:enumeration value="NONE"/>
+
+    </xsd:restriction>
+  </xsd:simpleType>
+
+<!-- **************************************************** -->
+
+<xsd:complexType name="many-to-many">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface ManyToMany {
+          Class targetEntity() default void.class;
+          CascadeType[] cascade() default {};
+          FetchType fetch() default LAZY;
+          String mappedBy() default "";
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:choice>
+        <xsd:element name="order-by" type="orm:order-by"
+                   minOccurs="0"/>
+        <xsd:element name="order-column" type="orm:order-column"
+                   minOccurs="0"/>
+      </xsd:choice>
+      <xsd:choice>
+        <xsd:element name="map-key" type="orm:map-key"
+                   minOccurs="0"/>
+        <xsd:sequence>
+          <xsd:element name="map-key-class" type="orm:map-key-class"
+                   minOccurs="0"/>
+          <xsd:choice>
+            <xsd:element name="map-key-temporal"
+                         type="orm:temporal"
+                         minOccurs="0"/>
+            <xsd:element name="map-key-enumerated"
+                         type="orm:enumerated"
+                         minOccurs="0"/>
+            <xsd:sequence>
+               <xsd:element name="map-key-attribute-override"
+                            type="orm:attribute-override"
+                            minOccurs="0" maxOccurs="unbounded"/>
+               <xsd:element name="map-key-convert" type="orm:convert"
+                            minOccurs="0" maxOccurs="unbounded"/>
+            </xsd:sequence>
+          </xsd:choice>
+          <xsd:choice>
+            <xsd:element name="map-key-column" type="orm:map-key-column"
+                   minOccurs="0"/>
+            <xsd:sequence>
+              <xsd:element name="map-key-join-column"
+                     type="orm:map-key-join-column"
+                     minOccurs="0" maxOccurs="unbounded"/>
+              <xsd:element name="map-key-foreign-key" 
+                           type="orm:foreign-key" 
+                           minOccurs="0"/>
+            </xsd:sequence>
+          </xsd:choice>
+        </xsd:sequence>
+      </xsd:choice>
+      <xsd:element name="join-table" type="orm:join-table"
+                   minOccurs="0"/>
+      <xsd:element name="cascade" type="orm:cascade-type"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="target-entity" type="xsd:string"/>
+    <xsd:attribute name="fetch" type="orm:fetch-type"/>
+    <xsd:attribute name="access" type="orm:access-type"/>
+    <xsd:attribute name="mapped-by" type="xsd:string"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="many-to-one">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface ManyToOne {
+          Class targetEntity() default void.class;
+          CascadeType[] cascade() default {};
+          FetchType fetch() default EAGER;
+          boolean optional() default true;
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:choice>       
+        <xsd:sequence>
+          <xsd:element name="join-column" type="orm:join-column" 
+                       minOccurs="0" maxOccurs="unbounded"/>
+          <xsd:element name="foreign-key" type="orm:foreign-key" 
+                       minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:element name="join-table" type="orm:join-table" 
+                     minOccurs="0"/>
+      </xsd:choice>       
+      <xsd:element name="cascade" type="orm:cascade-type" 
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="target-entity" type="xsd:string"/>
+    <xsd:attribute name="fetch" type="orm:fetch-type"/>
+    <xsd:attribute name="optional" type="xsd:boolean"/>
+    <xsd:attribute name="access" type="orm:access-type"/>
+    <xsd:attribute name="maps-id" type="xsd:string"/>
+    <xsd:attribute name="id" type="xsd:boolean"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="map-key">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface MapKey {
+          String name() default "";
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="name" type="xsd:string"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="map-key-class">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface MapKeyClass {
+          Class value();
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="class" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="map-key-column">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface MapKeyColumn {
+          String name() default "";
+          boolean unique() default false;
+          boolean nullable() default false;
+          boolean insertable() default true;
+          boolean updatable() default true;
+          String columnDefinition() default "";
+          String table() default "";
+          int length() default 255;
+          int precision() default 0; // decimal precision
+          int scale() default 0; // decimal scale
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="unique" type="xsd:boolean"/>
+    <xsd:attribute name="nullable" type="xsd:boolean"/>
+    <xsd:attribute name="insertable" type="xsd:boolean"/>
+    <xsd:attribute name="updatable" type="xsd:boolean"/>
+    <xsd:attribute name="column-definition" type="xsd:string"/>
+    <xsd:attribute name="table" type="xsd:string"/>
+    <xsd:attribute name="length" type="xsd:int"/>
+    <xsd:attribute name="precision" type="xsd:int"/>
+    <xsd:attribute name="scale" type="xsd:int"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="map-key-join-column">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface MapKeyJoinColumn {
+          String name() default "";
+          String referencedColumnName() default "";
+          boolean unique() default false;
+          boolean nullable() default false;
+          boolean insertable() default true;
+          boolean updatable() default true;
+          String columnDefinition() default "";
+          String table() default "";
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="referenced-column-name" type="xsd:string"/>
+    <xsd:attribute name="unique" type="xsd:boolean"/>
+    <xsd:attribute name="nullable" type="xsd:boolean"/>
+    <xsd:attribute name="insertable" type="xsd:boolean"/>
+    <xsd:attribute name="updatable" type="xsd:boolean"/>
+    <xsd:attribute name="column-definition" type="xsd:string"/>
+    <xsd:attribute name="table" type="xsd:string"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="mapped-superclass">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Defines the settings and mappings for a mapped superclass. Is 
+        allowed to be sparsely populated and used in conjunction with 
+        the annotations. Alternatively, the metadata-complete attribute 
+        can be used to indicate that no annotations are to be processed 
+        If this is the case then the defaulting rules will be recursively 
+        applied.
+
+        @Target(TYPE) @Retention(RUNTIME)
+        public @interface MappedSuperclass{}
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="id-class" type="orm:id-class" minOccurs="0"/>
+      <xsd:element name="exclude-default-listeners" type="orm:emptyType" 
+                   minOccurs="0"/>
+      <xsd:element name="exclude-superclass-listeners" type="orm:emptyType" 
+                   minOccurs="0"/>
+      <xsd:element name="entity-listeners" type="orm:entity-listeners" 
+                   minOccurs="0"/>
+      <xsd:element name="pre-persist" type="orm:pre-persist" minOccurs="0"/>
+      <xsd:element name="post-persist" type="orm:post-persist" 
+                   minOccurs="0"/>
+      <xsd:element name="pre-remove" type="orm:pre-remove" minOccurs="0"/>
+      <xsd:element name="post-remove" type="orm:post-remove" minOccurs="0"/>
+      <xsd:element name="pre-update" type="orm:pre-update" minOccurs="0"/>
+      <xsd:element name="post-update" type="orm:post-update" minOccurs="0"/>
+      <xsd:element name="post-load" type="orm:post-load" minOccurs="0"/>
+      <xsd:element name="attributes" type="orm:attributes" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="class" type="xsd:string" use="required"/>
+    <xsd:attribute name="access" type="orm:access-type"/>
+    <xsd:attribute name="metadata-complete" type="xsd:boolean"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="named-attribute-node">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({}) @Retention(RUNTIME)
+        public @interface NamedAttributeNode {
+          String value();
+          String subgraph() default "";
+          String keySubgraph() default "";
+        }
+ 
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="subgraph" type="xsd:string"/>
+    <xsd:attribute name="key-subgraph" type="xsd:string"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="named-entity-graph">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({TYPE}) @Retention(RUNTIME)
+        public @interface NamedEntityGraph {
+          String name() default "";
+          NamedAttributeNode[] attributeNodes() default {};
+          boolean includeAllAttributes() default false;
+          NamedSubgraph[] subgraphs() default {};
+          NamedSubGraph[] subclassSubgraphs() default {};
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="named-attribute-node" 
+                   type="orm:named-attribute-node" 
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="subgraph" 
+                   type="orm:named-subgraph" 
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="subclass-subgraph" 
+                   type="orm:named-subgraph" 
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="include-all-attributes" type="xsd:boolean"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="named-native-query">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({TYPE}) @Retention(RUNTIME)
+        public @interface NamedNativeQuery {
+          String name();
+          String query();
+          QueryHint[] hints() default {};
+          Class resultClass() default void.class;
+          String resultSetMapping() default ""; //named SqlResultSetMapping
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="query" type="xsd:string"/>
+      <xsd:element name="hint" type="orm:query-hint" 
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="result-class" type="xsd:string"/>
+    <xsd:attribute name="result-set-mapping" type="xsd:string"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="named-query">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({TYPE}) @Retention(RUNTIME)
+        public @interface NamedQuery {
+          String name();
+          String query();
+          LockModeType lockMode() default NONE;
+          QueryHint[] hints() default {};
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="query" type="xsd:string"/>
+      <xsd:element name="lock-mode" type="orm:lock-mode-type" minOccurs="0"/>
+      <xsd:element name="hint" type="orm:query-hint" 
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+</xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="named-stored-procedure-query">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({TYPE}) @Retention(RUNTIME)
+        public @interface NamedStoredProcedureQuery {
+          String name();
+          String procedureName();
+          StoredProcedureParameter[] parameters() default {};
+          Class[] resultClasses() default {};
+          String[] resultSetMappings() default{};
+          QueryHint[] hints() default {};
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="parameter" 
+                   type="orm:stored-procedure-parameter" 
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="result-class" type="xsd:string"  
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="result-set-mapping" type="xsd:string"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="hint" type="orm:query-hint" 
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="procedure-name" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="named-subgraph">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({}) @Retention(RUNTIME)
+        public @interface NamedSubgraph {
+          String name();
+          Class type() default void.class;
+          NamedAttributeNode[] attributeNodes();
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="named-attribute-node" 
+                   type="orm:named-attribute-node" 
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="class" type="xsd:string"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+<xsd:complexType name="one-to-many">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface OneToMany {
+          Class targetEntity() default void.class;
+          CascadeType[] cascade() default {};
+          FetchType fetch() default LAZY;
+          String mappedBy() default "";
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:choice>
+        <xsd:element name="order-by" type="orm:order-by"
+                   minOccurs="0"/>
+        <xsd:element name="order-column" type="orm:order-column"
+                   minOccurs="0"/>
+      </xsd:choice>
+      <xsd:choice>
+        <xsd:element name="map-key" type="orm:map-key"
+                   minOccurs="0"/>
+        <xsd:sequence>
+          <xsd:element name="map-key-class" type="orm:map-key-class"
+                   minOccurs="0"/>
+          <xsd:choice>
+            <xsd:element name="map-key-temporal"
+                         type="orm:temporal"
+                         minOccurs="0"/>
+            <xsd:element name="map-key-enumerated"
+                         type="orm:enumerated"
+                         minOccurs="0"/>
+            <xsd:sequence>
+               <xsd:element name="map-key-attribute-override"
+                            type="orm:attribute-override"
+                            minOccurs="0" maxOccurs="unbounded"/>
+               <xsd:element name="map-key-convert" type="orm:convert"
+                            minOccurs="0" maxOccurs="unbounded"/>
+            </xsd:sequence>
+          </xsd:choice>
+          <xsd:choice>
+            <xsd:element name="map-key-column" type="orm:map-key-column"
+                   minOccurs="0"/>
+            <xsd:sequence>
+              <xsd:element name="map-key-join-column"
+                           type="orm:map-key-join-column"
+                           minOccurs="0" maxOccurs="unbounded"/>
+              <xsd:element name="map-key-foreign-key" 
+                           type="orm:foreign-key" 
+                           minOccurs="0"/>
+            </xsd:sequence>
+          </xsd:choice>
+        </xsd:sequence>
+      </xsd:choice>
+      <xsd:choice>
+        <xsd:element name="join-table" type="orm:join-table"
+                     minOccurs="0"/>
+        <xsd:sequence>
+          <xsd:element name="join-column" type="orm:join-column"
+                       minOccurs="0" maxOccurs="unbounded"/>
+          <xsd:element name="foreign-key" type="orm:foreign-key" 
+                       minOccurs="0"/>
+        </xsd:sequence>
+      </xsd:choice>
+      <xsd:element name="cascade" type="orm:cascade-type"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="target-entity" type="xsd:string"/>
+    <xsd:attribute name="fetch" type="orm:fetch-type"/>
+    <xsd:attribute name="access" type="orm:access-type"/>
+    <xsd:attribute name="mapped-by" type="xsd:string"/>
+    <xsd:attribute name="orphan-removal" type="xsd:boolean"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="one-to-one">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface OneToOne {
+          Class targetEntity() default void.class;
+          CascadeType[] cascade() default {};
+          FetchType fetch() default EAGER;
+          boolean optional() default true;
+          String mappedBy() default "";
+          boolean orphanRemoval() default false;
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:choice>
+        <xsd:sequence>
+          <xsd:element name="primary-key-join-column" 
+                       type="orm:primary-key-join-column" 
+                       minOccurs="0" maxOccurs="unbounded"/>
+          <xsd:element name="primary-key-foreign-key" 
+                       type="orm:foreign-key" 
+                       minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:sequence>
+          <xsd:element name="join-column" type="orm:join-column" 
+                       minOccurs="0" maxOccurs="unbounded"/>
+          <xsd:element name="foreign-key" type="orm:foreign-key" 
+                       minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:element name="join-table" type="orm:join-table" 
+                     minOccurs="0"/>
+      </xsd:choice>
+      <xsd:element name="cascade" type="orm:cascade-type" 
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="target-entity" type="xsd:string"/>
+    <xsd:attribute name="fetch" type="orm:fetch-type"/>
+    <xsd:attribute name="optional" type="xsd:boolean"/>
+    <xsd:attribute name="access" type="orm:access-type"/>
+    <xsd:attribute name="mapped-by" type="xsd:string"/>
+    <xsd:attribute name="orphan-removal" type="xsd:boolean"/>
+    <xsd:attribute name="maps-id" type="xsd:string"/>
+    <xsd:attribute name="id" type="xsd:boolean"/>
+</xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:simpleType name="order-by">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface OrderBy {
+          String value() default "";
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string"/>
+  </xsd:simpleType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="order-column">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface OrderColumn {
+          String name() default "";
+          boolean nullable() default true;
+          boolean insertable() default true;
+          boolean updatable() default true;
+          String columnDefinition() default "";
+         }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="nullable" type="xsd:boolean"/>
+    <xsd:attribute name="insertable" type="xsd:boolean"/>
+    <xsd:attribute name="updatable" type="xsd:boolean"/>
+    <xsd:attribute name="column-definition" type="xsd:string"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:simpleType name="parameter-mode">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        public enum ParameterMode { IN, INOUT, OUT, REF_CURSOR};
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="IN"/>
+      <xsd:enumeration value="INOUT"/>
+      <xsd:enumeration value="OUT"/>
+      <xsd:enumeration value="REF_CURSOR"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="post-load">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD}) @Retention(RUNTIME)
+        public @interface PostLoad {}
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="method-name" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="post-persist">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD}) @Retention(RUNTIME)
+        public @interface PostPersist {}
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="method-name" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="post-remove">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD}) @Retention(RUNTIME)
+        public @interface PostRemove {}
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="method-name" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="post-update">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD}) @Retention(RUNTIME)
+        public @interface PostUpdate {}
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="method-name" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="pre-persist">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD}) @Retention(RUNTIME)
+        public @interface PrePersist {}
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="method-name" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="pre-remove">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD}) @Retention(RUNTIME)
+        public @interface PreRemove {}
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="method-name" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="pre-update">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD}) @Retention(RUNTIME)
+        public @interface PreUpdate {}
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="method-name" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="primary-key-join-column">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({TYPE, METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface PrimaryKeyJoinColumn {
+          String name() default "";
+          String referencedColumnName() default "";
+          String columnDefinition() default "";
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="referenced-column-name" type="xsd:string"/>
+    <xsd:attribute name="column-definition" type="xsd:string"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="query-hint">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({}) @Retention(RUNTIME) 
+        public @interface QueryHint {
+          String name();
+          String value();
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="value" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="secondary-table">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({TYPE}) @Retention(RUNTIME)
+        public @interface SecondaryTable {
+          String name();
+          String catalog() default "";
+          String schema() default "";
+          PrimaryKeyJoinColumn[] pkJoinColumns() default {};
+          UniqueConstraint[] uniqueConstraints() default {};
+          Index[] indexes() default {};
+         }
+
+       </xsd:documentation>
+     </xsd:annotation>
+     <xsd:sequence>
+       <xsd:sequence>
+         <xsd:element name="primary-key-join-column" 
+                      type="orm:primary-key-join-column" 
+                      minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element name="primary-key-foreign-key" 
+                      type="orm:foreign-key" 
+                      minOccurs="0"/>
+       </xsd:sequence>
+       <xsd:element name="unique-constraint" type="orm:unique-constraint" 
+                    minOccurs="0" maxOccurs="unbounded"/>
+       <xsd:element name="index" type="orm:index" 
+                    minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="catalog" type="xsd:string"/>
+    <xsd:attribute name="schema" type="xsd:string"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="sequence-generator">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({TYPE, METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface SequenceGenerator {
+          String name();
+          String sequenceName() default "";
+          String catalog() default "";
+          String schema() default "";
+          int initialValue() default 1;
+          int allocationSize() default 50;
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="sequence-name" type="xsd:string"/>
+    <xsd:attribute name="catalog" type="xsd:string"/>
+    <xsd:attribute name="schema" type="xsd:string"/>
+    <xsd:attribute name="initial-value" type="xsd:int"/>
+    <xsd:attribute name="allocation-size" type="xsd:int"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="sql-result-set-mapping">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({TYPE}) @Retention(RUNTIME)
+        public @interface SqlResultSetMapping {
+          String name();
+          EntityResult[] entities() default {};
+          ConstructorResult[] classes() default{};
+          ColumnResult[] columns() default {};
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="entity-result" type="orm:entity-result" 
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="constructor-result" type="orm:constructor-result" 
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="column-result" type="orm:column-result" 
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="stored-procedure-parameter">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({TYPE}) @Retention(RUNTIME)
+        public @interface StoredProcedureParameter {
+          String name() default "";
+          ParameterMode mode() default ParameterMode.IN;
+          Class type();
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" 
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="class" type="xsd:string" use="required"/>
+    <xsd:attribute name="mode" type="orm:parameter-mode"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="table">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({TYPE}) @Retention(RUNTIME)
+        public @interface Table {
+          String name() default "";
+          String catalog() default "";
+          String schema() default "";
+          UniqueConstraint[] uniqueConstraints() default {};
+          Index[] indexes() default {};
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="unique-constraint" type="orm:unique-constraint" 
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="index" type="orm:index" 
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="catalog" type="xsd:string"/>
+    <xsd:attribute name="schema" type="xsd:string"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="table-generator">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({TYPE, METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface TableGenerator {
+          String name();
+          String table() default "";
+          String catalog() default "";
+          String schema() default "";
+          String pkColumnName() default "";
+          String valueColumnName() default "";
+          String pkColumnValue() default "";
+          int initialValue() default 0;
+          int allocationSize() default 50;
+          UniqueConstraint[] uniqueConstraints() default {};
+          Indexes[] indexes() default {};
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="unique-constraint" type="orm:unique-constraint" 
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="index" type="orm:index" 
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="table" type="xsd:string"/>
+    <xsd:attribute name="catalog" type="xsd:string"/>
+    <xsd:attribute name="schema" type="xsd:string"/>
+    <xsd:attribute name="pk-column-name" type="xsd:string"/>
+    <xsd:attribute name="value-column-name" type="xsd:string"/>
+    <xsd:attribute name="pk-column-value" type="xsd:string"/>
+    <xsd:attribute name="initial-value" type="xsd:int"/>
+    <xsd:attribute name="allocation-size" type="xsd:int"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:simpleType name="temporal">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface Temporal {
+          TemporalType value();
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="orm:temporal-type"/>
+  </xsd:simpleType>
+
+  <!-- **************************************************** -->
+
+  <xsd:simpleType name="temporal-type">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        public enum TemporalType {
+          DATE, // java.sql.Date
+          TIME, // java.sql.Time
+          TIMESTAMP // java.sql.Timestamp
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+      <xsd:restriction base="xsd:token">
+        <xsd:enumeration value="DATE"/>
+        <xsd:enumeration value="TIME"/>
+        <xsd:enumeration value="TIMESTAMP"/>
+     </xsd:restriction>
+  </xsd:simpleType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="transient">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface Transient {}
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="unique-constraint">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({}) @Retention(RUNTIME)
+        public @interface UniqueConstraint {
+          String name() default "";
+          String[] columnNames();
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="column-name" type="xsd:string" 
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="version">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface Version {}
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="column" type="orm:column" minOccurs="0"/>
+      <xsd:element name="temporal" type="orm:temporal" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="access" type="orm:access-type"/>
+  </xsd:complexType>
+
+</xsd:schema>


### PR DESCRIPTION
This code change add into EclipseLink new ORM 3.1 schema from JPA 3.1.
There is also version fix in `eclipselink_orm_3_0.xsd`.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>