### PR TITLE
Modified getLogString with more NULL Safety

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/StoredProcedureCall.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/StoredProcedureCall.java
@@ -1116,12 +1116,12 @@ public class StoredProcedureCall extends DatabaseCall {
         }
     }
 
-	private boolean isIndexBased(List<String> procedureArgs, AbstractSession session) {
-    	boolean hasNoArgs = procedureArgs.size() == 0 || procedureArgs.get(0) == null;
-    	boolean isNamingIntoIndexed = false;
-    	if (session != null && session.getProject() != null) {
-    		isNamingIntoIndexed = session.getProject().namingIntoIndexed();
-    	}
-    	return hasNoArgs || isNamingIntoIndexed;
+    private boolean isIndexBased(List<String> procedureArgs, AbstractSession session) {
+        boolean hasNoArgs = procedureArgs.size() == 0 || procedureArgs.get(0) == null;
+        boolean isNamingIntoIndexed = false;
+        if (session != null && session.getProject() != null) {
+            isNamingIntoIndexed = session.getProject().namingIntoIndexed();
+        }
+        return hasNoArgs || isNamingIntoIndexed;
     }
 }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/StoredProcedureCall.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/StoredProcedureCall.java
@@ -1099,7 +1099,7 @@ public class StoredProcedureCall extends DatabaseCall {
                     session = getQuery().getSession();
                 }
                 List<String> procedureArgs = getProcedureArgumentNames();
-                boolean indexBased = procedureArgs.size() == 0 || procedureArgs.get(0) == null || session.getProject().namingIntoIndexed();
+                boolean indexBased = isIndexBased(procedureArgs, session);
                 Collection<String> parameters = new ArrayList<>();
                 for (int index = 0; index < getParameters().size(); index++) {
                     if (indexBased) {
@@ -1114,5 +1114,14 @@ public class StoredProcedureCall extends DatabaseCall {
         } else {
             return getSQLString();
         }
+    }
+
+	private boolean isIndexBased(List<String> procedureArgs, AbstractSession session) {
+    	boolean hasNoArgs = procedureArgs.size() == 0 || procedureArgs.get(0) == null;
+    	boolean isNamingIntoIndexed = false;
+    	if (session != null && session.getProject() != null) {
+    		isNamingIntoIndexed = session.getProject().namingIntoIndexed();
+    	}
+    	return hasNoArgs || isNamingIntoIndexed;
     }
 }


### PR DESCRIPTION
The old implementation causes a NPE if the `session` or the `project` is null in line 1102.  This new implementation of will not.

The session being NULL is plausible, because the `appendLogParameters` function, which is called in line 1111, starts with a NULL check.