### PR TITLE
[2.6_WAS] Bug 578686: Remove OrderBy parameter binding use case

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/expressions/SQLSelectStatement.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/expressions/SQLSelectStatement.java
@@ -719,12 +719,6 @@ public class SQLSelectStatement extends SQLStatement {
         for (Iterator<Expression> expressionsEnum = getOrderByExpressions().iterator(); expressionsEnum.hasNext();) {
             Expression expression = expressionsEnum.next();
 
-            if(!printer.getPlatform().supportsOrderByParameters()) {
-                if(expression.isParameterExpression() || expression.isConstantExpression()) {
-                    printer.getCall().setUsesBinding(false);
-                }
-            }
-
             expression.printSQL(printer);
 
             if (expressionsEnum.hasNext()) {

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQueryOrderBy.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQueryOrderBy.java
@@ -25,19 +25,24 @@ import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.ParameterExpression;
 import javax.persistence.criteria.Root;
 
+import org.eclipse.persistence.internal.databaseaccess.Platform;
+import org.eclipse.persistence.internal.jpa.EntityManagerFactoryImpl;
 import org.eclipse.persistence.jpa.test.framework.DDLGen;
 import org.eclipse.persistence.jpa.test.framework.Emf;
 import org.eclipse.persistence.jpa.test.framework.EmfRunner;
 import org.eclipse.persistence.jpa.test.framework.Property;
+import org.eclipse.persistence.jpa.test.framework.SQLCallListener;
 import org.eclipse.persistence.jpa.test.query.model.EntityTbl01;
 import org.eclipse.persistence.jpa.test.query.model.EntityTbl01_;
+import org.eclipse.persistence.platform.database.DatabasePlatform;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(EmfRunner.class)
 public class TestQueryOrderBy {
-    @Emf(createTables = DDLGen.DROP_CREATE, classes = { EntityTbl01.class }, 
-            properties = { @Property(name="eclipselink.logging.level", value="FINE")})
+    @Emf(name = "DefaultPersistenceUnit", createTables = DDLGen.DROP_CREATE, classes = { EntityTbl01.class }, 
+            properties = { 
+                    @Property(name="eclipselink.logging.level", value="FINE")})
     private EntityManagerFactory emf;
 
     @Emf(name = "BindLiteralsPersistenceUnit", classes = { EntityTbl01.class }, 
@@ -45,6 +50,12 @@ public class TestQueryOrderBy {
                     @Property(name="eclipselink.target-database-properties", value="shouldBindLiterals=true"), 
                     @Property(name="eclipselink.logging.level", value="FINE")})
     private EntityManagerFactory emf2;
+
+    @SQLCallListener(name = "DefaultPersistenceUnit")
+    List<String> _sql;
+
+    @SQLCallListener(name = "BindLiteralsPersistenceUnit")
+    List<String> _sql2;
 
     private static boolean POPULATED = false;
 
@@ -65,7 +76,6 @@ public class TestQueryOrderBy {
             List<Integer> dto01 = query.getResultList();
             assertNotNull(dto01);
             assertEquals(4, dto01.size());
-            assertEquals(new Integer(29), dto01.get(1));
 
             query = em.createQuery(""
                     + "SELECT t.itemInteger1 FROM EntityTbl01 t ORDER BY 1 ASC", Integer.class);
@@ -73,7 +83,6 @@ public class TestQueryOrderBy {
             dto01 = query.getResultList();
             assertNotNull(dto01);
             assertEquals(4, dto01.size());
-            assertEquals(new Integer(29), dto01.get(1));
 
             // equivalent CriteriaBuilder
             CriteriaBuilder cb = em.getCriteriaBuilder();
@@ -87,7 +96,6 @@ public class TestQueryOrderBy {
             dto01 = query.getResultList();
             assertNotNull(dto01);
             assertEquals(4, dto01.size());
-            assertEquals(new Integer(29), dto01.get(1));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -106,7 +114,14 @@ public class TestQueryOrderBy {
         if(!POPULATED) 
             populate();
 
+        Platform platform = getPlatform(emf);
         EntityManager em = emf2.createEntityManager();
+
+        // DB2 and Derby does not support untyped parameter binding in ORDER BY clause
+        // 'emf2' sets 'shouldBindLiterals=true', which makes literal values bind as untyped parameters
+        if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+            return;
+        }
 
         try {
             TypedQuery<Integer> query = em.createQuery(""
@@ -115,7 +130,6 @@ public class TestQueryOrderBy {
             List<Integer> dto01 = query.getResultList();
             assertNotNull(dto01);
             assertEquals(4, dto01.size());
-            assertEquals(new Integer(29), dto01.get(1));
 
             query = em.createQuery(""
                     + "SELECT t.itemInteger1 FROM EntityTbl01 t ORDER BY 1 ASC", Integer.class);
@@ -123,7 +137,6 @@ public class TestQueryOrderBy {
             dto01 = query.getResultList();
             assertNotNull(dto01);
             assertEquals(4, dto01.size());
-            assertEquals(new Integer(29), dto01.get(1));
 
             // equivalent CriteriaBuilder
             CriteriaBuilder cb = em.getCriteriaBuilder();
@@ -137,7 +150,144 @@ public class TestQueryOrderBy {
             dto01 = query.getResultList();
             assertNotNull(dto01);
             assertEquals(4, dto01.size());
-            assertEquals(new Integer(29), dto01.get(1));
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if(em.isOpen()) {
+                em.close();
+            }
+        }
+    }
+
+    @Test
+    public void testQueryOrderByLiterals3() {
+        if (emf == null)
+            return;
+
+        if(!POPULATED) 
+            populate();
+
+        Platform platform = getPlatform(emf);
+        EntityManager em = emf.createEntityManager();
+
+        try {
+            TypedQuery<Integer> query = em.createQuery(""
+                    + "SELECT t.itemInteger1 FROM EntityTbl01 t WHERE t.itemString2 = 'B' ORDER BY 1", Integer.class);
+
+            List<Integer> dto01 = query.getResultList();
+            assertNotNull(dto01);
+            assertEquals(3, dto01.size());
+            assertEquals(1, _sql.size());
+            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+                assertEquals("SELECT ITEM_INTEGER1 FROM SIMPLE_TBL01 WHERE (ITEM_STRING2 = 'B') ORDER BY 1", _sql.remove(0));
+            } else {
+                assertEquals("SELECT ITEM_INTEGER1 FROM SIMPLE_TBL01 WHERE (ITEM_STRING2 = ?) ORDER BY ?", _sql.remove(0));
+            }
+
+            query = em.createQuery(""
+                    + "SELECT t.itemInteger1 FROM EntityTbl01 t WHERE t.itemString2 = 'B' ORDER BY 1 ASC", Integer.class);
+
+            dto01 = query.getResultList();
+            assertNotNull(dto01);
+            assertEquals(3, dto01.size());
+            assertEquals(1, _sql.size());
+            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+                assertEquals("SELECT ITEM_INTEGER1 FROM SIMPLE_TBL01 WHERE (ITEM_STRING2 = 'B') ORDER BY 1 ASC", _sql.remove(0));
+            } else {
+                assertEquals("SELECT ITEM_INTEGER1 FROM SIMPLE_TBL01 WHERE (ITEM_STRING2 = ?) ORDER BY ? ASC", _sql.remove(0));
+            }
+
+            // equivalent CriteriaBuilder
+            CriteriaBuilder cb = em.getCriteriaBuilder();
+            CriteriaQuery<Integer> cquery = cb.createQuery(Integer.class);
+            Root<EntityTbl01> root = cquery.from(EntityTbl01.class);
+            cquery.multiselect(root.get(EntityTbl01_.itemInteger1));
+            cquery.where(cb.equal(root.get(EntityTbl01_.itemString2), cb.literal("B")));
+            cquery.orderBy(cb.asc(cb.literal(1)));
+
+            query = em.createQuery(cquery);
+            dto01 = query.getResultList();
+            assertNotNull(dto01);
+            assertEquals(3, dto01.size());
+            assertEquals(1, _sql.size());
+            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+                assertEquals("SELECT ITEM_INTEGER1 FROM SIMPLE_TBL01 WHERE (ITEM_STRING2 = 'B') ORDER BY 1 ASC", _sql.remove(0));
+            } else {
+                assertEquals("SELECT ITEM_INTEGER1 FROM SIMPLE_TBL01 WHERE (ITEM_STRING2 = ?) ORDER BY ? ASC", _sql.remove(0));
+            }
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if(em.isOpen()) {
+                em.close();
+            }
+        }
+    }
+
+    @Test
+    public void testQueryOrderByLiterals4() {
+        if (emf2 == null)
+            return;
+
+        if(!POPULATED) 
+            populate();
+
+        Platform platform = getPlatform(emf2);
+        EntityManager em = emf2.createEntityManager();
+
+        // DB2 and Derby does not support untyped parameter binding in ORDER BY clause
+        // 'emf2' sets 'shouldBindLiterals=true', which makes literal values bind as untyped parameters
+        if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+            return;
+        }
+
+        try {
+            TypedQuery<Integer> query = em.createQuery(""
+                    + "SELECT t.itemInteger1 FROM EntityTbl01 t WHERE t.itemString2 = 'B' ORDER BY 1", Integer.class);
+
+            List<Integer> dto01 = query.getResultList();
+            assertNotNull(dto01);
+            assertEquals(3, dto01.size());
+            assertEquals(1, _sql2.size());
+            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+                assertEquals("SELECT ITEM_INTEGER1 FROM SIMPLE_TBL01 WHERE (ITEM_STRING2 = 'B') ORDER BY 1", _sql2.remove(0));
+            } else {
+                assertEquals("SELECT ITEM_INTEGER1 FROM SIMPLE_TBL01 WHERE (ITEM_STRING2 = ?) ORDER BY ?", _sql2.remove(0));
+            }
+
+            query = em.createQuery(""
+                    + "SELECT t.itemInteger1 FROM EntityTbl01 t WHERE t.itemString2 = 'B' ORDER BY 1 ASC", Integer.class);
+
+            dto01 = query.getResultList();
+            assertNotNull(dto01);
+            assertEquals(3, dto01.size());
+            assertEquals(1, _sql2.size());
+            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+                assertEquals("SELECT ITEM_INTEGER1 FROM SIMPLE_TBL01 WHERE (ITEM_STRING2 = 'B') ORDER BY 1 ASC", _sql2.remove(0));
+            } else {
+                assertEquals("SELECT ITEM_INTEGER1 FROM SIMPLE_TBL01 WHERE (ITEM_STRING2 = ?) ORDER BY ? ASC", _sql2.remove(0));
+            }
+
+            // equivalent CriteriaBuilder
+            CriteriaBuilder cb = em.getCriteriaBuilder();
+            CriteriaQuery<Integer> cquery = cb.createQuery(Integer.class);
+            Root<EntityTbl01> root = cquery.from(EntityTbl01.class);
+            cquery.multiselect(root.get(EntityTbl01_.itemInteger1));
+            cquery.where(cb.equal(root.get(EntityTbl01_.itemString2), cb.literal("B")));
+            cquery.orderBy(cb.asc(cb.literal(1)));
+
+            query = em.createQuery(cquery);
+            dto01 = query.getResultList();
+            assertNotNull(dto01);
+            assertEquals(3, dto01.size());
+            assertEquals(1, _sql2.size());
+            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+                assertEquals("SELECT ITEM_INTEGER1 FROM SIMPLE_TBL01 WHERE (ITEM_STRING2 = 'B') ORDER BY 1 ASC", _sql2.remove(0));
+            } else {
+                assertEquals("SELECT ITEM_INTEGER1 FROM SIMPLE_TBL01 WHERE (ITEM_STRING2 = ?) ORDER BY ? ASC", _sql2.remove(0));
+            }
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -156,7 +306,13 @@ public class TestQueryOrderBy {
         if(!POPULATED) 
             populate();
 
+        Platform platform = getPlatform(emf);
         EntityManager em = emf.createEntityManager();
+
+        // DB2 and Derby does not support untyped parameter binding in ORDER BY clause
+        if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+            return;
+        }
 
         try {
             TypedQuery<Integer> query = em.createQuery(""
@@ -166,7 +322,6 @@ public class TestQueryOrderBy {
             List<Integer> dto01 = query.getResultList();
             assertNotNull(dto01);
             assertEquals(4, dto01.size());
-            assertEquals(new Integer(29), dto01.get(1));
 
             query = em.createQuery(""
                     + "SELECT t.itemInteger1 FROM EntityTbl01 t ORDER BY ?1 ASC", Integer.class);
@@ -175,7 +330,6 @@ public class TestQueryOrderBy {
             dto01 = query.getResultList();
             assertNotNull(dto01);
             assertEquals(4, dto01.size());
-            assertEquals(new Integer(29), dto01.get(1));
 
             // equivalent CriteriaBuilder
             CriteriaBuilder cb = em.getCriteriaBuilder();
@@ -191,7 +345,231 @@ public class TestQueryOrderBy {
             dto01 = query.getResultList();
             assertNotNull(dto01);
             assertEquals(4, dto01.size());
-            assertEquals(new Integer(29), dto01.get(1));
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if(em.isOpen()) {
+                em.close();
+            }
+        }
+    }
+
+    @Test
+    public void testQueryOrderByParameters2() {
+        if (emf == null)
+            return;
+
+        if(!POPULATED) 
+            populate();
+
+        Platform platform = getPlatform(emf);
+        EntityManager em = emf.createEntityManager();
+
+        // DB2 and Derby does not support untyped parameter binding in ORDER BY clause
+        if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+            return;
+        }
+
+        try {
+            TypedQuery<Integer> query = em.createQuery(""
+                    + "SELECT t.itemInteger1 FROM EntityTbl01 t WHERE t.itemString2 = ?1 ORDER BY ?2", Integer.class);
+            query.setParameter(1, "B");
+            query.setParameter(2, 1);
+
+            List<Integer> dto01 = query.getResultList();
+            assertNotNull(dto01);
+            assertEquals(3, dto01.size());
+            assertEquals(1, _sql.size());
+            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+                assertEquals("SELECT ITEM_INTEGER1 FROM SIMPLE_TBL01 WHERE (ITEM_STRING2 = ?) ORDER BY 1", _sql.remove(0));
+            } else {
+                assertEquals("SELECT ITEM_INTEGER1 FROM SIMPLE_TBL01 WHERE (ITEM_STRING2 = ?) ORDER BY ?", _sql.remove(0));
+            }
+
+            query = em.createQuery(""
+                    + "SELECT t.itemInteger1 FROM EntityTbl01 t WHERE t.itemString2 = ?1 ORDER BY ?2 ASC", Integer.class);
+            query.setParameter(1, "B");
+            query.setParameter(2, 1);
+
+            dto01 = query.getResultList();
+            assertNotNull(dto01);
+            assertEquals(3, dto01.size());
+            assertEquals(1, _sql.size());
+            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+                assertEquals("SELECT ITEM_INTEGER1 FROM SIMPLE_TBL01 WHERE (ITEM_STRING2 = ?) ORDER BY 1 ASC", _sql.remove(0));
+            } else {
+                assertEquals("SELECT ITEM_INTEGER1 FROM SIMPLE_TBL01 WHERE (ITEM_STRING2 = ?) ORDER BY ? ASC", _sql.remove(0));
+            }
+
+            // equivalent CriteriaBuilder
+            CriteriaBuilder cb = em.getCriteriaBuilder();
+            CriteriaQuery<Integer> cquery = cb.createQuery(Integer.class);
+            Root<EntityTbl01> root = cquery.from(EntityTbl01.class);
+            cquery.multiselect(root.get(EntityTbl01_.itemInteger1));
+            ParameterExpression<String> strParam1 = cb.parameter(String.class);
+            ParameterExpression<Integer> intParam2 = cb.parameter(Integer.class);
+            cquery.where(cb.equal(root.get(EntityTbl01_.itemString2), strParam1));
+            cquery.orderBy(cb.asc(intParam2));
+
+            query = em.createQuery(cquery);
+            query.setParameter(strParam1, "B");
+            query.setParameter(intParam2, 1);
+            dto01 = query.getResultList();
+            assertNotNull(dto01);
+            assertEquals(3, dto01.size());
+            assertEquals(1, _sql.size());
+            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+                assertEquals("SELECT ITEM_INTEGER1 FROM SIMPLE_TBL01 WHERE (ITEM_STRING2 = ?) ORDER BY 1 ASC", _sql.remove(0));
+            } else {
+                assertEquals("SELECT ITEM_INTEGER1 FROM SIMPLE_TBL01 WHERE (ITEM_STRING2 = ?) ORDER BY ? ASC", _sql.remove(0));
+            }
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if(em.isOpen()) {
+                em.close();
+            }
+        }
+    }
+
+    @Test
+    public void testQueryOrderByMix1() {
+        if (emf == null)
+            return;
+
+        if(!POPULATED) 
+            populate();
+
+        Platform platform = getPlatform(emf);
+        EntityManager em = emf.createEntityManager();
+
+        try {
+            TypedQuery<Integer> query = em.createQuery(""
+                    + "SELECT t.itemInteger1 FROM EntityTbl01 t WHERE t.itemString2 = ?1 ORDER BY 1", Integer.class);
+            query.setParameter(1, "B");
+
+            List<Integer> dto01 = query.getResultList();
+            assertNotNull(dto01);
+            assertEquals(3, dto01.size());
+            assertEquals(1, _sql.size());
+            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+                assertEquals("SELECT ITEM_INTEGER1 FROM SIMPLE_TBL01 WHERE (ITEM_STRING2 = ?) ORDER BY 1", _sql.remove(0));
+            } else {
+                assertEquals("SELECT ITEM_INTEGER1 FROM SIMPLE_TBL01 WHERE (ITEM_STRING2 = ?) ORDER BY ?", _sql.remove(0));
+            }
+
+            query = em.createQuery(""
+                    + "SELECT t.itemInteger1 FROM EntityTbl01 t WHERE t.itemString2 = ?1 ORDER BY 1 ASC", Integer.class);
+            query.setParameter(1, "B");
+
+            dto01 = query.getResultList();
+            assertNotNull(dto01);
+            assertEquals(3, dto01.size());
+            assertEquals(1, _sql.size());
+            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+                assertEquals("SELECT ITEM_INTEGER1 FROM SIMPLE_TBL01 WHERE (ITEM_STRING2 = 'B') ORDER BY 1 ASC", _sql.remove(0));
+            } else {
+                assertEquals("SELECT ITEM_INTEGER1 FROM SIMPLE_TBL01 WHERE (ITEM_STRING2 = ?) ORDER BY ? ASC", _sql.remove(0));
+            }
+
+            // equivalent CriteriaBuilder
+            CriteriaBuilder cb = em.getCriteriaBuilder();
+            CriteriaQuery<Integer> cquery = cb.createQuery(Integer.class);
+            Root<EntityTbl01> root = cquery.from(EntityTbl01.class);
+            cquery.multiselect(root.get(EntityTbl01_.itemInteger1));
+            ParameterExpression<String> strParam1 = cb.parameter(String.class);
+            cquery.where(cb.equal(root.get(EntityTbl01_.itemString2), strParam1));
+            cquery.orderBy(cb.asc(cb.literal(1)));
+
+            query = em.createQuery(cquery);
+            query.setParameter(strParam1, "B");
+            dto01 = query.getResultList();
+            assertNotNull(dto01);
+            assertEquals(3, dto01.size());
+            assertEquals(1, _sql.size());
+            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+                assertEquals("SELECT ITEM_INTEGER1 FROM SIMPLE_TBL01 WHERE (ITEM_STRING2 = 'B') ORDER BY 1 ASC", _sql.remove(0));
+            } else {
+                assertEquals("SELECT ITEM_INTEGER1 FROM SIMPLE_TBL01 WHERE (ITEM_STRING2 = ?) ORDER BY ? ASC", _sql.remove(0));
+            }
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if(em.isOpen()) {
+                em.close();
+            }
+        }
+    }
+
+    @Test
+    public void testQueryOrderByMix2() {
+        if (emf2 == null)
+            return;
+
+        if(!POPULATED) 
+            populate();
+
+        Platform platform = getPlatform(emf2);
+        EntityManager em = emf2.createEntityManager();
+
+        // DB2 and Derby does not support untyped parameter binding in ORDER BY clause
+        // 'emf2' sets 'shouldBindLiterals=true', which makes literal values bind as untyped parameters
+        if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+            return;
+        }
+
+        try {
+            TypedQuery<Integer> query = em.createQuery(""
+                    + "SELECT t.itemInteger1 FROM EntityTbl01 t WHERE t.itemString2 = ?1 ORDER BY 1", Integer.class);
+            query.setParameter(1, "B");
+
+            List<Integer> dto01 = query.getResultList();
+            assertNotNull(dto01);
+            assertEquals(3, dto01.size());
+            assertEquals(1, _sql2.size());
+            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+                assertEquals("SELECT ITEM_INTEGER1 FROM SIMPLE_TBL01 WHERE (ITEM_STRING2 = 'B') ORDER BY 1", _sql2.remove(0));
+            } else {
+                assertEquals("SELECT ITEM_INTEGER1 FROM SIMPLE_TBL01 WHERE (ITEM_STRING2 = ?) ORDER BY ?", _sql2.remove(0));
+            }
+
+            query = em.createQuery(""
+                    + "SELECT t.itemInteger1 FROM EntityTbl01 t WHERE t.itemString2 = ?1 ORDER BY 1 ASC", Integer.class);
+            query.setParameter(1, "B");
+
+            dto01 = query.getResultList();
+            assertNotNull(dto01);
+            assertEquals(3, dto01.size());
+            assertEquals(1, _sql2.size());
+            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+                assertEquals("SELECT ITEM_INTEGER1 FROM SIMPLE_TBL01 WHERE (ITEM_STRING2 = 'B') ORDER BY 1 ASC", _sql2.remove(0));
+            } else {
+                assertEquals("SELECT ITEM_INTEGER1 FROM SIMPLE_TBL01 WHERE (ITEM_STRING2 = ?) ORDER BY ? ASC", _sql2.remove(0));
+            }
+
+            // equivalent CriteriaBuilder
+            CriteriaBuilder cb = em.getCriteriaBuilder();
+            CriteriaQuery<Integer> cquery = cb.createQuery(Integer.class);
+            Root<EntityTbl01> root = cquery.from(EntityTbl01.class);
+            cquery.multiselect(root.get(EntityTbl01_.itemInteger1));
+            ParameterExpression<String> strParam1 = cb.parameter(String.class);
+            cquery.where(cb.equal(root.get(EntityTbl01_.itemString2), strParam1));
+            cquery.orderBy(cb.asc(cb.literal(1)));
+
+            query = em.createQuery(cquery);
+            query.setParameter(strParam1, "B");
+            dto01 = query.getResultList();
+            assertNotNull(dto01);
+            assertEquals(3, dto01.size());
+            assertEquals(1, _sql2.size());
+            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+                assertEquals("SELECT ITEM_INTEGER1 FROM SIMPLE_TBL01 WHERE (ITEM_STRING2 = 'B') ORDER BY 1 ASC", _sql2.remove(0));
+            } else {
+                assertEquals("SELECT ITEM_INTEGER1 FROM SIMPLE_TBL01 WHERE (ITEM_STRING2 = ?) ORDER BY ? ASC", _sql2.remove(0));
+            }
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -246,10 +624,16 @@ public class TestQueryOrderBy {
             em.getTransaction().commit();
 
             POPULATED = true;
+            _sql.clear();
+            _sql2.clear();
         } finally {
             if(em.isOpen()) {
                 em.close();
             }
         }
+    }
+
+    private DatabasePlatform getPlatform(EntityManagerFactory emf) {
+        return ((EntityManagerFactoryImpl)emf).getServerSession().getPlatform();
     }
 }


### PR DESCRIPTION
for #1429

For DB2/Derby, it is illegal to include untyped parameter markers in the ORDER BY clause. There are two JPQL scenarios where these untyped parameters can occur:
1) via JPQL "... ORDER BY ?1"
2) via JPQL "... ORDER BY 1" with `shouldBindLiterals=true`

My previous fix for 578686 included a minor fix to allow databases, that do not support untyped parameters, to disable parameter binding in the event that a marker is used within the ORDER BY clause. This fix was flawed and I ultimately decided it would be best to remove completely. 

The issue is that EclipseLink does not have the ability at this time to disable parameter binding per variable instance and instead disables binding for the whole query. The change that I made, and am now removing, altered existing behavior with Constant values and `shouldBindLiterals=true` that I did not intend. I have come to the conclusion that it would be best to continue to allow Derby/DB2 to fail with the 2 scenarios I outlined above until a more fine grained parameter binding strategy can be delivered (I am working on this at the moment)

Signed-off-by: Will Dazey <dazeydev.3@gmail.com>