### PR TITLE
Generate correct Informix SQL when parsing Concat Operator

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/InformixPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/InformixPlatform.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2015 IBM Corporation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 Payara Foundation and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,6 +17,7 @@
 //     12/11/2014 - Dalia Abo Sheasha
 //       - 454917 : Wrong SQL statement generated for Informix when GenerationType.IDENTITY strategy is used
 //     02/19/2015 - Rick Curtis
+//     05/13/2016 - David Weaver - Wrong SQL syntax generated for Informix when concat is used
 //       - 458877 : Add national character support
 package org.eclipse.persistence.platform.database;
 
@@ -28,6 +30,7 @@ import java.util.Calendar;
 import java.util.Hashtable;
 
 import org.eclipse.persistence.exceptions.ValidationException;
+import org.eclipse.persistence.expressions.ExpressionOperator;
 import org.eclipse.persistence.internal.databaseaccess.FieldTypeDefinition;
 import org.eclipse.persistence.internal.helper.Helper;
 import org.eclipse.persistence.queries.ValueReadQuery;
@@ -359,4 +362,15 @@ public class InformixPlatform extends org.eclipse.persistence.platform.database.
     public boolean isAlterSequenceObjectSupported() {
         return true;
     }
+
+    /**
+     * INTERNAL: Initialize any platform-specific operators
+     */
+    @Override
+    protected void initializePlatformOperators() {
+        super.initializePlatformOperators();
+        addOperator(ExpressionOperator.simpleLogicalNoParens(ExpressionOperator.Concat, "||"));
+    }
+
 }
+


### PR DESCRIPTION
Signed-off-by: Gaurav Gupta <gaurav.gupta@payara.fish>

EclipseLink generates SQL, that can't be parsed by the database. The problem is located in the handling of the Concat operator (JPQL and the criteria api are both affected).

Informix expectes the concat operation to be: `<op1> || <op2>`

Eclipselink generates: `<op1> + <op2>`

This is rejected by the DB server. The concat operator can be overridden for the db platform and if done so, the correct SQL is generated.
The test program is attached to demonstrate this issue. The program (de.persona.dev.blaesing.eclipselink.jpa.generation.test.Test) generates tables for a Demo Entity and then queries the concatenation of lastname and firstname.

Lines 17-18 instantiate the entitymanager 
Lines 20-21 demonstrate a fix (if commented out, the error exists, with this fix the query works) 
Lines 23-31 insert demo data 
Lines 35-43 reproduce the problem with the criteria api 
Lines 46-49 reproduce the problem with JPQL

The current result with line 20-21 commented throws an exception:

`Caused by: java.sql.SQLException: A character to numeric conversion process failed`

[test-app.zip](https://github.com/eclipse-ee4j/eclipselink/files/8395591/test-app.zip)


