### PR TITLE
[3.0] Eclipselink.jar bundle - version.properties fix

### DIFF
--- a/bundles/eclipselink/pom.xml
+++ b/bundles/eclipselink/pom.xml
@@ -437,8 +437,15 @@
                                     <directory>${gen.src.dir}</directory>
                                     <excludes>
                                         <exclude>**/*.java</exclude>
+                                        <exclude>org/eclipse/persistence/version.properties</exclude>
                                     </excludes>
+                                </resource>
+                                <resource>
+                                    <directory>${gen.src.dir}</directory>
                                     <filtering>true</filtering>
+                                    <includes>
+                                        <include>org/eclipse/persistence/version.properties</include>
+                                    </includes>
                                 </resource>
                             </resources>
                         </configuration>

--- a/bundles/eclipselink/pom.xml
+++ b/bundles/eclipselink/pom.xml
@@ -438,6 +438,7 @@
                                     <excludes>
                                         <exclude>**/*.java</exclude>
                                     </excludes>
+                                    <filtering>true</filtering>
                                 </resource>
                             </resources>
                         </configuration>


### PR DESCRIPTION
This is fix for `version.properties` file content included in `eclipselink.jar` bundle.
Before this fix version information related properties like `${release.version}, ${build.*}` wasn't replaced by correct values.
`version.properties` file content in `org.eclipse.persistence.core` is replaced correctly.
It happens in 3.0 branch only.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>