### PR TITLE
[master] Eclipselink.jar bundle - version.properties fix

### DIFF
--- a/bundles/eclipselink/pom.xml
+++ b/bundles/eclipselink/pom.xml
@@ -469,8 +469,15 @@
                                     <directory>${gen.src.dir}</directory>
                                     <excludes>
                                         <exclude>**/*.java</exclude>
+                                        <exclude>org/eclipse/persistence/version.properties</exclude>
                                     </excludes>
+                                </resource>
+                                <resource>
+                                    <directory>${gen.src.dir}</directory>
                                     <filtering>true</filtering>
+                                    <includes>
+                                        <include>org/eclipse/persistence/version.properties</include>
+                                    </includes>
                                 </resource>
                             </resources>
                         </configuration>


### PR DESCRIPTION
This is fix for `version.properties` file content included in `eclipselink.jar` bundle.
It more precisely specifies filtered and non-filtered resources included in eclipselink.jar bundle.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>