### PR TITLE
[3.0] Bug 579726: CriteriaBuilder neg() only returns Integer type, instead of it's argument expression type - backport from master

### DIFF
--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/criteria/TestNegFunction.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/criteria/TestNegFunction.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 IBM Corporation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+// Contributors:
+//     04/19/2022: Jody Grassel
+//       - Issue 579726: CriteriaBuilder neg() only returns Integer type, instead of it's argument expression type.
+package org.eclipse.persistence.jpa.test.criteria;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Selection;
+
+import org.eclipse.persistence.jpa.test.criteria.model.CoalesceEntity;
+import org.eclipse.persistence.jpa.test.criteria.model.CritEntity;
+import org.eclipse.persistence.jpa.test.framework.DDLGen;
+import org.eclipse.persistence.jpa.test.framework.Emf;
+import org.eclipse.persistence.jpa.test.framework.EmfRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(EmfRunner.class)
+public class TestNegFunction {
+    @Emf(createTables = DDLGen.DROP_CREATE, classes = { CritEntity.class })
+    private EntityManagerFactory emf;
+
+    @Test
+    public void testNegFunction() throws Exception {
+        EntityManager em = emf.createEntityManager();
+
+        try {
+            CritEntity ce = new CritEntity();
+            ce.setId(1);
+            ce.setValue(new BigDecimal("3.14"));
+
+            em.getTransaction().begin();
+            em.persist(ce);;
+            em.getTransaction().commit();
+            em.clear();
+
+            CriteriaBuilder criteriaBuilder = em.getCriteriaBuilder();
+            CriteriaQuery<DecHolder> criteriaQuery = criteriaBuilder.createQuery(DecHolder.class);
+            Root<CritEntity> entityRoot = criteriaQuery.from(CritEntity.class);
+
+            Collection<Selection<?>> selections = new ArrayList<Selection<?>>();
+
+            Expression<BigDecimal> valExpr = entityRoot.get("value");
+
+            selections.add(criteriaBuilder.sum(
+                  criteriaBuilder.<BigDecimal> selectCase()
+                        .when(criteriaBuilder.equal(entityRoot.get("id"), 0), valExpr)
+                        .otherwise(criteriaBuilder.neg(valExpr))));
+
+            criteriaQuery.multiselect(selections.toArray(new Selection[] {}));
+
+            List<DecHolder> retList = em.createQuery(criteriaQuery).getResultList();
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if(em.isOpen()) {
+                em.close();
+            }
+        }
+    }
+
+    public static class DecHolder {
+        private BigDecimal value;
+
+        public DecHolder(Object value) {
+            super();
+            this.value = (BigDecimal) value;
+        }
+
+        public BigDecimal getValue() {
+            return value;
+         }
+
+         public void setValue(BigDecimal value) {
+            this.value = value;
+         }
+
+         @Override
+         public String toString() {
+            return "DecHolder [value=" + value + "]";
+         }
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/criteria/model/CritEntity.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/criteria/model/CritEntity.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 IBM Corporation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+// Contributors:
+//     04/19/2022: Jody Grassel
+//       - Issue 579726: CriteriaBuilder neg() only returns Integer type, instead of it's argument expression type.
+package org.eclipse.persistence.jpa.test.criteria.model;
+
+import java.math.BigDecimal;
+
+import jakarta.persistence.Basic;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class CritEntity {
+    @Id
+    private int id;
+
+    @Basic
+    @Column(precision = 10, scale = 2)
+    private BigDecimal value;
+
+    public CritEntity() {
+
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public BigDecimal getValue() {
+        return value;
+    }
+
+    public void setValue(BigDecimal bigDec) {
+        this.value = bigDec;
+    }
+
+    @Override
+    public String toString() {
+        return "CritEntity [id=" + id + ", value=" + value + "]";
+    }
+
+
+}
+
+

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/CriteriaBuilderImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/CriteriaBuilderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, 2022 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -14,6 +14,8 @@
 // Contributors:
 //     Gordon Yorke - Initial development
 //
+//     04/19/2022: Jody Grassel
+//       - Issue 579726: CriteriaBuilder neg() only returns Integer type, instead of it's argument expression type.
 package org.eclipse.persistence.internal.jpa.querydef;
 
 import java.io.Serializable;
@@ -999,7 +1001,7 @@ public class CriteriaBuilderImpl implements JpaCriteriaBuilder, Serializable {
      */
     @Override
     public <N extends Number> Expression<N> neg(Expression<N> x){
-        return new FunctionExpressionImpl(this.metamodel, ClassConstants.INTEGER, ExpressionMath.negate(((InternalSelection)x).getCurrentNode()), buildList(x), "neg");
+        return new FunctionExpressionImpl(this.metamodel, (Class<N>) x.getJavaType(), ExpressionMath.negate(((InternalSelection)x).getCurrentNode()), buildList(x), "neg");
     }
 
     /**


### PR DESCRIPTION
https://bugs.eclipse.org/bugs/show_bug.cgi?id=579726

Signed-off-by: Joe Grassel <fyrewyld@gmail.com>

(cherry picked from commit d4ae22509cd177c0a3916f8540463b555bda9f36)
Signed-off-by: Radek Felcman <radek.felcman@oracle.com>