### PR TITLE
Fix NPE initializing ExpressionOperator indices Array

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/expressions/ExpressionOperator.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/expressions/ExpressionOperator.java
@@ -2358,16 +2358,10 @@ public class ExpressionOperator implements Serializable {
             dbStringIndex = 1;
         }
 
-        if (this.argumentIndices == null) {
-            this.argumentIndices = new int[items.size()];
-            for (int i = 0; i < this.argumentIndices.length; i++){
-                this.argumentIndices[i] = i;
-            }
-        }
-
+        int[] indices = getArgumentIndices(items.size());
         String[] dbStrings = getDatabaseStrings(items.size());
-        for (int i = 0; i < this.argumentIndices.length; i++) {
-            final int index = this.argumentIndices[i];
+        for (int i = 0; i < indices.length; i++) {
+            final int index = indices[i];
             Expression item = (Expression)items.elementAt(index);
 
             if ((this.selector == Ref) || ((this.selector == Deref) && (item.isObjectExpression()))) {
@@ -2600,6 +2594,23 @@ public class ExpressionOperator implements Serializable {
      */
     public void setArgumentIndices(int[] indices) {
         argumentIndices = indices;
+    }
+
+    /**
+     * Return the argumentIndices if set, otherwise initialize argumentIndices to the provided size
+     */
+    public int[] getArgumentIndices(int size) {
+        int[] indices = this.argumentIndices;
+        if (indices != null) {
+            return indices;
+        }
+
+        indices = new int[size];
+        for (int i = 0; i < indices.length; i++) {
+            indices[i] = i;
+        }
+        this.argumentIndices = indices;
+        return indices;
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/DB2Platform.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/DB2Platform.java
@@ -537,14 +537,6 @@ public class DB2Platform extends org.eclipse.persistence.platform.database.Datab
                     return;
                 }
 
-                // Initialize argumentIndices
-                if (this.argumentIndices == null) {
-                    this.argumentIndices = new int[items.size()];
-                    for (int i = 0; i < this.argumentIndices.length; i++){
-                        this.argumentIndices[i] = i;
-                    }
-                }
-
                 for(Object item : items) {
                     if(((Expression)item).isParameterExpression()) {
                         ((ParameterExpression) item).setCanBind(false);
@@ -649,17 +641,10 @@ public class DB2Platform extends org.eclipse.persistence.platform.database.Datab
                     return;
                 }
 
-                // Initialize argumentIndices
-                if (this.argumentIndices == null) {
-                    this.argumentIndices = new int[items.size()];
-                    for (int i = 0; i < this.argumentIndices.length; i++){
-                        this.argumentIndices[i] = i;
-                    }
-                }
-
+                int[] indices = getArgumentIndices(items.size());
                 boolean allBind = true;
                 for (int i = 0; i < items.size(); i++) {
-                    final int index = this.argumentIndices[i];
+                    final int index = indices[i];
                     Expression item = (Expression)items.elementAt(index);
                     boolean shouldBind = true;
 
@@ -670,7 +655,7 @@ public class DB2Platform extends org.eclipse.persistence.platform.database.Datab
 
                     if(allBind) {
                         if(printer.getPlatform().shouldBindLiterals()) {
-                            if((i == (this.argumentIndices.length - 1))) {
+                            if((i == (indices.length - 1))) {
                                 // The last parameter has to be disabled
                                 shouldBind = allBind = false;
                             }
@@ -678,7 +663,7 @@ public class DB2Platform extends org.eclipse.persistence.platform.database.Datab
                             if(item.isConstantExpression()) {
                                 // The first literal has to be disabled
                                 shouldBind = allBind = false;
-                            } else if((i == (this.argumentIndices.length - 1)) && item.isParameterExpression()) {
+                            } else if((i == (indices.length - 1)) && item.isParameterExpression()) {
                                 // The last parameter has to be disabled
                                 shouldBind = allBind = false;
                             }
@@ -963,16 +948,9 @@ public class DB2Platform extends org.eclipse.persistence.platform.database.Datab
                     }
                 }
 
-                // Initialize argumentIndices
-                if (this.argumentIndices == null) {
-                    this.argumentIndices = new int[items.size()];
-                    for (int k = 0; k < this.argumentIndices.length; k++){
-                        this.argumentIndices[k] = k;
-                    }
-                }
-
+                int[] indices = getArgumentIndices(items.size());
                 for (int j = 0; j < items.size(); j++) {
-                    final int index = this.argumentIndices[j];
+                    final int index = indices[j];
                     Expression item = (Expression)items.elementAt(index);
 
                     if(item.isParameterExpression()) {
@@ -1085,16 +1063,9 @@ public class DB2Platform extends org.eclipse.persistence.platform.database.Datab
                     }
                 }
 
-                // Initialize argumentIndices
-                if (this.argumentIndices == null) {
-                    this.argumentIndices = new int[items.size()];
-                    for (int k = 0; k < this.argumentIndices.length; k++){
-                        this.argumentIndices[k] = k;
-                    }
-                }
-
+                int[] indices = getArgumentIndices(items.size());
                 for (int j = 0; j < items.size(); j++) {
-                    final int index = this.argumentIndices[j];
+                    final int index = indices[j];
                     Expression item = (Expression)items.elementAt(index);
 
                     if(item.isParameterExpression()) {
@@ -1218,17 +1189,10 @@ public class DB2Platform extends org.eclipse.persistence.platform.database.Datab
                     return;
                 }
 
-                // Initialize argumentIndices
-                if (this.argumentIndices == null) {
-                    this.argumentIndices = new int[items.size()];
-                    for (int i = 0; i < this.argumentIndices.length; i++){
-                        this.argumentIndices[i] = i;
-                    }
-                }
-
+                int[] indices = getArgumentIndices(items.size());
                 boolean allBind = true;
                 for (int i = 0; i < items.size(); i++) {
-                    final int index = this.argumentIndices[i];
+                    final int index = indices[i];
                     Expression item = (Expression)items.elementAt(index);
                     boolean shouldBind = true;
 
@@ -1239,7 +1203,7 @@ public class DB2Platform extends org.eclipse.persistence.platform.database.Datab
 
                     if(allBind) {
                         if(printer.getPlatform().shouldBindLiterals()) {
-                            if((i == (this.argumentIndices.length - 1))) {
+                            if((i == (indices.length - 1))) {
                                 // The last parameter has to be disabled
                                 shouldBind = allBind = false;
                             }
@@ -1247,7 +1211,7 @@ public class DB2Platform extends org.eclipse.persistence.platform.database.Datab
                             if(item.isConstantExpression()) {
                                 // The first literal has to be disabled
                                 shouldBind = allBind = false;
-                            } else if((i == (this.argumentIndices.length - 1)) && item.isParameterExpression()) {
+                            } else if((i == (indices.length - 1)) && item.isParameterExpression()) {
                                 // The last parameter has to be disabled
                                 shouldBind = allBind = false;
                             }
@@ -1327,16 +1291,9 @@ public class DB2Platform extends org.eclipse.persistence.platform.database.Datab
                     return;
                 }
 
-                // Initialize argumentIndices
-                if (this.argumentIndices == null) {
-                    this.argumentIndices = new int[items.size()];
-                    for (int i = 0; i < this.argumentIndices.length; i++){
-                        this.argumentIndices[i] = i;
-                    }
-                }
-
+                int[] indices = getArgumentIndices(items.size());
                 for (int i = 0; i < items.size(); i++) {
-                    final int index = this.argumentIndices[i];
+                    final int index = indices[i];
                     Expression item = (Expression)items.elementAt(index);
 
                     // Disable the first item, which should be <operand2> for this operator
@@ -1407,16 +1364,9 @@ public class DB2Platform extends org.eclipse.persistence.platform.database.Datab
                     return;
                 }
 
-                // Initialize argumentIndices
-                if (this.argumentIndices == null) {
-                    this.argumentIndices = new int[items.size()];
-                    for (int i = 0; i < this.argumentIndices.length; i++){
-                        this.argumentIndices[i] = i;
-                    }
-                }
-
+                int[] indices = getArgumentIndices(items.size());
                 for (int i = 0; i < items.size(); i++) {
-                    final int index = this.argumentIndices[i];
+                    final int index = indices[i];
                     Expression item = (Expression)items.elementAt(index);
 
                     // Disable the first item, which should be <operand2> for this operator
@@ -1487,16 +1437,9 @@ public class DB2Platform extends org.eclipse.persistence.platform.database.Datab
                     return;
                 }
 
-                // Initialize argumentIndices
-                if (this.argumentIndices == null) {
-                    this.argumentIndices = new int[items.size()];
-                    for (int i = 0; i < this.argumentIndices.length; i++){
-                        this.argumentIndices[i] = i;
-                    }
-                }
-
+                int[] indices = getArgumentIndices(items.size());
                 for (int i = 0; i < items.size(); i++) {
-                    final int index = this.argumentIndices[i];
+                    final int index = indices[i];
                     Expression item = (Expression)items.elementAt(index);
 
                     // Disable the first item, which should be <operand2> for this operator


### PR DESCRIPTION
for #1504

```
 Caused by: java.lang.NullPointerException
 	at org.eclipse.persistence.expressions.ExpressionOperator.printCollection(ExpressionOperator.java:2369)
 	at org.eclipse.persistence.platform.database.DB2Platform$3.printCollection(DB2Platform.java:936)
 	at org.eclipse.persistence.internal.expressions.ArgumentListFunctionExpression.printSQL(ArgumentListFunctionExpression.java:99)
 	at org.eclipse.persistence.internal.expressions.FunctionExpression.writeFields(FunctionExpression.java:723)
 	at org.eclipse.persistence.internal.expressions.SQLSelectStatement.writeFieldsFromExpression(SQLSelectStatement.java:2082)
 	at org.eclipse.persistence.internal.expressions.SQLSelectStatement.writeFieldsIn(SQLSelectStatement.java:2097)
 	at org.eclipse.persistence.internal.expressions.SQLSelectStatement.printSQL(SQLSelectStatement.java:1716)
 	at org.eclipse.persistence.platform.database.DerbyPlatform.printSQLSelectStatement(DerbyPlatform.java:656)
 	at org.eclipse.persistence.internal.expressions.SQLSelectStatement.buildCall(SQLSelectStatement.java:816)
 	at org.eclipse.persistence.internal.expressions.SQLSelectStatement.buildCall(SQLSelectStatement.java:826)
 	at org.eclipse.persistence.descriptors.ClassDescriptor.buildCallFromStatement(ClassDescriptor.java:822)
 	at org.eclipse.persistence.internal.queries.StatementQueryMechanism.setCallFromStatement(StatementQueryMechanism.java:390)
 	at org.eclipse.persistence.internal.queries.ExpressionQueryMechanism.prepareReportQuerySelectAllRows(ExpressionQueryMechanism.java:1676)
 	at org.eclipse.persistence.queries.ReportQuery.prepareSelectAllRows(ReportQuery.java:1207)
 	at org.eclipse.persistence.queries.ReadAllQuery.prepare(ReadAllQuery.java:816)
 	at org.eclipse.persistence.queries.ReportQuery.prepare(ReportQuery.java:1075)
 	at org.eclipse.persistence.queries.DatabaseQuery.checkPrepare(DatabaseQuery.java:670)
```

The issue is that ExpressionOperators are shared and should not contain state. If multiple threads are running, with the same ExpressionOperators, it may be possible that the `ExpressionOperator.argumentIndices` are in inconsistent states across multiple threads. Some threads may be setting it to NULL after other threads just initialized it!

The solution is that `ExpressionOperator.argumentIndices` is being used incorrectly in `ExpressionOperator.printCollection()`. If an ExpressionOperator defines its own `argumentIndices`, then those are what we should go with. The `ExpressionOperator.argumentIndices` should not be retro-actively initialized!

One reason for the original implementation may be performance. If so, then we should just set `ExpressionOperator.argumentIndices` for each ExpressionOperator definition and have this implementation I am delivering be the default. 

Signed-off-by: Will Dazey <dazeydev.3@gmail.com>