### PR TITLE
#1507: Failing to create entity manager when running an app using module path

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/DBPlatformHelper.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/DBPlatformHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2021 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -87,9 +87,8 @@ public class DBPlatformHelper {
             if(_nameToVendorPlatform == null) {
                 _nameToVendorPlatform = new ArrayList<>();
                 try {
-                    loadFromResource(_nameToVendorPlatform, VENDOR_NAME_TO_PLATFORM_RESOURCE_NAME,
-                                            DBPlatformHelper.class.getClassLoader() );
-                } catch (IOException e) {
+                    loadFromResource(_nameToVendorPlatform, VENDOR_NAME_TO_PLATFORM_RESOURCE_NAME);
+                } catch (Throwable e) {
                     logger.log(SessionLog.WARNING, SessionLog.CONNECTION, "dbPlatformHelper_noMappingFound", VENDOR_NAME_TO_PLATFORM_RESOURCE_NAME);
                 }
             }
@@ -140,9 +139,9 @@ public class DBPlatformHelper {
     }
 
     //-----Property Loading helper methods ----/
-    private static void loadFromResource(List<String[]> properties, String resourceName, ClassLoader classLoader)
+    private static void loadFromResource(List<String[]> properties, String resourceName)
             throws IOException {
-        load(properties, resourceName, classLoader);
+        load(properties, resourceName);
     }
 
     /**
@@ -153,14 +152,11 @@ public class DBPlatformHelper {
      *                      If loadFromFile  is true, this is fully qualified path name to a file.
      *                      param classLoader is ignored.
      *                      If loadFromFile  is false,this is resource name.
-     * @param classLoader   The class loader that should be used to load the resource. If null,primordial
-     *                      class loader is used.
      */
-    private static void load(List<String[]> properties, final String resourceName,
-            final ClassLoader classLoader)
+    private static void load(List<String[]> properties, final String resourceName)
                             throws IOException {
         try (BufferedReader bin = new BufferedReader(
-                new InputStreamReader(openResourceInputStream(resourceName,classLoader)))) {
+                new InputStreamReader(openResourceInputStream(resourceName)))) {
             for (String line = bin.readLine(); line != null; line = bin.readLine()) {
                 String[] keyValue = validateLineForReturnAsKeyValueArray(line);
                 if (keyValue != null) {
@@ -173,16 +169,10 @@ public class DBPlatformHelper {
     /**
      * Open resourceName as input stream inside doPriviledged block
      */
-    private static InputStream openResourceInputStream(final String resourceName, final ClassLoader classLoader) {
-        return PrivilegedAccessHelper.callDoPrivileged(
-                () -> {
-                    if (classLoader != null) {
-                        return classLoader.getResourceAsStream(resourceName);
-                    } else {
-                        return ClassLoader.getSystemResourceAsStream(resourceName);
-                    }
-                }
-        );
+    private static InputStream openResourceInputStream(final String resourceName) throws IOException {
+        return PrivilegedAccessHelper.callDoPrivilegedWithException(
+                () -> DBPlatformHelper.class.getModule().getResourceAsStream(resourceName),
+                (ex) -> (IOException) ex);
     }
 
     private static String[] validateLineForReturnAsKeyValueArray(String line) {


### PR DESCRIPTION
Fixes #1507 

there were 2 problems:
- we need to ask the right module for the resource (from 9+)
- we need to catch `Throwable` to be able to recover/fallback from unexpected state and log appropriate warning