### PR TITLE
[master] Fix JSE tests failing on derby

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/SQLSelectStatement.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/SQLSelectStatement.java
@@ -776,6 +776,11 @@ public class SQLSelectStatement extends SQLStatement {
                     } else if(expression.isConstantExpression() && printer.getPlatform().shouldBindLiterals()) {
                         ((ConstantExpression) expression).setCanBind(false);
                     }
+                } else if (printer.getPlatform().isDynamicSQLRequiredForFunctions()) {
+                    if(expression.isParameterExpression() 
+                            || (expression.isConstantExpression() && printer.getPlatform().shouldBindLiterals())) {
+                        printer.getCall().setUsesBinding(false);
+                    }
                 }
             }
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/DerbyPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/DerbyPlatform.java
@@ -473,143 +473,38 @@ public class DerbyPlatform extends DB2Platform {
 
     // Emulate POWER(:a,:b) as EXP((:b)*LN(:a))
     private static ExpressionOperator derbyPowerOperator() {
-        ExpressionOperator exOperator = new ExpressionOperator() {
-            @Override
-            public void printDuo(Expression first, Expression second, ExpressionSQLPrinter printer) {
-                printer.printString(getDatabaseStrings()[0]);
-                if (second != null) {
-                    second.printSQL(printer);
-                } else {
-                    printer.printString("0");
-                }
-                printer.printString(getDatabaseStrings()[1]);
-                first.printSQL(printer);
-                printer.printString(getDatabaseStrings()[2]);
-            }
-            @Override
-            public void printCollection(List<Expression> items, ExpressionSQLPrinter printer) {
-                if (printer.getPlatform().isDynamicSQLRequiredForFunctions() && !isBindingSupported()) {
-                    printer.getCall().setUsesBinding(false);
-                }
-                if (items.size() > 0) {
-                    Expression firstItem = items.get(0);
-                    Expression secondItem = items.size() > 1 ? (Expression)items.get(1) : null;
-                    printDuo(firstItem, secondItem, printer);
-                } else {
-                    throw new IllegalArgumentException("List of items shall contain at least one item");
-                }
-            }
-            @Override
-            public void printJavaDuo(Expression first, Expression second, ExpressionJavaPrinter printer) {
-                printer.printString(getDatabaseStrings()[0]);
-                if (second != null) {
-                    second.printJava(printer);
-                } else {
-                    printer.printString("0");
-                }
-                printer.printString(getDatabaseStrings()[1]);
-                first.printJava(printer);
-                printer.printString(getDatabaseStrings()[2]);
-            }
-            @Override
-            public void printJavaCollection(List<Expression> items, ExpressionJavaPrinter printer) {
-                if (items.size() > 0) {
-                    Expression firstItem = items.get(0);
-                    Expression secondItem = items.size() > 1 ? (Expression)items.get(1) : null;
-                    printJavaDuo(firstItem, secondItem, printer);
-                } else {
-                    throw new IllegalArgumentException("List of items shall contain at least one item");
-                }
-            }
-        };
-        exOperator.setType(ExpressionOperator.FunctionOperator);
-        exOperator.setSelector(ExpressionOperator.Power);
-        exOperator.setName("POWER");
+        ExpressionOperator operator = ExpressionOperator.power();
+
         List<String> v = new ArrayList<>(4);
         v.add("EXP((");
         v.add(")*LN(");
         v.add("))");
-        exOperator.printsAs(v);
-        exOperator.bePrefix();
-        exOperator.setNodeClass(ClassConstants.FunctionExpression_Class);
-        return exOperator;
+        operator.printsAs(v);
+        int[] argumentIndices = new int[2];
+        argumentIndices[0] = 1;
+        argumentIndices[1] = 0;
+        operator.setArgumentIndices(argumentIndices);
+        return operator;
     }
 
     // Emulate ROUND as FLOOR((:x)*1e:n+0.5)/1e:n
     private static ExpressionOperator derbyRoundOperator() {
-        ExpressionOperator exOperator = new ExpressionOperator() {
-            @Override
-            public void printDuo(Expression first, Expression second, ExpressionSQLPrinter printer) {
-                printer.printString(getDatabaseStrings()[0]);
-                first.printSQL(printer);
-                printer.printString(getDatabaseStrings()[1]);
-                if (second != null) {
-                    second.printSQL(printer);
-                } else {
-                    printer.printString("0");
-                }
-                printer.printString(getDatabaseStrings()[2]);
-                if (second != null) {
-                    second.printSQL(printer);
-                } else {
-                    printer.printString("0");
-                }
-                printer.printString(getDatabaseStrings()[3]);
-            }
-            @Override
-            public void printCollection(List<Expression> items, ExpressionSQLPrinter printer) {
-                if (printer.getPlatform().isDynamicSQLRequiredForFunctions() && !isBindingSupported()) {
-                    printer.getCall().setUsesBinding(false);
-                }
-                if (items.size() > 0) {
-                    Expression firstItem = items.get(0);
-                    Expression secondItem = items.size() > 1 ? (Expression)items.get(1) : null;
-                    printDuo(firstItem, secondItem, printer);
-                } else {
-                    throw new IllegalArgumentException("List of items shall contain at least one item");
-                }
-            }
-            @Override
-            public void printJavaDuo(Expression first, Expression second, ExpressionJavaPrinter printer) {
-                printer.printString(getDatabaseStrings()[0]);
-                first.printJava(printer);
-                printer.printString(getDatabaseStrings()[1]);
-                if (second != null) {
-                    second.printJava(printer);
-                } else {
-                    printer.printString("0");
-                }
-                printer.printString(getDatabaseStrings()[2]);
-                if (second != null) {
-                    second.printJava(printer);
-                } else {
-                    printer.printString("0");
-                }
-                printer.printString(getDatabaseStrings()[3]);
-            }
-            @Override
-            public void printJavaCollection(List<Expression> items, ExpressionJavaPrinter printer) {
-                if (items.size() > 0) {
-                    Expression firstItem = items.get(0);
-                    Expression secondItem = items.size() > 1 ? (Expression)items.get(1) : null;
-                    printJavaDuo(firstItem, secondItem, printer);
-                } else {
-                    throw new IllegalArgumentException("List of items shall contain at least one item");
-                }
-            }
-        };
-        exOperator.setType(ExpressionOperator.FunctionOperator);
-        exOperator.setSelector(ExpressionOperator.Round);
-        exOperator.setName("ROUND");
+        ExpressionOperator operator = disableAllBindingExpression();
+        ExpressionOperator.round().copyTo(operator);
+
         List<String> v = new ArrayList<>(4);
         v.add("FLOOR((");
         v.add(")*1e");
         v.add("+0.5)/1e");
         v.add("");
-        exOperator.printsAs(v);
-        exOperator.bePrefix();
-        exOperator.setNodeClass(ClassConstants.FunctionExpression_Class);
-        return exOperator;
+        operator.printsAs(v);
+        int[] argumentIndices = new int[3];
+        argumentIndices[0] = 0;
+        argumentIndices[1] = 1;
+        argumentIndices[2] = 1;
+        operator.setArgumentIndices(argumentIndices);
+        operator.setIsBindingSupported(false);
+        return operator;
     }
 
     /**

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/property/TestParameterBinding.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/property/TestParameterBinding.java
@@ -71,7 +71,11 @@ public class TestParameterBinding {
 
             DatabasePlatform pl = (DatabasePlatform)forceBindEMF.unwrap(EntityManagerFactoryImpl.class).getDatabaseSession().getDatasourcePlatform();
             if(pl.shouldBindLiterals()) {
-                Assert.assertEquals("The number of parameters found does not match the number in the query" , 3, call.getParameters().size());
+                if(pl.allowBindingForSelectClause()) {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 3, call.getParameters().size());
+                } else {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 2, call.getParameters().size());
+                }
             } else {
                 Assert.assertEquals("The number of parameters found does not match the number supplied" , 2, call.getParameters().size());
             }
@@ -96,7 +100,11 @@ public class TestParameterBinding {
 
             DatabasePlatform pl = (DatabasePlatform)forceBindEMF.unwrap(EntityManagerFactoryImpl.class).getDatabaseSession().getDatasourcePlatform();
             if(pl.shouldBindLiterals()) {
-                Assert.assertEquals("The number of parameters found does not match the number supplied" , 3, call.getParameters().size());
+                if(pl.allowBindingForSelectClause()) {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 3, call.getParameters().size());
+                } else {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 2, call.getParameters().size());
+                }
             } else {
                 Assert.assertEquals("The number of parameters found does not match the number supplied" , 0, call.getParameters().size());
             }
@@ -128,7 +136,11 @@ public class TestParameterBinding {
             }
 
             if(pl.shouldBindLiterals()) {
-                Assert.assertEquals("The number of parameters found does not match the number supplied" , 4, call.getParameters().size());
+                if(pl.allowBindingForSelectClause()) {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 4, call.getParameters().size());
+                } else {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 3, call.getParameters().size());
+                }
             } else {
                 Assert.assertEquals("The number of parameters found does not match the number supplied" , 3, call.getParameters().size());
             }
@@ -178,7 +190,11 @@ public class TestParameterBinding {
             }
 
             if(pl.shouldBindLiterals()) {
-                Assert.assertEquals("The number of parameters found does not match the number supplied" , 3, call.getParameters().size());
+                if(pl.allowBindingForSelectClause()) {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 3, call.getParameters().size());
+                } else {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 2, call.getParameters().size());
+                }
             } else {
                 Assert.assertEquals("The number of parameters found does not match the number supplied" , 2, call.getParameters().size());
             }
@@ -212,7 +228,11 @@ public class TestParameterBinding {
 
             DatabasePlatform pl = (DatabasePlatform)forceBindEMF.unwrap(EntityManagerFactoryImpl.class).getDatabaseSession().getDatasourcePlatform();
             if(pl.shouldBindLiterals()) {
-                Assert.assertEquals("The number of parameters found does not match the number supplied" , 3, call.getParameters().size());
+                if(pl.allowBindingForSelectClause()) {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 3, call.getParameters().size());
+                } else {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 2, call.getParameters().size());
+                }
             } else {
                 Assert.assertEquals("The number of parameters found does not match the number supplied" , 0, call.getParameters().size());
             }
@@ -242,10 +262,31 @@ public class TestParameterBinding {
             Assert.assertFalse("Expected query parameter binding to not be set for the DatabaseCall", call.isUsesBindingSet());
 
             DatabasePlatform pl = (DatabasePlatform)forceBindEMF.unwrap(EntityManagerFactoryImpl.class).getDatabaseSession().getDatasourcePlatform();
+            if(pl.isDB2Z() || pl.isDerby()) {
+                Assert.fail("Expected a failure from " + pl);
+            }
+
             if(pl.shouldBindLiterals()) {
-                Assert.assertEquals("The number of parameters found does not match the number supplied" , 5, call.getParameters().size());
+                if(pl.allowBindingForSelectClause()) {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 5, call.getParameters().size());
+                } else {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 4, call.getParameters().size());
+                }
             } else {
                 Assert.assertEquals("The number of parameters found does not match the number supplied" , 2, call.getParameters().size());
+            }
+        } catch(PersistenceException e) {
+            Platform pl = forceBindEMF.unwrap(EntityManagerFactoryImpl.class).getDatabaseSession().getDatasourcePlatform();
+            //When both operands of a CONCAT operator are untyped parameters, error on DB2/z
+            if(pl.isDB2Z()) {
+                Assert.assertEquals(DatabaseException.class, e.getCause().getClass());
+                Assert.assertEquals("com.ibm.db2.jcc.am.SqlSyntaxErrorException", e.getCause().getCause().getClass().getName());
+            } else if(pl.isDerby()) {
+                //When all the operands of '||' expression are untyped parameters, error 42X35 on Derby
+                Assert.assertEquals(DatabaseException.class, e.getCause().getClass());
+                Assert.assertEquals("java.sql.SQLSyntaxErrorException", e.getCause().getCause().getClass().getName());
+            } else {
+                Assert.fail("Unexpected failure: " + e);
             }
         } finally {
             if (em.getTransaction().isActive()) {
@@ -275,7 +316,11 @@ public class TestParameterBinding {
             }
 
             if(pl.shouldBindLiterals()) {
-                Assert.assertEquals("The number of parameters found does not match the number supplied" , 5, call.getParameters().size());
+                if(pl.allowBindingForSelectClause()) {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 5, call.getParameters().size());
+                } else {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 4, call.getParameters().size());
+                }
             } else {
                 Assert.assertEquals("The number of parameters found does not match the number supplied" , 4, call.getParameters().size());
             }
@@ -319,7 +364,11 @@ public class TestParameterBinding {
 
             DatabasePlatform pl = (DatabasePlatform)forceBindEMF.unwrap(EntityManagerFactoryImpl.class).getDatabaseSession().getDatasourcePlatform();
             if(pl.shouldBindLiterals()) {
-                Assert.assertEquals("The number of parameters found does not match the number supplied" , 3, call.getParameters().size());
+                if(pl.allowBindingForSelectClause()) {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 3, call.getParameters().size());
+                } else {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 2, call.getParameters().size());
+                }
             } else {
                 Assert.assertEquals("The number of parameters found does not match the number supplied" , 2, call.getParameters().size());
             }
@@ -344,7 +393,11 @@ public class TestParameterBinding {
 
             DatabasePlatform pl = (DatabasePlatform)forceBindEMF.unwrap(EntityManagerFactoryImpl.class).getDatabaseSession().getDatasourcePlatform();
             if(pl.shouldBindLiterals()) {
-                Assert.assertEquals("The number of parameters found does not match the number supplied" , 3, call.getParameters().size());
+                if(pl.allowBindingForSelectClause()) {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 3, call.getParameters().size());
+                } else {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 2, call.getParameters().size());
+                }
             } else {
                 Assert.assertEquals("The number of parameters found does not match the number supplied" , 0, call.getParameters().size());
             }
@@ -474,7 +527,11 @@ public class TestParameterBinding {
             }
 
             if(pl.shouldBindLiterals()) {
-                Assert.assertEquals("The number of parameters found does not match the number supplied" , 5, call.getParameters().size());
+                if(pl.allowBindingForSelectClause()) {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 5, call.getParameters().size());
+                } else {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 4, call.getParameters().size());
+                }
             } else {
                 Assert.assertEquals("The number of parameters found does not match the number supplied" , 4, call.getParameters().size());
             }
@@ -514,7 +571,11 @@ public class TestParameterBinding {
 
             DatabasePlatform pl = (DatabasePlatform)forceBindEMF.unwrap(EntityManagerFactoryImpl.class).getDatabaseSession().getDatasourcePlatform();
             if(pl.shouldBindLiterals()) {
-                Assert.assertEquals("The number of parameters found does not match the number supplied" , 5, call.getParameters().size());
+                if(pl.allowBindingForSelectClause()) {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 5, call.getParameters().size());
+                } else {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 4, call.getParameters().size());
+                }
             } else {
                 Assert.assertEquals("The number of parameters found does not match the number supplied" , 2, call.getParameters().size());
             }
@@ -541,7 +602,11 @@ public class TestParameterBinding {
 
             DatabasePlatform pl = (DatabasePlatform)forceBindEMF.unwrap(EntityManagerFactoryImpl.class).getDatabaseSession().getDatasourcePlatform();
             if(pl.shouldBindLiterals()) {
-                Assert.assertEquals("The number of parameters found does not match the number supplied" , 5, call.getParameters().size());
+                if(pl.allowBindingForSelectClause()) {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 5, call.getParameters().size());
+                } else {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 4, call.getParameters().size());
+                }
             } else {
                 Assert.assertEquals("The number of parameters found does not match the number supplied" , 2, call.getParameters().size());
             }
@@ -568,7 +633,11 @@ public class TestParameterBinding {
 
             DatabasePlatform pl = (DatabasePlatform)forceBindEMF.unwrap(EntityManagerFactoryImpl.class).getDatabaseSession().getDatasourcePlatform();
             if(pl.shouldBindLiterals()) {
-                Assert.assertEquals("The number of parameters found does not match the number supplied" , 4, call.getParameters().size());
+                if(pl.allowBindingForSelectClause()) {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 4, call.getParameters().size());
+                } else {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 3, call.getParameters().size());
+                }
             } else {
                 Assert.assertEquals("The number of parameters found does not match the number supplied" , 2, call.getParameters().size());
             }
@@ -600,7 +669,11 @@ public class TestParameterBinding {
 
             DatabasePlatform pl = (DatabasePlatform)forceBindEMF.unwrap(EntityManagerFactoryImpl.class).getDatabaseSession().getDatasourcePlatform();
             if(pl.shouldBindLiterals()) {
-                Assert.assertEquals("The number of parameters found does not match the number supplied" , 4, call.getParameters().size());
+                if(pl.allowBindingForSelectClause()) {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 4, call.getParameters().size());
+                } else {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 3, call.getParameters().size());
+                }
             } else {
                 Assert.assertEquals("The number of parameters found does not match the number supplied" , 2, call.getParameters().size());
             }
@@ -628,7 +701,11 @@ public class TestParameterBinding {
 
             DatabasePlatform pl = (DatabasePlatform)forceBindEMF.unwrap(EntityManagerFactoryImpl.class).getDatabaseSession().getDatasourcePlatform();
             if(pl.shouldBindLiterals()) {
-                Assert.assertEquals("The number of parameters found does not match the number supplied" , 2, call.getParameters().size());
+                if(pl.allowBindingForSelectClause()) {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 2, call.getParameters().size());
+                } else {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 1, call.getParameters().size());
+                }
             } else {
                 Assert.assertEquals("The number of parameters found does not match the number supplied" , 1, call.getParameters().size());
             }
@@ -657,7 +734,11 @@ public class TestParameterBinding {
 
             DatabasePlatform pl = (DatabasePlatform)forceBindEMF.unwrap(EntityManagerFactoryImpl.class).getDatabaseSession().getDatasourcePlatform();
             if(pl.shouldBindLiterals()) {
-                Assert.assertEquals("The number of parameters found does not match the number supplied" , 4, call.getParameters().size());
+                if(pl.allowBindingForSelectClause()) {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 4, call.getParameters().size());
+                } else {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 3, call.getParameters().size());
+                }
             } else {
                 Assert.assertEquals("The number of parameters found does not match the number supplied" , 1, call.getParameters().size());
             }
@@ -684,7 +765,11 @@ public class TestParameterBinding {
 
             DatabasePlatform pl = (DatabasePlatform)forceBindEMF.unwrap(EntityManagerFactoryImpl.class).getDatabaseSession().getDatasourcePlatform();
             if(pl.shouldBindLiterals()) {
-                Assert.assertEquals("The number of parameters found does not match the number supplied" , 4, call.getParameters().size());
+                if(pl.allowBindingForSelectClause()) {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 4, call.getParameters().size());
+                } else {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 3, call.getParameters().size());
+                }
             } else {
                 Assert.assertEquals("The number of parameters found does not match the number supplied" , 2, call.getParameters().size());
             }
@@ -712,7 +797,11 @@ public class TestParameterBinding {
 
             DatabasePlatform pl = (DatabasePlatform)forceBindEMF.unwrap(EntityManagerFactoryImpl.class).getDatabaseSession().getDatasourcePlatform();
             if(pl.shouldBindLiterals()) {
-                Assert.assertEquals("The number of parameters found does not match the number supplied" , 4, call.getParameters().size());
+                if(pl.allowBindingForSelectClause()) {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 4, call.getParameters().size());
+                } else {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 3, call.getParameters().size());
+                }
             } else {
                 Assert.assertEquals("The number of parameters found does not match the number supplied" , 3, call.getParameters().size());
             }
@@ -742,7 +831,11 @@ public class TestParameterBinding {
 
             DatabasePlatform pl = (DatabasePlatform)forceBindEMF.unwrap(EntityManagerFactoryImpl.class).getDatabaseSession().getDatasourcePlatform();
             if(pl.shouldBindLiterals()) {
-                Assert.assertEquals("The number of parameters found does not match the number supplied" , 7, call.getParameters().size());
+                if(pl.allowBindingForSelectClause()) {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 7, call.getParameters().size());
+                } else {
+                    Assert.assertEquals("The number of parameters found does not match the number supplied" , 6, call.getParameters().size());
+                }
             } else {
                 Assert.assertEquals("The number of parameters found does not match the number supplied" , 5, call.getParameters().size());
             }

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/TestQueryOrderBy.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/TestQueryOrderBy.java
@@ -456,7 +456,7 @@ public class TestQueryOrderBy {
             assertEquals(3, dto01.size());
             assertEquals(1, _sql.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                assertEquals("SELECT ITEM_INTEGER1 FROM SIMPLE_TBL01 WHERE (ITEM_STRING2 = ?) ORDER BY 1", _sql.remove(0));
+                assertEquals("SELECT ITEM_INTEGER1 FROM SIMPLE_TBL01 WHERE (ITEM_STRING2 = 'B') ORDER BY 1", _sql.remove(0));
             } else {
                 assertEquals("SELECT ITEM_INTEGER1 FROM SIMPLE_TBL01 WHERE (ITEM_STRING2 = ?) ORDER BY ?", _sql.remove(0));
             }

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/TestQuerySyntaxAggregateTests.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/TestQuerySyntaxAggregateTests.java
@@ -109,7 +109,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery = cb.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
             ParameterExpression<Integer> intParam1 = cb.parameter(Integer.class);
             cquery.multiselect(cb.avg(intParam1));
 
@@ -125,7 +125,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery2 = cb2.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
             cquery2.multiselect(cb2.avg(cb2.literal(1)));
 
             query = em.createQuery(cquery2);
@@ -178,7 +178,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery = cb.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
             ParameterExpression<Integer> intParam1 = cb.parameter(Integer.class);
             cquery.multiselect(cb.avg(intParam1));
 
@@ -194,7 +194,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery2 = cb2.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
             cquery2.multiselect(cb2.avg(cb2.literal(1)));
 
             query = em.createQuery(cquery2);
@@ -247,7 +247,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery = cb.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
             ParameterExpression<Integer> intParam1 = cb.parameter(Integer.class);
             cquery.multiselect(cb.avg(intParam1));
 
@@ -263,7 +263,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery2 = cb2.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
             cquery2.multiselect(cb2.avg(cb2.literal(1)));
 
             query = em.createQuery(cquery2);
@@ -329,7 +329,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery = cb.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
             ParameterExpression<Integer> intParam1 = cb.parameter(Integer.class);
             ParameterExpression<Double> intParam2 = cb.parameter(Double.class);
             ParameterExpression<Integer> intParam3 = cb.parameter(Integer.class);
@@ -350,7 +350,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery2 = cb2.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
             cquery2.multiselect(cb2.avg(cb2.literal(1)));
             cquery2.having(cb2.lessThan(cb2.literal(0d), cb2.avg(cb2.literal(1))));
 
@@ -365,7 +365,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery3 = cb3.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root3 = cquery3.from(QuerySyntaxEntity.class);
+            cquery3.from(QuerySyntaxEntity.class);
             cquery3.multiselect(cb3.avg(cb3.literal(1)));
             ParameterExpression<Double> intParam4 = cb3.parameter(Double.class);
             ParameterExpression<Integer> intParam5 = cb3.parameter(Integer.class);
@@ -416,7 +416,7 @@ public class TestQuerySyntaxAggregateTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT AVG(1) FROM QUERYSYNTAXENTITY HAVING (0 < AVG(1))", _sql2.remove(0));
+                Assert.assertEquals("SELECT AVG(1) FROM QUERYSYNTAXENTITY HAVING (? < AVG(1))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT AVG(?) FROM QUERYSYNTAXENTITY HAVING (? < AVG(?))", _sql2.remove(0));
             }
@@ -428,8 +428,6 @@ public class TestQuerySyntaxAggregateTests {
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDerby()) {
                 Assert.assertEquals("SELECT AVG(1) FROM QUERYSYNTAXENTITY HAVING (? < AVG(1))", _sql2.remove(0));
-            } else if(platform.isDB2()) {
-                Assert.assertEquals("SELECT AVG(1) FROM QUERYSYNTAXENTITY HAVING (? < AVG(?))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT AVG(?) FROM QUERYSYNTAXENTITY HAVING (? < AVG(?))", _sql2.remove(0));
             }
@@ -438,7 +436,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery = cb.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
             ParameterExpression<Integer> intParam1 = cb.parameter(Integer.class);
             ParameterExpression<Double> intParam2 = cb.parameter(Double.class);
             ParameterExpression<Integer> intParam3 = cb.parameter(Integer.class);
@@ -459,22 +457,22 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery2 = cb2.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
             cquery2.multiselect(cb2.avg(cb2.literal(1)));
             cquery2.having(cb2.lessThan(cb2.literal(0d), cb2.avg(cb2.literal(1))));
 
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT AVG(1) FROM QUERYSYNTAXENTITY HAVING (0.0 < AVG(1))", _sql2.remove(0));
+            if(platform.isDB2Z() || platform.isDerby()) {
+                Assert.assertEquals("SELECT AVG(1) FROM QUERYSYNTAXENTITY HAVING (? < AVG(1))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT AVG(?) FROM QUERYSYNTAXENTITY HAVING (? < AVG(?))", _sql2.remove(0));
             }
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery3 = cb3.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root3 = cquery3.from(QuerySyntaxEntity.class);
+            cquery3.from(QuerySyntaxEntity.class);
             cquery3.multiselect(cb3.avg(cb3.literal(1)));
             ParameterExpression<Double> intParam4 = cb3.parameter(Double.class);
             ParameterExpression<Integer> intParam5 = cb3.parameter(Integer.class);
@@ -487,8 +485,6 @@ public class TestQuerySyntaxAggregateTests {
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDerby()) {
                 Assert.assertEquals("SELECT AVG(1) FROM QUERYSYNTAXENTITY HAVING (? < AVG(1))", _sql2.remove(0));
-            } else if(platform.isDB2()) {
-                Assert.assertEquals("SELECT AVG(1) FROM QUERYSYNTAXENTITY HAVING (? < AVG(?))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT AVG(?) FROM QUERYSYNTAXENTITY HAVING (? < AVG(?))", _sql2.remove(0));
             }
@@ -547,7 +543,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery = cb.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
             ParameterExpression<Integer> intParam1 = cb.parameter(Integer.class);
             ParameterExpression<Double> intParam2 = cb.parameter(Double.class);
             ParameterExpression<Integer> intParam3 = cb.parameter(Integer.class);
@@ -568,7 +564,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery2 = cb2.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
             cquery2.multiselect(cb2.avg(cb2.literal(1)));
             cquery2.having(cb2.lessThan(cb2.literal(0d), cb2.avg(cb2.literal(1))));
 
@@ -583,7 +579,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery3 = cb3.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root3 = cquery3.from(QuerySyntaxEntity.class);
+            cquery3.from(QuerySyntaxEntity.class);
             cquery3.multiselect(cb3.avg(cb3.literal(1)));
             ParameterExpression<Double> intParam4 = cb3.parameter(Double.class);
             ParameterExpression<Integer> intParam5 = cb3.parameter(Integer.class);
@@ -969,8 +965,10 @@ public class TestQuerySyntaxAggregateTests {
             query = em.createQuery("SELECT AVG(1) FROM QuerySyntaxEntity s HAVING 0 < AVG(DISTINCT 1)");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT AVG(1) FROM QUERYSYNTAXENTITY HAVING (0 < AVG(DISTINCT(1)))", _sql2.remove(0));
+            if(platform.isDB2Z() || platform.isDerby()) {
+                Assert.assertEquals("SELECT AVG(1) FROM QUERYSYNTAXENTITY HAVING (? < AVG(DISTINCT(1)))", _sql2.remove(0));
+            } else if(platform.isDB2()) {
+                Assert.assertEquals("SELECT AVG(?) FROM QUERYSYNTAXENTITY HAVING (? < AVG(DISTINCT(1)))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT AVG(?) FROM QUERYSYNTAXENTITY HAVING (? < AVG(DISTINCT(?)))", _sql2.remove(0));
             }
@@ -980,8 +978,10 @@ public class TestQuerySyntaxAggregateTests {
             query.setParameter(2, 1);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+            if(platform.isDB2Z() || platform.isDerby()) {
                 Assert.assertEquals("SELECT AVG(1) FROM QUERYSYNTAXENTITY HAVING (? < AVG(DISTINCT(1)))", _sql2.remove(0));
+            } else if(platform.isDB2()) {
+                Assert.assertEquals("SELECT AVG(?) FROM QUERYSYNTAXENTITY HAVING (? < AVG(DISTINCT(1)))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT AVG(?) FROM QUERYSYNTAXENTITY HAVING (? < AVG(DISTINCT(?)))", _sql2.remove(0));
             }
@@ -1207,7 +1207,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery = cb.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
             ParameterExpression<Integer> intParam1 = cb.parameter(Integer.class);
             cquery.multiselect(cb.count(intParam1));
 
@@ -1223,7 +1223,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery2 = cb2.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
             cquery2.multiselect(cb2.count(cb2.literal(1)));
 
             query = em.createQuery(cquery2);
@@ -1276,7 +1276,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery = cb.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
             ParameterExpression<Integer> intParam1 = cb.parameter(Integer.class);
             cquery.multiselect(cb.count(intParam1));
 
@@ -1292,7 +1292,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery2 = cb2.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
             cquery2.multiselect(cb2.count(cb2.literal(1)));
 
             query = em.createQuery(cquery2);
@@ -1345,7 +1345,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery = cb.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
             ParameterExpression<Integer> intParam1 = cb.parameter(Integer.class);
             cquery.multiselect(cb.count(intParam1));
 
@@ -1361,7 +1361,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery2 = cb2.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
             cquery2.multiselect(cb2.count(cb2.literal(1)));
 
             query = em.createQuery(cquery2);
@@ -1427,7 +1427,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery = cb.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
             ParameterExpression<Integer> intParam1 = cb.parameter(Integer.class);
             ParameterExpression<Long> intParam2 = cb.parameter(Long.class);
             ParameterExpression<Integer> intParam3 = cb.parameter(Integer.class);
@@ -1448,7 +1448,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery2 = cb2.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
             cquery2.multiselect(cb2.count(cb2.literal(1)));
             cquery2.having(cb2.lessThan(cb2.literal(0L), cb2.count(cb2.literal(1))));
 
@@ -1463,7 +1463,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery3 = cb3.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root3 = cquery3.from(QuerySyntaxEntity.class);
+            cquery3.from(QuerySyntaxEntity.class);
             cquery3.multiselect(cb3.count(cb3.literal(1)));
             ParameterExpression<Long> intParam4 = cb3.parameter(Long.class);
             ParameterExpression<Integer> intParam5 = cb3.parameter(Integer.class);
@@ -1514,7 +1514,7 @@ public class TestQuerySyntaxAggregateTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT COUNT(1) FROM QUERYSYNTAXENTITY HAVING (0 < COUNT(1))", _sql2.remove(0));
+                Assert.assertEquals("SELECT COUNT(1) FROM QUERYSYNTAXENTITY HAVING (? < COUNT(1))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT COUNT(?) FROM QUERYSYNTAXENTITY HAVING (? < COUNT(?))", _sql2.remove(0));
             }
@@ -1534,7 +1534,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery = cb.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
             ParameterExpression<Integer> intParam1 = cb.parameter(Integer.class);
             ParameterExpression<Long> intParam2 = cb.parameter(Long.class);
             ParameterExpression<Integer> intParam3 = cb.parameter(Integer.class);
@@ -1555,7 +1555,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery2 = cb2.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
             cquery2.multiselect(cb2.count(cb2.literal(1)));
             cquery2.having(cb2.lessThan(cb2.literal(0L), cb2.count(cb2.literal(1))));
 
@@ -1563,14 +1563,14 @@ public class TestQuerySyntaxAggregateTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT COUNT(1) FROM QUERYSYNTAXENTITY HAVING (0 < COUNT(1))", _sql2.remove(0));
+                Assert.assertEquals("SELECT COUNT(1) FROM QUERYSYNTAXENTITY HAVING (? < COUNT(1))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT COUNT(?) FROM QUERYSYNTAXENTITY HAVING (? < COUNT(?))", _sql2.remove(0));
             }
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery3 = cb3.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root3 = cquery3.from(QuerySyntaxEntity.class);
+            cquery3.from(QuerySyntaxEntity.class);
             cquery3.multiselect(cb3.count(cb3.literal(1)));
             ParameterExpression<Long> intParam4 = cb3.parameter(Long.class);
             ParameterExpression<Integer> intParam5 = cb3.parameter(Integer.class);
@@ -1641,7 +1641,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery = cb.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
             ParameterExpression<Integer> intParam1 = cb.parameter(Integer.class);
             ParameterExpression<Long> intParam2 = cb.parameter(Long.class);
             ParameterExpression<Integer> intParam3 = cb.parameter(Integer.class);
@@ -1662,7 +1662,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery2 = cb2.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
             cquery2.multiselect(cb2.count(cb2.literal(1)));
             cquery2.having(cb2.lessThan(cb2.literal(0L), cb2.count(cb2.literal(1))));
 
@@ -1677,7 +1677,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery3 = cb3.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root3 = cquery3.from(QuerySyntaxEntity.class);
+            cquery3.from(QuerySyntaxEntity.class);
             cquery3.multiselect(cb3.count(cb3.literal(1)));
             ParameterExpression<Long> intParam4 = cb3.parameter(Long.class);
             ParameterExpression<Integer> intParam5 = cb3.parameter(Integer.class);
@@ -1735,7 +1735,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery = cb.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
             ParameterExpression<Integer> intParam1 = cb.parameter(Integer.class);
             cquery.multiselect(cb.countDistinct(intParam1));
 
@@ -1751,7 +1751,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery2 = cb2.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
             cquery2.multiselect(cb2.countDistinct(cb2.literal(1)));
 
             query = em.createQuery(cquery2);
@@ -1804,7 +1804,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery = cb.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
             ParameterExpression<Integer> intParam1 = cb.parameter(Integer.class);
             cquery.multiselect(cb.countDistinct(intParam1));
 
@@ -1820,7 +1820,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery2 = cb2.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
             cquery2.multiselect(cb2.countDistinct(cb2.literal(1)));
 
             query = em.createQuery(cquery2);
@@ -1873,7 +1873,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery = cb.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
             ParameterExpression<Integer> intParam1 = cb.parameter(Integer.class);
             cquery.multiselect(cb.countDistinct(intParam1));
 
@@ -1889,7 +1889,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery2 = cb2.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
             cquery2.multiselect(cb2.countDistinct(cb2.literal(1)));
 
             query = em.createQuery(cquery2);
@@ -1955,7 +1955,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery = cb.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
             ParameterExpression<Integer> intParam1 = cb.parameter(Integer.class);
             ParameterExpression<Long> intParam2 = cb.parameter(Long.class);
             ParameterExpression<Integer> intParam3 = cb.parameter(Integer.class);
@@ -1976,7 +1976,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery2 = cb2.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
             cquery2.multiselect(cb2.count(cb2.literal(1)));
             cquery2.having(cb2.lessThan(cb2.literal(0L), cb2.countDistinct(cb2.literal(1))));
 
@@ -1991,7 +1991,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery3 = cb3.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root3 = cquery3.from(QuerySyntaxEntity.class);
+            cquery3.from(QuerySyntaxEntity.class);
             cquery3.multiselect(cb3.count(cb3.literal(1)));
             ParameterExpression<Long> intParam4 = cb3.parameter(Long.class);
             ParameterExpression<Integer> intParam5 = cb3.parameter(Integer.class);
@@ -2042,7 +2042,7 @@ public class TestQuerySyntaxAggregateTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT COUNT(1) FROM QUERYSYNTAXENTITY HAVING (0 < COUNT(DISTINCT(1)))", _sql2.remove(0));
+                Assert.assertEquals("SELECT COUNT(1) FROM QUERYSYNTAXENTITY HAVING (? < COUNT(DISTINCT(1)))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT COUNT(?) FROM QUERYSYNTAXENTITY HAVING (? < COUNT(DISTINCT(?)))", _sql2.remove(0));
             }
@@ -2062,7 +2062,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery = cb.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
             ParameterExpression<Integer> intParam1 = cb.parameter(Integer.class);
             ParameterExpression<Long> intParam2 = cb.parameter(Long.class);
             ParameterExpression<Integer> intParam3 = cb.parameter(Integer.class);
@@ -2083,7 +2083,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery2 = cb2.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
             cquery2.multiselect(cb2.count(cb2.literal(1)));
             cquery2.having(cb2.lessThan(cb2.literal(0L), cb2.countDistinct(cb2.literal(1))));
 
@@ -2091,14 +2091,14 @@ public class TestQuerySyntaxAggregateTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT COUNT(1) FROM QUERYSYNTAXENTITY HAVING (0 < COUNT(DISTINCT(1)))", _sql2.remove(0));
+                Assert.assertEquals("SELECT COUNT(1) FROM QUERYSYNTAXENTITY HAVING (? < COUNT(DISTINCT(1)))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT COUNT(?) FROM QUERYSYNTAXENTITY HAVING (? < COUNT(DISTINCT(?)))", _sql2.remove(0));
             }
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery3 = cb3.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root3 = cquery3.from(QuerySyntaxEntity.class);
+            cquery3.from(QuerySyntaxEntity.class);
             cquery3.multiselect(cb3.count(cb3.literal(1)));
             ParameterExpression<Long> intParam4 = cb3.parameter(Long.class);
             ParameterExpression<Integer> intParam5 = cb3.parameter(Integer.class);
@@ -2169,7 +2169,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery = cb.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
             ParameterExpression<Integer> intParam1 = cb.parameter(Integer.class);
             ParameterExpression<Long> intParam2 = cb.parameter(Long.class);
             ParameterExpression<Integer> intParam3 = cb.parameter(Integer.class);
@@ -2190,7 +2190,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery2 = cb2.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
             cquery2.multiselect(cb2.count(cb2.literal(1)));
             cquery2.having(cb2.lessThan(cb2.literal(0L), cb2.countDistinct(cb2.literal(1))));
 
@@ -2205,7 +2205,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery3 = cb3.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root3 = cquery3.from(QuerySyntaxEntity.class);
+            cquery3.from(QuerySyntaxEntity.class);
             cquery3.multiselect(cb3.count(cb3.literal(1)));
             ParameterExpression<Long> intParam4 = cb3.parameter(Long.class);
             ParameterExpression<Integer> intParam5 = cb3.parameter(Integer.class);
@@ -2263,7 +2263,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery = cb.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
             ParameterExpression<Integer> intParam1 = cb.parameter(Integer.class);
             cquery.multiselect(cb.sum(intParam1));
 
@@ -2279,7 +2279,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery2 = cb2.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
             cquery2.multiselect(cb2.sum(cb2.literal(1)));
 
             query = em.createQuery(cquery2);
@@ -2332,7 +2332,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery = cb.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
             ParameterExpression<Integer> intParam1 = cb.parameter(Integer.class);
             cquery.multiselect(cb.sum(intParam1));
 
@@ -2348,7 +2348,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery2 = cb2.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
             cquery2.multiselect(cb2.sum(cb2.literal(1)));
 
             query = em.createQuery(cquery2);
@@ -2401,7 +2401,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery = cb.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
             ParameterExpression<Integer> intParam1 = cb.parameter(Integer.class);
             cquery.multiselect(cb.sum(intParam1));
 
@@ -2417,7 +2417,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery2 = cb2.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
             cquery2.multiselect(cb2.sum(cb2.literal(1)));
 
             query = em.createQuery(cquery2);
@@ -2483,7 +2483,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery = cb.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
             ParameterExpression<Integer> intParam1 = cb.parameter(Integer.class);
             ParameterExpression<Integer> intParam2 = cb.parameter(Integer.class);
             ParameterExpression<Integer> intParam3 = cb.parameter(Integer.class);
@@ -2504,7 +2504,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery2 = cb2.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
             cquery2.multiselect(cb2.sum(cb2.literal(1)));
             cquery2.having(cb2.lessThan(cb2.literal(0), cb2.sum(cb2.literal(1))));
 
@@ -2519,7 +2519,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery3 = cb3.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root3 = cquery3.from(QuerySyntaxEntity.class);
+            cquery3.from(QuerySyntaxEntity.class);
             cquery3.multiselect(cb3.sum(cb3.literal(1)));
             ParameterExpression<Integer> intParam4 = cb3.parameter(Integer.class);
             ParameterExpression<Integer> intParam5 = cb3.parameter(Integer.class);
@@ -2570,7 +2570,7 @@ public class TestQuerySyntaxAggregateTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT SUM(1) FROM QUERYSYNTAXENTITY HAVING (0 < SUM(1))", _sql2.remove(0));
+                Assert.assertEquals("SELECT SUM(1) FROM QUERYSYNTAXENTITY HAVING (? < SUM(1))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT SUM(?) FROM QUERYSYNTAXENTITY HAVING (? < SUM(?))", _sql2.remove(0));
             }
@@ -2582,8 +2582,6 @@ public class TestQuerySyntaxAggregateTests {
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDerby()) {
                 Assert.assertEquals("SELECT SUM(1) FROM QUERYSYNTAXENTITY HAVING (? < SUM(1))", _sql2.remove(0));
-            } else if(platform.isDB2()) {
-                Assert.assertEquals("SELECT SUM(1) FROM QUERYSYNTAXENTITY HAVING (? < SUM(?))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT SUM(?) FROM QUERYSYNTAXENTITY HAVING (? < SUM(?))", _sql2.remove(0));
             }
@@ -2592,7 +2590,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery = cb.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
             ParameterExpression<Integer> intParam1 = cb.parameter(Integer.class);
             ParameterExpression<Integer> intParam2 = cb.parameter(Integer.class);
             ParameterExpression<Integer> intParam3 = cb.parameter(Integer.class);
@@ -2613,7 +2611,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery2 = cb2.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
             cquery2.multiselect(cb2.sum(cb2.literal(1)));
             cquery2.having(cb2.lessThan(cb2.literal(0), cb2.sum(cb2.literal(1))));
 
@@ -2621,14 +2619,14 @@ public class TestQuerySyntaxAggregateTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT SUM(1) FROM QUERYSYNTAXENTITY HAVING (0 < SUM(1))", _sql2.remove(0));
+                Assert.assertEquals("SELECT SUM(1) FROM QUERYSYNTAXENTITY HAVING (? < SUM(1))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT SUM(?) FROM QUERYSYNTAXENTITY HAVING (? < SUM(?))", _sql2.remove(0));
             }
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery3 = cb3.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root3 = cquery3.from(QuerySyntaxEntity.class);
+            cquery3.from(QuerySyntaxEntity.class);
             cquery3.multiselect(cb3.sum(cb3.literal(1)));
             ParameterExpression<Integer> intParam4 = cb3.parameter(Integer.class);
             ParameterExpression<Integer> intParam5 = cb3.parameter(Integer.class);
@@ -2641,8 +2639,6 @@ public class TestQuerySyntaxAggregateTests {
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDerby()) {
                 Assert.assertEquals("SELECT SUM(1) FROM QUERYSYNTAXENTITY HAVING (? < SUM(1))", _sql2.remove(0));
-            } else if(platform.isDB2()) {
-                Assert.assertEquals("SELECT SUM(1) FROM QUERYSYNTAXENTITY HAVING (? < SUM(?))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT SUM(?) FROM QUERYSYNTAXENTITY HAVING (? < SUM(?))", _sql2.remove(0));
             }
@@ -2701,7 +2697,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery = cb.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
             ParameterExpression<Integer> intParam1 = cb.parameter(Integer.class);
             ParameterExpression<Integer> intParam2 = cb.parameter(Integer.class);
             ParameterExpression<Integer> intParam3 = cb.parameter(Integer.class);
@@ -2722,7 +2718,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery2 = cb2.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
             cquery2.multiselect(cb2.sum(cb2.literal(1)));
             cquery2.having(cb2.lessThan(cb2.literal(0), cb2.sum(cb2.literal(1))));
 
@@ -2737,7 +2733,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery3 = cb3.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root3 = cquery3.from(QuerySyntaxEntity.class);
+            cquery3.from(QuerySyntaxEntity.class);
             cquery3.multiselect(cb3.sum(cb3.literal(1)));
             ParameterExpression<Integer> intParam4 = cb3.parameter(Integer.class);
             ParameterExpression<Integer> intParam5 = cb3.parameter(Integer.class);
@@ -2808,7 +2804,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery = cb.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
             ParameterExpression<Integer> intParam1 = cb.parameter(Integer.class);
             ParameterExpression<Integer> intParam2 = cb.parameter(Integer.class);
             ParameterExpression<Integer> intParam3 = cb.parameter(Integer.class);
@@ -2829,7 +2825,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery2 = cb2.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
             cquery2.multiselect(cb2.max(cb2.literal(1)));
             cquery2.having(cb2.lessThan(cb2.literal(0), cb2.max(cb2.literal(1))));
 
@@ -2844,7 +2840,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery3 = cb3.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root3 = cquery3.from(QuerySyntaxEntity.class);
+            cquery3.from(QuerySyntaxEntity.class);
             cquery3.multiselect(cb3.max(cb3.literal(1)));
             ParameterExpression<Integer> intParam4 = cb3.parameter(Integer.class);
             ParameterExpression<Integer> intParam5 = cb3.parameter(Integer.class);
@@ -2895,7 +2891,7 @@ public class TestQuerySyntaxAggregateTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT MAX(1) FROM QUERYSYNTAXENTITY HAVING (0 < MAX(1))", _sql2.remove(0));
+                Assert.assertEquals("SELECT MAX(1) FROM QUERYSYNTAXENTITY HAVING (? < MAX(1))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT MAX(?) FROM QUERYSYNTAXENTITY HAVING (? < MAX(?))", _sql2.remove(0));
             }
@@ -2915,7 +2911,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery = cb.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
             ParameterExpression<Integer> intParam1 = cb.parameter(Integer.class);
             ParameterExpression<Integer> intParam2 = cb.parameter(Integer.class);
             ParameterExpression<Integer> intParam3 = cb.parameter(Integer.class);
@@ -2936,7 +2932,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery2 = cb2.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
             cquery2.multiselect(cb2.max(cb2.literal(1)));
             cquery2.having(cb2.lessThan(cb2.literal(0), cb2.max(cb2.literal(1))));
 
@@ -2944,14 +2940,14 @@ public class TestQuerySyntaxAggregateTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT MAX(1) FROM QUERYSYNTAXENTITY HAVING (0 < MAX(1))", _sql2.remove(0));
+                Assert.assertEquals("SELECT MAX(1) FROM QUERYSYNTAXENTITY HAVING (? < MAX(1))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT MAX(?) FROM QUERYSYNTAXENTITY HAVING (? < MAX(?))", _sql2.remove(0));
             }
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery3 = cb3.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root3 = cquery3.from(QuerySyntaxEntity.class);
+            cquery3.from(QuerySyntaxEntity.class);
             cquery3.multiselect(cb3.max(cb3.literal(1)));
             ParameterExpression<Integer> intParam4 = cb3.parameter(Integer.class);
             ParameterExpression<Integer> intParam5 = cb3.parameter(Integer.class);
@@ -3022,7 +3018,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery = cb.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
             ParameterExpression<Integer> intParam1 = cb.parameter(Integer.class);
             ParameterExpression<Integer> intParam2 = cb.parameter(Integer.class);
             ParameterExpression<Integer> intParam3 = cb.parameter(Integer.class);
@@ -3043,7 +3039,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery2 = cb2.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
             cquery2.multiselect(cb2.max(cb2.literal(1)));
             cquery2.having(cb2.lessThan(cb2.literal(0), cb2.max(cb2.literal(1))));
 
@@ -3058,7 +3054,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery3 = cb3.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root3 = cquery3.from(QuerySyntaxEntity.class);
+            cquery3.from(QuerySyntaxEntity.class);
             cquery3.multiselect(cb3.max(cb3.literal(1)));
             ParameterExpression<Integer> intParam4 = cb3.parameter(Integer.class);
             ParameterExpression<Integer> intParam5 = cb3.parameter(Integer.class);
@@ -3090,7 +3086,6 @@ public class TestQuerySyntaxAggregateTests {
             return;
 
         EntityManager em = emf.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s GROUP BY s.intVal1 HAVING MAX(s.intVal1) > ?2");
@@ -3102,11 +3097,7 @@ public class TestQuerySyntaxAggregateTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s GROUP BY s.intVal1 HAVING MAX(s.intVal1) > 8");
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (MAX(INTVAL1) > 8)", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (MAX(INTVAL1) > ?)", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (MAX(INTVAL1) > ?)", _sql.remove(0));
 
             // -----------------------
 
@@ -3134,11 +3125,7 @@ public class TestQuerySyntaxAggregateTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (MAX(INTVAL1) > 8)", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (MAX(INTVAL1) > ?)", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (MAX(INTVAL1) > ?)", _sql.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -3155,7 +3142,6 @@ public class TestQuerySyntaxAggregateTests {
             return;
 
         EntityManager em = emf2.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s GROUP BY s.intVal1 HAVING MAX(s.intVal1) > ?2");
@@ -3167,11 +3153,7 @@ public class TestQuerySyntaxAggregateTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s GROUP BY s.intVal1 HAVING MAX(s.intVal1) > 8");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (MAX(INTVAL1) > 8)", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (MAX(INTVAL1) > ?)", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (MAX(INTVAL1) > ?)", _sql2.remove(0));
 
             // -----------------------
 
@@ -3199,11 +3181,7 @@ public class TestQuerySyntaxAggregateTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (MAX(INTVAL1) > 8)", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (MAX(INTVAL1) > ?)", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (MAX(INTVAL1) > ?)", _sql2.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -3315,7 +3293,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery = cb.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
             ParameterExpression<Integer> intParam1 = cb.parameter(Integer.class);
             ParameterExpression<Integer> intParam2 = cb.parameter(Integer.class);
             ParameterExpression<Integer> intParam3 = cb.parameter(Integer.class);
@@ -3336,7 +3314,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery2 = cb2.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
             cquery2.multiselect(cb2.min(cb2.literal(1)));
             cquery2.having(cb2.lessThan(cb2.literal(0), cb2.min(cb2.literal(1))));
 
@@ -3351,7 +3329,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery3 = cb3.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root3 = cquery3.from(QuerySyntaxEntity.class);
+            cquery3.from(QuerySyntaxEntity.class);
             cquery3.multiselect(cb3.min(cb3.literal(1)));
             ParameterExpression<Integer> intParam4 = cb3.parameter(Integer.class);
             ParameterExpression<Integer> intParam5 = cb3.parameter(Integer.class);
@@ -3402,7 +3380,7 @@ public class TestQuerySyntaxAggregateTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT MIN(1) FROM QUERYSYNTAXENTITY HAVING (0 < MIN(1))", _sql2.remove(0));
+                Assert.assertEquals("SELECT MIN(1) FROM QUERYSYNTAXENTITY HAVING (? < MIN(1))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT MIN(?) FROM QUERYSYNTAXENTITY HAVING (? < MIN(?))", _sql2.remove(0));
             }
@@ -3422,7 +3400,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery = cb.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
             ParameterExpression<Integer> intParam1 = cb.parameter(Integer.class);
             ParameterExpression<Integer> intParam2 = cb.parameter(Integer.class);
             ParameterExpression<Integer> intParam3 = cb.parameter(Integer.class);
@@ -3443,7 +3421,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery2 = cb2.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
             cquery2.multiselect(cb2.min(cb2.literal(1)));
             cquery2.having(cb2.lessThan(cb2.literal(0), cb2.min(cb2.literal(1))));
 
@@ -3451,14 +3429,14 @@ public class TestQuerySyntaxAggregateTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT MIN(1) FROM QUERYSYNTAXENTITY HAVING (0 < MIN(1))", _sql2.remove(0));
+                Assert.assertEquals("SELECT MIN(1) FROM QUERYSYNTAXENTITY HAVING (? < MIN(1))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT MIN(?) FROM QUERYSYNTAXENTITY HAVING (? < MIN(?))", _sql2.remove(0));
             }
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery3 = cb3.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root3 = cquery3.from(QuerySyntaxEntity.class);
+            cquery3.from(QuerySyntaxEntity.class);
             cquery3.multiselect(cb3.min(cb3.literal(1)));
             ParameterExpression<Integer> intParam4 = cb3.parameter(Integer.class);
             ParameterExpression<Integer> intParam5 = cb3.parameter(Integer.class);
@@ -3529,7 +3507,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery = cb.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
             ParameterExpression<Integer> intParam1 = cb.parameter(Integer.class);
             ParameterExpression<Integer> intParam2 = cb.parameter(Integer.class);
             ParameterExpression<Integer> intParam3 = cb.parameter(Integer.class);
@@ -3550,7 +3528,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery2 = cb2.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
             cquery2.multiselect(cb2.min(cb2.literal(1)));
             cquery2.having(cb2.lessThan(cb2.literal(0), cb2.min(cb2.literal(1))));
 
@@ -3565,7 +3543,7 @@ public class TestQuerySyntaxAggregateTests {
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery3 = cb3.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root3 = cquery3.from(QuerySyntaxEntity.class);
+            cquery3.from(QuerySyntaxEntity.class);
             cquery3.multiselect(cb3.min(cb3.literal(1)));
             ParameterExpression<Integer> intParam4 = cb3.parameter(Integer.class);
             ParameterExpression<Integer> intParam5 = cb3.parameter(Integer.class);
@@ -3597,7 +3575,6 @@ public class TestQuerySyntaxAggregateTests {
             return;
 
         EntityManager em = emf.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s GROUP BY s.intVal1 HAVING MIN(s.intVal1) > ?2");
@@ -3609,11 +3586,7 @@ public class TestQuerySyntaxAggregateTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s GROUP BY s.intVal1 HAVING MIN(s.intVal1) > 8");
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (MIN(INTVAL1) > 8)", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (MIN(INTVAL1) > ?)", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (MIN(INTVAL1) > ?)", _sql.remove(0));
 
             // -----------------------
 
@@ -3641,11 +3614,7 @@ public class TestQuerySyntaxAggregateTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (MIN(INTVAL1) > 8)", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (MIN(INTVAL1) > ?)", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (MIN(INTVAL1) > ?)", _sql.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -3662,7 +3631,6 @@ public class TestQuerySyntaxAggregateTests {
             return;
 
         EntityManager em = emf2.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf2);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s GROUP BY s.intVal1 HAVING MIN(s.intVal1) > ?2");
@@ -3674,11 +3642,7 @@ public class TestQuerySyntaxAggregateTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s GROUP BY s.intVal1 HAVING MIN(s.intVal1) > 8");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (MIN(INTVAL1) > 8)", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (MIN(INTVAL1) > ?)", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (MIN(INTVAL1) > ?)", _sql2.remove(0));
 
             // -----------------------
 
@@ -3706,11 +3670,7 @@ public class TestQuerySyntaxAggregateTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (MIN(INTVAL1) > 8)", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (MIN(INTVAL1) > ?)", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (MIN(INTVAL1) > ?)", _sql2.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -3875,7 +3835,7 @@ public class TestQuerySyntaxAggregateTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT DISTINCT 'HELLO' FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = 'WORLD')", _sql2.remove(0));
+                Assert.assertEquals("SELECT DISTINCT 'HELLO' FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = ?)", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT DISTINCT ? FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = ?)", _sql2.remove(0));
             }
@@ -3911,7 +3871,7 @@ public class TestQuerySyntaxAggregateTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT DISTINCT 'HELLO' FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = 'WORLD')", _sql2.remove(0));
+                Assert.assertEquals("SELECT DISTINCT 'HELLO' FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = ?)", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT DISTINCT ? FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = ?)", _sql2.remove(0));
             }

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/TestQuerySyntaxArithmeticTests.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/TestQuerySyntaxArithmeticTests.java
@@ -169,7 +169,7 @@ public class TestQuerySyntaxArithmeticTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE ABS(-36) = s.intVal1");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+            if(platform.isDB2Z()) {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (ABS(-36) = INTVAL1)", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (ABS(?) = INTVAL1)", _sql2.remove(0));
@@ -203,7 +203,7 @@ public class TestQuerySyntaxArithmeticTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+            if(platform.isDB2Z()) {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (ABS(-36) = INTVAL1)", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (ABS(?) = INTVAL1)", _sql2.remove(0));
@@ -384,7 +384,7 @@ public class TestQuerySyntaxArithmeticTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 = SQRT(36)");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+            if(platform.isDB2Z()) {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = SQRT(36))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = SQRT(?))", _sql2.remove(0));
@@ -419,7 +419,7 @@ public class TestQuerySyntaxArithmeticTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+            if(platform.isDB2Z()) {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = SQRT(36))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = SQRT(?))", _sql2.remove(0));
@@ -606,8 +606,10 @@ public class TestQuerySyntaxArithmeticTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 = MOD(36, 10)");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+            if(platform.isDB2Z()) {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = MOD(36, 10))", _sql2.remove(0));
+            } else if(platform.isDerby()) {
+                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = MOD(?, 10))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = MOD(?, ?))", _sql2.remove(0));
             }
@@ -644,8 +646,10 @@ public class TestQuerySyntaxArithmeticTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+            if(platform.isDB2Z()) {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = MOD(36, 10))", _sql2.remove(0));
+            } else if(platform.isDerby()) {
+                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = MOD(?, 10))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = MOD(?, ?))", _sql2.remove(0));
             }
@@ -867,8 +871,8 @@ public class TestQuerySyntaxArithmeticTests {
             query = em.createQuery("SELECT s.intVal1, (4 + 2) FROM QuerySyntaxEntity s WHERE s.intVal1 = (4 + 2)");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1, (4 + 2) FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = (4 + 2))", _sql2.remove(0));
+            if(platform.isDerby()) {
+                Assert.assertEquals("SELECT INTVAL1, (? + 2) FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = (? + 2))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = (? + ?))", _sql2.remove(0));
             }
@@ -877,8 +881,8 @@ public class TestQuerySyntaxArithmeticTests {
             query.setParameter(1, 2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1, (4 + ?) FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = (? + 4))", _sql2.remove(0));
+            if(platform.isDerby()) {
+                Assert.assertEquals("SELECT INTVAL1, (? + 2) FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = (? + 4))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = (? + ?))", _sql2.remove(0));
             }
@@ -913,8 +917,8 @@ public class TestQuerySyntaxArithmeticTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1, (4 + 2) FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = (4 + 2))", _sql2.remove(0));
+            if(platform.isDerby()) {
+                Assert.assertEquals("SELECT INTVAL1, (? + 2) FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = (? + 2))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = (? + ?))", _sql2.remove(0));
             }
@@ -930,8 +934,8 @@ public class TestQuerySyntaxArithmeticTests {
             query.setParameter(intParam3, 4);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1, (2 + ?) FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = (? + 2))", _sql2.remove(0));
+            if(platform.isDerby()) {
+                Assert.assertEquals("SELECT INTVAL1, (? + 4) FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = (? + 2))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = (? + ?))", _sql2.remove(0));
             }
@@ -1172,8 +1176,10 @@ public class TestQuerySyntaxArithmeticTests {
             query = em.createQuery("SELECT s.strVal1, 2 FROM QuerySyntaxEntity s WHERE s.intVal1 != (4 - 2)");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT STRVAL1, 2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 <> (4 - 2))", _sql2.remove(0));
+            if(platform.isDerby()) {
+                Assert.assertEquals("SELECT STRVAL1, 2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 <> (? - 2))", _sql2.remove(0));
+            } else if(platform.isDB2Z() || platform.isDB2()) {
+                Assert.assertEquals("SELECT STRVAL1, 2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 <> (? - ?))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1, ? FROM QUERYSYNTAXENTITY WHERE (INTVAL1 <> (? - ?))", _sql2.remove(0));
             }
@@ -1182,8 +1188,10 @@ public class TestQuerySyntaxArithmeticTests {
             query.setParameter(2, 2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT STRVAL1, 2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 <> (4 - ?))", _sql2.remove(0));
+            if(platform.isDerby()) {
+                Assert.assertEquals("SELECT STRVAL1, 2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 <> (? - 2))", _sql2.remove(0));
+            } else if(platform.isDB2Z() || platform.isDB2()) {
+                Assert.assertEquals("SELECT STRVAL1, 2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 <> (? - ?))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1, ? FROM QUERYSYNTAXENTITY WHERE (INTVAL1 <> (? - ?))", _sql2.remove(0));
             }
@@ -1220,8 +1228,10 @@ public class TestQuerySyntaxArithmeticTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT STRVAL1, 2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 <> (4 - 2))", _sql2.remove(0));
+            if(platform.isDerby()) {
+                Assert.assertEquals("SELECT STRVAL1, 2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 <> (? - 2))", _sql2.remove(0));
+            } else if (platform.isDB2Z() || platform.isDB2()) {
+                Assert.assertEquals("SELECT STRVAL1, 2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 <> (? - ?))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1, ? FROM QUERYSYNTAXENTITY WHERE (INTVAL1 <> (? - ?))", _sql2.remove(0));
             }
@@ -1238,8 +1248,10 @@ public class TestQuerySyntaxArithmeticTests {
             query.setParameter(intParam6, 2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT STRVAL1, 2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 <> (4 - ?))", _sql2.remove(0));
+            if(platform.isDerby()) {
+                Assert.assertEquals("SELECT STRVAL1, 2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 <> (? - 2))", _sql2.remove(0));
+            } else if(platform.isDB2Z() || platform.isDB2()) {
+                Assert.assertEquals("SELECT STRVAL1, 2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 <> (? - ?))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1, ? FROM QUERYSYNTAXENTITY WHERE (INTVAL1 <> (? - ?))", _sql2.remove(0));
             }

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/TestQuerySyntaxComparisonTests.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/TestQuerySyntaxComparisonTests.java
@@ -87,7 +87,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 = (?1)");
@@ -99,11 +98,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 = (4)");
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = 4)", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?)", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?)", _sql.remove(0));
 
             // -----------------------
 
@@ -129,11 +124,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = 4)", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?)", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?)", _sql.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -150,7 +141,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf2.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf2);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 = (?1)");
@@ -162,11 +152,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 = (4)");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = 4)", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?)", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?)", _sql2.remove(0));
 
             // -----------------------
 
@@ -192,11 +178,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = 4)", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?)", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?)", _sql2.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -387,8 +369,10 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1, 4 + -2 FROM QuerySyntaxEntity s WHERE 4 = (s.intVal1 + ABS(-2))");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1, (4 + -2) FROM QUERYSYNTAXENTITY WHERE (4 = (INTVAL1 + ABS(-2)))", _sql2.remove(0));
+            if(platform.isDB2Z()) {
+                Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM QUERYSYNTAXENTITY WHERE (? = (INTVAL1 + ABS(-2)))", _sql2.remove(0));
+            } else if(platform.isDerby()) {
+                Assert.assertEquals("SELECT INTVAL1, (? + -2) FROM QUERYSYNTAXENTITY WHERE (? = (INTVAL1 + ABS(?)))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM QUERYSYNTAXENTITY WHERE (? = (INTVAL1 + ABS(?)))", _sql2.remove(0));
             }
@@ -398,9 +382,9 @@ public class TestQuerySyntaxComparisonTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z()) {
-                Assert.assertEquals("SELECT INTVAL1, (4 + ?) FROM QUERYSYNTAXENTITY WHERE (4 = (INTVAL1 + ABS(-2)))", _sql2.remove(0));
-            } else if(platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1, (4 + ?) FROM QUERYSYNTAXENTITY WHERE (4 = (INTVAL1 + ABS(?)))", _sql2.remove(0));
+                Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM QUERYSYNTAXENTITY WHERE (? = (INTVAL1 + ABS(-2)))", _sql2.remove(0));
+            } else if(platform.isDerby()) {
+                Assert.assertEquals("SELECT INTVAL1, (? + -2) FROM QUERYSYNTAXENTITY WHERE (? = (INTVAL1 + ABS(?)))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM QUERYSYNTAXENTITY WHERE (? = (INTVAL1 + ABS(?)))", _sql2.remove(0));
             }
@@ -437,8 +421,10 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1, (4 + -2) FROM QUERYSYNTAXENTITY WHERE (4 = (INTVAL1 + ABS(-2)))", _sql2.remove(0));
+            if(platform.isDB2Z()) {
+                Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM QUERYSYNTAXENTITY WHERE (? = (INTVAL1 + ABS(-2)))", _sql2.remove(0));
+            } else if(platform.isDerby()) {
+                Assert.assertEquals("SELECT INTVAL1, (? + -2) FROM QUERYSYNTAXENTITY WHERE (? = (INTVAL1 + ABS(?)))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM QUERYSYNTAXENTITY WHERE (? = (INTVAL1 + ABS(?)))", _sql2.remove(0));
             }
@@ -455,9 +441,9 @@ public class TestQuerySyntaxComparisonTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z()) {
-                Assert.assertEquals("SELECT INTVAL1, (4 + ?) FROM QUERYSYNTAXENTITY WHERE (4 = (INTVAL1 + ABS(-2)))", _sql2.remove(0));
-            } else if(platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1, (4 + ?) FROM QUERYSYNTAXENTITY WHERE (4 = (INTVAL1 + ABS(?)))", _sql2.remove(0));
+                Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM QUERYSYNTAXENTITY WHERE (? = (INTVAL1 + ABS(-2)))", _sql2.remove(0));
+            } else if(platform.isDerby()) {
+                Assert.assertEquals("SELECT INTVAL1, (? + -2) FROM QUERYSYNTAXENTITY WHERE (? = (INTVAL1 + ABS(?)))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM QUERYSYNTAXENTITY WHERE (? = (INTVAL1 + ABS(?)))", _sql2.remove(0));
             }
@@ -590,7 +576,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s GROUP BY s.intVal1 HAVING s.intVal1 = (?1)");
@@ -602,11 +587,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s GROUP BY s.intVal1 HAVING s.intVal1 = (4)");
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 = 4)", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 = ?)", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 = ?)", _sql.remove(0));
 
             // -----------------------
 
@@ -634,11 +615,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 = 4)", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 = ?)", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 = ?)", _sql.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -655,7 +632,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf2.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf2);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s GROUP BY s.intVal1 HAVING s.intVal1 = (?1)");
@@ -667,11 +643,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s GROUP BY s.intVal1 HAVING s.intVal1 = (4)");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 = 4)", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 = ?)", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 = ?)", _sql2.remove(0));
 
             // -----------------------
 
@@ -699,11 +671,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 = 4)", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 = ?)", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 = ?)", _sql2.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -894,8 +862,8 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.strVal1 FROM QuerySyntaxEntity s WHERE (5 + 10) < (s.intVal1)");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE ((5 + 10) < INTVAL1)", _sql2.remove(0));
+            if(platform.isDerby()) {
+                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE ((? + 10) < INTVAL1)", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE ((? + ?) < INTVAL1)", _sql2.remove(0));
             }
@@ -904,8 +872,8 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(2, 10);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE ((5 + ?) < INTVAL1)", _sql2.remove(0));
+            if(platform.isDerby()) {
+                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE ((? + 10) < INTVAL1)", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE ((? + ?) < INTVAL1)", _sql2.remove(0));
             }
@@ -940,8 +908,8 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE ((5 + 10) < INTVAL1)", _sql2.remove(0));
+            if(platform.isDerby()) {
+                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE ((? + 10) < INTVAL1)", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE ((? + ?) < INTVAL1)", _sql2.remove(0));
             }
@@ -957,8 +925,8 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(intParam3, 10);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE ((5 + ?) < INTVAL1)", _sql2.remove(0));
+            if(platform.isDerby()) {
+                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE ((? + 10) < INTVAL1)", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE ((? + ?) < INTVAL1)", _sql2.remove(0));
             }
@@ -1079,7 +1047,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.strVal1 LIKE ?1");
@@ -1091,11 +1058,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.strVal1 LIKE '%ORL%'");
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE STRVAL1 LIKE '%ORL%'", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE STRVAL1 LIKE ?", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE STRVAL1 LIKE ?", _sql.remove(0));
 
             // -----------------------
 
@@ -1123,11 +1086,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE STRVAL1 LIKE '%ORL%'", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE STRVAL1 LIKE ?", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE STRVAL1 LIKE ?", _sql.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -1144,7 +1103,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf2.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf2);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.strVal1 LIKE ?1");
@@ -1156,11 +1114,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.strVal1 LIKE '%ORL%'");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE STRVAL1 LIKE '%ORL%'", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE STRVAL1 LIKE ?", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE STRVAL1 LIKE ?", _sql2.remove(0));
 
             // -----------------------
 
@@ -1188,11 +1142,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE STRVAL1 LIKE '%ORL%'", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE STRVAL1 LIKE ?", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE STRVAL1 LIKE ?", _sql2.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -1369,7 +1319,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf2.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf2);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE ?1 LIKE ?2");
@@ -1382,21 +1331,13 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 'WORLD' LIKE '%ORL%'");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE 'WORLD' LIKE '%ORL%'", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE ? LIKE ?", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE ? LIKE ?", _sql2.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 'WORLD' LIKE ?1");
             query.setParameter(1, "%ORL%");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE 'WORLD' LIKE ?", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE ? LIKE ?", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE ? LIKE ?", _sql2.remove(0));
 
             // -----------------------
 
@@ -1425,11 +1366,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE 'WORLD' LIKE '%ORL%'", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE ? LIKE ?", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE ? LIKE ?", _sql2.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery3 = cb3.createQuery(Object[].class);
@@ -1443,11 +1380,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(strParam3, "%ORL%");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE 'WORLD' LIKE ?", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE ? LIKE ?", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE ? LIKE ?", _sql2.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -1541,7 +1474,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.strVal1 NOT LIKE ?1");
@@ -1553,11 +1485,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.strVal1 NOT LIKE '%ORL%'");
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT (STRVAL1 LIKE '%ORL%')", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT (STRVAL1 LIKE ?)", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT (STRVAL1 LIKE ?)", _sql.remove(0));
 
             // -----------------------
 
@@ -1584,11 +1512,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE STRVAL1 NOT LIKE '%ORL%'", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE STRVAL1 NOT LIKE ?", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE STRVAL1 NOT LIKE ?", _sql.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -1605,7 +1529,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf2.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf2);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.strVal1 NOT LIKE ?1");
@@ -1617,11 +1540,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.strVal1 NOT LIKE '%ORL%'");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT (STRVAL1 LIKE '%ORL%')", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT (STRVAL1 LIKE ?)", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT (STRVAL1 LIKE ?)", _sql2.remove(0));
 
             // -----------------------
 
@@ -1649,11 +1568,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE STRVAL1 NOT LIKE '%ORL%'", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE STRVAL1 NOT LIKE ?", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE STRVAL1 NOT LIKE ?", _sql2.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -1818,8 +1733,8 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.strVal1 LIKE 'HELLO' ESCAPE 'R'");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE STRVAL1 LIKE 'HELLO' ESCAPE 'R'", _sql2.remove(0));
+            if(platform.isDB2Z() || platform.isDB2()) {
+                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE STRVAL1 LIKE ? ESCAPE ?", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE STRVAL1 LIKE ? ESCAPE ?", _sql2.remove(0));
             }
@@ -1855,8 +1770,8 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE STRVAL1 LIKE 'HELLO' ESCAPE 'R'", _sql2.remove(0));
+            if(platform.isDB2Z() || platform.isDB2()) {
+                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE STRVAL1 LIKE ? ESCAPE ?", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE STRVAL1 LIKE ? ESCAPE ?", _sql2.remove(0));
             }
@@ -2060,7 +1975,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf2.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf2);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE ?1 LIKE ?2 ESCAPE ?3");
@@ -2074,22 +1988,14 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 'HELLO' LIKE 'WORLD' ESCAPE 'A'");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE 'HELLO' LIKE 'WORLD' ESCAPE 'A'", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE ? LIKE ? ESCAPE ?", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE ? LIKE ? ESCAPE ?", _sql2.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 'HELLO' LIKE ?1 ESCAPE ?2");
             query.setParameter(1, "WORLD");
             query.setParameter(2, 'A');
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE 'HELLO' LIKE ? ESCAPE ?", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE ? LIKE ? ESCAPE ?", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE ? LIKE ? ESCAPE ?", _sql2.remove(0));
 
             // -----------------------
 
@@ -2120,11 +2026,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE 'HELLO' LIKE 'WORLD' ESCAPE 'A'", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE ? LIKE ? ESCAPE ?", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE ? LIKE ? ESCAPE ?", _sql2.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery3 = cb3.createQuery(Object[].class);
@@ -2140,11 +2042,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(chaParam2, 'A');
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE 'HELLO' LIKE ? ESCAPE ?", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE ? LIKE ? ESCAPE ?", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE ? LIKE ? ESCAPE ?", _sql2.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -2245,7 +2143,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 IN ?1");
@@ -2257,11 +2154,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 IN (1, 2, 3, 5, 8, 13, 21)");
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (1, 2, 3, 5, 8, 13, 21))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (?, ?, ?, ?, ?, ?, ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (?, ?, ?, ?, ?, ?, ?))", _sql.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 IN (1, ?1, 3, 5, 8, ?3, ?2)");
             query.setParameter(1, 2);
@@ -2269,11 +2162,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(3, 13);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (1, ?, 3, 5, 8, ?, ?))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (?, ?, ?, ?, ?, ?, ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (?, ?, ?, ?, ?, ?, ?))", _sql.remove(0));
 
             // -----------------------
 
@@ -2301,11 +2190,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (1, 2, 3, 5, 8, 13, 21))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (?, ?, ?, ?, ?, ?, ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (?, ?, ?, ?, ?, ?, ?))", _sql.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Integer[]> cquery3 = cb3.createQuery(Integer[].class);
@@ -2319,11 +2204,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(colValue2, java.util.Arrays.asList(2, 13, 21));
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE ((INTVAL1 IN (1, 3, 5, 8)) OR (INTVAL1 IN (?,?,?)))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE ((INTVAL1 IN (?, ?, ?, ?)) OR (INTVAL1 IN (?,?,?)))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE ((INTVAL1 IN (?, ?, ?, ?)) OR (INTVAL1 IN (?,?,?)))", _sql.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -2340,7 +2221,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf2.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf2);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 IN ?1");
@@ -2352,11 +2232,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 IN (1, 2, 3, 5, 8, 13, 21)");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (1, 2, 3, 5, 8, 13, 21))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (?, ?, ?, ?, ?, ?, ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (?, ?, ?, ?, ?, ?, ?))", _sql2.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 IN (1, ?1, 3, 5, 8, ?3, ?2)");
             query.setParameter(1, 2);
@@ -2364,11 +2240,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(3, 13);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (1, ?, 3, 5, 8, ?, ?))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (?, ?, ?, ?, ?, ?, ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (?, ?, ?, ?, ?, ?, ?))", _sql2.remove(0));
 
             // -----------------------
 
@@ -2396,11 +2268,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (1, 2, 3, 5, 8, 13, 21))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (?, ?, ?, ?, ?, ?, ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (?, ?, ?, ?, ?, ?, ?))", _sql2.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Integer[]> cquery3 = cb3.createQuery(Integer[].class);
@@ -2414,11 +2282,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(colValue2, java.util.Arrays.asList(2, 13, 21));
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE ((INTVAL1 IN (1, 3, 5, 8)) OR (INTVAL1 IN (?,?,?)))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE ((INTVAL1 IN (?, ?, ?, ?)) OR (INTVAL1 IN (?,?,?)))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE ((INTVAL1 IN (?, ?, ?, ?)) OR (INTVAL1 IN (?,?,?)))", _sql2.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -2513,7 +2377,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 IN (?1, ?2, ?3, ?4, ?5)");
@@ -2529,22 +2392,14 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 IN (1, 2, 3, 5, 8)");
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (1, 2, 3, 5, 8))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (?, ?, ?, ?, ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (?, ?, ?, ?, ?))", _sql.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 IN (1, ?1, 3, 5, ?3)");
             query.setParameter(1, 2);
             query.setParameter(3, 8);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (1, ?, 3, 5, ?))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (?, ?, ?, ?, ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (?, ?, ?, ?, ?))", _sql.remove(0));
 
             // -----------------------
 
@@ -2578,11 +2433,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (1, 2, 3, 5, 8))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (?, ?, ?, ?, ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (?, ?, ?, ?, ?))", _sql.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Integer[]> cquery3 = cb3.createQuery(Integer[].class);
@@ -2604,11 +2455,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(intValue7, 8);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (1, ?, 3, 5, ?))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (?, ?, ?, ?, ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (?, ?, ?, ?, ?))", _sql.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -2625,7 +2472,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf2.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf2);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 IN (?1, ?2, ?3, ?4, ?5)");
@@ -2641,22 +2487,14 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 IN (1, 2, 3, 5, 8)");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (1, 2, 3, 5, 8))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (?, ?, ?, ?, ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (?, ?, ?, ?, ?))", _sql2.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 IN (1, ?1, 3, 5, ?3)");
             query.setParameter(1, 2);
             query.setParameter(3, 8);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (1, ?, 3, 5, ?))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (?, ?, ?, ?, ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (?, ?, ?, ?, ?))", _sql2.remove(0));
 
             // -----------------------
 
@@ -2690,11 +2528,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (1, 2, 3, 5, 8))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (?, ?, ?, ?, ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (?, ?, ?, ?, ?))", _sql2.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Integer[]> cquery3 = cb3.createQuery(Integer[].class);
@@ -2716,11 +2550,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(intValue7, 8);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (1, ?, 3, 5, ?))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (?, ?, ?, ?, ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 IN (?, ?, ?, ?, ?))", _sql2.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -2833,7 +2663,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s GROUP BY s.intVal1 HAVING s.intVal1 IN ?1");
@@ -2845,11 +2674,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s GROUP BY s.intVal1 HAVING s.intVal1 IN (1, 2, 3, 5, 8, 13, 21)");
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (1, 2, 3, 5, 8, 13, 21))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (?, ?, ?, ?, ?, ?, ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (?, ?, ?, ?, ?, ?, ?))", _sql.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s GROUP BY s.intVal1 HAVING s.intVal1 IN (1, ?1, 3, 5, 8, ?3, ?2)");
             query.setParameter(1, 2);
@@ -2857,11 +2682,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(3, 13);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (1, ?, 3, 5, 8, ?, ?))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (?, ?, ?, ?, ?, ?, ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (?, ?, ?, ?, ?, ?, ?))", _sql.remove(0));
 
             // -----------------------
 
@@ -2891,11 +2712,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (1, 2, 3, 5, 8, 13, 21))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (?, ?, ?, ?, ?, ?, ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (?, ?, ?, ?, ?, ?, ?))", _sql.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Integer[]> cquery3 = cb3.createQuery(Integer[].class);
@@ -2910,11 +2727,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(colValue2, java.util.Arrays.asList(2, 13, 21));
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING ((INTVAL1 IN (1, 3, 5, 8)) OR (INTVAL1 IN (?,?,?)))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING ((INTVAL1 IN (?, ?, ?, ?)) OR (INTVAL1 IN (?,?,?)))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING ((INTVAL1 IN (?, ?, ?, ?)) OR (INTVAL1 IN (?,?,?)))", _sql.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -2931,7 +2744,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf2.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf2);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s GROUP BY s.intVal1 HAVING s.intVal1 IN ?1");
@@ -2943,11 +2755,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s GROUP BY s.intVal1 HAVING s.intVal1 IN (1, 2, 3, 5, 8, 13, 21)");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (1, 2, 3, 5, 8, 13, 21))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (?, ?, ?, ?, ?, ?, ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (?, ?, ?, ?, ?, ?, ?))", _sql2.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s GROUP BY s.intVal1 HAVING s.intVal1 IN (1, ?1, 3, 5, 8, ?3, ?2)");
             query.setParameter(1, 2);
@@ -2955,11 +2763,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(3, 13);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (1, ?, 3, 5, 8, ?, ?))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (?, ?, ?, ?, ?, ?, ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (?, ?, ?, ?, ?, ?, ?))", _sql2.remove(0));
 
             // -----------------------
 
@@ -2989,11 +2793,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (1, 2, 3, 5, 8, 13, 21))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (?, ?, ?, ?, ?, ?, ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (?, ?, ?, ?, ?, ?, ?))", _sql2.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Integer[]> cquery3 = cb3.createQuery(Integer[].class);
@@ -3008,11 +2808,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(colValue2, java.util.Arrays.asList(2, 13, 21));
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING ((INTVAL1 IN (1, 3, 5, 8)) OR (INTVAL1 IN (?,?,?)))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING ((INTVAL1 IN (?, ?, ?, ?)) OR (INTVAL1 IN (?,?,?)))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING ((INTVAL1 IN (?, ?, ?, ?)) OR (INTVAL1 IN (?,?,?)))", _sql2.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -3110,7 +2906,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s GROUP BY s.intVal1 HAVING s.intVal1 IN (?1, ?2, ?3, ?4, ?5)");
@@ -3126,22 +2921,14 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s GROUP BY s.intVal1 HAVING s.intVal1 IN (1, 2, 3, 5, 8)");
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (1, 2, 3, 5, 8))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (?, ?, ?, ?, ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (?, ?, ?, ?, ?))", _sql.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s GROUP BY s.intVal1 HAVING s.intVal1 IN (1, ?1, 3, 5, ?3)");
             query.setParameter(1, 2);
             query.setParameter(3, 8);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (1, ?, 3, 5, ?))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (?, ?, ?, ?, ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (?, ?, ?, ?, ?))", _sql.remove(0));
 
             // -----------------------
 
@@ -3177,11 +2964,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (1, 2, 3, 5, 8))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (?, ?, ?, ?, ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (?, ?, ?, ?, ?))", _sql.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Integer[]> cquery3 = cb3.createQuery(Integer[].class);
@@ -3204,11 +2987,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(intValue7, 8);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (1, ?, 3, 5, ?))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (?, ?, ?, ?, ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (?, ?, ?, ?, ?))", _sql.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -3225,7 +3004,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf2.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf2);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s GROUP BY s.intVal1 HAVING s.intVal1 IN (?1, ?2, ?3, ?4, ?5)");
@@ -3241,22 +3019,14 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s GROUP BY s.intVal1 HAVING s.intVal1 IN (1, 2, 3, 5, 8)");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (1, 2, 3, 5, 8))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (?, ?, ?, ?, ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (?, ?, ?, ?, ?))", _sql2.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s GROUP BY s.intVal1 HAVING s.intVal1 IN (1, ?1, 3, 5, ?3)");
             query.setParameter(1, 2);
             query.setParameter(3, 8);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (1, ?, 3, 5, ?))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (?, ?, ?, ?, ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (?, ?, ?, ?, ?))", _sql2.remove(0));
 
             // -----------------------
 
@@ -3292,11 +3062,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (1, 2, 3, 5, 8))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (?, ?, ?, ?, ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (?, ?, ?, ?, ?))", _sql2.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Integer[]> cquery3 = cb3.createQuery(Integer[].class);
@@ -3319,11 +3085,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(intValue7, 8);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (1, ?, 3, 5, ?))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (?, ?, ?, ?, ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY GROUP BY INTVAL1 HAVING (INTVAL1 IN (?, ?, ?, ?, ?))", _sql2.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -3438,7 +3200,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE ?1 IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = ?2)");
@@ -3451,21 +3212,13 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 5 IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = 9)");
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE 5 IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 5 IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = ?1)");
             query.setParameter(1, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE 5 IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql.remove(0));
 
             // -----------------------
 
@@ -3505,11 +3258,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE 5 IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Integer[]> cquery3 = cb3.createQuery(Integer[].class);
@@ -3528,11 +3277,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(intValue3, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE 5 IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -3549,7 +3294,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf2.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf2);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE ?1 IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = ?2)");
@@ -3562,21 +3306,13 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 5 IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = 9)");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE 5 IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql2.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 5 IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = ?1)");
             query.setParameter(1, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE 5 IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql2.remove(0));
 
             // -----------------------
 
@@ -3616,11 +3352,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE 5 IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql2.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Integer[]> cquery3 = cb3.createQuery(Integer[].class);
@@ -3639,11 +3371,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(intValue3, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE 5 IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql2.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -3754,7 +3482,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE ?1 IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = ?2)");
@@ -3767,21 +3494,13 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 5 IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = 9)");
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE 5 IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE ?1 IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = 9)");
             query.setParameter(1, 5);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql.remove(0));
 
             // -----------------------
 
@@ -3821,11 +3540,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE 5 IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Integer[]> cquery3 = cb3.createQuery(Integer[].class);
@@ -3844,11 +3559,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(intValue3, 5);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -3865,7 +3576,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf2.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf2);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE ?1 IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = ?2)");
@@ -3878,21 +3588,13 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 5 IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = 9)");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE 5 IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql2.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE ?1 IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = 9)");
             query.setParameter(1, 5);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql2.remove(0));
 
             // -----------------------
 
@@ -3932,11 +3634,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE 5 IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql2.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Integer[]> cquery3 = cb3.createQuery(Integer[].class);
@@ -3955,11 +3653,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(intValue3, 5);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql2.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -4070,7 +3764,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE ?1 IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 IN (?2, ?3, ?4))");
@@ -4085,22 +3778,14 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 5 IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 IN (6, 7, 8))");
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE 5 IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (6, 7, 8)))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (?, ?, ?)))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (?, ?, ?)))", _sql.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE ?1 IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 IN (6, 7, ?4))");
             query.setParameter(1, 5);
             query.setParameter(4, 8);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (6, 7, ?)))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (?, ?, ?)))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (?, ?, ?)))", _sql.remove(0));
 
             // -----------------------
 
@@ -4144,11 +3829,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE 5 IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (6, 7, 8)))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (?, ?, ?)))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (?, ?, ?)))", _sql.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Integer[]> cquery3 = cb3.createQuery(Integer[].class);
@@ -4170,11 +3851,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(intValue6, 8);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (6, 7, ?)))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (?, ?, ?)))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (?, ?, ?)))", _sql.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -4191,7 +3868,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf2.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf2);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE ?1 IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 IN (?2, ?3, ?4))");
@@ -4206,22 +3882,14 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 5 IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 IN (6, 7, 8))");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE 5 IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (6, 7, 8)))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (?, ?, ?)))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (?, ?, ?)))", _sql2.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE ?1 IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 IN (6, 7, ?4))");
             query.setParameter(1, 5);
             query.setParameter(4, 8);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (6, 7, ?)))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (?, ?, ?)))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (?, ?, ?)))", _sql2.remove(0));
 
             // -----------------------
 
@@ -4265,11 +3933,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE 5 IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (6, 7, 8)))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (?, ?, ?)))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (?, ?, ?)))", _sql2.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Integer[]> cquery3 = cb3.createQuery(Integer[].class);
@@ -4291,11 +3955,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(intValue6, 8);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (6, 7, ?)))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (?, ?, ?)))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (?, ?, ?)))", _sql2.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -4416,7 +4076,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 NOT IN ?1");
@@ -4428,11 +4087,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 NOT IN (1, 2, 3, 5, 8, 13, 21)");
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 NOT IN (1, 2, 3, 5, 8, 13, 21))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 NOT IN (?, ?, ?, ?, ?, ?, ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 NOT IN (?, ?, ?, ?, ?, ?, ?))", _sql.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 NOT IN (1, ?1, 3, 5, 8, ?3, ?2)");
             query.setParameter(1, 2);
@@ -4440,11 +4095,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(3, 13);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 NOT IN (1, ?, 3, 5, 8, ?, ?))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 NOT IN (?, ?, ?, ?, ?, ?, ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 NOT IN (?, ?, ?, ?, ?, ?, ?))", _sql.remove(0));
 
             // -----------------------
 
@@ -4472,11 +4123,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 IN (1, 2, 3, 5, 8, 13, 21)))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 IN (?, ?, ?, ?, ?, ?, ?)))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 IN (?, ?, ?, ?, ?, ?, ?)))", _sql.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Integer[]> cquery3 = cb3.createQuery(Integer[].class);
@@ -4490,11 +4137,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(colValue2, java.util.Arrays.asList(2, 13, 21));
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (NOT ((INTVAL1 IN (1, 3, 5, 8))) OR NOT ((INTVAL1 IN (?,?,?))))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (NOT ((INTVAL1 IN (?, ?, ?, ?))) OR NOT ((INTVAL1 IN (?,?,?))))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (NOT ((INTVAL1 IN (?, ?, ?, ?))) OR NOT ((INTVAL1 IN (?,?,?))))", _sql.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -4511,7 +4154,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf2.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf2);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 NOT IN ?1");
@@ -4523,11 +4165,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 NOT IN (1, 2, 3, 5, 8, 13, 21)");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 NOT IN (1, 2, 3, 5, 8, 13, 21))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 NOT IN (?, ?, ?, ?, ?, ?, ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 NOT IN (?, ?, ?, ?, ?, ?, ?))", _sql2.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 NOT IN (1, ?1, 3, 5, 8, ?3, ?2)");
             query.setParameter(1, 2);
@@ -4535,11 +4173,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(3, 13);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 NOT IN (1, ?, 3, 5, 8, ?, ?))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 NOT IN (?, ?, ?, ?, ?, ?, ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 NOT IN (?, ?, ?, ?, ?, ?, ?))", _sql2.remove(0));
 
             // -----------------------
 
@@ -4567,11 +4201,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 IN (1, 2, 3, 5, 8, 13, 21)))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 IN (?, ?, ?, ?, ?, ?, ?)))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 IN (?, ?, ?, ?, ?, ?, ?)))", _sql2.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Integer[]> cquery3 = cb3.createQuery(Integer[].class);
@@ -4585,11 +4215,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(colValue2, java.util.Arrays.asList(2, 13, 21));
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (NOT ((INTVAL1 IN (1, 3, 5, 8))) OR NOT ((INTVAL1 IN (?,?,?))))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (NOT ((INTVAL1 IN (?, ?, ?, ?))) OR NOT ((INTVAL1 IN (?,?,?))))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (NOT ((INTVAL1 IN (?, ?, ?, ?))) OR NOT ((INTVAL1 IN (?,?,?))))", _sql2.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -4684,7 +4310,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 NOT IN (?1, ?2, ?3, ?4, ?5)");
@@ -4700,22 +4325,14 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 NOT IN (1, 2, 3, 5, 8)");
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 NOT IN (1, 2, 3, 5, 8))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 NOT IN (?, ?, ?, ?, ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 NOT IN (?, ?, ?, ?, ?))", _sql.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 NOT IN (1, ?1, 3, 5, ?3)");
             query.setParameter(1, 2);
             query.setParameter(3, 8);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 NOT IN (1, ?, 3, 5, ?))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 NOT IN (?, ?, ?, ?, ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 NOT IN (?, ?, ?, ?, ?))", _sql.remove(0));
 
             // -----------------------
 
@@ -4749,11 +4366,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 IN (1, 2, 3, 5, 8)))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 IN (?, ?, ?, ?, ?)))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 IN (?, ?, ?, ?, ?)))", _sql.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Integer[]> cquery3 = cb3.createQuery(Integer[].class);
@@ -4775,11 +4388,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(intValue7, 8);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 IN (1, ?, 3, 5, ?)))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 IN (?, ?, ?, ?, ?)))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 IN (?, ?, ?, ?, ?)))", _sql.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -4796,7 +4405,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf2.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf2);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 NOT IN (?1, ?2, ?3, ?4, ?5)");
@@ -4812,22 +4420,14 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 NOT IN (1, 2, 3, 5, 8)");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 NOT IN (1, 2, 3, 5, 8))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 NOT IN (?, ?, ?, ?, ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 NOT IN (?, ?, ?, ?, ?))", _sql2.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 NOT IN (1, ?1, 3, 5, ?3)");
             query.setParameter(1, 2);
             query.setParameter(3, 8);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 NOT IN (1, ?, 3, 5, ?))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 NOT IN (?, ?, ?, ?, ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 NOT IN (?, ?, ?, ?, ?))", _sql2.remove(0));
 
             // -----------------------
 
@@ -4861,11 +4461,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 IN (1, 2, 3, 5, 8)))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 IN (?, ?, ?, ?, ?)))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 IN (?, ?, ?, ?, ?)))", _sql2.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Integer[]> cquery3 = cb3.createQuery(Integer[].class);
@@ -4887,11 +4483,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(intValue7, 8);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 IN (1, ?, 3, 5, ?)))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 IN (?, ?, ?, ?, ?)))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 IN (?, ?, ?, ?, ?)))", _sql2.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -5003,7 +4595,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE ?1 NOT IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = ?2)");
@@ -5016,21 +4607,13 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 5 NOT IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = 9)");
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE 5 NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 5 NOT IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = ?1)");
             query.setParameter(1, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE 5 NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql.remove(0));
 
             // -----------------------
 
@@ -5070,11 +4653,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (5 IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9)))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Integer[]> cquery3 = cb3.createQuery(Integer[].class);
@@ -5093,11 +4672,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(intValue3, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (5 IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -5114,7 +4689,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf2.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf2);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE ?1 NOT IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = ?2)");
@@ -5127,21 +4701,13 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 5 NOT IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = 9)");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE 5 NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql2.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 5 NOT IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = ?1)");
             query.setParameter(1, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE 5 NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql2.remove(0));
 
             // -----------------------
 
@@ -5181,11 +4747,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (5 IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9)))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Integer[]> cquery3 = cb3.createQuery(Integer[].class);
@@ -5204,11 +4766,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(intValue3, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (5 IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -5319,7 +4877,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE ?1 NOT IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = ?2)");
@@ -5332,21 +4889,13 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 5 NOT IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = 9)");
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE 5 NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE ?1 NOT IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = 9)");
             query.setParameter(1, 5);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql.remove(0));
 
             // -----------------------
 
@@ -5386,11 +4935,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (5 IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9)))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Integer[]> cquery3 = cb3.createQuery(Integer[].class);
@@ -5409,11 +4954,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(intValue3, 5);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9)))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -5430,7 +4971,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf2.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf2);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE ?1 NOT IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = ?2)");
@@ -5443,21 +4983,13 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 5 NOT IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = 9)");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE 5 NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql2.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE ?1 NOT IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = 9)");
             query.setParameter(1, 5);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?))", _sql2.remove(0));
 
             // -----------------------
 
@@ -5497,11 +5029,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (5 IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9)))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Integer[]> cquery3 = cb3.createQuery(Integer[].class);
@@ -5520,11 +5048,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(intValue3, 5);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9)))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -5635,7 +5159,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE ?1 NOT IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 IN (?2, ?3, ?4))");
@@ -5650,22 +5173,14 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 5 NOT IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 IN (6, 7, 8))");
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE 5 NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (6, 7, 8)))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (?, ?, ?)))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (?, ?, ?)))", _sql.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE ?1 NOT IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 IN (6, 7, ?4))");
             query.setParameter(1, 5);
             query.setParameter(4, 8);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (6, 7, ?)))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (?, ?, ?)))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (?, ?, ?)))", _sql.remove(0));
 
             // -----------------------
 
@@ -5709,11 +5224,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (5 IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE NOT ((t1.INTVAL2 IN (6, 7, 8)))))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE NOT ((t1.INTVAL2 IN (?, ?, ?)))))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE NOT ((t1.INTVAL2 IN (?, ?, ?)))))", _sql.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Integer[]> cquery3 = cb3.createQuery(Integer[].class);
@@ -5735,11 +5246,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(intValue6, 8);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE NOT ((t1.INTVAL2 IN (6, 7, ?)))))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE NOT ((t1.INTVAL2 IN (?, ?, ?)))))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE NOT ((t1.INTVAL2 IN (?, ?, ?)))))", _sql.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -5756,7 +5263,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf2.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf2);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE ?1 NOT IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 IN (?2, ?3, ?4))");
@@ -5771,22 +5277,14 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 5 NOT IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 IN (6, 7, 8))");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE 5 NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (6, 7, 8)))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (?, ?, ?)))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (?, ?, ?)))", _sql2.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE ?1 NOT IN (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 IN (6, 7, ?4))");
             query.setParameter(1, 5);
             query.setParameter(4, 8);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (6, 7, ?)))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (?, ?, ?)))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE ? NOT IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 IN (?, ?, ?)))", _sql2.remove(0));
 
             // -----------------------
 
@@ -5830,11 +5328,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (5 IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE NOT ((t1.INTVAL2 IN (6, 7, 8)))))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE NOT ((t1.INTVAL2 IN (?, ?, ?)))))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE NOT ((t1.INTVAL2 IN (?, ?, ?)))))", _sql2.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Integer[]> cquery3 = cb3.createQuery(Integer[].class);
@@ -5856,11 +5350,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(intValue6, 8);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE NOT ((t1.INTVAL2 IN (6, 7, ?)))))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE NOT ((t1.INTVAL2 IN (?, ?, ?)))))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (? IN (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE NOT ((t1.INTVAL2 IN (?, ?, ?)))))", _sql2.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -5981,7 +5471,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 BETWEEN ?1 AND ?2");
@@ -5994,21 +5483,13 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 BETWEEN 0 AND 9");
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 BETWEEN 0 AND 9)", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 BETWEEN ? AND ?)", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 BETWEEN ? AND ?)", _sql.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 BETWEEN 0 AND ?1");
             query.setParameter(1, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 BETWEEN 0 AND ?)", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 BETWEEN ? AND ?)", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 BETWEEN ? AND ?)", _sql.remove(0));
 
             // -----------------------
 
@@ -6038,11 +5519,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 BETWEEN 0 AND 9)", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 BETWEEN ? AND ?)", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 BETWEEN ? AND ?)", _sql.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery3 = cb3.createQuery(Object[].class);
@@ -6056,11 +5533,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(intParam3, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 BETWEEN 0 AND ?)", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 BETWEEN ? AND ?)", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 BETWEEN ? AND ?)", _sql.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -6077,7 +5550,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf2.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 BETWEEN ?1 AND ?2");
@@ -6090,21 +5562,13 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 BETWEEN 0 AND 9");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 BETWEEN 0 AND 9)", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 BETWEEN ? AND ?)", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 BETWEEN ? AND ?)", _sql2.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 BETWEEN 0 AND ?1");
             query.setParameter(1, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 BETWEEN 0 AND ?)", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 BETWEEN ? AND ?)", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 BETWEEN ? AND ?)", _sql2.remove(0));
 
             // -----------------------
 
@@ -6134,11 +5598,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 BETWEEN 0 AND 9)", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 BETWEEN ? AND ?)", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 BETWEEN ? AND ?)", _sql2.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery3 = cb3.createQuery(Object[].class);
@@ -6152,11 +5612,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(intParam3, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 BETWEEN 0 AND ?)", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 BETWEEN ? AND ?)", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 BETWEEN ? AND ?)", _sql2.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -6252,7 +5708,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE ?1 BETWEEN s.intVal1 AND ?2");
@@ -6265,21 +5720,13 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 4 BETWEEN s.intVal1 AND 9");
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (4 BETWEEN INTVAL1 AND 9)", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (? BETWEEN INTVAL1 AND ?)", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (? BETWEEN INTVAL1 AND ?)", _sql.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 4 BETWEEN s.intVal1 AND ?1");
             query.setParameter(1, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (4 BETWEEN INTVAL1 AND ?)", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (? BETWEEN INTVAL1 AND ?)", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (? BETWEEN INTVAL1 AND ?)", _sql.remove(0));
 
             // -----------------------
 
@@ -6309,11 +5756,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (4 BETWEEN INTVAL1 AND 9)", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (? BETWEEN INTVAL1 AND ?)", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (? BETWEEN INTVAL1 AND ?)", _sql.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery3 = cb3.createQuery(Object[].class);
@@ -6327,11 +5770,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(intParam3, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (4 BETWEEN INTVAL1 AND ?)", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (? BETWEEN INTVAL1 AND ?)", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (? BETWEEN INTVAL1 AND ?)", _sql.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -6348,7 +5787,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf2.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf2);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE ?1 BETWEEN s.intVal1 AND ?2");
@@ -6361,21 +5799,13 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 4 BETWEEN s.intVal1 AND 9");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (4 BETWEEN INTVAL1 AND 9)", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (? BETWEEN INTVAL1 AND ?)", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (? BETWEEN INTVAL1 AND ?)", _sql2.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 4 BETWEEN s.intVal1 AND ?1");
             query.setParameter(1, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (4 BETWEEN INTVAL1 AND ?)", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (? BETWEEN INTVAL1 AND ?)", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (? BETWEEN INTVAL1 AND ?)", _sql2.remove(0));
 
             // -----------------------
 
@@ -6405,11 +5835,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (4 BETWEEN INTVAL1 AND 9)", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (? BETWEEN INTVAL1 AND ?)", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (? BETWEEN INTVAL1 AND ?)", _sql2.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery3 = cb3.createQuery(Object[].class);
@@ -6423,11 +5849,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(intParam3, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (4 BETWEEN INTVAL1 AND ?)", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (? BETWEEN INTVAL1 AND ?)", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (? BETWEEN INTVAL1 AND ?)", _sql2.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -6650,8 +6072,8 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 4 BETWEEN 2 AND 9");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (4 BETWEEN 2 AND 9)", _sql2.remove(0));
+            if(platform.isDB2Z() || platform.isDerby()) {
+                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (? BETWEEN ? AND 9)", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (? BETWEEN ? AND ?)", _sql2.remove(0));
             }
@@ -6661,8 +6083,8 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(2, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (4 BETWEEN ? AND ?)", _sql2.remove(0));
+            if(platform.isDB2Z() || platform.isDerby()) {
+                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (? BETWEEN ? AND 9)", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (? BETWEEN ? AND ?)", _sql2.remove(0));
             }
@@ -6700,8 +6122,8 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (4 BETWEEN 2 AND 9)", _sql2.remove(0));
+            if(platform.isDB2Z() || platform.isDerby()) {
+                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (? BETWEEN ? AND 9)", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (? BETWEEN ? AND ?)", _sql2.remove(0));
             }
@@ -6720,8 +6142,8 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(intParam5, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (4 BETWEEN ? AND ?)", _sql2.remove(0));
+            if(platform.isDB2Z() || platform.isDerby()) {
+                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (? BETWEEN ? AND 9)", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (? BETWEEN ? AND ?)", _sql2.remove(0));
             }
@@ -6850,7 +6272,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 NOT BETWEEN ?1 AND ?2");
@@ -6863,21 +6284,13 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 NOT BETWEEN 0 AND 9");
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 BETWEEN 0 AND 9))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 BETWEEN ? AND ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 BETWEEN ? AND ?))", _sql.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 NOT BETWEEN 0 AND ?1");
             query.setParameter(1, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 BETWEEN 0 AND ?))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 BETWEEN ? AND ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 BETWEEN ? AND ?))", _sql.remove(0));
 
             // -----------------------
 
@@ -6907,11 +6320,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 BETWEEN 0 AND 9))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 BETWEEN ? AND ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 BETWEEN ? AND ?))", _sql.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery3 = cb3.createQuery(Object[].class);
@@ -6925,11 +6334,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(intParam3, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 BETWEEN 0 AND ?))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 BETWEEN ? AND ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 BETWEEN ? AND ?))", _sql.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -6946,7 +6351,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf2.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf2);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 NOT BETWEEN ?1 AND ?2");
@@ -6959,21 +6363,13 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 NOT BETWEEN 0 AND 9");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 BETWEEN 0 AND 9))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 BETWEEN ? AND ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 BETWEEN ? AND ?))", _sql2.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 NOT BETWEEN 0 AND ?1");
             query.setParameter(1, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 BETWEEN 0 AND ?))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 BETWEEN ? AND ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 BETWEEN ? AND ?))", _sql2.remove(0));
 
             // -----------------------
 
@@ -7003,11 +6399,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 BETWEEN 0 AND 9))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 BETWEEN ? AND ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 BETWEEN ? AND ?))", _sql2.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery3 = cb3.createQuery(Object[].class);
@@ -7021,11 +6413,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(intParam3, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 BETWEEN 0 AND ?))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 BETWEEN ? AND ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((INTVAL1 BETWEEN ? AND ?))", _sql2.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -7121,7 +6509,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE ?1 NOT BETWEEN s.intVal1 AND ?2");
@@ -7134,21 +6521,13 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 4 NOT BETWEEN s.intVal1 AND 9");
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((4 BETWEEN INTVAL1 AND 9))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((? BETWEEN INTVAL1 AND ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((? BETWEEN INTVAL1 AND ?))", _sql.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 4 NOT BETWEEN s.intVal1 AND ?1");
             query.setParameter(1, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((4 BETWEEN INTVAL1 AND ?))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((? BETWEEN INTVAL1 AND ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((? BETWEEN INTVAL1 AND ?))", _sql.remove(0));
 
             // -----------------------
 
@@ -7178,11 +6557,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((4 BETWEEN INTVAL1 AND 9))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((? BETWEEN INTVAL1 AND ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((? BETWEEN INTVAL1 AND ?))", _sql.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery3 = cb3.createQuery(Object[].class);
@@ -7196,11 +6571,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(intParam3, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((4 BETWEEN INTVAL1 AND ?))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((? BETWEEN INTVAL1 AND ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((? BETWEEN INTVAL1 AND ?))", _sql.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -7217,7 +6588,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf2.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf2);
 
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE ?1 NOT BETWEEN s.intVal1 AND ?2");
@@ -7230,21 +6600,13 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 4 NOT BETWEEN s.intVal1 AND 9");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((4 BETWEEN INTVAL1 AND 9))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((? BETWEEN INTVAL1 AND ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((? BETWEEN INTVAL1 AND ?))", _sql2.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 4 NOT BETWEEN s.intVal1 AND ?1");
             query.setParameter(1, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((4 BETWEEN INTVAL1 AND ?))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((? BETWEEN INTVAL1 AND ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((? BETWEEN INTVAL1 AND ?))", _sql2.remove(0));
 
             // -----------------------
 
@@ -7274,11 +6636,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((4 BETWEEN INTVAL1 AND 9))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((? BETWEEN INTVAL1 AND ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((? BETWEEN INTVAL1 AND ?))", _sql2.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery3 = cb3.createQuery(Object[].class);
@@ -7292,11 +6650,7 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(intParam3, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((4 BETWEEN INTVAL1 AND ?))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((? BETWEEN INTVAL1 AND ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((? BETWEEN INTVAL1 AND ?))", _sql2.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -7520,8 +6874,8 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 4 NOT BETWEEN 2 AND 9");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((4 BETWEEN 2 AND 9))", _sql2.remove(0));
+            if(platform.isDB2Z() || platform.isDerby()) {
+                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((? BETWEEN ? AND 9))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((? BETWEEN ? AND ?))", _sql2.remove(0));
             }
@@ -7531,8 +6885,8 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(2, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((4 BETWEEN ? AND ?))", _sql2.remove(0));
+            if(platform.isDB2Z() || platform.isDerby()) {
+                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((? BETWEEN ? AND 9))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((? BETWEEN ? AND ?))", _sql2.remove(0));
             }
@@ -7571,8 +6925,8 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((4 BETWEEN 2 AND 9))", _sql2.remove(0));
+            if(platform.isDB2Z() || platform.isDerby()) {
+                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((? BETWEEN ? AND 9))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((? BETWEEN ? AND ?))", _sql2.remove(0));
             }
@@ -7591,8 +6945,8 @@ public class TestQuerySyntaxComparisonTests {
             query.setParameter(intParam5, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((4 BETWEEN ? AND ?))", _sql2.remove(0));
+            if(platform.isDB2Z() || platform.isDerby()) {
+                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((? BETWEEN ? AND 9))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE NOT ((? BETWEEN ? AND ?))", _sql2.remove(0));
             }
@@ -7812,7 +7166,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 'HELLO' IS NULL");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+            if(platform.isDB2Z()) {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE ('HELLO' IS NULL)", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (? IS NULL)", _sql2.remove(0));
@@ -7848,7 +7202,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+            if(platform.isDB2Z()) {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE ('HELLO' IS NULL)", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (? IS NULL)", _sql2.remove(0));
@@ -8031,7 +7385,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 'HELLO' IS NOT NULL");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+            if(platform.isDB2Z()) {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE ('HELLO' IS NOT NULL)", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (? IS NOT NULL)", _sql2.remove(0));
@@ -8067,7 +7421,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+            if(platform.isDB2Z()) {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE ('HELLO' IS NOT NULL)", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (? IS NOT NULL)", _sql2.remove(0));
@@ -8182,7 +7536,6 @@ public class TestQuerySyntaxComparisonTests {
             } else {
                 Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE EXISTS (SELECT ? FROM QUERYSYNTAXENTITY t1 WHERE (t1.STRVAL1 = ?))", _sql.remove(0));
             }
-
             // -----------------------
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
@@ -8219,11 +7572,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE EXISTS (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.STRVAL1 = 'HELLO'))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE EXISTS (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.STRVAL1 = ?))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE EXISTS (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.STRVAL1 = ?))", _sql.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -8257,7 +7606,7 @@ public class TestQuerySyntaxComparisonTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE EXISTS (SELECT 1 FROM QUERYSYNTAXENTITY t1 WHERE (t1.STRVAL1 = 'HELLO'))", _sql2.remove(0));
+                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE EXISTS (SELECT 1 FROM QUERYSYNTAXENTITY t1 WHERE (t1.STRVAL1 = ?))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE EXISTS (SELECT ? FROM QUERYSYNTAXENTITY t1 WHERE (t1.STRVAL1 = ?))", _sql2.remove(0));
             }
@@ -8298,11 +7647,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE EXISTS (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.STRVAL1 = 'HELLO'))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE EXISTS (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.STRVAL1 = ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE EXISTS (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.STRVAL1 = ?))", _sql2.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -8422,7 +7767,7 @@ public class TestQuerySyntaxComparisonTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object> cquery = cb.createQuery(Object.class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
 
             ParameterExpression<String> strValue1 = cb.parameter(String.class);
             Subquery<Integer> subquery = cquery.subquery(Integer.class);
@@ -8453,7 +7798,7 @@ public class TestQuerySyntaxComparisonTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object> cquery2 = cb2.createQuery(Object.class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
 
             Subquery<Integer> subquery2 = cquery2.subquery(Integer.class);
             Root<QuerySyntaxEntity> subroot2 = subquery2.from(QuerySyntaxEntity.class);
@@ -8509,7 +7854,7 @@ public class TestQuerySyntaxComparisonTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT CASE  WHEN EXISTS (SELECT 1 FROM QUERYSYNTAXENTITY t1 WHERE (t1.STRVAL1 = 'HELLO')) THEN 1 ELSE 0 END FROM QUERYSYNTAXENTITY t0", _sql2.remove(0));
+                Assert.assertEquals("SELECT CASE  WHEN EXISTS (SELECT 1 FROM QUERYSYNTAXENTITY t1 WHERE (t1.STRVAL1 = ?)) THEN 1 ELSE 0 END FROM QUERYSYNTAXENTITY t0", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT CASE  WHEN EXISTS (SELECT ? FROM QUERYSYNTAXENTITY t1 WHERE (t1.STRVAL1 = ?)) THEN ? ELSE ? END FROM QUERYSYNTAXENTITY t0", _sql2.remove(0));
             }
@@ -8518,7 +7863,7 @@ public class TestQuerySyntaxComparisonTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object> cquery = cb.createQuery(Object.class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
 
             ParameterExpression<String> strValue1 = cb.parameter(String.class);
             Subquery<Integer> subquery = cquery.subquery(Integer.class);
@@ -8549,7 +7894,7 @@ public class TestQuerySyntaxComparisonTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object> cquery2 = cb2.createQuery(Object.class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
 
             Subquery<Integer> subquery2 = cquery2.subquery(Integer.class);
             Root<QuerySyntaxEntity> subroot2 = subquery2.from(QuerySyntaxEntity.class);
@@ -8566,7 +7911,7 @@ public class TestQuerySyntaxComparisonTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT CASE WHEN EXISTS (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.STRVAL1 = 'HELLO')) THEN 1 ELSE 0 END  FROM QUERYSYNTAXENTITY t0", _sql2.remove(0));
+                Assert.assertEquals("SELECT CASE WHEN EXISTS (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.STRVAL1 = ?)) THEN 1 ELSE 0 END  FROM QUERYSYNTAXENTITY t0", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT CASE WHEN EXISTS (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.STRVAL1 = ?)) THEN ? ELSE ? END  FROM QUERYSYNTAXENTITY t0", _sql2.remove(0));
             }
@@ -8614,7 +7959,7 @@ public class TestQuerySyntaxComparisonTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object> cquery = cb.createQuery(Object.class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
 
             ParameterExpression<String> strValue1 = cb.parameter(String.class);
             Subquery<Integer> subquery = cquery.subquery(Integer.class);
@@ -8645,7 +7990,7 @@ public class TestQuerySyntaxComparisonTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object> cquery2 = cb2.createQuery(Object.class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
 
             Subquery<Integer> subquery2 = cquery2.subquery(Integer.class);
             Root<QuerySyntaxEntity> subroot2 = subquery2.from(QuerySyntaxEntity.class);
@@ -8705,6 +8050,7 @@ public class TestQuerySyntaxComparisonTests {
             }
 
             // -----------------------
+            // TODO: https://bugs.eclipse.org/bugs/show_bug.cgi?id=464833
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Integer[]> cquery = cb.createQuery(Integer[].class);
@@ -8740,11 +8086,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (EXISTS (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.STRVAL1 = 'HELLO')))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (EXISTS (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.STRVAL1 = ?)))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (EXISTS (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.STRVAL1 = ?)))", _sql.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -8778,12 +8120,13 @@ public class TestQuerySyntaxComparisonTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT EXISTS (SELECT 1 FROM QUERYSYNTAXENTITY t1 WHERE (t1.STRVAL1 = 'HELLO'))", _sql2.remove(0));
+                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT EXISTS (SELECT 1 FROM QUERYSYNTAXENTITY t1 WHERE (t1.STRVAL1 = ?))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT EXISTS (SELECT ? FROM QUERYSYNTAXENTITY t1 WHERE (t1.STRVAL1 = ?))", _sql2.remove(0));
             }
 
             // -----------------------
+            // TODO: https://bugs.eclipse.org/bugs/show_bug.cgi?id=464833
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Integer[]> cquery = cb.createQuery(Integer[].class);
@@ -8819,11 +8162,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (EXISTS (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.STRVAL1 = 'HELLO')))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (EXISTS (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.STRVAL1 = ?)))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE NOT (EXISTS (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.STRVAL1 = ?)))", _sql2.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -8863,6 +8202,7 @@ public class TestQuerySyntaxComparisonTests {
             }
 
             // -----------------------
+            // TODO: https://bugs.eclipse.org/bugs/show_bug.cgi?id=464833
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Integer[]> cquery = cb.createQuery(Integer[].class);
@@ -8940,10 +8280,11 @@ public class TestQuerySyntaxComparisonTests {
             }
 
             // -----------------------
+            // TODO: https://bugs.eclipse.org/bugs/show_bug.cgi?id=464833
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object> cquery = cb.createQuery(Object.class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
 
             ParameterExpression<String> strValue1 = cb.parameter(String.class);
             Subquery<Integer> subquery = cquery.subquery(Integer.class);
@@ -8974,7 +8315,7 @@ public class TestQuerySyntaxComparisonTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object> cquery2 = cb2.createQuery(Object.class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
 
             Subquery<Integer> subquery2 = cquery2.subquery(Integer.class);
             Root<QuerySyntaxEntity> subroot2 = subquery2.from(QuerySyntaxEntity.class);
@@ -9030,16 +8371,17 @@ public class TestQuerySyntaxComparisonTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT CASE  WHEN NOT EXISTS (SELECT 1 FROM QUERYSYNTAXENTITY t1 WHERE (t1.STRVAL1 = 'HELLO')) THEN 1 ELSE 0 END FROM QUERYSYNTAXENTITY t0", _sql2.remove(0));
+                Assert.assertEquals("SELECT CASE  WHEN NOT EXISTS (SELECT 1 FROM QUERYSYNTAXENTITY t1 WHERE (t1.STRVAL1 = ?)) THEN 1 ELSE 0 END FROM QUERYSYNTAXENTITY t0", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT CASE  WHEN NOT EXISTS (SELECT ? FROM QUERYSYNTAXENTITY t1 WHERE (t1.STRVAL1 = ?)) THEN ? ELSE ? END FROM QUERYSYNTAXENTITY t0", _sql2.remove(0));
             }
 
             // -----------------------
+            // TODO: https://bugs.eclipse.org/bugs/show_bug.cgi?id=464833
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object> cquery = cb.createQuery(Object.class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
 
             ParameterExpression<String> strValue1 = cb.parameter(String.class);
             Subquery<Integer> subquery = cquery.subquery(Integer.class);
@@ -9070,7 +8412,7 @@ public class TestQuerySyntaxComparisonTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object> cquery2 = cb2.createQuery(Object.class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
 
             Subquery<Integer> subquery2 = cquery2.subquery(Integer.class);
             Root<QuerySyntaxEntity> subroot2 = subquery2.from(QuerySyntaxEntity.class);
@@ -9087,7 +8429,7 @@ public class TestQuerySyntaxComparisonTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT CASE WHEN NOT (EXISTS (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.STRVAL1 = 'HELLO'))) THEN 1 ELSE 0 END  FROM QUERYSYNTAXENTITY t0", _sql2.remove(0));
+                Assert.assertEquals("SELECT CASE WHEN NOT (EXISTS (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.STRVAL1 = ?))) THEN 1 ELSE 0 END  FROM QUERYSYNTAXENTITY t0", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT CASE WHEN NOT (EXISTS (SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.STRVAL1 = ?))) THEN ? ELSE ? END  FROM QUERYSYNTAXENTITY t0", _sql2.remove(0));
             }
@@ -9132,10 +8474,11 @@ public class TestQuerySyntaxComparisonTests {
             }
 
             // -----------------------
+            // TODO: https://bugs.eclipse.org/bugs/show_bug.cgi?id=464833
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object> cquery = cb.createQuery(Object.class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
 
             ParameterExpression<String> strValue1 = cb.parameter(String.class);
             Subquery<Integer> subquery = cquery.subquery(Integer.class);
@@ -9166,7 +8509,7 @@ public class TestQuerySyntaxComparisonTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object> cquery2 = cb2.createQuery(Object.class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
 
             Subquery<Integer> subquery2 = cquery2.subquery(Integer.class);
             Root<QuerySyntaxEntity> subroot2 = subquery2.from(QuerySyntaxEntity.class);
@@ -9370,7 +8713,7 @@ public class TestQuerySyntaxComparisonTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = CASE INTVAL2 WHEN 5 THEN 6 WHEN 15 THEN 16 ELSE 26 END)", _sql2.remove(0));
+                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = CASE INTVAL2 WHEN ? THEN 6 WHEN ? THEN 16 ELSE 26 END)", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = CASE INTVAL2 WHEN ? THEN ? WHEN ? THEN ? ELSE ? END)", _sql2.remove(0));
             }
@@ -9381,7 +8724,7 @@ public class TestQuerySyntaxComparisonTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = CASE INTVAL2 WHEN ? THEN 6 WHEN 15 THEN 16 ELSE 26 END)", _sql2.remove(0));
+                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = CASE INTVAL2 WHEN ? THEN 6 WHEN ? THEN 16 ELSE 26 END)", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = CASE INTVAL2 WHEN ? THEN ? WHEN ? THEN ? ELSE ? END)", _sql2.remove(0));
             }
@@ -9443,7 +8786,7 @@ public class TestQuerySyntaxComparisonTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = CASE INTVAL2 WHEN 5 THEN 6 WHEN 15 THEN 16 ELSE 26 END)", _sql2.remove(0));
+                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = CASE INTVAL2 WHEN ? THEN 6 WHEN ? THEN 16 ELSE 26 END)", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = CASE INTVAL2 WHEN ? THEN ? WHEN ? THEN ? ELSE ? END)", _sql2.remove(0));
             }
@@ -9794,7 +9137,7 @@ public class TestQuerySyntaxComparisonTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = CASE  WHEN (INTVAL2 = 5) THEN 6 WHEN (INTVAL2 = 15) THEN 16 ELSE 26 END)", _sql2.remove(0));
+                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = CASE  WHEN (INTVAL2 = ?) THEN 6 WHEN (INTVAL2 = ?) THEN 16 ELSE 26 END)", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = CASE  WHEN (INTVAL2 = ?) THEN ? WHEN (INTVAL2 = ?) THEN ? ELSE ? END)", _sql2.remove(0));
             }
@@ -9805,7 +9148,7 @@ public class TestQuerySyntaxComparisonTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = CASE  WHEN (INTVAL2 = ?) THEN 6 WHEN (INTVAL2 = 15) THEN 16 ELSE 26 END)", _sql2.remove(0));
+                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = CASE  WHEN (INTVAL2 = ?) THEN 6 WHEN (INTVAL2 = ?) THEN 16 ELSE 26 END)", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = CASE  WHEN (INTVAL2 = ?) THEN ? WHEN (INTVAL2 = ?) THEN ? ELSE ? END)", _sql2.remove(0));
             }
@@ -9862,7 +9205,7 @@ public class TestQuerySyntaxComparisonTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = CASE WHEN (INTVAL2 = 5) THEN 6 WHEN (INTVAL2 = 15) THEN 16 ELSE 26 END )", _sql2.remove(0));
+                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = CASE WHEN (INTVAL2 = ?) THEN 6 WHEN (INTVAL2 = ?) THEN 16 ELSE 26 END )", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = CASE WHEN (INTVAL2 = ?) THEN ? WHEN (INTVAL2 = ?) THEN ? ELSE ? END )", _sql2.remove(0));
             }
@@ -9889,7 +9232,7 @@ public class TestQuerySyntaxComparisonTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = CASE WHEN (INTVAL2 = ?) THEN 6 WHEN (INTVAL2 = 15) THEN 16 ELSE 26 END )", _sql2.remove(0));
+                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = CASE WHEN (INTVAL2 = ?) THEN 6 WHEN (INTVAL2 = ?) THEN 16 ELSE 26 END )", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = CASE WHEN (INTVAL2 = ?) THEN ? WHEN (INTVAL2 = ?) THEN ? ELSE ? END )", _sql2.remove(0));
             }
@@ -10212,7 +9555,7 @@ public class TestQuerySyntaxComparisonTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT CASE INTVAL2 WHEN 5 THEN 6 WHEN 15 THEN 16 ELSE 26 END FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = 99)", _sql2.remove(0));
+                Assert.assertEquals("SELECT CASE INTVAL2 WHEN ? THEN 6 WHEN ? THEN 16 ELSE 26 END FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?)", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT CASE INTVAL2 WHEN ? THEN ? WHEN ? THEN ? ELSE ? END FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?)", _sql2.remove(0));
             }
@@ -10224,7 +9567,7 @@ public class TestQuerySyntaxComparisonTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT CASE INTVAL2 WHEN ? THEN 6 WHEN 15 THEN 16 ELSE 26 END FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?)", _sql2.remove(0));
+                Assert.assertEquals("SELECT CASE INTVAL2 WHEN ? THEN 6 WHEN ? THEN 16 ELSE 26 END FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?)", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT CASE INTVAL2 WHEN ? THEN ? WHEN ? THEN ? ELSE ? END FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?)", _sql2.remove(0));
             }
@@ -10286,7 +9629,7 @@ public class TestQuerySyntaxComparisonTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT CASE INTVAL2 WHEN 5 THEN 6 WHEN 15 THEN 16 ELSE 26 END FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = 99)", _sql2.remove(0));
+                Assert.assertEquals("SELECT CASE INTVAL2 WHEN ? THEN 6 WHEN ? THEN 16 ELSE 26 END FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?)", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT CASE INTVAL2 WHEN ? THEN ? WHEN ? THEN ? ELSE ? END FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?)", _sql2.remove(0));
             }
@@ -10645,7 +9988,7 @@ public class TestQuerySyntaxComparisonTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT CASE  WHEN (INTVAL2 = 5) THEN 6 WHEN (INTVAL2 = 15) THEN 16 ELSE 26 END FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = 99)", _sql2.remove(0));
+                Assert.assertEquals("SELECT CASE  WHEN (INTVAL2 = ?) THEN 6 WHEN (INTVAL2 = ?) THEN 16 ELSE 26 END FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?)", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT CASE  WHEN (INTVAL2 = ?) THEN ? WHEN (INTVAL2 = ?) THEN ? ELSE ? END FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?)", _sql2.remove(0));
             }
@@ -10657,7 +10000,7 @@ public class TestQuerySyntaxComparisonTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT CASE  WHEN (INTVAL2 = ?) THEN 6 WHEN (INTVAL2 = 15) THEN 16 ELSE 26 END FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?)", _sql2.remove(0));
+                Assert.assertEquals("SELECT CASE  WHEN (INTVAL2 = ?) THEN 6 WHEN (INTVAL2 = ?) THEN 16 ELSE 26 END FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?)", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT CASE  WHEN (INTVAL2 = ?) THEN ? WHEN (INTVAL2 = ?) THEN ? ELSE ? END FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?)", _sql2.remove(0));
             }
@@ -10714,7 +10057,7 @@ public class TestQuerySyntaxComparisonTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT CASE WHEN (INTVAL2 = 5) THEN 6 WHEN (INTVAL2 = 15) THEN 16 ELSE 26 END  FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = 99)", _sql2.remove(0));
+                Assert.assertEquals("SELECT CASE WHEN (INTVAL2 = ?) THEN 6 WHEN (INTVAL2 = ?) THEN 16 ELSE 26 END  FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?)", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT CASE WHEN (INTVAL2 = ?) THEN ? WHEN (INTVAL2 = ?) THEN ? ELSE ? END  FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?)", _sql2.remove(0));
             }
@@ -10742,7 +10085,7 @@ public class TestQuerySyntaxComparisonTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT CASE WHEN (INTVAL2 = ?) THEN 6 WHEN (INTVAL2 = 15) THEN 16 ELSE 26 END  FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?)", _sql2.remove(0));
+                Assert.assertEquals("SELECT CASE WHEN (INTVAL2 = ?) THEN 6 WHEN (INTVAL2 = ?) THEN 16 ELSE 26 END  FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?)", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT CASE WHEN (INTVAL2 = ?) THEN ? WHEN (INTVAL2 = ?) THEN ? ELSE ? END  FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?)", _sql2.remove(0));
             }
@@ -10993,7 +10336,7 @@ public class TestQuerySyntaxComparisonTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT 1 FROM QUERYSYNTAXENTITY WHERE ('HELLO' = NULLIF(STRVAL1, 'WORLD'))", _sql2.remove(0));
+                Assert.assertEquals("SELECT 1 FROM QUERYSYNTAXENTITY WHERE (? = NULLIF(STRVAL1, ?))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM QUERYSYNTAXENTITY WHERE (? = NULLIF(STRVAL1, ?))", _sql2.remove(0));
             }
@@ -11029,7 +10372,7 @@ public class TestQuerySyntaxComparisonTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT 1 FROM QUERYSYNTAXENTITY WHERE ('HELLO' = NULLIF(STRVAL1, 'WORLD'))", _sql2.remove(0));
+                Assert.assertEquals("SELECT 1 FROM QUERYSYNTAXENTITY WHERE (? = NULLIF(STRVAL1, ?))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM QUERYSYNTAXENTITY WHERE (? = NULLIF(STRVAL1, ?))", _sql2.remove(0));
             }
@@ -11215,7 +10558,7 @@ public class TestQuerySyntaxComparisonTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT 1 FROM QUERYSYNTAXENTITY WHERE ('HELLO' = NULLIF('WORLD', STRVAL1))", _sql2.remove(0));
+                Assert.assertEquals("SELECT 1 FROM QUERYSYNTAXENTITY WHERE (? = NULLIF(?, STRVAL1))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM QUERYSYNTAXENTITY WHERE (? = NULLIF(?, STRVAL1))", _sql2.remove(0));
             }
@@ -11251,7 +10594,7 @@ public class TestQuerySyntaxComparisonTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT 1 FROM QUERYSYNTAXENTITY WHERE ('HELLO' = NULLIF('WORLD', STRVAL1))", _sql2.remove(0));
+                Assert.assertEquals("SELECT 1 FROM QUERYSYNTAXENTITY WHERE (? = NULLIF(?, STRVAL1))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM QUERYSYNTAXENTITY WHERE (? = NULLIF(?, STRVAL1))", _sql2.remove(0));
             }
@@ -11382,7 +10725,7 @@ public class TestQuerySyntaxComparisonTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery = cb.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
             ParameterExpression<String> strParam1 = cb.parameter(String.class);
             ParameterExpression<String> strParam2 = cb.parameter(String.class);
             cquery.multiselect(cb.nullif(strParam1, strParam2));
@@ -11400,7 +10743,7 @@ public class TestQuerySyntaxComparisonTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery2 = cb2.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
             cquery2.multiselect(cb2.nullif((Expression<String>) cb2.literal("HELLO"), cb2.literal("WORLD")));
 
             query = em.createQuery(cquery2);
@@ -11414,7 +10757,7 @@ public class TestQuerySyntaxComparisonTests {
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery3 = cb3.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root3 = cquery3.from(QuerySyntaxEntity.class);
+            cquery3.from(QuerySyntaxEntity.class);
             ParameterExpression<String> strParam3 = cb3.parameter(String.class);
             cquery3.multiselect(cb3.nullif(strParam3, cb3.literal("WORLD")));
 
@@ -11461,7 +10804,7 @@ public class TestQuerySyntaxComparisonTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT NULLIF('HELLO', 'WORLD') FROM QUERYSYNTAXENTITY", _sql2.remove(0));
+                Assert.assertEquals("SELECT NULLIF(?, 'WORLD') FROM QUERYSYNTAXENTITY", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT NULLIF(?, ?) FROM QUERYSYNTAXENTITY", _sql2.remove(0));
             }
@@ -11480,7 +10823,7 @@ public class TestQuerySyntaxComparisonTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery = cb.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
             ParameterExpression<String> strParam1 = cb.parameter(String.class);
             ParameterExpression<String> strParam2 = cb.parameter(String.class);
             cquery.multiselect(cb.nullif(strParam1, strParam2));
@@ -11498,21 +10841,21 @@ public class TestQuerySyntaxComparisonTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery2 = cb2.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
             cquery2.multiselect(cb2.nullif((Expression<String>) cb2.literal("HELLO"), cb2.literal("WORLD")));
 
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT NULLIF('HELLO', 'WORLD') FROM QUERYSYNTAXENTITY", _sql2.remove(0));
+                Assert.assertEquals("SELECT NULLIF(?, 'WORLD') FROM QUERYSYNTAXENTITY", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT NULLIF(?, ?) FROM QUERYSYNTAXENTITY", _sql2.remove(0));
             }
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery3 = cb3.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root3 = cquery3.from(QuerySyntaxEntity.class);
+            cquery3.from(QuerySyntaxEntity.class);
             ParameterExpression<String> strParam3 = cb3.parameter(String.class);
             cquery3.multiselect(cb3.nullif(strParam3, cb3.literal("WORLD")));
 
@@ -11578,7 +10921,7 @@ public class TestQuerySyntaxComparisonTests {
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery = cb.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root = cquery.from(QuerySyntaxEntity.class);
+            cquery.from(QuerySyntaxEntity.class);
             ParameterExpression<String> strParam1 = cb.parameter(String.class);
             ParameterExpression<String> strParam2 = cb.parameter(String.class);
             cquery.multiselect(cb.nullif(strParam1, strParam2));
@@ -11596,7 +10939,7 @@ public class TestQuerySyntaxComparisonTests {
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery2 = cb2.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root2 = cquery2.from(QuerySyntaxEntity.class);
+            cquery2.from(QuerySyntaxEntity.class);
             cquery2.multiselect(cb2.nullif((Expression<String>) cb2.literal("HELLO"), cb2.literal("WORLD")));
 
             query = em.createQuery(cquery2);
@@ -11610,7 +10953,7 @@ public class TestQuerySyntaxComparisonTests {
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery3 = cb3.createQuery(Object[].class);
-            Root<QuerySyntaxEntity> root3 = cquery3.from(QuerySyntaxEntity.class);
+            cquery3.from(QuerySyntaxEntity.class);
             ParameterExpression<String> strParam3 = cb3.parameter(String.class);
             cquery3.multiselect(cb3.nullif(strParam3, cb3.literal("WORLD")));
 
@@ -11639,7 +10982,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf);
 
         try {
             Query query = em.createQuery("SELECT s.strVal2 FROM QuerySyntaxEntity s WHERE COALESCE(s.intVal1, ?3) = s.intVal2");
@@ -11651,11 +10993,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.strVal2 FROM QuerySyntaxEntity s WHERE COALESCE(s.intVal1, 5) = s.intVal2");
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT STRVAL2 FROM QUERYSYNTAXENTITY WHERE (COALESCE(INTVAL1, 5) = INTVAL2)", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT STRVAL2 FROM QUERYSYNTAXENTITY WHERE (COALESCE(INTVAL1, ?) = INTVAL2)", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT STRVAL2 FROM QUERYSYNTAXENTITY WHERE (COALESCE(INTVAL1, ?) = INTVAL2)", _sql.remove(0));
 
             // -----------------------
 
@@ -11704,11 +11042,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery3);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT STRVAL2 FROM QUERYSYNTAXENTITY WHERE (COALESCE(INTVAL1, 5) = INTVAL2)", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT STRVAL2 FROM QUERYSYNTAXENTITY WHERE (COALESCE(INTVAL1, ?) = INTVAL2)", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT STRVAL2 FROM QUERYSYNTAXENTITY WHERE (COALESCE(INTVAL1, ?) = INTVAL2)", _sql.remove(0));
 
             CriteriaBuilder cb4 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery4 = cb4.createQuery(Object[].class);
@@ -11721,11 +11055,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery4);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT STRVAL2 FROM QUERYSYNTAXENTITY WHERE (COALESCE(INTVAL1, 5) = INTVAL2)", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT STRVAL2 FROM QUERYSYNTAXENTITY WHERE (COALESCE(INTVAL1, ?) = INTVAL2)", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT STRVAL2 FROM QUERYSYNTAXENTITY WHERE (COALESCE(INTVAL1, ?) = INTVAL2)", _sql.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -11742,7 +11072,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf2.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf2);
 
         try {
             Query query = em.createQuery("SELECT s.strVal2 FROM QuerySyntaxEntity s WHERE COALESCE(s.intVal1, ?3) = s.intVal2");
@@ -11754,11 +11083,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT s.strVal2 FROM QuerySyntaxEntity s WHERE COALESCE(s.intVal1, 5) = s.intVal2");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT STRVAL2 FROM QUERYSYNTAXENTITY WHERE (COALESCE(INTVAL1, 5) = INTVAL2)", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT STRVAL2 FROM QUERYSYNTAXENTITY WHERE (COALESCE(INTVAL1, ?) = INTVAL2)", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT STRVAL2 FROM QUERYSYNTAXENTITY WHERE (COALESCE(INTVAL1, ?) = INTVAL2)", _sql2.remove(0));
 
             // -----------------------
 
@@ -11807,11 +11132,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery3);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT STRVAL2 FROM QUERYSYNTAXENTITY WHERE (COALESCE(INTVAL1, 5) = INTVAL2)", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT STRVAL2 FROM QUERYSYNTAXENTITY WHERE (COALESCE(INTVAL1, ?) = INTVAL2)", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT STRVAL2 FROM QUERYSYNTAXENTITY WHERE (COALESCE(INTVAL1, ?) = INTVAL2)", _sql2.remove(0));
 
             CriteriaBuilder cb4 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery4 = cb4.createQuery(Object[].class);
@@ -11824,11 +11145,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery4);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT STRVAL2 FROM QUERYSYNTAXENTITY WHERE (COALESCE(INTVAL1, 5) = INTVAL2)", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT STRVAL2 FROM QUERYSYNTAXENTITY WHERE (COALESCE(INTVAL1, ?) = INTVAL2)", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT STRVAL2 FROM QUERYSYNTAXENTITY WHERE (COALESCE(INTVAL1, ?) = INTVAL2)", _sql2.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -11935,7 +11252,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf);
 
         try {
             Query query = em.createQuery("SELECT COALESCE(s.intVal1, ?3) FROM QuerySyntaxEntity s");
@@ -11947,11 +11263,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT COALESCE(s.intVal1, 5) FROM QuerySyntaxEntity s");
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT COALESCE(INTVAL1, 5) FROM QUERYSYNTAXENTITY", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT COALESCE(INTVAL1, ?) FROM QUERYSYNTAXENTITY", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT COALESCE(INTVAL1, ?) FROM QUERYSYNTAXENTITY", _sql.remove(0));
 
             // -----------------------
 
@@ -11997,11 +11309,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery3);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT COALESCE(INTVAL1, 5) FROM QUERYSYNTAXENTITY", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT COALESCE(INTVAL1, ?) FROM QUERYSYNTAXENTITY", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT COALESCE(INTVAL1, ?) FROM QUERYSYNTAXENTITY", _sql.remove(0));
 
             CriteriaBuilder cb4 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery4 = cb4.createQuery(Object[].class);
@@ -12013,11 +11321,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery4);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT COALESCE(INTVAL1, 5) FROM QUERYSYNTAXENTITY", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT COALESCE(INTVAL1, ?) FROM QUERYSYNTAXENTITY", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT COALESCE(INTVAL1, ?) FROM QUERYSYNTAXENTITY", _sql.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -12034,7 +11338,6 @@ public class TestQuerySyntaxComparisonTests {
             return;
 
         EntityManager em = emf2.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf2);
 
         try {
             Query query = em.createQuery("SELECT COALESCE(s.intVal1, ?3) FROM QuerySyntaxEntity s");
@@ -12046,11 +11349,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery("SELECT COALESCE(s.intVal1, 5) FROM QuerySyntaxEntity s");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT COALESCE(INTVAL1, 5) FROM QUERYSYNTAXENTITY", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT COALESCE(INTVAL1, ?) FROM QUERYSYNTAXENTITY", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT COALESCE(INTVAL1, ?) FROM QUERYSYNTAXENTITY", _sql2.remove(0));
 
             // -----------------------
 
@@ -12096,11 +11395,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery3);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT COALESCE(INTVAL1, 5) FROM QUERYSYNTAXENTITY", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT COALESCE(INTVAL1, ?) FROM QUERYSYNTAXENTITY", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT COALESCE(INTVAL1, ?) FROM QUERYSYNTAXENTITY", _sql2.remove(0));
 
             CriteriaBuilder cb4 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery4 = cb4.createQuery(Object[].class);
@@ -12112,11 +11407,7 @@ public class TestQuerySyntaxComparisonTests {
             query = em.createQuery(cquery4);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT COALESCE(INTVAL1, 5) FROM QUERYSYNTAXENTITY", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT COALESCE(INTVAL1, ?) FROM QUERYSYNTAXENTITY", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT COALESCE(INTVAL1, ?) FROM QUERYSYNTAXENTITY", _sql2.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -12387,13 +11678,9 @@ public class TestQuerySyntaxComparisonTests {
             } catch(Exception e) {
                 exception = e;
             } finally {
-                if(platform.isDB2Z() || platform.isDerby()) {
-                    // DB2 z throws `DB2 SQL Error: SQLCODE=-206, SQLSTATE=42703` because a "NULL" value is being passed
-                    // Derby throws `ERROR 42X01: Syntax error: Encountered "NULL" at line 1, column 50.`
-                    Assert.assertNotNull("Expected query '" + _sql2.remove(0) + "' to fail", exception);
-                } else if(platform.isDB2()) {
+                if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
                     Assert.assertNull(exception);
-                    Assert.assertEquals("SELECT STRVAL2 FROM QUERYSYNTAXENTITY WHERE (COALESCE(NULL, 7, 5, 9, 12) = INTVAL2)", _sql2.remove(0));
+                    Assert.assertEquals("SELECT STRVAL2 FROM QUERYSYNTAXENTITY WHERE (COALESCE(?, ?, ?, ?, 12) = INTVAL2)", _sql2.remove(0));
                 } else {
                     Assert.assertNull(exception);
                     Assert.assertEquals("SELECT STRVAL2 FROM QUERYSYNTAXENTITY WHERE (COALESCE(?, ?, ?, ?, ?) = INTVAL2)", _sql2.remove(0));
@@ -12463,13 +11750,9 @@ public class TestQuerySyntaxComparisonTests {
             } catch(Exception e) {
                 exception = e;
             } finally {
-                if(platform.isDB2Z() || platform.isDerby()) {
-                    // DB2 z throws `DB2 SQL Error: SQLCODE=-206, SQLSTATE=42703` because a "NULL" value is being passed
-                    // Derby throws `ERROR 42X01: Syntax error: Encountered "NULL" at line 1, column 50.`
-                    Assert.assertNotNull("Expected query '" + _sql2.remove(0) + "' to fail", exception);
-                } else if(platform.isDB2()) {
+                if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
                     Assert.assertNull(exception);
-                    Assert.assertEquals("SELECT STRVAL2 FROM QUERYSYNTAXENTITY WHERE (COALESCE(NULL, 7, 5, 9, 12) = INTVAL2)", _sql2.remove(0));
+                    Assert.assertEquals("SELECT STRVAL2 FROM QUERYSYNTAXENTITY WHERE (COALESCE(?, ?, ?, ?, 12) = INTVAL2)", _sql2.remove(0));
                 } else {
                     Assert.assertNull(exception);
                     Assert.assertEquals("SELECT STRVAL2 FROM QUERYSYNTAXENTITY WHERE (COALESCE(?, ?, ?, ?, ?) = INTVAL2)", _sql2.remove(0));

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/TestQuerySyntaxFunctionTests.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/TestQuerySyntaxFunctionTests.java
@@ -173,7 +173,7 @@ public class TestQuerySyntaxFunctionTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = UCASE('HELLO WORLD'))", _sql2.remove(0));
+                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = UCASE(?))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = UPPER(?))", _sql2.remove(0));
             }
@@ -207,7 +207,7 @@ public class TestQuerySyntaxFunctionTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = UCASE('HELLO WORLD'))", _sql2.remove(0));
+                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = UCASE(?))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = UPPER(?))", _sql2.remove(0));
             }
@@ -386,7 +386,7 @@ public class TestQuerySyntaxFunctionTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = LCASE('HELLO WORLD'))", _sql2.remove(0));
+                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = LCASE(?))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = LOWER(?))", _sql2.remove(0));
             }
@@ -420,7 +420,7 @@ public class TestQuerySyntaxFunctionTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = LCASE('HELLO WORLD'))", _sql2.remove(0));
+                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = LCASE(?))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = LOWER(?))", _sql2.remove(0));
             }
@@ -595,7 +595,7 @@ public class TestQuerySyntaxFunctionTests {
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = VARCHAR(? || VARCHAR(' ' || STRVAL2)))", _sql.remove(0));
+                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = VARCHAR(? || VARCHAR(? || STRVAL2)))", _sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = CONCAT(?, CONCAT(?, STRVAL2)))", _sql.remove(0));
             }
@@ -635,8 +635,10 @@ public class TestQuerySyntaxFunctionTests {
             query = em.createQuery("SELECT s.strVal1 FROM QuerySyntaxEntity s WHERE s.strVal1 = CONCAT('HELLO', ' ', 'WORLD')");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = VARCHAR(VARCHAR('HELLO' || ' ') || 'WORLD'))", _sql2.remove(0));
+            if(platform.isDB2Z() || platform.isDerby()) {
+                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = VARCHAR(VARCHAR(? || ' ') || ?))", _sql2.remove(0));
+            } else if(platform.isDB2()) {
+                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = VARCHAR(VARCHAR(? || ?) || ?))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = CONCAT(CONCAT(?, ?), ?))", _sql2.remove(0));
             }
@@ -645,8 +647,10 @@ public class TestQuerySyntaxFunctionTests {
             query.setParameter(1, "HELLO");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+            if(platform.isDB2Z() || platform.isDerby()) {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = VARCHAR(VARCHAR(? || ' ') || STRVAL2))", _sql2.remove(0));
+            } else if(platform.isDB2()) {
+                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = VARCHAR(VARCHAR(? || ?) || STRVAL2))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = CONCAT(CONCAT(?, ?), STRVAL2))", _sql2.remove(0));
             }
@@ -685,8 +689,10 @@ public class TestQuerySyntaxFunctionTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = VARCHAR(VARCHAR('HELLO' || ' ') || 'WORLD'))", _sql2.remove(0));
+            if(platform.isDB2Z() || platform.isDerby()) {
+                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = VARCHAR(VARCHAR(? || ' ') || ?))", _sql2.remove(0));
+            } else if(platform.isDB2()) {
+                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = VARCHAR(VARCHAR(? || ?) || ?))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = CONCAT(CONCAT(?, ?), ?))", _sql2.remove(0));
             }
@@ -703,7 +709,7 @@ public class TestQuerySyntaxFunctionTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = VARCHAR(? || VARCHAR(' ' || STRVAL2)))", _sql2.remove(0));
+                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = VARCHAR(? || VARCHAR(? || STRVAL2)))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = CONCAT(?, CONCAT(?, STRVAL2)))", _sql2.remove(0));
             }
@@ -854,7 +860,7 @@ public class TestQuerySyntaxFunctionTests {
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT VARCHAR(STRVAL1 || 'HELLO') FROM QUERYSYNTAXENTITY", _sql.remove(0));
+                Assert.assertEquals("SELECT VARCHAR(STRVAL1 || ?) FROM QUERYSYNTAXENTITY", _sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT CONCAT(STRVAL1, ?) FROM QUERYSYNTAXENTITY", _sql.remove(0));
             }
@@ -864,7 +870,7 @@ public class TestQuerySyntaxFunctionTests {
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT VARCHAR(VARCHAR(STRVAL1 || 'HELLO') || ?) FROM QUERYSYNTAXENTITY", _sql.remove(0));
+                Assert.assertEquals("SELECT VARCHAR(VARCHAR(STRVAL1 || ?) || ?) FROM QUERYSYNTAXENTITY", _sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT CONCAT(CONCAT(STRVAL1, ?), ?) FROM QUERYSYNTAXENTITY", _sql.remove(0));
             }
@@ -896,7 +902,7 @@ public class TestQuerySyntaxFunctionTests {
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT VARCHAR(STRVAL1 || 'HELLO') FROM QUERYSYNTAXENTITY", _sql.remove(0));
+                Assert.assertEquals("SELECT VARCHAR(STRVAL1 || ?) FROM QUERYSYNTAXENTITY", _sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT CONCAT(STRVAL1, ?) FROM QUERYSYNTAXENTITY", _sql.remove(0));
             }
@@ -912,7 +918,7 @@ public class TestQuerySyntaxFunctionTests {
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT VARCHAR(VARCHAR(STRVAL1 || 'HELLO') || ?) FROM QUERYSYNTAXENTITY", _sql.remove(0));
+                Assert.assertEquals("SELECT VARCHAR(VARCHAR(STRVAL1 || ?) || ?) FROM QUERYSYNTAXENTITY", _sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT CONCAT(CONCAT(STRVAL1, ?), ?) FROM QUERYSYNTAXENTITY", _sql.remove(0));
             }
@@ -949,7 +955,7 @@ public class TestQuerySyntaxFunctionTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT VARCHAR(STRVAL1 || 'HELLO') FROM QUERYSYNTAXENTITY", _sql2.remove(0));
+                Assert.assertEquals("SELECT VARCHAR(STRVAL1 || ?) FROM QUERYSYNTAXENTITY", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT CONCAT(STRVAL1, ?) FROM QUERYSYNTAXENTITY", _sql2.remove(0));
             }
@@ -959,7 +965,7 @@ public class TestQuerySyntaxFunctionTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT VARCHAR(VARCHAR(STRVAL1 || 'HELLO') || ?) FROM QUERYSYNTAXENTITY", _sql2.remove(0));
+                Assert.assertEquals("SELECT VARCHAR(VARCHAR(STRVAL1 || ?) || ?) FROM QUERYSYNTAXENTITY", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT CONCAT(CONCAT(STRVAL1, ?), ?) FROM QUERYSYNTAXENTITY", _sql2.remove(0));
             }
@@ -991,7 +997,7 @@ public class TestQuerySyntaxFunctionTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT VARCHAR(STRVAL1 || 'HELLO') FROM QUERYSYNTAXENTITY", _sql2.remove(0));
+                Assert.assertEquals("SELECT VARCHAR(STRVAL1 || ?) FROM QUERYSYNTAXENTITY", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT CONCAT(STRVAL1, ?) FROM QUERYSYNTAXENTITY", _sql2.remove(0));
             }
@@ -1007,7 +1013,7 @@ public class TestQuerySyntaxFunctionTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT VARCHAR(VARCHAR(STRVAL1 || 'HELLO') || ?) FROM QUERYSYNTAXENTITY", _sql2.remove(0));
+                Assert.assertEquals("SELECT VARCHAR(VARCHAR(STRVAL1 || ?) || ?) FROM QUERYSYNTAXENTITY", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT CONCAT(CONCAT(STRVAL1, ?), ?) FROM QUERYSYNTAXENTITY", _sql2.remove(0));
             }
@@ -1209,7 +1215,7 @@ public class TestQuerySyntaxFunctionTests {
             query = em.createQuery("SELECT s.strVal1 FROM QuerySyntaxEntity s WHERE s.strVal1 = TRIM(LEADING '  HELLO WORD ')");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+            if(platform.isDB2Z()) {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = LTRIM('  HELLO WORD '))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = LTRIM(?))", _sql2.remove(0));
@@ -1243,7 +1249,7 @@ public class TestQuerySyntaxFunctionTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+            if(platform.isDB2Z()) {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = LTRIM('  HELLO WORD '))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = LTRIM(?))", _sql2.remove(0));
@@ -1422,7 +1428,7 @@ public class TestQuerySyntaxFunctionTests {
             query = em.createQuery("SELECT s.strVal1 FROM QuerySyntaxEntity s WHERE s.strVal1 = TRIM(TRAILING '  HELLO WORD ')");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+            if(platform.isDB2Z()) {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = RTRIM('  HELLO WORD '))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = RTRIM(?))", _sql2.remove(0));
@@ -1457,7 +1463,7 @@ public class TestQuerySyntaxFunctionTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+            if(platform.isDB2Z()) {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = RTRIM('  HELLO WORD '))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = RTRIM(?))", _sql2.remove(0));
@@ -1667,21 +1673,13 @@ public class TestQuerySyntaxFunctionTests {
             query = em.createQuery("SELECT s.strVal1 FROM QuerySyntaxEntity s WHERE s.strVal1 = SUBSTRING('HELLO WORLD', 1, 5)");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = SUBSTR('HELLO WORLD', 1, 5))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = SUBSTR(?, ?, ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = SUBSTR(?, ?, ?))", _sql2.remove(0));
 
             query = em.createQuery("SELECT s.strVal1 FROM QuerySyntaxEntity s WHERE s.strVal1 = SUBSTRING('HELLO WORLD', 1, ?3)");
             query.setParameter(3, 5);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = SUBSTR('HELLO WORLD', 1, ?))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = SUBSTR(?, ?, ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = SUBSTR(?, ?, ?))", _sql2.remove(0));
 
             // -----------------------
 
@@ -1711,11 +1709,7 @@ public class TestQuerySyntaxFunctionTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = SUBSTR('HELLO WORLD', 1, 5))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = SUBSTR(?, ?, ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = SUBSTR(?, ?, ?))", _sql2.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery3 = cb3.createQuery(Object[].class);
@@ -1728,11 +1722,7 @@ public class TestQuerySyntaxFunctionTests {
             query.setParameter(strParam4, 5);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = SUBSTR('HELLO WORLD', 1, ?))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = SUBSTR(?, ?, ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = SUBSTR(?, ?, ?))", _sql2.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -1954,22 +1944,14 @@ public class TestQuerySyntaxFunctionTests {
             query = em.createQuery("SELECT SUBSTRING('HELLO WORLD', 1, 5), s.strVal2 FROM QuerySyntaxEntity s WHERE s.strVal1 = SUBSTRING(SUBSTRING(s.strVal2, 1, 5), 1, 2)");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT SUBSTR('HELLO WORLD', 1, 5), STRVAL2 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = SUBSTR(SUBSTR(STRVAL2, 1, 5), 1, 2))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT SUBSTR(?, ?, ?), STRVAL2 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = SUBSTR(SUBSTR(STRVAL2, ?, ?), ?, ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT SUBSTR(?, ?, ?), STRVAL2 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = SUBSTR(SUBSTR(STRVAL2, ?, ?), ?, ?))", _sql2.remove(0));
 
             query = em.createQuery("SELECT SUBSTRING('HELLO WORLD', 1, ?2), s.strVal2 FROM QuerySyntaxEntity s WHERE s.strVal1 = SUBSTRING(SUBSTRING(s.strVal2, 1, ?2), 1, ?3)");
             query.setParameter(2, 5);
             query.setParameter(3, 2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT SUBSTR('HELLO WORLD', 1, ?), STRVAL2 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = SUBSTR(SUBSTR(STRVAL2, 1, ?), 1, ?))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT SUBSTR(?, ?, ?), STRVAL2 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = SUBSTR(SUBSTR(STRVAL2, ?, ?), ?, ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT SUBSTR(?, ?, ?), STRVAL2 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = SUBSTR(SUBSTR(STRVAL2, ?, ?), ?, ?))", _sql2.remove(0));
 
             // -----------------------
 
@@ -2001,11 +1983,7 @@ public class TestQuerySyntaxFunctionTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT SUBSTR('HELLO WORLD', 1, 5), STRVAL2 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = SUBSTR(SUBSTR(STRVAL2, 1, 5), 1, 2))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT SUBSTR(?, ?, ?), STRVAL2 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = SUBSTR(SUBSTR(STRVAL2, ?, ?), ?, ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT SUBSTR(?, ?, ?), STRVAL2 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = SUBSTR(SUBSTR(STRVAL2, ?, ?), ?, ?))", _sql2.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery3 = cb3.createQuery(Object[].class);
@@ -2021,11 +1999,7 @@ public class TestQuerySyntaxFunctionTests {
             query.setParameter(strParam6, 2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT SUBSTR('HELLO WORLD', 1, ?), STRVAL2 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = SUBSTR(SUBSTR(STRVAL2, 1, ?), 1, ?))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT SUBSTR(?, ?, ?), STRVAL2 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = SUBSTR(SUBSTR(STRVAL2, ?, ?), ?, ?))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT SUBSTR(?, ?, ?), STRVAL2 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = SUBSTR(SUBSTR(STRVAL2, ?, ?), ?, ?))", _sql2.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -2215,7 +2189,7 @@ public class TestQuerySyntaxFunctionTests {
             query = em.createQuery("SELECT s.strVal1 FROM QuerySyntaxEntity s WHERE s.strVal1 = TRIM('  HELLO WORD ')");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+            if(platform.isDB2Z()) {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = TRIM('  HELLO WORD '))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = TRIM(?))", _sql2.remove(0));
@@ -2249,7 +2223,7 @@ public class TestQuerySyntaxFunctionTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+            if(platform.isDB2Z()) {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = TRIM('  HELLO WORD '))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = TRIM(?))", _sql2.remove(0));
@@ -2432,8 +2406,8 @@ public class TestQuerySyntaxFunctionTests {
             query = em.createQuery("SELECT TRIM('  HELLO WORD '), s.strVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 = 23");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT TRIM('  HELLO WORD '), STRVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = 23)", _sql2.remove(0));
+            if(platform.isDB2Z()) {
+                Assert.assertEquals("SELECT TRIM('  HELLO WORD '), STRVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?)", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT TRIM(?), STRVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?)", _sql2.remove(0));
             }
@@ -2468,8 +2442,8 @@ public class TestQuerySyntaxFunctionTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT TRIM('  HELLO WORD '), STRVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = 23)", _sql2.remove(0));
+            if(platform.isDB2Z()) {
+                Assert.assertEquals("SELECT TRIM('  HELLO WORD '), STRVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?)", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT TRIM(?), STRVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?)", _sql2.remove(0));
             }
@@ -2655,7 +2629,7 @@ public class TestQuerySyntaxFunctionTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (11 = LENGTH('HELLO WORLD'))", _sql2.remove(0));
+                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (? = LENGTH('HELLO WORLD'))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (? = LENGTH(?))", _sql2.remove(0));
             }
@@ -2691,7 +2665,7 @@ public class TestQuerySyntaxFunctionTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (11 = LENGTH('HELLO WORLD'))", _sql2.remove(0));
+                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (? = LENGTH('HELLO WORLD'))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (? = LENGTH(?))", _sql2.remove(0));
             }
@@ -3134,8 +3108,8 @@ public class TestQuerySyntaxFunctionTests {
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z()) {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = LOCATE('HI', 'ABCDEFGHIJKLMNOP'))", _sql2.remove(0));
-            } else if(platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = LOCATE('HI', 'ABCDEFGHIJKLMNOP'))", _sql2.remove(0));
+            } else if(platform.isDB2()) {
+                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = LOCATE(?, ?))", _sql2.remove(0));
             } else if(platform.isOracle()) {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = INSTR(?, ?))", _sql2.remove(0));
             } else {
@@ -3148,8 +3122,8 @@ public class TestQuerySyntaxFunctionTests {
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z()) {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = LOCATE('HI', 'ABCDEFGHIJKLMNOP'))", _sql2.remove(0));
-            } else if(platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = LOCATE(?, 'ABCDEFGHIJKLMNOP'))", _sql2.remove(0));
+            } else if(platform.isDB2()) {
+                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = LOCATE(?, ?))", _sql2.remove(0));
             } else if(platform.isOracle()) {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = INSTR(?, ?))", _sql2.remove(0));
             } else {
@@ -3191,9 +3165,9 @@ public class TestQuerySyntaxFunctionTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = LOCATE('HI', 'ABCDEFGHIJKLMNOP'))", _sql.remove(0));
-            } else if(platform.isDB2() || platform.isDerby()) {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = LOCATE('HI', 'ABCDEFGHIJKLMNOP'))", _sql2.remove(0));
+            } else if(platform.isDB2()) {
+                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = LOCATE(?, ?))", _sql2.remove(0));
             } else if(platform.isOracle()) {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = INSTR(?, ?))", _sql2.remove(0));
             } else {
@@ -3213,8 +3187,8 @@ public class TestQuerySyntaxFunctionTests {
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z()) {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = LOCATE('HI', 'ABCDEFGHIJKLMNOP'))", _sql2.remove(0));
-            } else if(platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = LOCATE(?, 'ABCDEFGHIJKLMNOP'))", _sql2.remove(0));
+            } else if(platform.isDB2()) {
+                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = LOCATE(?, ?))", _sql2.remove(0));
             } else if(platform.isOracle()) {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = INSTR(?, ?))", _sql2.remove(0));
             } else {
@@ -3499,7 +3473,7 @@ public class TestQuerySyntaxFunctionTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE s.intVal1 = LOCATE('X', 'OXOOOOOXXOOOOOOXX', 3)");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+            if(platform.isDB2Z()) {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = LOCATE('X', 'OXOOOOOXXOOOOOOXX', 3))", _sql2.remove(0));
             } else if(platform.isOracle()) {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = INSTR(?, ?, ?))", _sql2.remove(0));
@@ -3513,8 +3487,6 @@ public class TestQuerySyntaxFunctionTests {
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z()) {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = LOCATE('X', 'OXOOOOOXXOOOOOOXX', 3))", _sql2.remove(0));
-            } else if(platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = LOCATE('X', ?, 3))", _sql2.remove(0));
             } else if(platform.isOracle()) {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = INSTR(?, ?, ?))", _sql2.remove(0));
             } else {
@@ -3555,7 +3527,7 @@ public class TestQuerySyntaxFunctionTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+            if(platform.isDB2Z()) {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = LOCATE('X', 'OXOOOOOXXOOOOOOXX', 3))", _sql2.remove(0));
             } else if(platform.isOracle()) {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = INSTR(?, ?, ?))", _sql2.remove(0));
@@ -3578,8 +3550,6 @@ public class TestQuerySyntaxFunctionTests {
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z()) {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = LOCATE('X', 'OXOOOOOXXOOOOOOXX', 3))", _sql2.remove(0));
-            } else if(platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = LOCATE('X', ?, ?))", _sql2.remove(0));
             } else if(platform.isOracle()) {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = INSTR(?, ?, ?))", _sql2.remove(0));
             } else {
@@ -3840,8 +3810,10 @@ public class TestQuerySyntaxFunctionTests {
             query = em.createQuery("SELECT s.strVal1 FROM QuerySyntaxEntity s WHERE s.strVal1 = TRIM('A' FROM 'AAAHELLO WORDAA')");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+            if(platform.isDB2Z()) {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = TRIM('A' FROM 'AAAHELLO WORDAA'))", _sql2.remove(0));
+            } else if(platform.isDB2()) {
+                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = TRIM('A' FROM ?))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = TRIM(? FROM ?))", _sql2.remove(0));
             }
@@ -3852,7 +3824,7 @@ public class TestQuerySyntaxFunctionTests {
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z()) {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = TRIM('A' FROM 'AAAHELLO WORDAA'))", _sql2.remove(0));
-            } else if(platform.isDB2() || platform.isDerby()) {
+            } else if(platform.isDB2()) {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = TRIM('A' FROM ?))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = TRIM(? FROM ?))", _sql2.remove(0));
@@ -3890,8 +3862,10 @@ public class TestQuerySyntaxFunctionTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+            if(platform.isDB2Z()) {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = TRIM('A' FROM 'AAAHELLO WORDAA'))", _sql2.remove(0));
+            } else if(platform.isDB2()) {
+                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = TRIM('A' FROM ?))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = TRIM(? FROM ?))", _sql2.remove(0));
             }
@@ -3910,7 +3884,7 @@ public class TestQuerySyntaxFunctionTests {
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z()) {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = TRIM('A' FROM 'AAAHELLO WORDAA'))", _sql2.remove(0));
-            } else if(platform.isDB2() || platform.isDerby()) {
+            } else if(platform.isDB2()) {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = TRIM('A' FROM ?))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = TRIM(? FROM ?))", _sql2.remove(0));
@@ -4148,8 +4122,10 @@ public class TestQuerySyntaxFunctionTests {
             query = em.createQuery("SELECT s.strVal1 FROM QuerySyntaxEntity s WHERE s.strVal1 = TRIM(TRAILING 'A' FROM 'AAAHELLO WORDAA')");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+            if(platform.isDB2Z()) {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = TRIM(TRAILING 'A' FROM 'AAAHELLO WORDAA'))", _sql2.remove(0));
+            } else if(platform.isDB2()) {
+                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = TRIM(TRAILING 'A' FROM ?))", _sql2.remove(0));
             } else if(platform.isOracle()) {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = RTRIM(?, ?))", _sql2.remove(0));
             } else {
@@ -4190,8 +4166,10 @@ public class TestQuerySyntaxFunctionTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+            if(platform.isDB2Z()) {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = TRIM(TRAILING 'A' FROM 'AAAHELLO WORDAA'))", _sql2.remove(0));
+            } else if(platform.isDB2()) {
+                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = TRIM(TRAILING 'A' FROM ?))", _sql2.remove(0));
             } else if(platform.isOracle()) {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = RTRIM(?, ?))", _sql2.remove(0));
             } else {
@@ -4437,8 +4415,10 @@ public class TestQuerySyntaxFunctionTests {
             query = em.createQuery("SELECT s.strVal1 FROM QuerySyntaxEntity s WHERE s.strVal1 = TRIM(LEADING 'A' FROM 'AAAHELLO WORDAA')");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+            if(platform.isDB2Z()) {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = TRIM(LEADING 'A' FROM 'AAAHELLO WORDAA'))", _sql2.remove(0));
+            } else if(platform.isDB2()) {
+                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = TRIM(LEADING 'A' FROM ?))", _sql2.remove(0));
             } else if(platform.isOracle()) {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = LTRIM(?, ?))", _sql2.remove(0));
             } else {
@@ -4451,7 +4431,7 @@ public class TestQuerySyntaxFunctionTests {
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z()) {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = TRIM(LEADING 'A' FROM 'AAAHELLO WORDAA'))", _sql2.remove(0));
-            } else if(platform.isDB2() || platform.isDerby()) {
+            } else if(platform.isDB2()) {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = TRIM(LEADING 'A' FROM ?))", _sql2.remove(0));
             } else if(platform.isOracle()) {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = LTRIM(?, ?))", _sql2.remove(0));
@@ -4493,8 +4473,10 @@ public class TestQuerySyntaxFunctionTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+            if(platform.isDB2Z()) {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = TRIM(LEADING 'A' FROM 'AAAHELLO WORDAA'))", _sql2.remove(0));
+            } else if(platform.isDB2()) {
+                Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = TRIM(LEADING 'A' FROM ?))", _sql2.remove(0));
             } else if(platform.isOracle()) {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = LTRIM(?, ?))", _sql2.remove(0));
             } else {
@@ -4514,7 +4496,7 @@ public class TestQuerySyntaxFunctionTests {
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z()) {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = TRIM(LEADING 'A' FROM 'AAAHELLO WORDAA'))", _sql2.remove(0));
-            } else if(platform.isDB2() || platform.isDerby()) {
+            } else if(platform.isDB2()) {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = TRIM(LEADING 'A' FROM ?))", _sql2.remove(0));
             } else if(platform.isOracle()) {
                 Assert.assertEquals("SELECT STRVAL1 FROM QUERYSYNTAXENTITY WHERE (STRVAL1 = LTRIM(?, ?))", _sql2.remove(0));
@@ -4675,21 +4657,13 @@ public class TestQuerySyntaxFunctionTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 5 > ANY (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = 9)");
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (5 > ANY(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9)))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? > ANY(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? > ANY(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 5 > ANY (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = ?1)");
             query.setParameter(1, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (5 > ANY(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? > ANY(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? > ANY(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
 
             // -----------------------
 
@@ -4729,11 +4703,7 @@ public class TestQuerySyntaxFunctionTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (5 > ANY(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9)))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? > ANY(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? > ANY(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Integer[]> cquery3 = cb3.createQuery(Integer[].class);
@@ -4752,11 +4722,7 @@ public class TestQuerySyntaxFunctionTests {
             query.setParameter(intValue3, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (5 > ANY(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? > ANY(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? > ANY(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -4786,21 +4752,13 @@ public class TestQuerySyntaxFunctionTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 5 > ANY (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = 9)");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (5 > ANY(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9)))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? > ANY(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? > ANY(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 5 > ANY (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = ?1)");
             query.setParameter(1, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (5 > ANY(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? > ANY(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? > ANY(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
 
             // -----------------------
 
@@ -4840,11 +4798,7 @@ public class TestQuerySyntaxFunctionTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (5 > ANY(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9)))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? > ANY(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? > ANY(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Integer[]> cquery3 = cb3.createQuery(Integer[].class);
@@ -4863,11 +4817,7 @@ public class TestQuerySyntaxFunctionTests {
             query.setParameter(intValue3, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (5 > ANY(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? > ANY(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? > ANY(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -4991,21 +4941,13 @@ public class TestQuerySyntaxFunctionTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 5 = ALL (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = 9)");
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (5 = ALL(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9)))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? = ALL(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? = ALL(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 5 = ALL (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = ?1)");
             query.setParameter(1, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (5 = ALL(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? = ALL(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? = ALL(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
 
             // -----------------------
 
@@ -5045,11 +4987,7 @@ public class TestQuerySyntaxFunctionTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (5 = ALL(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9)))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? = ALL(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? = ALL(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Integer[]> cquery3 = cb3.createQuery(Integer[].class);
@@ -5068,11 +5006,7 @@ public class TestQuerySyntaxFunctionTests {
             query.setParameter(intValue3, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (5 = ALL(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? = ALL(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? = ALL(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -5102,21 +5036,13 @@ public class TestQuerySyntaxFunctionTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 5 = ALL (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = 9)");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (5 = ALL(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9)))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? = ALL(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? = ALL(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 5 = ALL (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = ?1)");
             query.setParameter(1, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (5 = ALL(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? = ALL(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? = ALL(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
 
             // -----------------------
 
@@ -5156,11 +5082,7 @@ public class TestQuerySyntaxFunctionTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (5 = ALL(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9)))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? = ALL(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? = ALL(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Integer[]> cquery3 = cb3.createQuery(Integer[].class);
@@ -5179,11 +5101,7 @@ public class TestQuerySyntaxFunctionTests {
             query.setParameter(intValue3, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (5 = ALL(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? = ALL(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? = ALL(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -5307,21 +5225,13 @@ public class TestQuerySyntaxFunctionTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 5 = SOME (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = 9)");
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (5 = SOME(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9)))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? = SOME(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? = SOME(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 5 = SOME (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = ?1)");
             query.setParameter(1, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (5 = SOME(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? = SOME(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? = SOME(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
 
             // -----------------------
 
@@ -5361,11 +5271,7 @@ public class TestQuerySyntaxFunctionTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (5 = SOME(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9)))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? = SOME(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? = SOME(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Integer[]> cquery3 = cb3.createQuery(Integer[].class);
@@ -5384,11 +5290,7 @@ public class TestQuerySyntaxFunctionTests {
             query.setParameter(intValue3, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (5 = SOME(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? = SOME(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? = SOME(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -5418,21 +5320,13 @@ public class TestQuerySyntaxFunctionTests {
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 5 = SOME (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = 9)");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (5 = SOME(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9)))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? = SOME(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? = SOME(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s WHERE 5 = SOME (SELECT u.intVal2 FROM QuerySyntaxEntity u WHERE u.intVal2 = ?1)");
             query.setParameter(1, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (5 = SOME(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? = SOME(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? = SOME(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
 
             // -----------------------
 
@@ -5472,11 +5366,7 @@ public class TestQuerySyntaxFunctionTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (5 = SOME(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = 9)))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? = SOME(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? = SOME(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
             CriteriaQuery<Integer[]> cquery3 = cb3.createQuery(Integer[].class);
@@ -5495,11 +5385,7 @@ public class TestQuerySyntaxFunctionTests {
             query.setParameter(intValue3, 9);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (5 = SOME(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? = SOME(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT t0.INTVAL1 FROM QUERYSYNTAXENTITY t0 WHERE (? = SOME(SELECT t1.INTVAL2 FROM QUERYSYNTAXENTITY t1 WHERE (t1.INTVAL2 = ?)))", _sql2.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -5698,7 +5584,7 @@ public class TestQuerySyntaxFunctionTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT 1 FROM QUERYSYNTAXENTITY t0 WHERE ((SELECT COUNT(t1.ID) FROM COLTABLE1 t2, QUERYSYNTAXENTITY t1 WHERE (t2.ent_id = t0.ID)) = 36)", _sql2.remove(0));
+                Assert.assertEquals("SELECT 1 FROM QUERYSYNTAXENTITY t0 WHERE ((SELECT COUNT(t1.ID) FROM COLTABLE1 t2, QUERYSYNTAXENTITY t1 WHERE (t2.ent_id = t0.ID)) = ?)", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM QUERYSYNTAXENTITY t0 WHERE ((SELECT COUNT(t1.ID) FROM COLTABLE1 t2, QUERYSYNTAXENTITY t1 WHERE (t2.ent_id = t0.ID)) = ?)", _sql2.remove(0));
             }
@@ -5732,7 +5618,7 @@ public class TestQuerySyntaxFunctionTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT 1 FROM QUERYSYNTAXENTITY t0 WHERE ((SELECT COUNT(t1.ID) FROM COLTABLE1 t2, QUERYSYNTAXENTITY t1 WHERE (t2.ent_id = t0.ID)) = 36)", _sql2.remove(0));
+                Assert.assertEquals("SELECT 1 FROM QUERYSYNTAXENTITY t0 WHERE ((SELECT COUNT(t1.ID) FROM COLTABLE1 t2, QUERYSYNTAXENTITY t1 WHERE (t2.ent_id = t0.ID)) = ?)", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM QUERYSYNTAXENTITY t0 WHERE ((SELECT COUNT(t1.ID) FROM COLTABLE1 t2, QUERYSYNTAXENTITY t1 WHERE (t2.ent_id = t0.ID)) = ?)", _sql2.remove(0));
             }
@@ -5840,7 +5726,7 @@ public class TestQuerySyntaxFunctionTests {
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT CAST(65 AS CHAR(2)) FROM QUERYSYNTAXENTITY", _sql.remove(0));
+                Assert.assertEquals("SELECT CAST(? AS CHAR(2)) FROM QUERYSYNTAXENTITY", _sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT CAST(? AS CHAR(2)) FROM QUERYSYNTAXENTITY", _sql.remove(0));
             }
@@ -5860,27 +5746,18 @@ public class TestQuerySyntaxFunctionTests {
             return;
 
         EntityManager em = emf2.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf2);
 
         try {
             Query query = em.createQuery("SELECT CAST(?1 AS CHAR(2)) FROM QuerySyntaxEntity s");
             query.setParameter(1, 65);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT CAST(? AS CHAR(2)) FROM QUERYSYNTAXENTITY", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT CAST(? AS CHAR(2)) FROM QUERYSYNTAXENTITY", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT CAST(? AS CHAR(2)) FROM QUERYSYNTAXENTITY", _sql2.remove(0));
 
             query = em.createQuery("SELECT CAST(65 AS CHAR(2)) FROM QuerySyntaxEntity s");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT CAST(65 AS CHAR(2)) FROM QUERYSYNTAXENTITY", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT CAST(? AS CHAR(2)) FROM QUERYSYNTAXENTITY", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT CAST(? AS CHAR(2)) FROM QUERYSYNTAXENTITY", _sql2.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -5897,7 +5774,6 @@ public class TestQuerySyntaxFunctionTests {
             return;
 
         EntityManager em = emf3.createEntityManager();
-        DatabasePlatform platform = getPlatform(emf3);
 
         try {
             Query query = em.createQuery("SELECT CAST(?1 AS CHAR(2)) FROM QuerySyntaxEntity s");

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/TestQuerySyntaxOrderingTests.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/TestQuerySyntaxOrderingTests.java
@@ -418,7 +418,7 @@ public class TestQuerySyntaxOrderingTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = 36) ORDER BY 1 ASC", _sql2.remove(0));
+                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?) ORDER BY 1 ASC", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?) ORDER BY ? ASC", _sql2.remove(0));
             }
@@ -466,7 +466,7 @@ public class TestQuerySyntaxOrderingTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = 36) ORDER BY 1 DESC", _sql2.remove(0));
+                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?) ORDER BY 1 DESC", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?) ORDER BY ? DESC", _sql2.remove(0));
             }
@@ -943,7 +943,7 @@ public class TestQuerySyntaxOrderingTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = 36) ORDER BY 1 DESC", _sql2.remove(0));
+                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?) ORDER BY 1 DESC", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?) ORDER BY ? DESC", _sql2.remove(0));
             }
@@ -991,7 +991,7 @@ public class TestQuerySyntaxOrderingTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = 36) ORDER BY 1 DESC", _sql2.remove(0));
+                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?) ORDER BY 1 DESC", _sql2.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?) ORDER BY ? DESC", _sql2.remove(0));
             }
@@ -1138,18 +1138,12 @@ public class TestQuerySyntaxOrderingTests {
         try {
             Query query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s ORDER BY ?1");
             query.setParameter(1, 1);
-            Exception exception = null;
-            try {
-                query.getResultList();
-                Assert.assertEquals(1, _sql.size());
-            } catch(Exception e) {
-                exception = e;
-            } finally {
-                if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                    Assert.assertNotNull("Expected query '" + _sql.remove(0) + "' to fail", exception);
-                } else {
-                    Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY ORDER BY ?", _sql.remove(0));
-                }
+            query.getResultList();
+            Assert.assertEquals(1, _sql.size());
+            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY ORDER BY 1", _sql.remove(0));
+            } else {
+                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY ORDER BY ?", _sql.remove(0));
             }
 
             query = em.createQuery("SELECT s.intVal1 FROM QuerySyntaxEntity s ORDER BY 1");
@@ -1358,18 +1352,12 @@ public class TestQuerySyntaxOrderingTests {
             Query query = em.createQuery("SELECT s.intVal1, s.intVal2 FROM QuerySyntaxEntity s ORDER BY ?1, ?2");
             query.setParameter(1, 1);
             query.setParameter(2, 2);
-            Exception exception = null;
-            try {
-                query.getResultList();
-                Assert.assertEquals(1, _sql.size());
-            } catch(Exception e) {
-                exception = e;
-            } finally {
-                if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                    Assert.assertNotNull("Expected query '" + _sql.remove(0) + "' to fail", exception);
-                } else {
-                    Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY ORDER BY ?, ?", _sql.remove(0));
-                }
+            query.getResultList();
+            Assert.assertEquals(1, _sql.size());
+            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY ORDER BY 1, 2", _sql.remove(0));
+            } else {
+                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY ORDER BY ?, ?", _sql.remove(0));
             }
 
             query = em.createQuery("SELECT s.intVal1, s.intVal2 FROM QuerySyntaxEntity s ORDER BY 1, 2");
@@ -1383,18 +1371,12 @@ public class TestQuerySyntaxOrderingTests {
 
             query = em.createQuery("SELECT s.intVal1, s.intVal2 FROM QuerySyntaxEntity s ORDER BY 1, ?1");
             query.setParameter(1, 2);
-            exception = null;
-            try {
-                query.getResultList();
-                Assert.assertEquals(1, _sql.size());
-            } catch(Exception e) {
-                exception = e;
-            } finally {
-                if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                    Assert.assertNotNull("Expected query '" + _sql.remove(0) + "' to fail", exception);
-                } else {
-                    Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY ORDER BY ?, ?", _sql.remove(0));
-                }
+            query.getResultList();
+            Assert.assertEquals(1, _sql.size());
+            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
+                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY ORDER BY 1, 2", _sql.remove(0));
+            } else {
+                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY ORDER BY ?, ?", _sql.remove(0));
             }
 
             // -----------------------
@@ -1674,20 +1656,12 @@ public class TestQuerySyntaxOrderingTests {
             query.setParameter(1, 5);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?) ORDER BY INTVAL2", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?) ORDER BY INTVAL2", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?) ORDER BY INTVAL2", _sql.remove(0));
 
             query = em.createQuery("SELECT s.intVal1, s.intVal2 FROM QuerySyntaxEntity s WHERE s.intVal1 = 5 ORDER BY s.intVal2");
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = 5) ORDER BY INTVAL2", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?) ORDER BY INTVAL2", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?) ORDER BY INTVAL2", _sql.remove(0));
 
             // -----------------------
 
@@ -1703,11 +1677,7 @@ public class TestQuerySyntaxOrderingTests {
             query.setParameter(intParam1, 5);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?) ORDER BY INTVAL2 DESC", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?) ORDER BY INTVAL2 DESC", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?) ORDER BY INTVAL2 DESC", _sql.remove(0));
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery2 = cb2.createQuery(Object[].class);
@@ -1719,11 +1689,7 @@ public class TestQuerySyntaxOrderingTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = 5) ORDER BY INTVAL2 DESC", _sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?) ORDER BY INTVAL2 DESC", _sql.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?) ORDER BY INTVAL2 DESC", _sql.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -1747,20 +1713,12 @@ public class TestQuerySyntaxOrderingTests {
             query.setParameter(1, 5);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?) ORDER BY INTVAL2", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?) ORDER BY INTVAL2", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?) ORDER BY INTVAL2", _sql2.remove(0));
 
             query = em.createQuery("SELECT s.intVal1, s.intVal2 FROM QuerySyntaxEntity s WHERE s.intVal1 = 5 ORDER BY s.intVal2");
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = 5) ORDER BY INTVAL2", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?) ORDER BY INTVAL2", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?) ORDER BY INTVAL2", _sql2.remove(0));
 
             // -----------------------
 
@@ -1776,11 +1734,7 @@ public class TestQuerySyntaxOrderingTests {
             query.setParameter(intParam1, 5);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?) ORDER BY INTVAL2 DESC", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?) ORDER BY INTVAL2 DESC", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?) ORDER BY INTVAL2 DESC", _sql2.remove(0));
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object[]> cquery2 = cb2.createQuery(Object[].class);
@@ -1792,11 +1746,7 @@ public class TestQuerySyntaxOrderingTests {
             query = em.createQuery(cquery2);
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
-            if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = 5) ORDER BY INTVAL2 DESC", _sql2.remove(0));
-            } else {
-                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?) ORDER BY INTVAL2 DESC", _sql2.remove(0));
-            }
+            Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = ?) ORDER BY INTVAL2 DESC", _sql2.remove(0));
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/TestQuerySyntaxUpdateTests.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/TestQuerySyntaxUpdateTests.java
@@ -220,7 +220,7 @@ public class TestQuerySyntaxUpdateTests {
             em.getTransaction().commit();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("UPDATE QUERYSYNTAXENTITY SET INTVAL1 = 9 WHERE (STRVAL2 = LCASE('HELLO'))", _sql2.remove(0));
+                Assert.assertEquals("UPDATE QUERYSYNTAXENTITY SET INTVAL1 = ? WHERE (STRVAL2 = LCASE(?))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("UPDATE QUERYSYNTAXENTITY SET INTVAL1 = ? WHERE (STRVAL2 = LOWER(?))", _sql2.remove(0));
             }
@@ -232,7 +232,7 @@ public class TestQuerySyntaxUpdateTests {
             em.getTransaction().commit();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("UPDATE QUERYSYNTAXENTITY SET INTVAL1 = ? WHERE (STRVAL2 = LCASE('HELLO'))", _sql2.remove(0));
+                Assert.assertEquals("UPDATE QUERYSYNTAXENTITY SET INTVAL1 = ? WHERE (STRVAL2 = LCASE(?))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("UPDATE QUERYSYNTAXENTITY SET INTVAL1 = ? WHERE (STRVAL2 = LOWER(?))", _sql2.remove(0));
             }
@@ -273,7 +273,7 @@ public class TestQuerySyntaxUpdateTests {
             em.getTransaction().commit();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("UPDATE QUERYSYNTAXENTITY SET INTVAL1 = 9 WHERE (STRVAL2 = LCASE('HELLO'))", _sql2.remove(0));
+                Assert.assertEquals("UPDATE QUERYSYNTAXENTITY SET INTVAL1 = ? WHERE (STRVAL2 = LCASE(?))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("UPDATE QUERYSYNTAXENTITY SET INTVAL1 = ? WHERE (STRVAL2 = LOWER(?))", _sql2.remove(0));
             }
@@ -293,7 +293,7 @@ public class TestQuerySyntaxUpdateTests {
             em.getTransaction().commit();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z() || platform.isDB2() || platform.isDerby()) {
-                Assert.assertEquals("UPDATE QUERYSYNTAXENTITY SET INTVAL1 = 9 WHERE (STRVAL2 = LCASE(?))", _sql2.remove(0));
+                Assert.assertEquals("UPDATE QUERYSYNTAXENTITY SET INTVAL1 = ? WHERE (STRVAL2 = LCASE(?))", _sql2.remove(0));
             } else {
                 Assert.assertEquals("UPDATE QUERYSYNTAXENTITY SET INTVAL1 = ? WHERE (STRVAL2 = LOWER(?))", _sql2.remove(0));
             }


### PR DESCRIPTION
for #1443

There were several test failures in the `TestMathFunctions` tests on Derby. These failures were because using untyped parameters with the new "ROUND" operator syntax is invalid

```sql
SELECT FLOOR((DOUBLEVALUE)*1e?+0.5)/1e? FROM NUMBERENTITY WHERE (ID = ?)
```
I updated the implementation in DerbyPlatform to that issue by not allowing parameter binding. Also, I cleaned up the implementation.

for #1504

The tests delivered by for this issue didn't respect that `DB2Platform.shouldBindLiterals` was changing the default from "false" -> "true". As a result, almost all the `TestQuerySyntax*Tests` failed as the expected default query syntax was not correct for DB2 & Derby

Also, there were failures with the "IN" operator for Derby and DB2/zOS. Those failures were because it is invalid on those platforms for ALL arguments to be untyped parameters (ie "... ? IN (?, ?, ?)". So, I updated DerbyPlatform and DB2ZPlatform to not allow that syntax.