### PR TITLE
[master] Fix issue 1504 JSE test failure on Derby pt2

### DIFF
--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/property/TestParameterBinding.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/property/TestParameterBinding.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2019 IBM Corporation. All rights reserved.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -570,6 +570,10 @@ public class TestParameterBinding {
             Assert.assertFalse("Expected query parameter binding to not be set for the DatabaseCall", call.isUsesBindingSet());
 
             DatabasePlatform pl = (DatabasePlatform)forceBindEMF.unwrap(EntityManagerFactoryImpl.class).getDatabaseSession().getDatasourcePlatform();
+            if(pl.isDB2Z() || pl.isDerby()) {
+                Assert.fail("Expected a failure from " + pl);
+            }
+
             if(pl.shouldBindLiterals()) {
                 if(pl.allowBindingForSelectClause()) {
                     Assert.assertEquals("The number of parameters found does not match the number supplied" , 5, call.getParameters().size());
@@ -578,6 +582,19 @@ public class TestParameterBinding {
                 }
             } else {
                 Assert.assertEquals("The number of parameters found does not match the number supplied" , 2, call.getParameters().size());
+            }
+        } catch(PersistenceException e) {
+            Platform pl = forceBindEMF.unwrap(EntityManagerFactoryImpl.class).getDatabaseSession().getDatasourcePlatform();
+            if(pl.isDB2Z()) {
+                //When all the operands of an IN predicate are untyped parameters, error on DB2/z
+                Assert.assertEquals(DatabaseException.class, e.getCause().getClass());
+                Assert.assertEquals("com.ibm.db2.jcc.am.SqlSyntaxErrorException", e.getCause().getCause().getClass().getName());
+            } else if(pl.isDerby()) {
+                //Use as the left operand of an IN list is not allowed when all operands are untyped parameters, error 42X35 on Derby
+                Assert.assertEquals(DatabaseException.class, e.getCause().getClass());
+                Assert.assertEquals("java.sql.SQLSyntaxErrorException", e.getCause().getCause().getClass().getName());
+            } else {
+                Assert.fail("Unexpected failure: " + e);
             }
         } finally {
             if (em.getTransaction().isActive()) {
@@ -601,6 +618,10 @@ public class TestParameterBinding {
             Assert.assertFalse("Expected query parameter binding to not be set for the DatabaseCall", call.isUsesBindingSet());
 
             DatabasePlatform pl = (DatabasePlatform)forceBindEMF.unwrap(EntityManagerFactoryImpl.class).getDatabaseSession().getDatasourcePlatform();
+            if(pl.isDB2Z() || pl.isDerby()) {
+                Assert.fail("Expected a failure from " + pl);
+            }
+
             if(pl.shouldBindLiterals()) {
                 if(pl.allowBindingForSelectClause()) {
                     Assert.assertEquals("The number of parameters found does not match the number supplied" , 5, call.getParameters().size());
@@ -609,6 +630,19 @@ public class TestParameterBinding {
                 }
             } else {
                 Assert.assertEquals("The number of parameters found does not match the number supplied" , 2, call.getParameters().size());
+            }
+        } catch(PersistenceException e) {
+            Platform pl = forceBindEMF.unwrap(EntityManagerFactoryImpl.class).getDatabaseSession().getDatasourcePlatform();
+            if(pl.isDB2Z()) {
+                //When all the operands of an IN predicate are untyped parameters, error on DB2/z
+                Assert.assertEquals(DatabaseException.class, e.getCause().getClass());
+                Assert.assertEquals("com.ibm.db2.jcc.am.SqlSyntaxErrorException", e.getCause().getCause().getClass().getName());
+            } else if(pl.isDerby()) {
+                //Use as the left operand of an IN list is not allowed when all operands are untyped parameters, error 42X35 on Derby
+                Assert.assertEquals(DatabaseException.class, e.getCause().getClass());
+                Assert.assertEquals("java.sql.SQLSyntaxErrorException", e.getCause().getCause().getClass().getName());
+            } else {
+                Assert.fail("Unexpected failure: " + e);
             }
         } finally {
             if (em.getTransaction().isActive()) {


### PR DESCRIPTION
A test fix was missed in https://github.com/eclipse-ee4j/eclipselink/pull/1534

`org.eclipse.persistence.jpa.test.property.TestParameterBinding.testIN_ForceBindJPQLParameters()` 
```
java.sql.SQLSyntaxErrorException: It is not allowed for both operands of 'IN' to be ? parameters.
Error Code: 30000
Call: SELECT 2 FROM GENERICENTITY WHERE (? IN (?, ?, ?))
 bind => [a, a, b, c]
Query: ReportQuery(referenceClass=GenericEntity sql="SELECT 2 FROM GENERICENTITY WHERE (? IN (?, ?, ?))")
```

This test was failing on Derby because the test is testing the persistence property `eclipselink.jdbc.force-bind-parameters`. With this property set, all parameters are bound as parameters, which is illegal on Derby. I recently changed `DB2Platform.shouldBindLiterals` to default to "true", making the literals in the test to now also bind as parameters. This causes a failure on Derby as it is invalid syntax. The test needs updated to respect that this test will fail on Derby

The property `eclipselink.jdbc.force-bind-parameters` should be deprecated really. The latest property `eclipselink.jdbc.allow-partial-bind-parameters` is much more comprehensive as it doesn't completely "force" parameter binding and respects platform syntax legality.

Signed-off-by: Will Dazey <dazeydev.3@gmail.com>