### PR TITLE
Issue #1538: Type Conversion error with the CEILING/FLOOR Operations

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabaseAccessor.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabaseAccessor.java
@@ -1399,6 +1399,34 @@ public class DatabaseAccessor extends DatasourceAccessor {
         } else if ((fieldType == ClassConstants.SHORT) || (fieldType == ClassConstants.PSHORT)) {
             value = resultSet.getShort(columnNumber);
             isPrimitive = (Short) value == 0;
+        // Sometimes field type is just Number and it's child type is stored as field.typeName
+        } else if (fieldType == ClassConstants.NUMBER) {
+            switch(field.typeName) {
+                case "java.lang.Byte":
+                    value = resultSet.getByte(columnNumber);
+                    isPrimitive = (Byte) value == 0;
+                    break;
+                case "java.lang.Short":
+                    value = resultSet.getShort(columnNumber);
+                    isPrimitive = (Short) value == 0;
+                    break;
+                case "java.lang.Integer":
+                    value = resultSet.getInt(columnNumber);
+                    isPrimitive = (Integer) value == 0;
+                    break;
+                case "java.lang.Long":
+                    value = resultSet.getLong(columnNumber);
+                    isPrimitive = (Long) value == 0L;
+                    break;
+                case "java.lang.Float":
+                    value = resultSet.getFloat(columnNumber);
+                    isPrimitive = (Float) value == 0f;
+                    break;
+                case "java.lang.Double":
+                    value = resultSet.getDouble(columnNumber);
+                    isPrimitive = (Double) value == 0f;
+                    break;
+            }
         } else if ((fieldType == ClassConstants.BOOLEAN) || (fieldType == ClassConstants.PBOOLEAN))  {
             value = resultSet.getBoolean(columnNumber);
             isPrimitive = !((Boolean) value);

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/criteria/TestMathFunctions.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/criteria/TestMathFunctions.java
@@ -556,7 +556,7 @@ public class TestMathFunctions {
     // Call SELECT ROUND(n.doubleValue, d) FROM NumberEntity n WHERE n.id = id
     // using CriteriaQuery
     // Matches Expression<Double> power(Expression<? extends Number> x, Number y) prototype
-    private static Double callRound(final EntityManager em, final int d, final int id) {
+    private static Double callDoubleRound(final EntityManager em, final int d, final int id) {
         try {
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Double> cq = cb.createQuery(Double.class);
@@ -570,21 +570,56 @@ public class TestMathFunctions {
         }
     }
 
-    // Call ROUND(n) on n>0.
+    // Call SELECT ROUND(n.floatValue, d) FROM NumberEntity n WHERE n.id = id
+    // using CriteriaQuery
+    // Matches Expression<Float> power(Expression<? extends Number> x, Number y) prototype
+    private static Float callFloatRound(final EntityManager em, final int d, final int id) {
+        try {
+            CriteriaBuilder cb = em.getCriteriaBuilder();
+            CriteriaQuery<Float> cq = cb.createQuery(Float.class);
+            Root<NumberEntity> number = cq.from(NumberEntity.class);
+            cq.select(cb.round(number.get("floatValue"), d));
+            cq.where(cb.equal(number.get("id"), id));
+            return em.createQuery(cq).getSingleResult();
+        } catch (Throwable t) {
+            t.printStackTrace();
+            throw t;
+        }
+    }
+
+    // Call ROUND(n) on Double n>0.
     @Test
-    public void testRoundMethodWithPositive() {
+    public void testRoundDoubleMethodWithPositive() {
         try (final EntityManager em = emf.createEntityManager()) {
-            Double result = callRound(em, 6,8);
+            Double result = callDoubleRound(em, 6,8);
             Assert.assertEquals(Double.valueOf(44.754238D), result);
         }
     }
 
-    // Call ROUND(n) on n<0.
+    // Call ROUND(n) on Float n>0.
     @Test
-    public void testRoundMethodWithNegative() {
+    public void testRoundFloatMethodWithPositive() {
         try (final EntityManager em = emf.createEntityManager()) {
-            Double result = callRound(em, 6, 9);
+            Float result = callFloatRound(em, 6,8);
+            Assert.assertEquals(Float.valueOf(44.754238F), result);
+        }
+    }
+
+    // Call ROUND(n) on Double n<0.
+    @Test
+    public void testRoundDoubleMethodWithNegative() {
+        try (final EntityManager em = emf.createEntityManager()) {
+            Double result = callDoubleRound(em, 6, 9);
             Assert.assertEquals(Double.valueOf(-214.245732D), result);
+        }
+    }
+
+    // Call ROUND(n) on Float n<0.
+    @Test
+    public void testRoundFloatMethodWithNegative() {
+        try (final EntityManager em = emf.createEntityManager()) {
+            Float result = callFloatRound(em, 6, 9);
+            Assert.assertEquals(Float.valueOf(-214.245732F), result);
         }
     }
 

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/criteria/TestMathFunctions.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/criteria/TestMathFunctions.java
@@ -60,16 +60,16 @@ public class TestMathFunctions {
     private EntityManagerFactory emf;
 
     private final NumberEntity[] NUMBER = {
-            new NumberEntity(0, 0L, 0D),
-            new NumberEntity(1, 1L, 1D),
-            new NumberEntity(2, -1L, -1D),
-            new NumberEntity(3, 42L, 42.42D),
-            new NumberEntity(4, -342L, -342.42D),
-            new NumberEntity(5, 4L, 4D),
-            new NumberEntity(6, -4L, -4D),
-            new NumberEntity(7, 4L, 14.23D),
-            new NumberEntity(8, 6L, 44.7542383252D),
-            new NumberEntity(9, 8L, -214.2457321233D)
+            new NumberEntity(0, 0L, 0F, 0D),
+            new NumberEntity(1, 1L, 1F, 1D),
+            new NumberEntity(2, -1L, -1F, -1D),
+            new NumberEntity(3, 42L, 42.42F, 42.42D),
+            new NumberEntity(4, -342L, -342.42F, -342.42D),
+            new NumberEntity(5, 4L, 4F, 4D),
+            new NumberEntity(6, -4L, -4F, -4D),
+            new NumberEntity(7, 4L, 14.23F, 14.23D),
+            new NumberEntity(8, 6L, 44.7542383252F, 44.7542383252D),
+            new NumberEntity(9, 8L, -214.2457321233F, -214.2457321233D)
     };
 
     @Before
@@ -157,7 +157,7 @@ public class TestMathFunctions {
 
     // Call SELECT CEILING(n.doubleValue) FROM NumberEntity n WHERE n.id = id
     // using CriteriaQuery
-    private static Double callCeiling(final EntityManager em, final int id) {
+    private static Double callCeilingDouble(final EntityManager em, final int id) {
         CriteriaBuilder cb = em.getCriteriaBuilder();
         CriteriaQuery<Double> cq = cb.createQuery(Double.class);
         Root<NumberEntity> number = cq.from(NumberEntity.class);
@@ -166,38 +166,78 @@ public class TestMathFunctions {
         return em.createQuery(cq).getSingleResult();
     }
 
-    // Call CEILING(n) on n=0.
+    // Call SELECT CEILING(n.floatValue) FROM NumberEntity n WHERE n.id = id
+    // using CriteriaQuery
+    private static Float callCeilingFloat(final EntityManager em, final int id) {
+        CriteriaBuilder cb = em.getCriteriaBuilder();
+        CriteriaQuery<Float> cq = cb.createQuery(Float.class);
+        Root<NumberEntity> number = cq.from(NumberEntity.class);
+        cq.select(cb.ceiling(number.get("floatValue")));
+        cq.where(cb.equal(number.get("id"), id));
+        return em.createQuery(cq).getSingleResult();
+    }
+
+    // Call CEILING(n) on Double n=0.
     @Test
-    public void testCeilingMethodWithZero() {
+    public void testCeilingDoubleMethodWithZero() {
         try (final EntityManager em = emf.createEntityManager()) {
-            Double result = callCeiling(em, 0);
+            Double result = callCeilingDouble(em, 0);
             Assert.assertEquals(Double.valueOf(0), result);
         }
     }
 
-    // Call CEILING(n) on n>0.
+    // Call CEILING(n) on Float n=0.
     @Test
-    public void testCeilingMethodWithPositive() {
+    public void testCeilingFloatMethodWithZero() {
         try (final EntityManager em = emf.createEntityManager()) {
-            Double result = callCeiling(em, 3);
+            Float result = callCeilingFloat(em, 0);
+            Assert.assertEquals(Float.valueOf(0), result);
+        }
+    }
+
+    // Call CEILING(n) on Double n>0.
+    @Test
+    public void testCeilingDoubleMethodWithPositive() {
+        try (final EntityManager em = emf.createEntityManager()) {
+            Double result = callCeilingDouble(em, 3);
             Assert.assertEquals(
                     Double.valueOf(NUMBER[3].getLongValue().intValue()+1), result);
         }
     }
 
-    // Call CEILING(n) on n<0.
+    // Call CEILING(n) on Float n>0.
     @Test
-    public void testCeilingMethodWithNegative() {
+    public void testCeilingFloatMethodWithPositive() {
         try (final EntityManager em = emf.createEntityManager()) {
-            Double result = callCeiling(em, 4);
+            Float result = callCeilingFloat(em, 3);
+            Assert.assertEquals(
+                    Float.valueOf(NUMBER[3].getLongValue().intValue()+1), result);
+        }
+    }
+
+    // Call CEILING(n) on Double n<0.
+    @Test
+    public void testCeilingDoubleMethodWithNegative() {
+        try (final EntityManager em = emf.createEntityManager()) {
+            Double result = callCeilingDouble(em, 4);
             Assert.assertEquals(
                     Double.valueOf(NUMBER[4].getLongValue().intValue()), result);
         }
     }
 
+    // Call CEILING(n) on Float n<0.
+    @Test
+    public void testCeilingFloatMethodWithNegative() {
+        try (final EntityManager em = emf.createEntityManager()) {
+            Float result = callCeilingFloat(em, 4);
+            Assert.assertEquals(
+                    Float.valueOf(NUMBER[4].getLongValue().intValue()), result);
+        }
+    }
+
     // Call SELECT FLOOR(n.doubleValue) FROM NumberEntity n WHERE n.id = id
     // using CriteriaQuery
-    private static Double callFloor(final EntityManager em, final int id) {
+    private static Double callFloorDouble(final EntityManager em, final int id) {
         CriteriaBuilder cb = em.getCriteriaBuilder();
         CriteriaQuery<Double> cq = cb.createQuery(Double.class);
         Root<NumberEntity> number = cq.from(NumberEntity.class);
@@ -206,32 +246,72 @@ public class TestMathFunctions {
         return em.createQuery(cq).getSingleResult();
     }
 
-    // Call FLOOR(n) on n=0.
+    // Call SELECT FLOOR(n.floatValue) FROM NumberEntity n WHERE n.id = id
+    // using CriteriaQuery
+    private static Float callFloorFloat(final EntityManager em, final int id) {
+        CriteriaBuilder cb = em.getCriteriaBuilder();
+        CriteriaQuery<Float> cq = cb.createQuery(Float.class);
+        Root<NumberEntity> number = cq.from(NumberEntity.class);
+        cq.select(cb.floor(number.get("floatValue")));
+        cq.where(cb.equal(number.get("id"), id));
+        return em.createQuery(cq).getSingleResult();
+    }
+
+    // Call FLOOR(n) on Double n=0.
     @Test
-    public void testFloorMethodWithZero() {
+    public void testFloorDoubleMethodWithZero() {
         try (final EntityManager em = emf.createEntityManager()) {
-            Double result = callFloor(em, 0);
+            Double result = callFloorDouble(em, 0);
             Assert.assertEquals(Double.valueOf(0), result);
         }
     }
 
-    // Call FLOOR(n) on n>0.
+    // Call FLOOR(n) on Float n=0.
     @Test
-    public void testFloorMethodWithPositive() {
+    public void testFloorFloatMethodWithZero() {
         try (final EntityManager em = emf.createEntityManager()) {
-            Double result = callFloor(em, 3);
+            Float result = callFloorFloat(em, 0);
+            Assert.assertEquals(Float.valueOf(0), result);
+        }
+    }
+
+    // Call FLOOR(n) on Double n>0.
+    @Test
+    public void testFloorDoubleMethodWithPositive() {
+        try (final EntityManager em = emf.createEntityManager()) {
+            Double result = callFloorDouble(em, 3);
             Assert.assertEquals(
                     Double.valueOf(NUMBER[3].getLongValue().intValue()), result);
         }
     }
 
-    // Call FLOOR(n) on n<0.
+    // Call FLOOR(n) on Float n>0.
     @Test
-    public void testFloorMethodWithNegative() {
+    public void testFloorFloatMethodWithPositive() {
         try (final EntityManager em = emf.createEntityManager()) {
-            Double result = callFloor(em, 4);
+            Float result = callFloorFloat(em, 3);
+            Assert.assertEquals(
+                    Float.valueOf(NUMBER[3].getLongValue().intValue()), result);
+        }
+    }
+
+    // Call FLOOR(n) on Double n<0.
+    @Test
+    public void testFloorDoubleMethodWithNegative() {
+        try (final EntityManager em = emf.createEntityManager()) {
+            Double result = callFloorDouble(em, 4);
             Assert.assertEquals(
                     Double.valueOf(NUMBER[4].getLongValue().intValue()-1), result);
+        }
+    }
+
+    // Call FLOOR(n) on Float n<0.
+    @Test
+    public void testFloorFloatMethodWithNegative() {
+        try (final EntityManager em = emf.createEntityManager()) {
+            Float result = callFloorFloat(em, 4);
+            Assert.assertEquals(
+                    Float.valueOf(NUMBER[4].getLongValue().intValue()-1), result);
         }
     }
 

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/criteria/TestSimpleCase.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/criteria/TestSimpleCase.java
@@ -56,12 +56,12 @@ public class TestSimpleCase {
     private EntityManagerFactory emf;
 
     private final NumberEntity[] NUMBER = {
-            new NumberEntity(1, 0L, 0D),
-            new NumberEntity(2, 3L, 10D),
-            new NumberEntity(3, 3L, 100D),
-            new NumberEntity(4, 5L, 10D),
-            new NumberEntity(5, 5L, 100D),
-            new NumberEntity(6, 5L, 1000D)
+            new NumberEntity(1, 0L, 0F, 0D),
+            new NumberEntity(2, 3L, 10F, 10D),
+            new NumberEntity(3, 3L, 100F, 100D),
+            new NumberEntity(4, 5L, 10F, 10D),
+            new NumberEntity(5, 5L, 100F, 100D),
+            new NumberEntity(6, 5L, 1000F, 1000D)
     };
 
     @Before

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/criteria/model/NumberEntity.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/criteria/model/NumberEntity.java
@@ -29,14 +29,17 @@ public class NumberEntity {
 
     private Long longValue;
 
+    private Float floatValue;
+
     private Double doubleValue;
 
     public NumberEntity() {
     }
 
-    public NumberEntity(final Integer id, final Long longValue, final Double doubleValue) {
+    public NumberEntity(final Integer id, final Long longValue, final Float floatValue, final Double doubleValue) {
         this.setId(id);
         this.setLongValue(longValue);
+        this.setFloatValue(floatValue);
         this.setDoubleValue(doubleValue);
     }
 
@@ -54,6 +57,14 @@ public class NumberEntity {
 
     public void setLongValue(final Long longValue) {
         this.longValue = longValue;
+    }
+
+    public Float getFloatValue() {
+        return floatValue;
+    }
+
+    public void setFloatValue(final Float floatValue) {
+        this.floatValue = floatValue;
     }
 
     public Double getDoubleValue() {

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/TestMathFunctions.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/TestMathFunctions.java
@@ -527,7 +527,7 @@ public class TestMathFunctions {
 
     // Call SELECT ROUND(n.doubleValue, $round) FROM NumberEntity n WHERE n.id = :id using JPQL
     // Matches Expression<Double> round(Expression<? extends Number> x, Number y) prototype
-    private static Double callRound(final EntityManager em, final int d, final int id) {
+    private static Double callRoundDouble(final EntityManager em, final int d, final int id) {
         try {
             TypedQuery<Double> query = em.createQuery(
                     "SELECT ROUND(n.doubleValue," + d + ") FROM NumberEntity n WHERE n.id = :id", Double.class);
@@ -540,27 +540,60 @@ public class TestMathFunctions {
         }
     }
 
+    // Call SELECT ROUND(n.floatValue, $round) FROM NumberEntity n WHERE n.id = :id using JPQL
+    // Matches Expression<Float> round(Expression<? extends Number> x, Number y) prototype
+    private static Float callRoundFloat(final EntityManager em, final int d, final int id) {
+        try {
+            TypedQuery<Float> query = em.createQuery(
+                    "SELECT ROUND(n.floatValue," + d + ") FROM NumberEntity n WHERE n.id = :id", Float.class);
+            query.setParameter("id", id);
+            System.out.println("RESULT LIST: "+query.getSingleResult().toString());
+            return query.getSingleResult();
+        } catch (Throwable t) {
+            t.printStackTrace();
+            throw t;
+        }
+    }
+
     // Call ROUND(n.doubleValue, 6) on n>0.
     @Test
-    public void testRoundMethodWithPositive() {
+    public void testRoundDoubleMethodWithPositive() {
         try (final EntityManager em = emf.createEntityManager()) {
-            Double result = callRound(em, 6,8);
+            Double result = callRoundDouble(em, 6,8);
             Assert.assertEquals(Double.valueOf(44.754238D), result);
+        }
+    }
+
+    // Call ROUND(n.floatValue, 6) on n>0.
+    @Test
+    public void testRoundFloatMethodWithPositive() {
+        try (final EntityManager em = emf.createEntityManager()) {
+            Float result = callRoundFloat(em, 6,8);
+            Assert.assertEquals(Float.valueOf(44.754238F), result);
         }
     }
 
     // Call ROUND(n.doubleValue, 6) on n<0.
     @Test
-    public void testRoundMethodWithNegative() {
+    public void testRoundDoubleMethodWithNegative() {
         try (final EntityManager em = emf.createEntityManager()) {
-            Double result = callRound(em, 6, 9);
+            Double result = callRoundDouble(em, 6, 9);
             Assert.assertEquals(Double.valueOf(-214.245732D), result);
+        }
+    }
+
+    // Call ROUND(n.floatValue, 6) on n<0.
+    @Test
+    public void testRoundFloatMethodWithNegative() {
+        try (final EntityManager em = emf.createEntityManager()) {
+            Float result = callRoundFloat(em, 6, 9);
+            Assert.assertEquals(Float.valueOf(-214.245732F), result);
         }
     }
 
     // Call SELECT ROUND(n.doubleValue, :round) FROM NumberEntity n WHERE n.id = :id using JPQL
     // Matches Expression<Double> round(Expression<? extends Number> x, Number y) prototype
-    private static Double callRoundDigitsAsParam(final EntityManager em, final int d, final int id) {
+    private static Double callRoundDoubleDigitsAsParam(final EntityManager em, final int d, final int id) {
         try {
             TypedQuery<Double> query = em.createQuery(
                     "SELECT ROUND(n.doubleValue, :round) FROM NumberEntity n WHERE n.id = :id", Double.class);
@@ -573,26 +606,64 @@ public class TestMathFunctions {
         }
     }
 
+    // Call SELECT ROUND(n.floatValue, :round) FROM NumberEntity n WHERE n.id = :id using JPQL
+    // Matches Expression<Float> round(Expression<? extends Number> x, Number y) prototype
+    private static Float callRoundFloatDigitsAsParam(final EntityManager em, final int d, final int id) {
+        try {
+            TypedQuery<Float> query = em.createQuery(
+                    "SELECT ROUND(n.floatValue, :round) FROM NumberEntity n WHERE n.id = :id", Float.class);
+            query.setParameter("round", d);
+            query.setParameter("id", id);
+            return query.getSingleResult();
+        } catch (Throwable t) {
+            t.printStackTrace();
+            throw t;
+        }
+    }
+
     // Call ROUND(n.doubleValue, :round) with :round = 6 on n>0.
     // Derby emulation does not support 2nd ROUND argument as query parameter
     @Test
-    public void testRoundMethodWithPositiveDigitsAsParam() {
+    public void testRoundDoubleMethodWithPositiveDigitsAsParam() {
         Assume.assumeFalse(emf.unwrap(Session.class).getPlatform().isDerby());
         try (final EntityManager em = emf.createEntityManager()) {
-            Double result = callRoundDigitsAsParam(em, 6,8);
+            Double result = callRoundDoubleDigitsAsParam(em, 6,8);
             Assert.assertEquals(Double.valueOf(44.754238D), result);
+        }
+    }
+
+    // Call ROUND(n.floatValue, :round) with :round = 6 on n>0.
+    // Derby emulation does not support 2nd ROUND argument as query parameter
+    @Test
+    public void testRoundFloatMethodWithPositiveDigitsAsParam() {
+        Assume.assumeFalse(emf.unwrap(Session.class).getPlatform().isDerby());
+        try (final EntityManager em = emf.createEntityManager()) {
+            Float result = callRoundFloatDigitsAsParam(em, 6,8);
+            Assert.assertEquals(Float.valueOf(44.754238F), result);
         }
     }
 
     // Call ROUND(n.doubleValue, :round) with :round = 6 on n<0.
     // Derby emulation does not support 2nd ROUND argument as query parameter
     @Test
-    public void testRoundMethodWithNegativeDigitsAsParam() {
+    public void testRoundDoubleMethodWithNegativeDigitsAsParam() {
         Assume.assumeFalse(emf.unwrap(Session.class).getPlatform().isDerby());
         try (final EntityManager em = emf.createEntityManager()) {
-            Double result = callRoundDigitsAsParam(em, 6, 9);
+            Double result = callRoundDoubleDigitsAsParam(em, 6, 9);
             Assert.assertEquals(Double.valueOf(-214.245732D), result);
         }
     }
+
+    // Call ROUND(n.floatValue, :round) with :round = 6 on n<0.
+    // Derby emulation does not support 2nd ROUND argument as query parameter
+    @Test
+    public void testRoundFloatMethodWithNegativeDigitsAsParam() {
+        Assume.assumeFalse(emf.unwrap(Session.class).getPlatform().isDerby());
+        try (final EntityManager em = emf.createEntityManager()) {
+            Float result = callRoundFloatDigitsAsParam(em, 6, 9);
+            Assert.assertEquals(Float.valueOf(-214.245732F), result);
+        }
+    }
+
 
 }

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/TestMathFunctions.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/TestMathFunctions.java
@@ -58,16 +58,16 @@ public class TestMathFunctions {
     private EntityManagerFactory emf;
 
     private final NumberEntity[] NUMBER = {
-            new NumberEntity(0, 0L, 0D),
-            new NumberEntity(1, 1L, 1D),
-            new NumberEntity(2, -1L, -1D),
-            new NumberEntity(3, 42L, 42.42D),
-            new NumberEntity(4, -342L, -342.42D),
-            new NumberEntity(5, 4L, 4D),
-            new NumberEntity(6, -4L, -4D),
-            new NumberEntity(7, 4L, 14.23D),
-            new NumberEntity(8, 6L, 44.7542383252D),
-            new NumberEntity(9, 8L, -214.2457321233D)
+            new NumberEntity(0, 0L, 0F, 0D),
+            new NumberEntity(1, 1L, 1F, 1D),
+            new NumberEntity(2, -1L, -1F, -1D),
+            new NumberEntity(3, 42L, 42.42F, 42.42D),
+            new NumberEntity(4, -342L, -342.42F, -342.42D),
+            new NumberEntity(5, 4L, 4F, 4D),
+            new NumberEntity(6, -4L, -4F, -4D),
+            new NumberEntity(7, 4L, 14.23F, 14.23D),
+            new NumberEntity(8, 6L, 44.7542383252F, 44.7542383252D),
+            new NumberEntity(9, 8L, -214.2457321233F, -214.2457321233D)
     };
 
     @Before
@@ -151,76 +151,150 @@ public class TestMathFunctions {
     }
 
     // Call SELECT CEILING(n.doubleValue) FROM NumberEntity n WHERE n.id = :id using JPQL
-    private static Double callCeiling(final EntityManager em, final int id) {
+    private static Double callCeilingDouble(final EntityManager em, final int id) {
         TypedQuery<Double> query = em.createQuery(
                 "SELECT CEILING(n.doubleValue) FROM NumberEntity n WHERE n.id = :id", Double.class);
         query.setParameter("id", id);
         return query.getSingleResult();
     }
 
-    // Call CEILING(n) on n=0.
+    // Call SELECT CEILING(n.floatValue) FROM NumberEntity n WHERE n.id = :id using JPQL
+    private static Float callCeilingFloat(final EntityManager em, final int id) {
+        TypedQuery<Float> query = em.createQuery(
+                "SELECT CEILING(n.floatValue) FROM NumberEntity n WHERE n.id = :id", Float.class);
+        query.setParameter("id", id);
+        return query.getSingleResult();
+    }
+
+    // Call CEILING(n) on Double n=0.
     @Test
-    public void testCeilingMethodWithZero() {
+    public void testCeilingDoubleMethodWithZero() {
         try (final EntityManager em = emf.createEntityManager()) {
-            Double result = callCeiling(em, 0);
+            Double result = callCeilingDouble(em, 0);
             Assert.assertEquals(Double.valueOf(0), result);
         }
     }
 
-    // Call CEILING(n) on n>0.
+    // Call CEILING(n) on Float n=0.
     @Test
-    public void testCeilingMethodWithPositive() {
+    public void testCeilingFloatMethodWithZero() {
         try (final EntityManager em = emf.createEntityManager()) {
-            Double result = callCeiling(em, 3);
+            Float result = callCeilingFloat(em, 0);
+            Assert.assertEquals(Float.valueOf(0), result);
+        }
+    }
+
+    // Call CEILING(n) on Double n>0.
+    @Test
+    public void testCeilingDoubleMethodWithPositive() {
+        try (final EntityManager em = emf.createEntityManager()) {
+            Double result = callCeilingDouble(em, 3);
             Assert.assertEquals(
                     Double.valueOf(NUMBER[3].getLongValue().intValue()+1), result);
         }
     }
 
-    // Call CEILING(n) on n<0.
+    // Call CEILING(n) on Float n>0.
     @Test
-    public void testCeilingMethodWithNegative() {
+    public void testCeilingFloatMethodWithPositive() {
         try (final EntityManager em = emf.createEntityManager()) {
-            Double result = callCeiling(em, 4);
+            Float result = callCeilingFloat(em, 3);
+            Assert.assertEquals(
+                    Float.valueOf(NUMBER[3].getLongValue().intValue()+1), result);
+        }
+    }
+
+    // Call CEILING(n) on Double n<0.
+    @Test
+    public void testCeilingDoubleMethodWithNegative() {
+        try (final EntityManager em = emf.createEntityManager()) {
+            Double result = callCeilingDouble(em, 4);
             Assert.assertEquals(
                     Double.valueOf(NUMBER[4].getLongValue().intValue()), result);
         }
     }
 
+    // Call CEILING(n) on Float n<0.
+    @Test
+    public void testCeilingFloatMethodWithNegative() {
+        try (final EntityManager em = emf.createEntityManager()) {
+            Float result = callCeilingFloat(em, 4);
+            Assert.assertEquals(
+                    Float.valueOf(NUMBER[4].getLongValue().intValue()), result);
+        }
+    }
+
     // Call SELECT FLOOR(n.doubleValue) FROM NumberEntity n WHERE n.id = :id using JPQL
-    private static Double callFloor(final EntityManager em, final int id) {
+    private static Double callFloorDouble(final EntityManager em, final int id) {
         TypedQuery<Double> query = em.createQuery(
                 "SELECT FLOOR(n.doubleValue) FROM NumberEntity n WHERE n.id = :id", Double.class);
         query.setParameter("id", id);
         return query.getSingleResult();
     }
 
-    // Call FLOOR(n) on n=0.
+    // Call SELECT FLOOR(n.floatValue) FROM NumberEntity n WHERE n.id = :id using JPQL
+    private static Float callFloorFloat(final EntityManager em, final int id) {
+        TypedQuery<Float> query = em.createQuery(
+                "SELECT FLOOR(n.floatValue) FROM NumberEntity n WHERE n.id = :id", Float.class);
+        query.setParameter("id", id);
+        return query.getSingleResult();
+    }
+
+    // Call FLOOR(n) on Double n=0.
     @Test
-    public void testFloorMethodWithZero() {
+    public void testFloorDoubleMethodWithZero() {
         try (final EntityManager em = emf.createEntityManager()) {
-            Double result = callFloor(em, 0);
+            Double result = callFloorDouble(em, 0);
             Assert.assertEquals(Double.valueOf(0), result);
         }
     }
 
-    // Call FLOOR(n) on n>0.
+    // Call FLOOR(n) on Float n=0.
     @Test
-    public void testFloorMethodWithPositive() {
+    public void testFloorFloatMethodWithZero() {
         try (final EntityManager em = emf.createEntityManager()) {
-            Double result = callFloor(em, 3);
+            Float result = callFloorFloat(em, 0);
+            Assert.assertEquals(Float.valueOf(0), result);
+        }
+    }
+
+    // Call FLOOR(n) on Double n>0.
+    @Test
+    public void testFloorDoubleMethodWithPositive() {
+        try (final EntityManager em = emf.createEntityManager()) {
+            Double result = callFloorDouble(em, 3);
             Assert.assertEquals(
                     Double.valueOf(NUMBER[3].getLongValue().intValue()), result);
         }
     }
 
-    // Call FLOOR(n) on n<0.
+    // Call FLOOR(n) on Float n>0.
     @Test
-    public void testFloorMethodWithNegative() {
+    public void testFloorFloatMethodWithPositive() {
         try (final EntityManager em = emf.createEntityManager()) {
-            Double result = callFloor(em, 4);
+            Float result = callFloorFloat(em, 3);
+            Assert.assertEquals(
+                    Float.valueOf(NUMBER[3].getLongValue().intValue()), result);
+        }
+    }
+
+    // Call FLOOR(n) on Double n<0.
+    @Test
+    public void testFloorDoubleMethodWithNegative() {
+        try (final EntityManager em = emf.createEntityManager()) {
+            Double result = callFloorDouble(em, 4);
             Assert.assertEquals(
                     Double.valueOf(NUMBER[4].getLongValue().intValue()-1), result);
+        }
+    }
+
+    // Call FLOOR(n) on Float n<0.
+    @Test
+    public void testFloorFloatMethodWithNegative() {
+        try (final EntityManager em = emf.createEntityManager()) {
+            Float result = callFloorFloat(em, 4);
+            Assert.assertEquals(
+                    Float.valueOf(NUMBER[4].getLongValue().intValue()-1), result);
         }
     }
 


### PR DESCRIPTION
Fixes DB ResultSet conversion when returned type is common Number and specific type is stored only in `typeName`.
Fixes issue #1538 