### PR TITLE
Issue #1554: JPA 3.1 CriteriaBuilder Query exception

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
@@ -427,217 +427,6 @@ public class DatabasePlatform extends DatasourcePlatform {
     }
 
     /**
-     * Appends a Boolean value as a number
-     */
-    protected void appendBoolean(Boolean bool, Writer writer) throws IOException {
-        if (bool) {
-            writer.write("1");
-        } else {
-            writer.write("0");
-        }
-    }
-
-    /**
-     * Append the ByteArray in ODBC literal format ({b hexString}).
-     * This limits the amount of Binary data by the length of the SQL. Binding should increase this limit.
-     */
-    protected void appendByteArray(byte[] bytes, Writer writer) throws IOException {
-        writer.write("{b '");
-        Helper.writeHexString(bytes, writer);
-        writer.write("'}");
-    }
-
-    /**
-     * Answer a platform correct string representation of a Date, suitable for SQL generation.
-     * The date is printed in the ODBC platform independent format {d 'yyyy-mm-dd'}.
-     */
-    protected void appendDate(java.sql.Date date, Writer writer) throws IOException {
-        writer.write("{d '");
-        writer.write(Helper.printDate(date));
-        writer.write("'}");
-    }
-
-    /**
-     * Write number to SQL string. This is provided so that database which do not support
-     * Exponential format can customize their printing.
-     */
-    protected void appendNumber(Number number, Writer writer) throws IOException {
-        writer.write(number.toString());
-    }
-
-    /**
-     * INTERNAL:
-     * In case shouldBindLiterals is true, instead of null value a DatabaseField
-     * value may be passed (so that it's type could be used for binding null).
-     * 
-     * @param canBind - allows higher up the stack (where more context exists) to tell if this literal can be bound
-     */
-    public void appendLiteralToCall(Call call, Writer writer, Object literal, Boolean canBind) {
-        if(!Boolean.FALSE.equals(canBind) && shouldBindLiterals()) {
-            appendLiteralToCallWithBinding(call, writer, literal);
-        } else {
-            int nParametersToAdd = appendParameterInternal(call, writer, literal);
-            for (int i = 0; i < nParametersToAdd; i++) {
-                ((DatabaseCall)call).getParameterTypes().add(ParameterType.LITERAL);
-            }
-        }
-    }
-
-    /**
-     * INTERNAL:
-     * Override this method in case the platform needs to do something special for binding literals.
-     * Note that instead of null value a DatabaseField
-     * value may be passed (so that it's type could be used for binding null).
-     */
-    protected void appendLiteralToCallWithBinding(Call call, Writer writer, Object literal) {
-        ((DatabaseCall)call).appendLiteral(writer, literal);
-    }
-
-    /**
-     * Write a database-friendly representation of the given parameter to the writer.
-     * Determine the class of the object to be written, and invoke the appropriate print method
-     * for that object. The default is "toString".
-     * The platform may decide to bind some types, such as byte arrays and large strings.
-     * Should only be called in case binding is not used.
-     */
-    @Override
-    public void appendParameter(Call call, Writer writer, Object parameter) {
-        appendParameterInternal(call, writer, parameter);
-    }
-
-    /**
-     * Returns the number of parameters that used binding.
-     * Should only be called in case binding is not used.
-     */
-    public int appendParameterInternal(Call call, Writer writer, Object parameter) {
-        int nBoundParameters = 0;
-        DatabaseCall databaseCall = (DatabaseCall)call;
-        try {
-            // PERF: Print Calendars directly avoiding timestamp conversion,
-            // Must be before conversion as you cannot bind calendars.
-            if (parameter instanceof Calendar) {
-                appendCalendar((Calendar)parameter, writer);
-                return nBoundParameters;
-            }
-            Object dbValue = convertToDatabaseType(parameter);
-
-            if (dbValue instanceof String) {// String and number first as they are most common.
-                if (usesStringBinding() && (((String)dbValue).length() >= getStringBindingSize())) {
-                    databaseCall.bindParameter(writer, dbValue);
-                    nBoundParameters = 1;
-                } else {
-                    appendString((String)dbValue, writer);
-                }
-            } else if (dbValue instanceof Number) {
-                appendNumber((Number)dbValue, writer);
-            } else if (dbValue instanceof java.sql.Time) {
-                appendTime((java.sql.Time)dbValue, writer);
-            } else if (dbValue instanceof java.sql.Timestamp) {
-                appendTimestamp((java.sql.Timestamp)dbValue, writer);
-            } else if (dbValue instanceof java.time.LocalDate){
-                appendDate(java.sql.Date.valueOf((java.time.LocalDate) dbValue), writer);
-            } else if (dbValue instanceof java.time.LocalDateTime){
-                appendTimestamp(java.sql.Timestamp.valueOf((java.time.LocalDateTime) dbValue), writer);
-            } else if (dbValue instanceof java.time.OffsetDateTime) {
-                appendTimestamp(java.sql.Timestamp.from(((java.time.OffsetDateTime) dbValue).toInstant()), writer);
-            } else if (dbValue instanceof java.time.LocalTime){
-                java.time.LocalTime lt = (java.time.LocalTime) dbValue;
-                java.sql.Timestamp ts = java.sql.Timestamp.valueOf(java.time.LocalDateTime.of(java.time.LocalDate.ofEpochDay(0), lt));
-                appendTimestamp(ts, writer);
-            } else if (dbValue instanceof java.time.OffsetTime) {
-                java.time.OffsetTime ot = (java.time.OffsetTime) dbValue;
-                java.sql.Timestamp ts = java.sql.Timestamp.valueOf(java.time.LocalDateTime.of(java.time.LocalDate.ofEpochDay(0), ot.toLocalTime()));
-                appendTimestamp(ts, writer);
-            } else if (dbValue instanceof java.sql.Date) {
-                appendDate((java.sql.Date)dbValue, writer);
-            } else if (dbValue == null) {
-                writer.write("NULL");
-            } else if (dbValue instanceof Boolean) {
-                appendBoolean((Boolean)dbValue, writer);
-            } else if (dbValue instanceof byte[]) {
-                if (usesByteArrayBinding()) {
-                    databaseCall.bindParameter(writer, dbValue);
-                    nBoundParameters = 1;
-                } else {
-                    appendByteArray((byte[])dbValue, writer);
-                }
-            } else if (dbValue instanceof Collection) {
-                nBoundParameters = printValuelist((Collection<?>)dbValue, databaseCall, writer);
-            } else if (typeConverters != null && typeConverters.containsKey(dbValue.getClass())){
-                dbValue = new BindCallCustomParameter(dbValue);
-                // custom binding is required, object to be bound is wrapped (example NCHAR, NVARCHAR2, NCLOB on Oracle9)
-                databaseCall.bindParameter(writer, dbValue);
-            } else if ((parameter instanceof Struct) || (parameter instanceof Array) || (parameter instanceof Ref)) {
-                databaseCall.bindParameter(writer, parameter);
-                nBoundParameters = 1;
-            } else if (dbValue.getClass() == int[].class) {
-                nBoundParameters = printValuelist((int[])dbValue, databaseCall, writer);
-            } else if (dbValue instanceof AppendCallCustomParameter) {
-                // custom append is required (example BLOB, CLOB on Oracle8)
-                ((AppendCallCustomParameter)dbValue).append(writer);
-                nBoundParameters = 1;
-            } else if (dbValue instanceof BindCallCustomParameter) {
-                // custom binding is required, object to be bound is wrapped (example NCHAR, NVARCHAR2, NCLOB on Oracle9)
-                databaseCall.bindParameter(writer, dbValue);
-                nBoundParameters = 1;
-            } else {
-                // Assume database driver primitive that knows how to print itself, this is required for drivers
-                // such as Oracle JDBC, Informix JDBC and others, as well as client specific classes.
-                writer.write(dbValue.toString());
-            }
-        } catch (IOException exception) {
-            throw ValidationException.fileError(exception);
-        }
-
-        return nBoundParameters;
-    }
-
-    /**
-     * Write the string.  Quotes must be double quoted.
-     */
-    protected void appendString(String string, Writer writer) throws IOException {
-        writer.write('\'');
-        for (int position = 0; position < string.length(); position++) {
-            if (string.charAt(position) == '\'') {
-                writer.write("''");
-            } else {
-                writer.write(string.charAt(position));
-            }
-        }
-        writer.write('\'');
-    }
-
-    /**
-     * Answer a platform correct string representation of a Time, suitable for SQL generation.
-     * The time is printed in the ODBC platform independent format {t'hh:mm:ss'}.
-     */
-    protected void appendTime(java.sql.Time time, Writer writer) throws IOException {
-        writer.write("{t '");
-        writer.write(Helper.printTime(time));
-        writer.write("'}");
-    }
-
-    /**
-     * Answer a platform correct string representation of a Timestamp, suitable for SQL generation.
-     * The timestamp is printed in the ODBC platform independent timestamp format {ts'YYYY-MM-DD HH:MM:SS.NNNNNNNNN'}.
-     */
-    protected void appendTimestamp(java.sql.Timestamp timestamp, Writer writer) throws IOException {
-        writer.write("{ts '");
-        writer.write(Helper.printTimestamp(timestamp));
-        writer.write("'}");
-    }
-
-    /**
-     * Answer a platform correct string representation of a Calendar as a Timestamp, suitable for SQL generation.
-     * The calendar is printed in the ODBC platform independent timestamp format {ts'YYYY-MM-DD HH:MM:SS.NNNNNNNNN'}.
-     */
-    protected void appendCalendar(Calendar calendar, Writer writer) throws IOException {
-        writer.write("{ts '");
-        writer.write(Helper.printCalendar(calendar));
-        writer.write("'}");
-    }
-
-    /**
      * Used by JDBC drivers that do not support autocommit so simulate an autocommit.
      */
     public void autoCommit(DatabaseAccessor accessor) throws SQLException {
@@ -2555,6 +2344,9 @@ public class DatabasePlatform extends DatasourcePlatform {
         this.pingSQL = pingSQL;
     }
 
+    // Following methods add parameters into PreparedStatement. They are being called when
+    // eclipselink.jdbc.bind-parameters PU property is set to true.
+
     /**
      * INTERNAL
      * Set the parameter in the JDBC statement at the given index.
@@ -2762,6 +2554,8 @@ public class DatabasePlatform extends DatasourcePlatform {
             StructConverter converter = typeConverters.get(parameter.getClass());
             parameter = converter.convertToStruct(parameter, getConnection(session, statement.getConnection()));
             statement.setObject(name, parameter);
+        } else if (parameter instanceof UUID) {
+            statement.setString(name, convertObject(parameter, ClassConstants.STRING));
         } else {
             statement.setObject(name, parameter);
         }
@@ -2810,6 +2604,222 @@ public class DatabasePlatform extends DatasourcePlatform {
      */
     public Object getParameterValueFromDatabaseCall(CallableStatement statement, String name, AbstractSession session) throws SQLException {
         return statement.getObject(name);
+    }
+
+    // Following method adds parameters values directly into Statement. This method is being called when
+    // eclipselink.jdbc.bind-parameters PU property is set to false.
+
+    /**
+     * Returns the number of parameters that used binding.
+     * Should only be called in case binding is not used.
+     */
+    public int appendParameterInternal(Call call, Writer writer, Object parameter) {
+        int nBoundParameters = 0;
+        DatabaseCall databaseCall = (DatabaseCall)call;
+        try {
+            // PERF: Print Calendars directly avoiding timestamp conversion,
+            // Must be before conversion as you cannot bind calendars.
+            if (parameter instanceof Calendar) {
+                appendCalendar((Calendar)parameter, writer);
+                return nBoundParameters;
+            }
+            Object dbValue = convertToDatabaseType(parameter);
+
+            if (dbValue instanceof String) {// String and number first as they are most common.
+                if (usesStringBinding() && (((String)dbValue).length() >= getStringBindingSize())) {
+                    databaseCall.bindParameter(writer, dbValue);
+                    nBoundParameters = 1;
+                } else {
+                    appendString((String)dbValue, writer);
+                }
+            } else if (dbValue instanceof Number) {
+                appendNumber((Number)dbValue, writer);
+            } else if (dbValue instanceof java.sql.Time) {
+                appendTime((java.sql.Time)dbValue, writer);
+            } else if (dbValue instanceof java.sql.Timestamp) {
+                appendTimestamp((java.sql.Timestamp)dbValue, writer);
+            } else if (dbValue instanceof java.time.LocalDate){
+                appendDate(java.sql.Date.valueOf((java.time.LocalDate) dbValue), writer);
+            } else if (dbValue instanceof java.time.LocalDateTime){
+                appendTimestamp(java.sql.Timestamp.valueOf((java.time.LocalDateTime) dbValue), writer);
+            } else if (dbValue instanceof java.time.OffsetDateTime) {
+                appendTimestamp(java.sql.Timestamp.from(((java.time.OffsetDateTime) dbValue).toInstant()), writer);
+            } else if (dbValue instanceof java.time.LocalTime){
+                java.time.LocalTime lt = (java.time.LocalTime) dbValue;
+                java.sql.Timestamp ts = java.sql.Timestamp.valueOf(java.time.LocalDateTime.of(java.time.LocalDate.ofEpochDay(0), lt));
+                appendTimestamp(ts, writer);
+            } else if (dbValue instanceof java.time.OffsetTime) {
+                java.time.OffsetTime ot = (java.time.OffsetTime) dbValue;
+                java.sql.Timestamp ts = java.sql.Timestamp.valueOf(java.time.LocalDateTime.of(java.time.LocalDate.ofEpochDay(0), ot.toLocalTime()));
+                appendTimestamp(ts, writer);
+            } else if (dbValue instanceof java.sql.Date) {
+                appendDate((java.sql.Date)dbValue, writer);
+            } else if (dbValue == null) {
+                writer.write("NULL");
+            } else if (dbValue instanceof Boolean) {
+                appendBoolean((Boolean)dbValue, writer);
+            } else if (dbValue instanceof byte[]) {
+                if (usesByteArrayBinding()) {
+                    databaseCall.bindParameter(writer, dbValue);
+                    nBoundParameters = 1;
+                } else {
+                    appendByteArray((byte[])dbValue, writer);
+                }
+            } else if (dbValue instanceof Collection) {
+                nBoundParameters = printValuelist((Collection<?>)dbValue, databaseCall, writer);
+            } else if (typeConverters != null && typeConverters.containsKey(dbValue.getClass())){
+                dbValue = new BindCallCustomParameter(dbValue);
+                // custom binding is required, object to be bound is wrapped (example NCHAR, NVARCHAR2, NCLOB on Oracle9)
+                databaseCall.bindParameter(writer, dbValue);
+            } else if ((parameter instanceof Struct) || (parameter instanceof Array) || (parameter instanceof Ref)) {
+                databaseCall.bindParameter(writer, parameter);
+                nBoundParameters = 1;
+            } else if (dbValue.getClass() == int[].class) {
+                nBoundParameters = printValuelist((int[])dbValue, databaseCall, writer);
+            } else if (dbValue instanceof AppendCallCustomParameter) {
+                // custom append is required (example BLOB, CLOB on Oracle8)
+                ((AppendCallCustomParameter)dbValue).append(writer);
+                nBoundParameters = 1;
+            } else if (dbValue instanceof BindCallCustomParameter) {
+                // custom binding is required, object to be bound is wrapped (example NCHAR, NVARCHAR2, NCLOB on Oracle9)
+                databaseCall.bindParameter(writer, dbValue);
+                nBoundParameters = 1;
+            } else if (parameter instanceof UUID) {
+                appendString(((UUID)dbValue).toString(), writer);
+            } else {
+                // Assume database driver primitive that knows how to print itself, this is required for drivers
+                // such as Oracle JDBC, Informix JDBC and others, as well as client specific classes.
+                writer.write(dbValue.toString());
+            }
+        } catch (IOException exception) {
+            throw ValidationException.fileError(exception);
+        }
+
+        return nBoundParameters;
+    }
+
+    /**
+     * Appends a Boolean value as a number
+     */
+    protected void appendBoolean(Boolean bool, Writer writer) throws IOException {
+        if (bool) {
+            writer.write("1");
+        } else {
+            writer.write("0");
+        }
+    }
+
+    /**
+     * Append the ByteArray in ODBC literal format ({b hexString}).
+     * This limits the amount of Binary data by the length of the SQL. Binding should increase this limit.
+     */
+    protected void appendByteArray(byte[] bytes, Writer writer) throws IOException {
+        writer.write("{b '");
+        Helper.writeHexString(bytes, writer);
+        writer.write("'}");
+    }
+
+    /**
+     * Answer a platform correct string representation of a Date, suitable for SQL generation.
+     * The date is printed in the ODBC platform independent format {d 'yyyy-mm-dd'}.
+     */
+    protected void appendDate(java.sql.Date date, Writer writer) throws IOException {
+        writer.write("{d '");
+        writer.write(Helper.printDate(date));
+        writer.write("'}");
+    }
+
+    /**
+     * Write number to SQL string. This is provided so that database which do not support
+     * Exponential format can customize their printing.
+     */
+    protected void appendNumber(Number number, Writer writer) throws IOException {
+        writer.write(number.toString());
+    }
+
+    /**
+     * INTERNAL:
+     * In case shouldBindLiterals is true, instead of null value a DatabaseField
+     * value may be passed (so that it's type could be used for binding null).
+     *
+     * @param canBind - allows higher up the stack (where more context exists) to tell if this literal can be bound
+     */
+    public void appendLiteralToCall(Call call, Writer writer, Object literal, Boolean canBind) {
+        if(!Boolean.FALSE.equals(canBind) && shouldBindLiterals()) {
+            appendLiteralToCallWithBinding(call, writer, literal);
+        } else {
+            int nParametersToAdd = appendParameterInternal(call, writer, literal);
+            for (int i = 0; i < nParametersToAdd; i++) {
+                ((DatabaseCall)call).getParameterTypes().add(ParameterType.LITERAL);
+            }
+        }
+    }
+
+    /**
+     * INTERNAL:
+     * Override this method in case the platform needs to do something special for binding literals.
+     * Note that instead of null value a DatabaseField
+     * value may be passed (so that it's type could be used for binding null).
+     */
+    protected void appendLiteralToCallWithBinding(Call call, Writer writer, Object literal) {
+        ((DatabaseCall)call).appendLiteral(writer, literal);
+    }
+
+    /**
+     * Write a database-friendly representation of the given parameter to the writer.
+     * Determine the class of the object to be written, and invoke the appropriate print method
+     * for that object. The default is "toString".
+     * The platform may decide to bind some types, such as byte arrays and large strings.
+     * Should only be called in case binding is not used.
+     */
+    @Override
+    public void appendParameter(Call call, Writer writer, Object parameter) {
+        appendParameterInternal(call, writer, parameter);
+    }
+
+    /**
+     * Write the string.  Quotes must be double quoted.
+     */
+    protected void appendString(String string, Writer writer) throws IOException {
+        writer.write('\'');
+        for (int position = 0; position < string.length(); position++) {
+            if (string.charAt(position) == '\'') {
+                writer.write("''");
+            } else {
+                writer.write(string.charAt(position));
+            }
+        }
+        writer.write('\'');
+    }
+
+    /**
+     * Answer a platform correct string representation of a Time, suitable for SQL generation.
+     * The time is printed in the ODBC platform independent format {t'hh:mm:ss'}.
+     */
+    protected void appendTime(java.sql.Time time, Writer writer) throws IOException {
+        writer.write("{t '");
+        writer.write(Helper.printTime(time));
+        writer.write("'}");
+    }
+
+    /**
+     * Answer a platform correct string representation of a Timestamp, suitable for SQL generation.
+     * The timestamp is printed in the ODBC platform independent timestamp format {ts'YYYY-MM-DD HH:MM:SS.NNNNNNNNN'}.
+     */
+    protected void appendTimestamp(java.sql.Timestamp timestamp, Writer writer) throws IOException {
+        writer.write("{ts '");
+        writer.write(Helper.printTimestamp(timestamp));
+        writer.write("'}");
+    }
+
+    /**
+     * Answer a platform correct string representation of a Calendar as a Timestamp, suitable for SQL generation.
+     * The calendar is printed in the ODBC platform independent timestamp format {ts'YYYY-MM-DD HH:MM:SS.NNNNNNNNN'}.
+     */
+    protected void appendCalendar(Calendar calendar, Writer writer) throws IOException {
+        writer.write("{ts '");
+        writer.write(Helper.printCalendar(calendar));
+        writer.write("'}");
     }
 
     public boolean usesBatchWriting() {

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/uuid/TestUUIDUUID.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/uuid/TestUUIDUUID.java
@@ -137,4 +137,44 @@ public class TestUUIDUUID {
             em.close();
         }
     }
+
+    @Test
+    public void testIssue1554() {
+        final String uuidName = "Issue testIssue1554 UUID";
+        EntityManager em = uuidEmf.createEntityManager();
+        try {
+            em.getTransaction().begin();
+            UUIDUUIDEntity entity = new UUIDUUIDEntity();
+            entity.setName(uuidName);
+            em.persist(entity);
+            em.flush();
+            em.getTransaction().commit();
+            UUID id = entity.getId();
+            em.getTransaction().begin();
+            var cb = em.getCriteriaBuilder();
+            var query = cb.createTupleQuery();
+            var root = query.from(UUIDUUIDEntity.class);
+            query.multiselect(root.get("name"),
+                    cb.localTime(),
+                    cb.localDateTime(),
+                    cb.localDate()
+            );
+            query.where(cb.equal(root.get("id"), id));
+            List<?> result = em.createQuery(query).getResultList();
+            em.getTransaction().commit();
+            assertEquals(result.size(), 1);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException();
+        }
+        finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            em.close();
+        }
+    }
+
+
+
 }

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/uuid/TestUuidCommon.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/uuid/TestUuidCommon.java
@@ -14,30 +14,27 @@
 //     Oracle - initial API and implementation
 package org.eclipse.persistence.jpa.test.uuid;
 
+import java.util.List;
+import java.util.UUID;
+
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.Query;
-import org.eclipse.persistence.jpa.test.framework.DDLGen;
-import org.eclipse.persistence.jpa.test.framework.Emf;
-import org.eclipse.persistence.jpa.test.framework.EmfRunner;
-import org.eclipse.persistence.jpa.test.uuid.model.UUIDUUIDEntity;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 
-import java.util.List;
-import java.util.UUID;
+import org.eclipse.persistence.jpa.test.uuid.model.UUIDUUIDEntity;
+import org.junit.Ignore;
+import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(EmfRunner.class)
-public class TestUUIDUUID {
+@Ignore
+public abstract class TestUuidCommon {
 
     private static final String NAME_UUID = "Persist UUID UUID 1";
 
-    @Emf(name = "uuidUUIDEmf", createTables = DDLGen.DROP_CREATE, classes = { UUIDUUIDEntity.class })
-    private EntityManagerFactory uuidEmf;
+    abstract EntityManagerFactory getEmf();
 
     /**
      * Tests GenerationType.UUID with field based on java.util.UUID type.
@@ -51,7 +48,7 @@ public class TestUUIDUUID {
     }
 
     private UUID persistUUIDUUIDEntity() {
-        EntityManager em = uuidEmf.createEntityManager();
+        EntityManager em = getEmf().createEntityManager();
         UUID uuidResult = null;
         try {
             em.getTransaction().begin();
@@ -75,7 +72,7 @@ public class TestUUIDUUID {
     }
 
     public void queryAllUUIDUUIDEntity() {
-        EntityManager em = uuidEmf.createEntityManager();
+        EntityManager em = getEmf().createEntityManager();
         try {
             List<UUIDUUIDEntity> testEntities = em.createQuery("SELECT e FROM UUIDUUIDEntity AS e").getResultList();
             assertTrue(testEntities.size() > 0);
@@ -95,7 +92,7 @@ public class TestUUIDUUID {
     }
 
     public void queryWithParameterUUIDUUIDEntity(UUID id) {
-        EntityManager em = uuidEmf.createEntityManager();
+        EntityManager em = getEmf().createEntityManager();
         try {
             Query query = em.createQuery("SELECT e FROM UUIDUUIDEntity AS e WHERE e.id = :id");
             query.setParameter("id", id);
@@ -120,7 +117,7 @@ public class TestUUIDUUID {
     }
 
     public void findUUIDUUIDEntityTest(UUID id) {
-        EntityManager em = uuidEmf.createEntityManager();
+        EntityManager em = getEmf().createEntityManager();
         try {
             UUIDUUIDEntity entity = em.find(UUIDUUIDEntity.class, id);
             assertNotNull(entity);
@@ -141,11 +138,12 @@ public class TestUUIDUUID {
     @Test
     public void testIssue1554() {
         final String uuidName = "Issue testIssue1554 UUID";
-        EntityManager em = uuidEmf.createEntityManager();
+        EntityManager em = getEmf().createEntityManager();
         try {
             em.getTransaction().begin();
             UUIDUUIDEntity entity = new UUIDUUIDEntity();
             entity.setName(uuidName);
+            entity.setId(UUID.fromString("d04a98a2-4408-4cf3-b232-5cfaab58afc9"));
             em.persist(entity);
             em.flush();
             em.getTransaction().commit();
@@ -174,7 +172,5 @@ public class TestUUIDUUID {
             em.close();
         }
     }
-
-
 
 }

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/uuid/TestUuidWithAppendParameters.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/uuid/TestUuidWithAppendParameters.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.jpa.test.uuid;
+
+import jakarta.persistence.EntityManagerFactory;
+
+import org.eclipse.persistence.jpa.test.framework.DDLGen;
+import org.eclipse.persistence.jpa.test.framework.Emf;
+import org.eclipse.persistence.jpa.test.framework.EmfRunner;
+import org.eclipse.persistence.jpa.test.framework.Property;
+import org.eclipse.persistence.jpa.test.uuid.model.UUIDUUIDEntity;
+import org.junit.runner.RunWith;
+
+// Run TestUuidCommon tests with eclipselink.jdbc.bind-parameters property set to false
+@RunWith(EmfRunner.class)
+public class TestUuidWithAppendParameters extends TestUuidCommon {
+
+    @Emf(
+            name = "uuidUUIDEmf",
+            createTables = DDLGen.DROP_CREATE,
+            classes = { UUIDUUIDEntity.class },
+            properties = {
+                    @Property(name = "eclipselink.logging.level.sql", value = "FINE"),
+                    @Property(name = "eclipselink.jdbc.bind-parameters", value = "false")
+            }
+    )
+    private EntityManagerFactory emf;
+
+    EntityManagerFactory getEmf() {
+        return emf;
+    }
+
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/uuid/TestUuidWithBindParameters.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/uuid/TestUuidWithBindParameters.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.jpa.test.uuid;
+
+import jakarta.persistence.EntityManagerFactory;
+
+import org.eclipse.persistence.jpa.test.framework.DDLGen;
+import org.eclipse.persistence.jpa.test.framework.Emf;
+import org.eclipse.persistence.jpa.test.framework.EmfRunner;
+import org.eclipse.persistence.jpa.test.framework.Property;
+import org.eclipse.persistence.jpa.test.uuid.model.UUIDUUIDEntity;
+import org.junit.runner.RunWith;
+
+// Run TestUuidCommon tests with eclipselink.jdbc.bind-parameters property set to true
+@RunWith(EmfRunner.class)
+public class TestUuidWithBindParameters extends TestUuidCommon {
+
+    @Emf(
+            name = "uuidUUIDEmf",
+            createTables = DDLGen.DROP_CREATE,
+            classes = { UUIDUUIDEntity.class },
+            properties = {
+                    @Property(name = "eclipselink.logging.level.sql", value = "FINE"),
+                    @Property(name = "eclipselink.jdbc.bind-parameters", value = "true")
+            }
+    )
+    private EntityManagerFactory emf;
+
+    EntityManagerFactory getEmf() {
+        return emf;
+    }
+
+}


### PR DESCRIPTION
1. Added missing UUID value handling in `setParameterValueInDatabaseCall` and `appendParameterInternal` methods.

2. Did small refactoring in DatabasePlatform:
moved `public int appendParameterInternal(Call call, Writer writer, Object parameter)` and all related helper methods right after `setParameterValueInDatabaseCall` methods and added comments explaining close relation between them.

It was not for the first time when we forgot to implement some feature in both code paths for `eclipselink.jdbc.bind-parameters` PU property so hope that having both methods close together may avoid repeating the same mistake next time.