### PR TITLE
avoid the need to set ejb.lookup property

### DIFF
--- a/foundation/org.eclipse.persistence.core.test.framework/src/main/java/org/eclipse/persistence/testing/framework/junit/JUnitTestCaseHelper.java
+++ b/foundation/org.eclipse.persistence.core.test.framework/src/main/java/org/eclipse/persistence/testing/framework/junit/JUnitTestCaseHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -102,7 +102,8 @@ public class JUnitTestCaseHelper {
             if (puProperties == null) {
                 if (puName.equals("composite-advanced") || puName.equals("xml-composite-advanced") || puName.equals("xml-extended-composite-advanced")) {
                     String prefix = puName;
-                    if (puName.equals("xml-extended-composite-advanced")) {
+                    //temporary during the rename of the xml-extended-composite-advanced members
+                    if (!Boolean.getBoolean("el.skip.prefix-check") && puName.equals("xml-extended-composite-advanced")) {
                         prefix = "xml-composite-advanced";
                     }
                     String[] sessions = {"member_1", "member_2", "member_3"};

--- a/jpa/org.eclipse.persistence.jpa.test.framework/pom.xml
+++ b/jpa/org.eclipse.persistence.jpa.test.framework/pom.xml
@@ -37,6 +37,11 @@
             <artifactId>jakarta.persistence-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
         <!--Other modules-->
         <dependency>
             <groupId>org.eclipse.persistence</groupId>

--- a/jpa/org.eclipse.persistence.jpa.test.framework/src/main/java/org/eclipse/persistence/testing/framework/server/GenericTestRunner.java
+++ b/jpa/org.eclipse.persistence.jpa.test.framework/src/main/java/org/eclipse/persistence/testing/framework/server/GenericTestRunner.java
@@ -62,6 +62,7 @@ public class GenericTestRunner implements TestRunner {
                 JUnitTestCase jpaTest = (JUnitTestCase) testInstance;
                 JEEPlatform.entityManager = getEntityManager();
                 JEEPlatform.entityManagerFactory = getEntityManagerFactory();
+                JEEPlatform.ejbLookup = getEjbLookup();
                 jpaTest.runBareServer();
             } else {
                 testInstance.runBare();
@@ -78,5 +79,9 @@ public class GenericTestRunner implements TestRunner {
 
     protected EntityManagerFactory getEntityManagerFactory() {
         return null;
+    }
+
+    protected boolean getEjbLookup() {
+        return false;
     }
 }

--- a/jpa/org.eclipse.persistence.jpa.test.framework/src/main/java/org/eclipse/persistence/testing/framework/server/SingleUnitTestRunnerBean.java
+++ b/jpa/org.eclipse.persistence.jpa.test.framework/src/main/java/org/eclipse/persistence/testing/framework/server/SingleUnitTestRunnerBean.java
@@ -14,6 +14,7 @@
 //     Oracle - initial API and implementation from Oracle TopLink
  package org.eclipse.persistence.testing.framework.server;
 
+import jakarta.annotation.Resource;
 import jakarta.ejb.Remote;
 import jakarta.ejb.Stateless;
 import jakarta.ejb.TransactionManagement;
@@ -22,9 +23,6 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.PersistenceUnit;
-
-import org.eclipse.persistence.testing.framework.server.GenericTestRunner;
-import org.eclipse.persistence.testing.framework.server.TestRunner;
 
 /**
  * Server side JUnit test invocation implemented as a stateless session bean.
@@ -47,6 +45,9 @@ public class SingleUnitTestRunnerBean extends GenericTestRunner {
     @PersistenceUnit
     private EntityManagerFactory entityManagerFactory;
 
+    @Resource(name="ejbLookup")
+    private Boolean ejbLookup = false;
+
     @Override
     protected EntityManager getEntityManager() {
         return entityManager;
@@ -55,5 +56,10 @@ public class SingleUnitTestRunnerBean extends GenericTestRunner {
     @Override
     protected EntityManagerFactory getEntityManagerFactory() {
         return entityManagerFactory;
+    }
+
+    @Override
+    protected boolean getEjbLookup() {
+        return ejbLookup;
     }
 }


### PR DESCRIPTION
on the server by introducing the ability to provide it directly to the test itself
via env-entry in ejb-jar.xml;
provide temporary hook to NOT prefix member PU names for extended.xml.composite members

Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>