### PR TITLE
Fix ConcurrentModificationException in BatchFetchPolicy

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/BatchFetchPolicy.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/BatchFetchPolicy.java
@@ -79,7 +79,7 @@ public class BatchFetchPolicy implements Serializable, Cloneable {
         clone.setDataResults(dataResults);
 
         if(this.attributeExpressions != null) {
-            this.attributeExpressions = new ArrayList<>(this.attributeExpressions);
+            clone.attributeExpressions = new ArrayList<>(this.attributeExpressions);
         }
         return clone;
     }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/BatchFetchPolicy.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/BatchFetchPolicy.java
@@ -77,6 +77,10 @@ public class BatchFetchPolicy implements Serializable, Cloneable {
             dataResults.put(clone, list);
         }
         clone.setDataResults(dataResults);
+
+        if(this.attributeExpressions != null) {
+            this.attributeExpressions = new ArrayList<>(this.attributeExpressions);
+        }
         return clone;
     }
 


### PR DESCRIPTION
See #1506

The memory leak mentioned in the issue has already been solved by #1245 
This PR will fix the ConcurrentModificationException of the attributeExpression list, when running the same (batch)query with different entity managers.