### PR TITLE
buildBase64StringFromBytes more memory efficient

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/oxm/XMLConversionManager.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/oxm/XMLConversionManager.java
@@ -1641,12 +1641,7 @@ public class XMLConversionManager extends ConversionManager implements org.eclip
 
     @Override
     public String buildBase64StringFromBytes(byte[] bytes) {
-        byte[] convertedBytes = Base64.base64Encode(bytes);
-        StringBuilder buffer = new StringBuilder();
-        for (int i = 0; i < convertedBytes.length; i++) {
-            buffer.append((char) convertedBytes[i]);
-        }
-        return buffer.toString();
+        return Base64.base64EncodeToString(bytes);
     }
 
     public String buildBase64StringFromObjectBytes(Byte[] bytes) {

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/oxm/conversion/Base64.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/oxm/conversion/Base64.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,6 +13,8 @@
 // Contributors:
 //     Oracle - initial API and implementation from Oracle TopLink
 package org.eclipse.persistence.internal.oxm.conversion;
+
+import jakarta.xml.bind.DatatypeConverter;
 
 /**
  * INTERNAL:
@@ -49,5 +51,15 @@ public class Base64 {
      */
     public static byte[] base64Encode(byte[] data) {
         return java.util.Base64.getEncoder().encode(data);
+    }
+
+    /**
+     * This method encodes the given byte[] using java.util.Base64.
+     *
+     * @param  data the data
+     * @return the base64-encoded <var>data</var> as a String
+     */
+    public static String base64EncodeToString(byte[] data) {
+        return DatatypeConverter.printBase64Binary(data);
     }
 }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/oxm/conversion/Base64.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/oxm/conversion/Base64.java
@@ -14,18 +14,12 @@
 //     Oracle - initial API and implementation from Oracle TopLink
 package org.eclipse.persistence.internal.oxm.conversion;
 
-import java.util.Arrays;
-import java.util.Base64.Encoder;
-
 /**
  * INTERNAL:
  * <p><b>Purpose</b>: Convert to/from XML base64Binary.</p>
  */
 
 public class Base64 {
-
-    // 0.3MB (must be multiple of 3)
-    private static final int BASE64_CHUNK_SIZE = 3 * 100000;
     /**
      * Base64 constructor comment.
      */
@@ -58,25 +52,12 @@ public class Base64 {
 
     /**
      * This method encodes the given byte[] using java.util.Base64.
-     * To improve memory consumption it is parsing data in chunks.
      *
      * @param  data the data
      * @return the base64-encoded <var>data</var> as a String
      */
     public static String base64EncodeToString(byte[] data) {
-        Encoder encoder = java.util.Base64.getEncoder();
-        StringBuilder builder = new StringBuilder();
-        int i = 0;
-        while (i < data.length) {
-            int from = i + BASE64_CHUNK_SIZE;
-            if (from > data.length) {
-                from = data.length;
-            }
-            byte[] chunk = Arrays.copyOfRange(data, i, from);
-            builder.append(encoder.encodeToString(chunk));
-            i = from;
-        }
-        // Total memory pick is 'data' + 'builder x 2'. Builder makes a defensive copy
-        return builder.toString();
+        // Total memory pick is 'data' + 'encoded x 2'
+        return java.util.Base64.getEncoder().encodeToString(data);
     }
 }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/oxm/conversion/Base64.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/oxm/conversion/Base64.java
@@ -14,7 +14,8 @@
 //     Oracle - initial API and implementation from Oracle TopLink
 package org.eclipse.persistence.internal.oxm.conversion;
 
-import jakarta.xml.bind.DatatypeConverter;
+import java.util.Arrays;
+import java.util.Base64.Encoder;
 
 /**
  * INTERNAL:
@@ -23,6 +24,8 @@ import jakarta.xml.bind.DatatypeConverter;
 
 public class Base64 {
 
+    // 0.3MB (must be multiple of 3)
+    private static final int BASE64_CHUNK_SIZE = 3 * 100000;
     /**
      * Base64 constructor comment.
      */
@@ -55,11 +58,25 @@ public class Base64 {
 
     /**
      * This method encodes the given byte[] using java.util.Base64.
+     * To improve memory consumption it is parsing data in chunks.
      *
      * @param  data the data
      * @return the base64-encoded <var>data</var> as a String
      */
     public static String base64EncodeToString(byte[] data) {
-        return DatatypeConverter.printBase64Binary(data);
+        Encoder encoder = java.util.Base64.getEncoder();
+        StringBuilder builder = new StringBuilder();
+        int i = 0;
+        while (i < data.length) {
+            int from = i + BASE64_CHUNK_SIZE;
+            if (from > data.length) {
+                from = data.length;
+            }
+            byte[] chunk = Arrays.copyOfRange(data, i, from);
+            builder.append(encoder.encodeToString(chunk));
+            i = from;
+        }
+        // Total memory pick is 'data' + 'builder x 2'. Builder makes a defensive copy
+        return builder.toString();
     }
 }

--- a/foundation/org.eclipse.persistence.core/src/test/java/org/eclipse/persistence/testing/oxm/xmlconversionmanager/Base64TestCases.java
+++ b/foundation/org.eclipse.persistence.core/src/test/java/org/eclipse/persistence/testing/oxm/xmlconversionmanager/Base64TestCases.java
@@ -60,7 +60,8 @@ public class Base64TestCases extends OXTestCase {
             big[i] = (byte) i;
         }
         String base64 = xcm.buildBase64StringFromBytes(big);
-        // Verifies the implementation is not changing the expected result
+        // Verifies the implementation is not changing the expected result.
+        // Currently this check is unnecessary because implementation is the same.
         assertEquals(java.util.Base64.getEncoder().encodeToString(big), base64);
     }
 }

--- a/foundation/org.eclipse.persistence.core/src/test/java/org/eclipse/persistence/testing/oxm/xmlconversionmanager/Base64TestCases.java
+++ b/foundation/org.eclipse.persistence.core/src/test/java/org/eclipse/persistence/testing/oxm/xmlconversionmanager/Base64TestCases.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -50,5 +50,17 @@ public class Base64TestCases extends OXTestCase {
         } catch(Exception ex) {
             fail("an unexpected exception was thrown " + ex.getMessage());
         }
+    }
+    
+    public void testBase64EncodeToString() {
+        // 2 MB
+        byte[] big = new byte[2000000];
+        // Initialize it with some data
+        for (int i = 0; i < big.length; i++) {
+            big[i] = (byte) i;
+        }
+        String base64 = xcm.buildBase64StringFromBytes(big);
+        // Verifies the implementation is not changing the expected result
+        assertEquals(java.util.Base64.getEncoder().encodeToString(big), base64);
     }
 }


### PR DESCRIPTION
Makes this method more memory efficient getting rid of a byte[] having the base64 encoded.

Although that byte[] will be garbage collected when the method finishes, this is relevant when there are many bytes to encode and multiple tasks like this in parallel.