### PR TITLE
Issue 1573 and 1574 - Fixed types returned by JPQL EXTRACT()

### DIFF
--- a/etc/el-test.mssql.properties
+++ b/etc/el-test.mssql.properties
@@ -13,11 +13,11 @@
 # DB Connection properties
 db.driver=com.microsoft.sqlserver.jdbc.SQLServerDriver
 db.xa.driver=com.microsoft.sqlserver.jdbc.SQLServerDriver
-db.url=jdbc:sqlserver://localhost:1433;database=ecltests
+db.url=jdbc:sqlserver://localhost:1433;database=ecltests;trustServerCertificate=true
 db.user=SA
 db.pwd=SA
 db.platform=org.eclipse.persistence.platform.database.SQLServerPlatform
-db.properties=url=jdbc:sqlserver://localhost:1433;database=ecltests
+db.properties=url=jdbc:sqlserver://localhost:1433;database=ecltests;trustServerCertificate=true
 #db.ddl.debug=true
 datasource.type=java.sql.Driver
 #datasource.type=javax.sql.XADataSource

--- a/etc/el-test.oracle.properties
+++ b/etc/el-test.oracle.properties
@@ -15,6 +15,7 @@ db.driver=oracle.jdbc.OracleDriver
 db.xa.driver=oracle.jdbc.OracleDriver
 #db.xa.driver=oracle.jdbc.xa.client.OracleXADataSource
 db.url=jdbc:oracle:thin:@localhost:1521:ORCL
+#db.url=jdbc:oracle:thin:@localhost:1521/XEPDB1
 #db.url=jdbc:oracle:oci:@localhost:1521:ORCL
 db.user=scott
 db.pwd=tiger
@@ -22,6 +23,7 @@ db.pwd=tiger
 db.platform=org.eclipse.persistence.platform.database.oracle.Oracle12Platform
 #Property names in the next line (URL, User, Password) are case sensitive (Oracle driver only).
 db.properties=URL=jdbc:oracle:thin:@localhost:1521:ORCL;User=scott;Password=tiger
+#db.properties=URL=jdbc:oracle:thin:@localhost:1521/XEPDB1;User=scott;Password=tiger
 #db.properties=URL=jdbc:oracle:oci:@localhost:1521:ORCL;User=scott;Password=tiger
 #Required for Oracle extension modules/tests
 db.platform.oracle.ext=org.eclipse.persistence.platform.database.oracle.Oracle12Platform

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/expressions/ExpressionOperator.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/expressions/ExpressionOperator.java
@@ -36,6 +36,7 @@ import org.eclipse.persistence.exceptions.QueryException;
 import org.eclipse.persistence.internal.expressions.ArgumentListFunctionExpression;
 import org.eclipse.persistence.internal.expressions.ExpressionJavaPrinter;
 import org.eclipse.persistence.internal.expressions.ExpressionSQLPrinter;
+import org.eclipse.persistence.internal.expressions.ExtractOperator;
 import org.eclipse.persistence.internal.expressions.FunctionExpression;
 import org.eclipse.persistence.internal.expressions.LogicalExpression;
 import org.eclipse.persistence.internal.expressions.ObjectExpression;

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/expressions/ExpressionOperator.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/expressions/ExpressionOperator.java
@@ -3135,22 +3135,7 @@ public class ExpressionOperator implements Serializable {
      * Build operator.
      */
     public static ExpressionOperator extract() {
-        ExpressionOperator exOperator = new ExpressionOperator();
-        exOperator.setType(FunctionOperator);
-        exOperator.setSelector(Extract);
-        exOperator.setName("EXTRACT");
-        List<String> v = new ArrayList<>(5);
-        v.add("EXTRACT(");
-        v.add(" FROM ");
-        v.add(")");
-        exOperator.printsAs(v);
-        int[] indices = new int[2];
-        indices[0] = 1;
-        indices[1] = 0;
-        exOperator.setArgumentIndices(indices);
-        exOperator.bePrefix();
-        exOperator.setNodeClass(ClassConstants.FunctionExpression_Class);
-        return exOperator;
+        return new ExtractOperator();
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/expressions/ExtractOperator.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/expressions/ExtractOperator.java
@@ -1,0 +1,486 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     07/29/2022-4.0.0 Tomas Kraus - 1573: Fixed types returned by JPQL EXTRACT()
+package org.eclipse.persistence.expressions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.persistence.internal.expressions.ExpressionJavaPrinter;
+import org.eclipse.persistence.internal.expressions.ExpressionSQLPrinter;
+import org.eclipse.persistence.internal.expressions.LiteralExpression;
+import org.eclipse.persistence.internal.helper.ClassConstants;
+
+/**
+ * Expression operator customization for {@code EXTRACT(<date-time-part> FROM <date-time>)}.
+ * Contains support for platform specific native SQL override for individual {@code <date-time-part>}
+ * values.
+ */
+public class ExtractOperator extends ExpressionOperator {
+
+    // Default native database Strings to be printed for EXTRACT expression
+    private static List<String> defaultDbStrings() {
+        final List<String> dbStrings = new ArrayList<>(5);
+        dbStrings.add("EXTRACT(");
+        dbStrings.add(" FROM ");
+        dbStrings.add(")");
+        return dbStrings;
+    }
+
+    /**
+     * Creates an instance of {@link ExtractOperator} expression.
+     * Default native database Strings are set for EXTRACT expression.
+     */
+    protected ExtractOperator() {
+        this(defaultDbStrings());
+    }
+
+    /**
+     * Creates an instance of {@link ExtractOperator} expression.
+     * Custom native database Strings are set for EXTRACT expression.
+     *
+     * @param dbStrings native database Strings
+     */
+    protected ExtractOperator(List<String> dbStrings) {
+        this.setType(ExpressionOperator.FunctionOperator);
+        this.setSelector(ExpressionOperator.Extract);
+        this.setName("EXTRACT");
+        this.printsAs(dbStrings);
+        this.setArgumentIndices(new int[] {1, 0});
+        this.bePrefix();
+        this.setNodeClass(ClassConstants.FunctionExpression_Class);
+    }
+
+    /**
+     * Default SQL printer for {@code EXTRACT(<date-time-part> FROM <date-time>)}.
+     * It expects 2 arguments (first, second), argument indices array of size 2
+     * and 3 database Strings (prefix, arguments separator and suffix).
+     * Indices swap first and second expression order by default.
+     *
+     * @param first first expression ({@code <date-time>} argument)
+     * @param second second expression ({@code <date-time-part>} argument)
+     * @param printer target printer
+     */
+    private void printPartSql(final Expression first, Expression second, final ExpressionSQLPrinter printer) {
+        if (printer.getPlatform().isDynamicSQLRequiredForFunctions() && Boolean.FALSE.equals(isBindingSupported())) {
+            printer.getCall().setUsesBinding(false);
+        }
+        final int[] indices = getArgumentIndices(2);
+        final String[] dbString = getDatabaseStrings();
+        int dbStringPos = 0;
+        // Print 1st database String (prefix) if defined
+        if (isPrefix() && dbString.length > dbStringPos) {
+            printer.printString(dbString[dbStringPos++]);
+        }
+        // Print first or second argument depending on indices
+        if (indices[0] == 0) {
+            first.printSQL(printer);
+        }
+        if (indices[0] == 1) {
+            second.printSQL(printer);
+        }
+        // Print 2nd database String (arguments separator) if defined
+        if (dbString.length > dbStringPos) {
+            printer.printString(dbString[dbStringPos++]);
+        }
+        // Print first or second argument depending on indices
+        if (indices[1] == 0) {
+            first.printSQL(printer);
+        }
+        if (indices[1] == 1) {
+            second.printSQL(printer);
+        }
+        // Print 3rd database String (suffix) if defined
+        if (dbString.length > dbStringPos) {
+            printer.printString(dbString[dbStringPos]);
+        }
+    }
+
+    /**
+     * Printer for YEAR ({@code <date-time-part>} argument.
+     * This method shall be overriden to implement platform specific SQL printer.
+     *
+     * @param first first expression ({@code <date-time>} argument)
+     * @param second second expression ({@code <date-time-part>} argument)
+     * @param printer target printer
+     */
+    protected void printYearSQL(final Expression first, Expression second, final ExpressionSQLPrinter printer) {
+        printPartSql(first, second, printer);
+    }
+
+    /**
+     * Printer for QUARTER ({@code <date-time-part>} argument.
+     * This method shall be overriden to implement platform specific SQL printer.
+     *
+     * @param first first expression ({@code <date-time>} argument)
+     * @param second second expression ({@code <date-time-part>} argument)
+     * @param printer target printer
+     */
+    protected void printQuarterSQL(final Expression first, Expression second, final ExpressionSQLPrinter printer) {
+        printPartSql(first, second, printer);
+    }
+
+    /**
+     * Printer for MONTH ({@code <date-time-part>} argument.
+     * This method shall be overriden to implement platform specific SQL printer.
+     *
+     * @param first first expression ({@code <date-time>} argument)
+     * @param second second expression ({@code <date-time-part>} argument)
+     * @param printer target printer
+     */
+    protected void printMonthSQL(final Expression first, Expression second, final ExpressionSQLPrinter printer) {
+        printPartSql(first, second, printer);
+    }
+
+    /**
+     * Printer for WEEK ({@code <date-time-part>} argument.
+     * This method shall be overriden to implement platform specific SQL printer.
+     *
+     * @param first first expression ({@code <date-time>} argument)
+     * @param second second expression ({@code <date-time-part>} argument)
+     * @param printer target printer
+     */
+    protected void printWeekSQL(final Expression first, Expression second, final ExpressionSQLPrinter printer) {
+        printPartSql(first, second, printer);
+    }
+
+    /**
+     * Printer for DAY ({@code <date-time-part>} argument.
+     * This method shall be overriden to implement platform specific SQL printer.
+     *
+     * @param first first expression ({@code <date-time>} argument)
+     * @param second second expression ({@code <date-time-part>} argument)
+     * @param printer target printer
+     */
+    protected void printDaySQL(final Expression first, Expression second, final ExpressionSQLPrinter printer) {
+        printPartSql(first, second, printer);
+    }
+
+    /**
+     * Printer for HOUR ({@code <date-time-part>} argument.
+     * This method shall be overriden to implement platform specific SQL printer.
+     *
+     * @param first first expression ({@code <date-time>} argument)
+     * @param second second expression ({@code <date-time-part>} argument)
+     * @param printer target printer
+     */
+    protected void printHourSQL(final Expression first, Expression second, final ExpressionSQLPrinter printer) {
+        printPartSql(first, second, printer);
+    }
+
+    /**
+     * Printer for MINUTE ({@code <date-time-part>} argument.
+     * This method shall be overriden to implement platform specific SQL printer.
+     *
+     * @param first first expression ({@code <date-time>} argument)
+     * @param second second expression ({@code <date-time-part>} argument)
+     * @param printer target printer
+     */
+    protected void printMinuteSQL(final Expression first, Expression second, final ExpressionSQLPrinter printer) {
+        printPartSql(first, second, printer);
+    }
+
+    /**
+     * Printer for SECOND ({@code <date-time-part>} argument.
+     * This method shall be overriden to implement platform specific SQL printer.
+     *
+     * @param first first expression ({@code <date-time>} argument)
+     * @param second second expression ({@code <date-time-part>} argument)
+     * @param printer target printer
+     */
+    protected void printSecondSQL(final Expression first, Expression second, final ExpressionSQLPrinter printer) {
+        printPartSql(first, second, printer);
+    }
+
+    @Override
+    @SuppressWarnings("fallthrough")
+    public void printDuo(Expression first, Expression second, ExpressionSQLPrinter printer) {
+        if (second instanceof LiteralExpression) {
+            switch (((LiteralExpression) second).getValue().toUpperCase()) {
+                case "YEAR":
+                    printYearSQL(first, second, printer);
+                    return;
+                case "QUARTER":
+                    printQuarterSQL(first, second, printer);
+                    return;
+                case "MONTH":
+                    printMonthSQL(first, second, printer);
+                    return;
+                case "WEEK":
+                    printWeekSQL(first, second, printer);
+                    return;
+                case "DAY":
+                    printDaySQL(first, second, printer);
+                    return;
+                case "HOUR":
+                    printHourSQL(first, second, printer);
+                    return;
+                case "MINUTE":
+                    printMinuteSQL(first, second, printer);
+                    return;
+                case "SECOND":
+                    printSecondSQL(first, second, printer);
+                    return;
+            }
+        }
+        super.printDuo(first, second, printer);
+    }
+
+    @Override
+    @SuppressWarnings("fallthrough")
+    public void printCollection(List<Expression> items, ExpressionSQLPrinter printer) {
+        if (items.size() == 2) {
+            final Expression second = items.get(1);
+            if (second instanceof LiteralExpression) {
+                switch (((LiteralExpression) second).getValue().toUpperCase()) {
+                    case "YEAR":
+                        printYearSQL(items.get(0), second, printer);
+                        return;
+                    case "QUARTER":
+                        printQuarterSQL(items.get(0), second, printer);
+                        return;
+                    case "MONTH":
+                        printMonthSQL(items.get(0), second, printer);
+                        return;
+                    case "WEEK":
+                        printWeekSQL(items.get(0), second, printer);
+                        return;
+                    case "DAY":
+                        printDaySQL(items.get(0), second, printer);
+                        return;
+                    case "HOUR":
+                        printHourSQL(items.get(0), second, printer);
+                        return;
+                    case "MINUTE":
+                        printMinuteSQL(items.get(0), second, printer);
+                        return;
+                    case "SECOND":
+                        printSecondSQL(items.get(0), second, printer);
+                        return;
+                }
+            }
+        }
+        super.printCollection(items, printer);
+    }
+
+    /**
+     * Default Java printer for {@code EXTRACT(<date-time-part> FROM <date-time>)}.
+     * It expects 2 arguments (first, second), argument indices array of size 2
+     * and 3 database Strings (prefix, arguments separator and suffix).
+     * Indices swap first and second expression order by default.
+     *
+     * @param first first expression ({@code <date-time>} argument)
+     * @param second second expression ({@code <date-time-part>} argument)
+     * @param printer target printer
+     */
+    private void printPartJava(final Expression first, Expression second, final ExpressionJavaPrinter printer) {
+        final int[] indices = getArgumentIndices(2);
+        final String[] dbString = getDatabaseStrings();
+        // Print prefix from database Strings
+        if (isPrefix()) {
+            printer.printString(dbString[0]);
+        }
+        // Print first or second argument depending on indices
+        if (indices[0] == 0) {
+            first.printJava(printer);
+        }
+        if (indices[0] == 1) {
+            second.printJava(printer);
+        }
+        // Print 2nd database String if defined
+        if (dbString.length > 1) {
+            printer.printString(dbString[1]);
+        }
+        // Print first or second argument depending on indices
+        if (indices[1] == 0) {
+            first.printJava(printer);
+        }
+        if (indices[1] == 1) {
+            second.printJava(printer);
+        }
+        // Print 3rd database String if defined
+        if (dbString.length > 2) {
+            printer.printString(dbString[2]);
+        }
+    }
+
+    /**
+     * Printer for YEAR ({@code <date-time-part>} argument.
+     * This method shall be overriden to implement platform specific Java printer.
+     *
+     * @param first first expression ({@code <date-time>} argument)
+     * @param second second expression ({@code <date-time-part>} argument)
+     * @param printer target printer
+     */
+    protected void printYearJava(final Expression first, Expression second, final ExpressionJavaPrinter printer) {
+        printPartJava(first, second, printer);
+    }
+
+    /**
+     * Printer for QUARTER ({@code <date-time-part>} argument.
+     * This method shall be overriden to implement platform specific Java printer.
+     *
+     * @param first first expression ({@code <date-time>} argument)
+     * @param second second expression ({@code <date-time-part>} argument)
+     * @param printer target printer
+     */
+    protected void printQuarterJava(final Expression first, Expression second, final ExpressionJavaPrinter printer) {
+        printPartJava(first, second, printer);
+    }
+
+    /**
+     * Printer for MONTH ({@code <date-time-part>} argument.
+     * This method shall be overriden to implement platform specific Java printer.
+     *
+     * @param first first expression ({@code <date-time>} argument)
+     * @param second second expression ({@code <date-time-part>} argument)
+     * @param printer target printer
+     */
+    protected void printMonthJava(final Expression first, Expression second, final ExpressionJavaPrinter printer) {
+        printPartJava(first, second, printer);
+    }
+
+    /**
+     * Printer for WEEK ({@code <date-time-part>} argument.
+     * This method shall be overriden to implement platform specific Java printer.
+     *
+     * @param first first expression ({@code <date-time>} argument)
+     * @param second second expression ({@code <date-time-part>} argument)
+     * @param printer target printer
+     */
+    protected void printWeekJava(final Expression first, Expression second, final ExpressionJavaPrinter printer) {
+        printPartJava(first, second, printer);
+    }
+
+    /**
+     * Printer for DAY ({@code <date-time-part>} argument.
+     * This method shall be overriden to implement platform specific Java printer.
+     *
+     * @param first first expression ({@code <date-time>} argument)
+     * @param second second expression ({@code <date-time-part>} argument)
+     * @param printer target printer
+     */
+    protected void printDayJava(final Expression first, Expression second, final ExpressionJavaPrinter printer) {
+        printPartJava(first, second, printer);
+    }
+
+    /**
+     * Printer for HOUR ({@code <date-time-part>} argument.
+     * This method shall be overriden to implement platform specific Java printer.
+     *
+     * @param first first expression ({@code <date-time>} argument)
+     * @param second second expression ({@code <date-time-part>} argument)
+     * @param printer target printer
+     */
+    protected void printHourJava(final Expression first, Expression second, final ExpressionJavaPrinter printer) {
+        printPartJava(first, second, printer);
+    }
+
+    /**
+     * Printer for MINUTE ({@code <date-time-part>} argument.
+     * This method shall be overriden to implement platform specific Java printer.
+     *
+     * @param first first expression ({@code <date-time>} argument)
+     * @param second second expression ({@code <date-time-part>} argument)
+     * @param printer target printer
+     */
+    protected void printMinuteJava(final Expression first, Expression second, final ExpressionJavaPrinter printer) {
+        printPartJava(first, second, printer);
+    }
+
+    /**
+     * Printer for SECOND ({@code <date-time-part>} argument.
+     * This method shall be overriden to implement platform specific Java printer.
+     *
+     * @param first first expression ({@code <date-time>} argument)
+     * @param second second expression ({@code <date-time-part>} argument)
+     * @param printer target printer
+     */
+    protected void printSecondJava(final Expression first, Expression second, final ExpressionJavaPrinter printer) {
+        printPartJava(first, second, printer);
+    }
+
+
+    @Override
+    @SuppressWarnings("fallthrough")
+    public void printJavaDuo(Expression first, Expression second, ExpressionJavaPrinter printer) {
+        if (second instanceof LiteralExpression) {
+            switch (((LiteralExpression) second).getValue().toUpperCase()) {
+                case "YEAR":
+                    printYearJava(first, second, printer);
+                    return;
+                case "QUARTER":
+                    printQuarterJava(first, second, printer);
+                    return;
+                case "MONTH":
+                    printMonthJava(first, second, printer);
+                    return;
+                case "WEEK":
+                    printWeekJava(first, second, printer);
+                    return;
+                case "DAY":
+                    printDayJava(first, second, printer);
+                    return;
+                case "HOUR":
+                    printHourJava(first, second, printer);
+                    return;
+                case "MINUTE":
+                    printMinuteJava(first, second, printer);
+                    return;
+                case "SECOND":
+                    printSecondJava(first, second, printer);
+                    return;
+            }
+        }
+        super.printJavaDuo(first, second, printer);
+    }
+
+    @Override
+    @SuppressWarnings("fallthrough")
+    public void printJavaCollection(List<Expression> items, ExpressionJavaPrinter printer) {
+        if (items.size() == 2) {
+            final Expression second = items.get(1);
+            if (second instanceof LiteralExpression) {
+                switch (((LiteralExpression) second).getValue().toUpperCase()) {
+                    case "YEAR":
+                        printYearJava(items.get(0), second, printer);
+                        return;
+                    case "QUARTER":
+                        printQuarterJava(items.get(0), second, printer);
+                        return;
+                    case "MONTH":
+                        printMonthJava(items.get(0), second, printer);
+                        return;
+                    case "WEEK":
+                        printWeekJava(items.get(0), second, printer);
+                        return;
+                    case "DAY":
+                        printDayJava(items.get(0), second, printer);
+                        return;
+                    case "HOUR":
+                        printHourJava(items.get(0), second, printer);
+                        return;
+                    case "MINUTE":
+                        printMinuteJava(items.get(0), second, printer);
+                        return;
+                    case "SECOND":
+                        printSecondJava(items.get(0), second, printer);
+                        return;
+                }
+            }
+        }
+        super.printJavaCollection(items, printer);
+    }
+
+}

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/ExtractOperator.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/ExtractOperator.java
@@ -203,7 +203,6 @@ public class ExtractOperator extends ExpressionOperator {
     }
 
     @Override
-    @SuppressWarnings("fallthrough")
     public void printDuo(Expression first, Expression second, ExpressionSQLPrinter printer) {
         if (second instanceof LiteralExpression) {
             switch (((LiteralExpression) second).getValue().toUpperCase()) {
@@ -231,13 +230,15 @@ public class ExtractOperator extends ExpressionOperator {
                 case "SECOND":
                     printSecondSQL(first, second, printer);
                     return;
+                default:
+                    throw new IllegalArgumentException("Unknown EXTRACT function datetime_field: "
+                            + ((LiteralExpression) second).getValue().toUpperCase());
             }
         }
         super.printDuo(first, second, printer);
     }
 
     @Override
-    @SuppressWarnings("fallthrough")
     public void printCollection(List<Expression> items, ExpressionSQLPrinter printer) {
         if (items.size() == 2) {
             final Expression second = items.get(1);
@@ -267,6 +268,9 @@ public class ExtractOperator extends ExpressionOperator {
                     case "SECOND":
                         printSecondSQL(items.get(0), second, printer);
                         return;
+                    default:
+                        throw new IllegalArgumentException("Unknown EXTRACT function datetime_field: "
+                                + ((LiteralExpression) second).getValue().toUpperCase());
                 }
             }
         }
@@ -412,7 +416,6 @@ public class ExtractOperator extends ExpressionOperator {
 
 
     @Override
-    @SuppressWarnings("fallthrough")
     public void printJavaDuo(Expression first, Expression second, ExpressionJavaPrinter printer) {
         if (second instanceof LiteralExpression) {
             switch (((LiteralExpression) second).getValue().toUpperCase()) {
@@ -440,13 +443,15 @@ public class ExtractOperator extends ExpressionOperator {
                 case "SECOND":
                     printSecondJava(first, second, printer);
                     return;
+                default:
+                    throw new IllegalArgumentException("Unknown EXTRACT function datetime_field: "
+                            + ((LiteralExpression) second).getValue().toUpperCase());
             }
         }
         super.printJavaDuo(first, second, printer);
     }
 
     @Override
-    @SuppressWarnings("fallthrough")
     public void printJavaCollection(List<Expression> items, ExpressionJavaPrinter printer) {
         if (items.size() == 2) {
             final Expression second = items.get(1);
@@ -476,6 +481,9 @@ public class ExtractOperator extends ExpressionOperator {
                     case "SECOND":
                         printSecondJava(items.get(0), second, printer);
                         return;
+                    default:
+                        throw new IllegalArgumentException("Unknown EXTRACT function datetime_field: "
+                                + ((LiteralExpression) second).getValue().toUpperCase());
                 }
             }
         }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/ExtractOperator.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/ExtractOperator.java
@@ -12,14 +12,13 @@
 
 // Contributors:
 //     07/29/2022-4.0.0 Tomas Kraus - 1573: Fixed types returned by JPQL EXTRACT()
-package org.eclipse.persistence.expressions;
+package org.eclipse.persistence.internal.expressions;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import org.eclipse.persistence.internal.expressions.ExpressionJavaPrinter;
-import org.eclipse.persistence.internal.expressions.ExpressionSQLPrinter;
-import org.eclipse.persistence.internal.expressions.LiteralExpression;
+import org.eclipse.persistence.expressions.Expression;
+import org.eclipse.persistence.expressions.ExpressionOperator;
 import org.eclipse.persistence.internal.helper.ClassConstants;
 
 /**
@@ -42,7 +41,7 @@ public class ExtractOperator extends ExpressionOperator {
      * Creates an instance of {@link ExtractOperator} expression.
      * Default native database Strings are set for EXTRACT expression.
      */
-    protected ExtractOperator() {
+    public ExtractOperator() {
         this(defaultDbStrings());
     }
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/jpa/jpql/ExpressionBuilderVisitor.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/jpa/jpql/ExpressionBuilderVisitor.java
@@ -996,7 +996,26 @@ final class ExpressionBuilderVisitor implements EclipseLinkExpressionVisitor {
         queryExpression = queryExpression.extract(expression.getDatePart());
 
         // Set the expression type
-        type[0] = Object.class;
+        if (expression.hasFrom()) {
+            switch (expression.getDatePart()) {
+                case "YEAR":
+                case "QUARTER":
+                case "MONTH":
+                case "WEEK":
+                case "DAY":
+                case "HOUR":
+                case "MINUTE":
+                    type[0] = Integer.class;
+                    break;
+                case "SECOND":
+                    type[0] = Double.class;
+                    break;
+                default:
+                    type[0] = Object.class;
+            }
+        } else {
+            type[0] = Object.class;
+        }
     }
 
     @Override

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/jpa/jpql/ExpressionBuilderVisitor.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/jpa/jpql/ExpressionBuilderVisitor.java
@@ -987,6 +987,7 @@ final class ExpressionBuilderVisitor implements EclipseLinkExpressionVisitor {
     }
 
     @Override
+    @SuppressWarnings("fallthrough")
     public void visit(ExtractExpression expression) {
 
         // First create the expression from the encapsulated expression
@@ -996,7 +997,7 @@ final class ExpressionBuilderVisitor implements EclipseLinkExpressionVisitor {
         queryExpression = queryExpression.extract(expression.getDatePart());
 
         // Set the expression type
-        if (expression.hasFrom()) {
+        if (expression.hasDatePart()) {
             switch (expression.getDatePart()) {
                 case "YEAR":
                 case "QUARTER":

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/DerbyPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/DerbyPlatform.java
@@ -39,7 +39,7 @@ import java.util.Vector;
 import org.eclipse.persistence.exceptions.ValidationException;
 import org.eclipse.persistence.expressions.Expression;
 import org.eclipse.persistence.expressions.ExpressionOperator;
-import org.eclipse.persistence.expressions.ExtractOperator;
+import org.eclipse.persistence.internal.expressions.ExtractOperator;
 import org.eclipse.persistence.internal.databaseaccess.DatabaseCall;
 import org.eclipse.persistence.internal.databaseaccess.FieldTypeDefinition;
 import org.eclipse.persistence.internal.expressions.CollectionExpression;

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/DerbyPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/DerbyPlatform.java
@@ -518,6 +518,8 @@ public class DerbyPlatform extends DB2Platform {
 
             // QUARTER emulation: ((MONTH(:first)+2)/3)
             private final String[] QUARTER_STRINGS = new String[] {"((MONTH(", ")+2)/3)"};
+            // CAST as FLOAT
+            private final String[] CAST_FLOAT = new String[] {"CAST(", " AS FLOAT)"};
 
             private void printQuarterSQL(final Expression first, final ExpressionSQLPrinter printer) {
                 printer.printString(QUARTER_STRINGS[0]);
@@ -533,21 +535,36 @@ public class DerbyPlatform extends DB2Platform {
 
             @Override
             public void printDuo(Expression first, Expression second, ExpressionSQLPrinter printer) {
-                if (second instanceof LiteralExpression && "QUARTER".equals(((LiteralExpression)second).getValue().toUpperCase())) {
-                    printQuarterSQL(first, printer);
-                } else {
-                    super.printDuo(first, second, printer);
+                if (second instanceof LiteralExpression) {
+                    switch (((LiteralExpression) second).getValue().toUpperCase()) {
+                        case "QUARTER":
+                            printQuarterSQL(first, printer);
+                            return;
+                        case "SECOND":
+                            printer.printString(CAST_FLOAT[0]);
+                            super.printDuo(first, second, printer);
+                            printer.printString(CAST_FLOAT[1]);
+                            return;
+                    }
                 }
+                super.printDuo(first, second, printer);
             }
 
             @Override
             public void printCollection(List<Expression> items, ExpressionSQLPrinter printer) {
                 if (items.size() == 2) {
-                    Expression first = items.get(0);
-                    Expression second = items.get(1);
-                    if (second instanceof LiteralExpression && "QUARTER".equals(((LiteralExpression)second).getValue().toUpperCase())) {
-                        printQuarterSQL(first, printer);
-                        return;
+                    final Expression second = items.get(1);
+                    if (second instanceof LiteralExpression) {
+                        switch (((LiteralExpression) second).getValue().toUpperCase()) {
+                            case "QUARTER":
+                                printQuarterSQL(items.get(0), printer);
+                                return;
+                            case "SECOND":
+                                printer.printString(CAST_FLOAT[0]);
+                                super.printCollection(items, printer);
+                                printer.printString(CAST_FLOAT[1]);
+                                return;
+                        }
                     }
                 }
                 super.printCollection(items, printer);
@@ -555,21 +572,36 @@ public class DerbyPlatform extends DB2Platform {
 
             @Override
             public void printJavaDuo(Expression first, Expression second, ExpressionJavaPrinter printer) {
-                if (second instanceof LiteralExpression && "QUARTER".equals(((LiteralExpression)second).getValue().toUpperCase())) {
-                    printQuarterJava(first, printer);
-                } else {
-                    super.printJavaDuo(first, second, printer);
+                if (second instanceof LiteralExpression) {
+                    switch (((LiteralExpression) second).getValue().toUpperCase()) {
+                        case "QUARTER":
+                            printQuarterJava(first, printer);
+                            return;
+                        case "SECOND":
+                            printer.printString(CAST_FLOAT[0]);
+                            super.printJavaDuo(first, second, printer);
+                            printer.printString(CAST_FLOAT[1]);
+                            return;
+                    }
                 }
+                super.printJavaDuo(first, second, printer);
             }
 
             @Override
             public void printJavaCollection(List<Expression> items, ExpressionJavaPrinter printer) {
                 if (items.size() == 2) {
-                    Expression first = items.get(0);
-                    Expression second = items.get(1);
-                    if (second instanceof LiteralExpression && "QUARTER".equals(((LiteralExpression)second).getValue().toUpperCase())) {
-                        printQuarterJava(first, printer);
-                        return;
+                    final Expression second = items.get(1);
+                    if (second instanceof LiteralExpression) {
+                        switch (((LiteralExpression) second).getValue().toUpperCase()) {
+                            case "QUARTER":
+                                printQuarterJava(items.get(0), printer);
+                                return;
+                            case "SECOND":
+                                printer.printString(CAST_FLOAT[0]);
+                                super.printJavaCollection(items, printer);
+                                printer.printString(CAST_FLOAT[1]);
+                                return;
+                        }
                     }
                 }
                 super.printJavaCollection(items, printer);

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/DerbyPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/DerbyPlatform.java
@@ -39,14 +39,13 @@ import java.util.Vector;
 import org.eclipse.persistence.exceptions.ValidationException;
 import org.eclipse.persistence.expressions.Expression;
 import org.eclipse.persistence.expressions.ExpressionOperator;
-import org.eclipse.persistence.expressions.ListExpressionOperator;
+import org.eclipse.persistence.expressions.ExtractOperator;
 import org.eclipse.persistence.internal.databaseaccess.DatabaseCall;
 import org.eclipse.persistence.internal.databaseaccess.FieldTypeDefinition;
 import org.eclipse.persistence.internal.expressions.CollectionExpression;
 import org.eclipse.persistence.internal.expressions.ConstantExpression;
 import org.eclipse.persistence.internal.expressions.ExpressionJavaPrinter;
 import org.eclipse.persistence.internal.expressions.ExpressionSQLPrinter;
-import org.eclipse.persistence.internal.expressions.LiteralExpression;
 import org.eclipse.persistence.internal.expressions.ParameterExpression;
 import org.eclipse.persistence.internal.expressions.SQLSelectStatement;
 import org.eclipse.persistence.internal.helper.ClassConstants;
@@ -508,121 +507,65 @@ public class DerbyPlatform extends DB2Platform {
         return operator;
     }
 
-    /**
-     * INTERNAL:
-     * Derby does not support EXTRACT, but does have YEAR, MONTH, DAY, etc.
-     */
-    protected ExpressionOperator derbyExtractOperator() {
+    // Derby does not suport native EXTRACT at all. There are specific functions for most of the date/time parts.
+    // QUARTER part needs to be calculated from MONTH value.
+    // SECOND does not return fraction part and there is no fraction specific function available.
+    private static final class DerbyExtractOperator extends ExtractOperator {
 
-        ExpressionOperator exOperator = new ExpressionOperator() {
+        // QUARTER emulation: ((MONTH(:first)+2)/3)
+        private static final String[] QUARTER_STRINGS = new String[] {"((MONTH(", ")+2)/3)"};
+        // SECOND emulation: CAST(SECOND(:first) AS FLOAT)
+        private static final String[] SECOND_STRINGS = new String[] {"CAST(SECOND(", ") AS FLOAT)"};
 
-            // QUARTER emulation: ((MONTH(:first)+2)/3)
-            private final String[] QUARTER_STRINGS = new String[] {"((MONTH(", ")+2)/3)"};
-            // CAST as FLOAT
-            private final String[] CAST_FLOAT = new String[] {"CAST(", " AS FLOAT)"};
+        // Derby native database Strings to be printed for EXTRACT expression
+        // Printing of prefix database String is set to be skipped for Derby
+        private static List<String> derbyDbStrings() {
+            final List<String> dbStrings = new ArrayList<>(2);
+            dbStrings.add("(");
+            dbStrings.add(")");
+            return dbStrings;
+        }
 
-            private void printQuarterSQL(final Expression first, final ExpressionSQLPrinter printer) {
-                printer.printString(QUARTER_STRINGS[0]);
-                first.printSQL(printer);
-                printer.printString(QUARTER_STRINGS[1]);
-            }
+        private DerbyExtractOperator() {
+            // Register custom native database Strings
+            super(derbyDbStrings());
+            // Skip prefix to be printed from database Strings
+            bePostfix();
+        }
 
-            private void printQuarterJava(final Expression first, final ExpressionJavaPrinter printer) {
-                printer.printString(QUARTER_STRINGS[0]);
-                first.printJava(printer);
-                printer.printString(QUARTER_STRINGS[1]);
-            }
+        @Override
+        protected void printQuarterSQL(final Expression first, Expression second, final ExpressionSQLPrinter printer) {
+            printer.printString(QUARTER_STRINGS[0]);
+            first.printSQL(printer);
+            printer.printString(QUARTER_STRINGS[1]);
+        }
 
-            @Override
-            public void printDuo(Expression first, Expression second, ExpressionSQLPrinter printer) {
-                if (second instanceof LiteralExpression) {
-                    switch (((LiteralExpression) second).getValue().toUpperCase()) {
-                        case "QUARTER":
-                            printQuarterSQL(first, printer);
-                            return;
-                        case "SECOND":
-                            printer.printString(CAST_FLOAT[0]);
-                            super.printDuo(first, second, printer);
-                            printer.printString(CAST_FLOAT[1]);
-                            return;
-                    }
-                }
-                super.printDuo(first, second, printer);
-            }
+        @Override
+        protected void printQuarterJava(final Expression first, Expression second, final ExpressionJavaPrinter printer) {
+            printer.printString(QUARTER_STRINGS[0]);
+            first.printJava(printer);
+            printer.printString(QUARTER_STRINGS[1]);
+        }
 
-            @Override
-            public void printCollection(List<Expression> items, ExpressionSQLPrinter printer) {
-                if (items.size() == 2) {
-                    final Expression second = items.get(1);
-                    if (second instanceof LiteralExpression) {
-                        switch (((LiteralExpression) second).getValue().toUpperCase()) {
-                            case "QUARTER":
-                                printQuarterSQL(items.get(0), printer);
-                                return;
-                            case "SECOND":
-                                printer.printString(CAST_FLOAT[0]);
-                                super.printCollection(items, printer);
-                                printer.printString(CAST_FLOAT[1]);
-                                return;
-                        }
-                    }
-                }
-                super.printCollection(items, printer);
-            }
+        @Override
+        protected void printSecondSQL(final Expression first, Expression second, final ExpressionSQLPrinter printer) {
+            printer.printString(SECOND_STRINGS[0]);
+            first.printSQL(printer);
+            printer.printString(SECOND_STRINGS[1]);
+        }
 
-            @Override
-            public void printJavaDuo(Expression first, Expression second, ExpressionJavaPrinter printer) {
-                if (second instanceof LiteralExpression) {
-                    switch (((LiteralExpression) second).getValue().toUpperCase()) {
-                        case "QUARTER":
-                            printQuarterJava(first, printer);
-                            return;
-                        case "SECOND":
-                            printer.printString(CAST_FLOAT[0]);
-                            super.printJavaDuo(first, second, printer);
-                            printer.printString(CAST_FLOAT[1]);
-                            return;
-                    }
-                }
-                super.printJavaDuo(first, second, printer);
-            }
+        @Override
+        protected void printSecondJava(final Expression first, Expression second, final ExpressionJavaPrinter printer) {
+            printer.printString(SECOND_STRINGS[0]);
+            first.printJava(printer);
+            printer.printString(SECOND_STRINGS[1]);
+        }
 
-            @Override
-            public void printJavaCollection(List<Expression> items, ExpressionJavaPrinter printer) {
-                if (items.size() == 2) {
-                    final Expression second = items.get(1);
-                    if (second instanceof LiteralExpression) {
-                        switch (((LiteralExpression) second).getValue().toUpperCase()) {
-                            case "QUARTER":
-                                printQuarterJava(items.get(0), printer);
-                                return;
-                            case "SECOND":
-                                printer.printString(CAST_FLOAT[0]);
-                                super.printJavaCollection(items, printer);
-                                printer.printString(CAST_FLOAT[1]);
-                                return;
-                        }
-                    }
-                }
-                super.printJavaCollection(items, printer);
-            }
-        };
+    }
 
-        exOperator.setType(ExpressionOperator.FunctionOperator);
-        exOperator.setSelector(ExpressionOperator.Extract);
-        exOperator.setName("EXTRACT");
-        List<String> v = new ArrayList<>(3);
-        v.add("");
-        v.add("(");
-        v.add(")");
-        exOperator.printsAs(v);
-        int[] indices = new int[2];
-        indices[0] = 1;
-        indices[1] = 0;
-        exOperator.setArgumentIndices(indices);
-        exOperator.bePrefix();
-        exOperator.setNodeClass(ClassConstants.FunctionExpression_Class);
-        return exOperator;
+    // Create EXTRACT operator form Derby platform
+    private static ExpressionOperator derbyExtractOperator() {
+        return new DerbyExtractOperator();
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/MySQLPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/MySQLPlatform.java
@@ -44,7 +44,7 @@ import java.util.Vector;
 import org.eclipse.persistence.exceptions.ValidationException;
 import org.eclipse.persistence.expressions.Expression;
 import org.eclipse.persistence.expressions.ExpressionOperator;
-import org.eclipse.persistence.expressions.ExtractOperator;
+import org.eclipse.persistence.internal.expressions.ExtractOperator;
 import org.eclipse.persistence.internal.databaseaccess.DatabaseCall;
 import org.eclipse.persistence.internal.databaseaccess.DatasourcePlatform;
 import org.eclipse.persistence.internal.databaseaccess.FieldTypeDefinition;

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/MySQLPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/MySQLPlatform.java
@@ -44,13 +44,13 @@ import java.util.Vector;
 import org.eclipse.persistence.exceptions.ValidationException;
 import org.eclipse.persistence.expressions.Expression;
 import org.eclipse.persistence.expressions.ExpressionOperator;
+import org.eclipse.persistence.expressions.ExtractOperator;
 import org.eclipse.persistence.internal.databaseaccess.DatabaseCall;
 import org.eclipse.persistence.internal.databaseaccess.DatasourcePlatform;
 import org.eclipse.persistence.internal.databaseaccess.FieldTypeDefinition;
 import org.eclipse.persistence.internal.expressions.ExpressionJavaPrinter;
 import org.eclipse.persistence.internal.expressions.ExpressionSQLPrinter;
 import org.eclipse.persistence.internal.expressions.FunctionExpression;
-import org.eclipse.persistence.internal.expressions.LiteralExpression;
 import org.eclipse.persistence.internal.expressions.ParameterExpression;
 import org.eclipse.persistence.internal.expressions.SQLSelectStatement;
 import org.eclipse.persistence.internal.helper.ClassConstants;
@@ -601,99 +601,39 @@ public class MySQLPlatform extends DatabasePlatform {
         return ExpressionOperator.simpleFunctionNoParentheses(ExpressionOperator.CurrentDate, "CURRENT_DATE");
     }
 
-    // MySQL EXTRACT SECOND operator requires CAST to not return Long value.
+    // MySQL EXTRACT SECOND operator need more complex statement to join values of SECOND and MICROSECOND
+    private static final class MySQLExtractOperator extends ExtractOperator {
+
+        // SECOND emulation: (EXTRACT(MICROSECOND FROM date)/1e6+EXTRACT(SECOND FROM date))
+        private static final String[] SECOND_STRINGS = new String[] {"(EXTRACT(MICROSECOND FROM ", ")/1e6+EXTRACT(SECOND FROM ", "))"};
+
+        private MySQLExtractOperator() {
+            super();
+        }
+
+        @Override
+        protected void printSecondSQL(final Expression first, Expression second, final ExpressionSQLPrinter printer) {
+            printer.printString(SECOND_STRINGS[0]);
+            first.printSQL(printer);
+            printer.printString(SECOND_STRINGS[1]);
+            first.printSQL(printer);
+            printer.printString(SECOND_STRINGS[2]);
+        }
+
+        @Override
+        protected void printSecondJava(final Expression first, Expression second, final ExpressionJavaPrinter printer) {
+            printer.printString(SECOND_STRINGS[0]);
+            first.printJava(printer);
+            printer.printString(SECOND_STRINGS[1]);
+            first.printJava(printer);
+            printer.printString(SECOND_STRINGS[2]);
+        }
+
+    }
+
+    // Create EXTRACT operator form MySQL platform
     private static ExpressionOperator mysqlExtractOperator() {
-        ExpressionOperator exOperator = new ExpressionOperator() {
-
-            // SECOND emulation: (EXTRACT(MICROSECOND FROM date)/1e6+EXTRACT(SECOND FROM date))
-            private final String[] SECOND_STRINGS = new String[] {"(EXTRACT(MICROSECOND FROM ", ")/1e6+EXTRACT(SECOND FROM ", "))"};
-
-            private void printSecondSQL(final Expression first, final ExpressionSQLPrinter printer) {
-                printer.printString(SECOND_STRINGS[0]);
-                first.printSQL(printer);
-                printer.printString(SECOND_STRINGS[1]);
-                first.printSQL(printer);
-                printer.printString(SECOND_STRINGS[2]);
-            }
-
-            private void printSecondJava(final Expression first, final ExpressionJavaPrinter printer) {
-                printer.printString(SECOND_STRINGS[0]);
-                first.printJava(printer);
-                printer.printString(SECOND_STRINGS[1]);
-                first.printJava(printer);
-                printer.printString(SECOND_STRINGS[2]);
-            }
-
-            @Override
-            public void printDuo(Expression first, Expression second, ExpressionSQLPrinter printer) {
-                if (second instanceof LiteralExpression) {
-                    switch (((LiteralExpression) second).getValue().toUpperCase()) {
-                        case "SECOND":
-                            printSecondSQL(first, printer);
-                            return;
-                    }
-                }
-                super.printDuo(first, second, printer);
-            }
-
-            @Override
-            public void printCollection(List<Expression> items, ExpressionSQLPrinter printer) {
-                if (items.size() == 2) {
-                    final Expression second = items.get(1);
-                    if (second instanceof LiteralExpression) {
-                        switch (((LiteralExpression) second).getValue().toUpperCase()) {
-                            case "SECOND":
-                                printSecondSQL(items.get(0), printer);
-                                return;
-                        }
-                    }
-                }
-                super.printCollection(items, printer);
-            }
-
-            @Override
-            public void printJavaDuo(Expression first, Expression second, ExpressionJavaPrinter printer) {
-                if (second instanceof LiteralExpression) {
-                    switch (((LiteralExpression) second).getValue().toUpperCase()) {
-                        case "SECOND":
-                            printSecondJava(first, printer);
-                            return;
-                    }
-                }
-                super.printJavaDuo(first, second, printer);
-            }
-
-            @Override
-            public void printJavaCollection(List<Expression> items, ExpressionJavaPrinter printer) {
-                if (items.size() == 2) {
-                    final Expression second = items.get(1);
-                    if (second instanceof LiteralExpression) {
-                        switch (((LiteralExpression) second).getValue().toUpperCase()) {
-                            case "SECOND":
-                                printSecondJava(items.get(0), printer);
-                                return;
-                        }
-                    }
-                }
-                super.printJavaCollection(items, printer);
-            }
-        };
-
-        exOperator.setType(ExpressionOperator.FunctionOperator);
-        exOperator.setSelector(ExpressionOperator.Extract);
-        exOperator.setName("EXTRACT");
-        List<String> v = new ArrayList<>(5);
-        v.add("EXTRACT(");
-        v.add(" FROM ");
-        v.add(")");
-        exOperator.printsAs(v);
-        int[] indices = new int[2];
-        indices[0] = 1;
-        indices[1] = 0;
-        exOperator.setArgumentIndices(indices);
-        exOperator.bePrefix();
-        exOperator.setNodeClass(ClassConstants.FunctionExpression_Class);
-        return exOperator;
+        return new MySQLExtractOperator();
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/OraclePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/OraclePlatform.java
@@ -49,13 +49,13 @@ import org.eclipse.persistence.exceptions.DatabaseException;
 import org.eclipse.persistence.exceptions.ValidationException;
 import org.eclipse.persistence.expressions.Expression;
 import org.eclipse.persistence.expressions.ExpressionOperator;
+import org.eclipse.persistence.expressions.ExtractOperator;
 import org.eclipse.persistence.internal.databaseaccess.DatabaseCall;
 import org.eclipse.persistence.internal.databaseaccess.DatasourceCall.ParameterType;
 import org.eclipse.persistence.internal.databaseaccess.FieldTypeDefinition;
 import org.eclipse.persistence.internal.expressions.ExpressionJavaPrinter;
 import org.eclipse.persistence.internal.expressions.ExpressionSQLPrinter;
 import org.eclipse.persistence.internal.expressions.FunctionExpression;
-import org.eclipse.persistence.internal.expressions.LiteralExpression;
 import org.eclipse.persistence.internal.expressions.RelationExpression;
 import org.eclipse.persistence.internal.expressions.SQLSelectStatement;
 import org.eclipse.persistence.internal.helper.ClassConstants;
@@ -725,117 +725,51 @@ public class OraclePlatform extends org.eclipse.persistence.platform.database.Da
         return exOperator;
     }
 
-    /**
-     * Oracle does not support EXTRACT QUARTER. Can be emulated using TO_NUMBER(TO_CHAR(", ", 'Q')).
-     */
-    private ExpressionOperator oracleExtractOperator() {
+    // Oracle EXTRACT operator needs emulation of QUARTER and WEEK date/time parts.
+    private static final class OracleExtractOperator extends ExtractOperator {
 
-        ExpressionOperator exOperator = new ExpressionOperator() {
+        // QUARTER emulation: TO_NUMBER(TO_CHAR(", ", 'Q'))
+        private static final String[] QUARTER_STRINGS = new String[] {"TO_NUMBER(TO_CHAR(", ", 'Q'))"};
+        // ISO WEEK emulation: TO_NUMBER(TO_CHAR(", ", 'IW'))
+        private static final String[] WEEK_STRINGS = new String[] {"TO_NUMBER(TO_CHAR(", ", 'IW'))"};
 
-            // QUARTER emulation: TO_NUMBER(TO_CHAR(", ", 'Q'))
-            private final String[] QUARTER_STRINGS = new String[] {"TO_NUMBER(TO_CHAR(", ", 'Q'))"};
-            // ISO WEEK emulation: TO_NUMBER(TO_CHAR(", ", 'IW'))
-            private final String[] WEEK_STRINGS = new String[] {"TO_NUMBER(TO_CHAR(", ", 'IW'))"};
+        private OracleExtractOperator() {
+            super();
+        }
 
-            private void printQuarterSQL(final Expression first, final ExpressionSQLPrinter printer) {
-                printer.printString(QUARTER_STRINGS[0]);
-                first.printSQL(printer);
-                printer.printString(QUARTER_STRINGS[1]);
-            }
+        @Override
+        protected void printQuarterSQL(final Expression first, Expression second, final ExpressionSQLPrinter printer) {
+            printer.printString(QUARTER_STRINGS[0]);
+            first.printSQL(printer);
+            printer.printString(QUARTER_STRINGS[1]);
+        }
 
-            private void printQuarterJava(final Expression first, final ExpressionJavaPrinter printer) {
-                printer.printString(QUARTER_STRINGS[0]);
-                first.printJava(printer);
-                printer.printString(QUARTER_STRINGS[1]);
-            }
+        @Override
+        protected void printQuarterJava(final Expression first, Expression second, final ExpressionJavaPrinter printer) {
+            printer.printString(QUARTER_STRINGS[0]);
+            first.printJava(printer);
+            printer.printString(QUARTER_STRINGS[1]);
+        }
 
-            private void printWeekSQL(final Expression first, final ExpressionSQLPrinter printer) {
-                printer.printString(WEEK_STRINGS[0]);
-                first.printSQL(printer);
-                printer.printString(WEEK_STRINGS[1]);
-            }
+        @Override
+        protected void printWeekSQL(final Expression first, Expression second, final ExpressionSQLPrinter printer) {
+            printer.printString(WEEK_STRINGS[0]);
+            first.printSQL(printer);
+            printer.printString(WEEK_STRINGS[1]);
+        }
 
-            private void printWeekJava(final Expression first, final ExpressionJavaPrinter printer) {
-                printer.printString(WEEK_STRINGS[0]);
-                first.printJava(printer);
-                printer.printString(WEEK_STRINGS[1]);
-            }
+        @Override
+        protected void printWeekJava(final Expression first, Expression second, final ExpressionJavaPrinter printer) {
+            printer.printString(WEEK_STRINGS[0]);
+            first.printJava(printer);
+            printer.printString(WEEK_STRINGS[1]);
+        }
 
-            @Override
-            public void printDuo(Expression first, Expression second, ExpressionSQLPrinter printer) {
-                if (second instanceof LiteralExpression) {
-                    switch (((LiteralExpression) second).getValue().toUpperCase()) {
-                        case "QUARTER":
-                            printQuarterSQL(first, printer);
-                            return;
-                        case "WEEK":
-                            printWeekSQL(first, printer);
-                            return;
-                    }
-                }
-                super.printDuo(first, second, printer);
-            }
+    }
 
-            @Override
-            public void printCollection(List<Expression> items, ExpressionSQLPrinter printer) {
-                if (items.size() == 2) {
-                    switch (((LiteralExpression) items.get(1)).getValue().toUpperCase()) {
-                        case "QUARTER":
-                            printQuarterSQL(items.get(0), printer);
-                            return;
-                        case "WEEK":
-                            printWeekSQL(items.get(0), printer);
-                            return;
-                    }
-                }
-                super.printCollection(items, printer);
-            }
-
-            @Override
-            public void printJavaDuo(Expression first, Expression second, ExpressionJavaPrinter printer) {
-                if (second instanceof LiteralExpression) {
-                    switch (((LiteralExpression) second).getValue().toUpperCase()) {
-                        case "QUARTER":
-                            printQuarterJava(first, printer);
-                            return;
-                        case "WEEK":
-                            printWeekJava(first, printer);
-                            return;
-                    }
-                }
-                super.printJavaDuo(first, second, printer);
-            }
-
-            @Override
-            public void printJavaCollection(List<Expression> items, ExpressionJavaPrinter printer) {
-                if (items.size() == 2) {
-                    switch (((LiteralExpression) items.get(1)).getValue().toUpperCase()) {
-                        case "QUARTER":
-                            printQuarterJava(items.get(0), printer);
-                            return;
-                        case "WEEK":
-                            printWeekJava(items.get(0), printer);
-                            return;
-                    }
-                }
-                super.printJavaCollection(items, printer);
-            }
-        };
-        List<String> v = new ArrayList<>(5);
-        exOperator.setType(ExpressionOperator.FunctionOperator);
-        exOperator.setSelector(ExpressionOperator.Extract);
-        exOperator.setName("EXTRACT");
-        v.add("EXTRACT(");
-        v.add(" FROM ");
-        v.add(")");
-        exOperator.printsAs(v);
-        int[] indices = new int[2];
-        indices[0] = 1;
-        indices[1] = 0;
-        exOperator.setArgumentIndices(indices);
-        exOperator.bePrefix();
-        exOperator.setNodeClass(ClassConstants.FunctionExpression_Class);
-        return exOperator;
+    // Create EXTRACT operator form Oracle platform
+    private static ExpressionOperator oracleExtractOperator() {
+        return new OracleExtractOperator();
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/OraclePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/OraclePlatform.java
@@ -49,7 +49,7 @@ import org.eclipse.persistence.exceptions.DatabaseException;
 import org.eclipse.persistence.exceptions.ValidationException;
 import org.eclipse.persistence.expressions.Expression;
 import org.eclipse.persistence.expressions.ExpressionOperator;
-import org.eclipse.persistence.expressions.ExtractOperator;
+import org.eclipse.persistence.internal.expressions.ExtractOperator;
 import org.eclipse.persistence.internal.databaseaccess.DatabaseCall;
 import org.eclipse.persistence.internal.databaseaccess.DatasourceCall.ParameterType;
 import org.eclipse.persistence.internal.databaseaccess.FieldTypeDefinition;

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/PostgreSQLPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/PostgreSQLPlatform.java
@@ -147,6 +147,8 @@ public class PostgreSQLPlatform extends DatabasePlatform {
         addOperator(toNumberOperator());
         addOperator(regexpOperator());
         addOperator(pgsqlRoundOperator());
+        addOperator(ExpressionOperator.simpleFunctionNoParentheses(ExpressionOperator.LocalTime, "LOCALTIME"));
+        addOperator(ExpressionOperator.simpleFunctionNoParentheses(ExpressionOperator.LocalDateTime, "LOCALTIMESTAMP"));
     }
 
     // Emulate ROUND(:x,:n) as FLOOR((:x)*10^(:n)+0.5)/10^(:n)
@@ -231,7 +233,7 @@ public class PostgreSQLPlatform extends DatabasePlatform {
      * Create the ~ operator.
      * REGEXP allows for comparison through regular expression.
      */
-    public static ExpressionOperator regexpOperator() {
+    private static ExpressionOperator regexpOperator() {
         ExpressionOperator result = new ExpressionOperator();
         result.setSelector(ExpressionOperator.Regexp);
         result.setType(ExpressionOperator.FunctionOperator);
@@ -252,7 +254,7 @@ public class PostgreSQLPlatform extends DatabasePlatform {
     /**
      * INTERNAL: Postgres to_number has two arguments, as fix format argument.
      */
-    protected ExpressionOperator toNumberOperator() {
+    private static ExpressionOperator toNumberOperator() {
         ExpressionOperator exOperator = new ExpressionOperator();
         exOperator.setType(ExpressionOperator.FunctionOperator);
         exOperator.setSelector(ExpressionOperator.ToNumber);

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/PostgreSQLPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/PostgreSQLPlatform.java
@@ -233,7 +233,7 @@ public class PostgreSQLPlatform extends DatabasePlatform {
      * Create the ~ operator.
      * REGEXP allows for comparison through regular expression.
      */
-    private static ExpressionOperator regexpOperator() {
+    public static ExpressionOperator regexpOperator() {
         ExpressionOperator result = new ExpressionOperator();
         result.setSelector(ExpressionOperator.Regexp);
         result.setType(ExpressionOperator.FunctionOperator);
@@ -254,7 +254,7 @@ public class PostgreSQLPlatform extends DatabasePlatform {
     /**
      * INTERNAL: Postgres to_number has two arguments, as fix format argument.
      */
-    private static ExpressionOperator toNumberOperator() {
+    protected ExpressionOperator toNumberOperator() {
         ExpressionOperator exOperator = new ExpressionOperator();
         exOperator.setType(ExpressionOperator.FunctionOperator);
         exOperator.setSelector(ExpressionOperator.ToNumber);

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/SQLServerPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/SQLServerPlatform.java
@@ -515,8 +515,26 @@ public class SQLServerPlatform extends org.eclipse.persistence.platform.database
     protected static ExpressionOperator mssqlExtractOperator() {
         ExpressionOperator exOperator = new ExpressionOperator() {
 
+            // SECOND emulation: (CAST(DATEPART(NANOSECOND, date) AS FLOAT)/1000000000 + DATEPART(SECOND, date))
+            private final String[] SECOND_STRINGS = new String[] {"(CAST(DATEPART(NANOSECOND, ", ") AS FLOAT)/1000000000 + DATEPART(SECOND, ", "))"};
             // WEEK replacement: ISO_WEEK
             private final String[] WEEK_STRINGS = new String[] {"DATEPART(ISO_WEEK,", ")"};
+
+            private void printSecondSQL(final Expression first, final ExpressionSQLPrinter printer) {
+                printer.printString(SECOND_STRINGS[0]);
+                first.printSQL(printer);
+                printer.printString(SECOND_STRINGS[1]);
+                first.printSQL(printer);
+                printer.printString(SECOND_STRINGS[2]);
+            }
+
+            private void printSecondJava(final Expression first, final ExpressionJavaPrinter printer) {
+                printer.printString(SECOND_STRINGS[0]);
+                first.printJava(printer);
+                printer.printString(SECOND_STRINGS[1]);
+                first.printJava(printer);
+                printer.printString(SECOND_STRINGS[2]);
+            }
 
             private void printWeekSQL(final Expression first, final ExpressionSQLPrinter printer) {
                 printer.printString(WEEK_STRINGS[0]);
@@ -532,21 +550,32 @@ public class SQLServerPlatform extends org.eclipse.persistence.platform.database
 
             @Override
             public void printDuo(Expression first, Expression second, ExpressionSQLPrinter printer) {
-                if (second instanceof LiteralExpression && "WEEK".equals(((LiteralExpression)second).getValue().toUpperCase())) {
-                    printWeekSQL(first, printer);
-                } else {
-                    super.printDuo(first, second, printer);
+                if (second instanceof LiteralExpression) {
+                    switch (((LiteralExpression) second).getValue().toUpperCase()) {
+                        case "SECOND":
+                            printSecondSQL(first, printer);
+                            return;
+                        case "WEEK":
+                            printWeekSQL(first, printer);
+                            return;
+                    }
                 }
+                super.printDuo(first, second, printer);
             }
 
             @Override
             public void printCollection(List<Expression> items, ExpressionSQLPrinter printer) {
                 if (items.size() == 2) {
-                    Expression first = items.get(0);
-                    Expression second = items.get(1);
-                    if (second instanceof LiteralExpression && "WEEK".equals(((LiteralExpression)second).getValue().toUpperCase())) {
-                        printWeekSQL(first, printer);
-                        return;
+                    final Expression second = items.get(1);
+                    if (second instanceof LiteralExpression) {
+                        switch (((LiteralExpression) second).getValue().toUpperCase()) {
+                            case "SECOND":
+                                printSecondSQL(items.get(0), printer);
+                                return;
+                            case "WEEK":
+                                printWeekSQL(items.get(0), printer);
+                                return;
+                        }
                     }
                 }
                 super.printCollection(items, printer);
@@ -554,21 +583,32 @@ public class SQLServerPlatform extends org.eclipse.persistence.platform.database
 
             @Override
             public void printJavaDuo(Expression first, Expression second, ExpressionJavaPrinter printer) {
-                if (second instanceof LiteralExpression && "WEEK".equals(((LiteralExpression)second).getValue().toUpperCase())) {
-                    printWeekJava(first, printer);
-                } else {
-                    super.printJavaDuo(first, second, printer);
+                if (second instanceof LiteralExpression) {
+                    switch (((LiteralExpression) second).getValue().toUpperCase()) {
+                        case "SECOND":
+                            printSecondJava(first, printer);
+                            return;
+                        case "WEEK":
+                            printWeekJava(first, printer);
+                            return;
+                    }
                 }
+                super.printJavaDuo(first, second, printer);
             }
 
             @Override
             public void printJavaCollection(List<Expression> items, ExpressionJavaPrinter printer) {
                 if (items.size() == 2) {
-                    Expression first = items.get(0);
-                    Expression second = items.get(1);
-                    if (second instanceof LiteralExpression && "WEEK".equals(((LiteralExpression)second).getValue().toUpperCase())) {
-                        printWeekJava(first, printer);
-                        return;
+                    final Expression second = items.get(1);
+                    if (second instanceof LiteralExpression) {
+                        switch (((LiteralExpression) second).getValue().toUpperCase()) {
+                            case "SECOND":
+                                printSecondJava(items.get(0), printer);
+                                return;
+                            case "WEEK":
+                                printWeekJava(items.get(0), printer);
+                                return;
+                        }
                     }
                 }
                 super.printJavaCollection(items, printer);


### PR DESCRIPTION
Issue #1573 - EXTRACT() on second should return a float
              Derby EXTRACT(SECOND FROM ...) returns just seconds (0..55) but added cast to Float type.
Issue #1574 - JPQL parser now sets default expression type based on extracted field.

Also added test to verify EXTRACT(SECOND FROM ...) fraction with expected FP/rounding error less than 1e-6. This test is skipped on Derby where EXTRACT(SECOND FROM ...) returns just seconds.

Tested on Oracle DB/SQL Server/Postgres/MySQL/Derby

TODO: Criteria API implementation for EXTRACT may require similar default type settings.