### PR TITLE
[Master] Add additional UUID tests, including ORM XML declared generators.

### DIFF
--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/uuid/TestUUIDGenerator.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/uuid/TestUUIDGenerator.java
@@ -1,0 +1,413 @@
+/*
+ * Copyright (c) 2022 IBM and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     IBM - initial API and implementation
+
+package org.eclipse.persistence.jpa.test.uuid;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+
+import java.util.UUID;
+
+import org.eclipse.persistence.jpa.test.framework.DDLGen;
+import org.eclipse.persistence.jpa.test.framework.Emf;
+import org.eclipse.persistence.jpa.test.framework.EmfRunner;
+import org.eclipse.persistence.jpa.test.framework.Property;
+import org.eclipse.persistence.jpa.test.uuid.model.EmbeddableUUID_ID;
+import org.eclipse.persistence.jpa.test.uuid.model.UUIDAutoGenEntity;
+import org.eclipse.persistence.jpa.test.uuid.model.UUIDEmbeddableIdEntity;
+import org.eclipse.persistence.jpa.test.uuid.model.UUIDIdClassEntity;
+import org.eclipse.persistence.jpa.test.uuid.model.UUIDUUIDEntity;
+import org.eclipse.persistence.jpa.test.uuid.model.UUIDUUIDGenEntity;
+import org.eclipse.persistence.jpa.test.uuid.model.UUID_IDClass;
+import org.eclipse.persistence.jpa.test.uuid.model.XMLEmbeddableUUID_ID;
+import org.eclipse.persistence.jpa.test.uuid.model.XMLUUIDEmbeddableIdEntity;
+import org.eclipse.persistence.jpa.test.uuid.model.XMLUUIDEntity;
+import org.eclipse.persistence.jpa.test.uuid.model.XMLUUIDIdClassEntity;
+import org.eclipse.persistence.jpa.test.uuid.model.XMLUUIDUUIDGenEntity;
+import org.eclipse.persistence.jpa.test.uuid.model.XMLUUID_IDClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+
+@RunWith(EmfRunner.class)
+public class TestUUIDGenerator {
+	@Emf(name = "uuidGeneratorsEmf", createTables = DDLGen.DROP_CREATE, classes = { 
+			EmbeddableUUID_ID.class, UUID_IDClass.class, UUIDEmbeddableIdEntity.class, UUIDIdClassEntity.class, UUIDUUIDEntity.class, 
+			UUIDUUIDGenEntity.class, UUIDAutoGenEntity.class, 
+			XMLEmbeddableUUID_ID.class, XMLUUID_IDClass.class, XMLUUIDEmbeddableIdEntity.class , XMLUUIDIdClassEntity.class, XMLUUIDEntity.class, 
+			XMLUUIDUUIDGenEntity.class}, 
+			mappingFiles = { "META-INF/uuid-orm.xml"},
+			properties = { @Property(name="eclipselink.cache.shared.default", value="false") } )
+    private EntityManagerFactory uuidEmf;
+	
+	@Test
+    public void testBasicUUIDIdentity() {
+		EntityManager em = uuidEmf.createEntityManager();
+		
+        try {
+            em.getTransaction().begin();
+            
+            UUID id = UUID.randomUUID();
+            UUIDUUIDEntity entity = new UUIDUUIDEntity();
+            entity.setId(id);
+            entity.setName("Victor Von Doom");
+            em.persist(entity);
+            
+            em.getTransaction().commit();
+            
+            em.clear();
+            assertFalse(em.contains(entity));
+
+            UUIDUUIDEntity findEntity = em.find(UUIDUUIDEntity.class, id);
+            assertNotNull(findEntity);
+            assertEquals(id, findEntity.getId());
+            assertNotSame(id, findEntity.getId());
+            assertNotSame(entity, findEntity);
+        } catch (AssertionError ae) {
+            throw ae;
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            em.close();
+        }
+    }
+	
+	@Test
+    public void testBasicUUIDIdentity_XML() {
+		EntityManager em = uuidEmf.createEntityManager();
+		
+        try {
+            em.getTransaction().begin();
+            
+            UUID id = UUID.randomUUID();
+            XMLUUIDEntity entity = new XMLUUIDEntity();
+            entity.setId(id);
+            entity.setName("Victor Von Doom");
+            em.persist(entity);
+            
+            em.getTransaction().commit();
+            
+            em.clear();
+            assertFalse(em.contains(entity));
+
+            XMLUUIDEntity findEntity = em.find(XMLUUIDEntity.class, id);
+            assertNotNull(findEntity);
+            assertEquals(id, findEntity.getId());
+            assertNotSame(id, findEntity.getId());
+            assertNotSame(entity, findEntity);
+        } catch (AssertionError ae) {
+            throw ae;
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            em.close();
+        }
+    }
+	
+	@Test
+    public void testBasic_EmbeddableID_UUIDIdentity() {
+		EntityManager em = uuidEmf.createEntityManager();
+		
+        try {
+            em.getTransaction().begin();
+            
+            UUID id = UUID.randomUUID();
+            EmbeddableUUID_ID emb_id = new EmbeddableUUID_ID();
+            emb_id.setId(id);
+            
+            UUIDEmbeddableIdEntity entity = new UUIDEmbeddableIdEntity();
+            entity.setId(emb_id);
+            entity.setName("Kang the Conquerer");
+            em.persist(entity);
+            
+            em.getTransaction().commit();
+            
+            em.clear();
+            assertFalse(em.contains(entity));
+
+            EmbeddableUUID_ID find_emb_id = new EmbeddableUUID_ID();
+            find_emb_id.setId(id);
+            UUIDEmbeddableIdEntity findEntity = em.find(UUIDEmbeddableIdEntity.class, find_emb_id);
+            
+            assertNotNull(findEntity);
+            assertEquals(emb_id, findEntity.getId());
+            assertNotSame(emb_id, findEntity.getId());
+            assertNotSame(entity, findEntity);
+        } catch (AssertionError ae) {
+            throw ae;
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            em.close();
+        }
+    }
+	
+	@Test
+    public void testBasic_EmbeddableID_UUIDIdentity_XML() {
+		EntityManager em = uuidEmf.createEntityManager();
+		
+        try {
+            em.getTransaction().begin();
+            
+            UUID id = UUID.randomUUID();
+            XMLEmbeddableUUID_ID emb_id = new XMLEmbeddableUUID_ID();
+            emb_id.setEId(id);
+            
+            XMLUUIDEmbeddableIdEntity entity = new XMLUUIDEmbeddableIdEntity();
+            entity.setId(emb_id);
+            entity.setName("Kang the Conquerer");
+            em.persist(entity);
+            
+            em.getTransaction().commit();
+            
+            em.clear();
+            assertFalse(em.contains(entity));
+
+            XMLEmbeddableUUID_ID find_emb_id = new XMLEmbeddableUUID_ID();
+            find_emb_id.setEId(id);
+            XMLUUIDEmbeddableIdEntity findEntity = em.find(XMLUUIDEmbeddableIdEntity.class, find_emb_id);
+            
+            assertNotNull(findEntity);
+            assertEquals(emb_id, findEntity.getId());
+            assertNotSame(emb_id, findEntity.getId());
+            assertNotSame(entity, findEntity);
+        } catch (AssertionError ae) {
+            throw ae;
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            em.close();
+        }
+    }
+	
+	@Test
+    public void testBasic_IDClass_UUIDIdentity() {
+		EntityManager em = uuidEmf.createEntityManager();
+		
+        try {
+            em.getTransaction().begin();
+            
+            UUID id = UUID.randomUUID();
+            long lid = System.currentTimeMillis();
+            
+            UUIDIdClassEntity entity = new UUIDIdClassEntity();
+            entity.setUuid_id(id);
+            entity.setL_id(lid);
+            entity.setName("Thanos the Mad Titan");
+            em.persist(entity);
+            
+            em.getTransaction().commit();
+            
+            em.clear();
+            assertFalse(em.contains(entity));
+
+            UUID_IDClass find_idclass = new UUID_IDClass();
+            find_idclass.setUuid_id(id);
+            find_idclass.setL_id(lid);
+            
+            UUIDIdClassEntity findEntity = em.find(UUIDIdClassEntity.class, find_idclass);
+            assertNotNull(findEntity);
+            assertEquals(id, findEntity.getUuid_id());
+            assertNotSame(id, findEntity.getUuid_id());
+            assertNotSame(entity, findEntity);
+        } catch (AssertionError ae) {
+            throw ae;
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            em.close();
+        }
+    }
+	
+	@Test
+    public void testBasic_IDClass_UUIDIdentity_XML() {
+		EntityManager em = uuidEmf.createEntityManager();
+		
+        try {
+            em.getTransaction().begin();
+            
+            UUID id = UUID.randomUUID();
+            long lid = System.currentTimeMillis();
+            
+            XMLUUIDIdClassEntity entity = new XMLUUIDIdClassEntity();
+            entity.setUuid_id(id);
+            entity.setL_id(lid);
+            entity.setName("Thanos the Mad Titan");
+            em.persist(entity);
+            
+            em.getTransaction().commit();
+            
+            em.clear();
+            assertFalse(em.contains(entity));
+
+            XMLUUID_IDClass find_idclass = new XMLUUID_IDClass();
+            find_idclass.setUuid_id(id);
+            find_idclass.setL_id(lid);
+            
+            XMLUUIDIdClassEntity findEntity = em.find(XMLUUIDIdClassEntity.class, find_idclass);
+            assertNotNull(findEntity);
+            assertEquals(id, findEntity.getUuid_id());
+            assertNotSame(id, findEntity.getUuid_id());
+            assertNotSame(entity, findEntity);
+        } catch (AssertionError ae) {
+            throw ae;
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            em.close();
+        }
+    }
+	
+    // @Test // Fails, see https://github.com/eclipse-ee4j/eclipselink/issues/1625
+    public void testBasicUUIDIdentity_AUTO_Generator() {
+		EntityManager em = uuidEmf.createEntityManager();
+		
+        try {
+            em.getTransaction().begin();
+            
+            UUIDAutoGenEntity entity = new UUIDAutoGenEntity();
+            entity.setName("Ultron");
+            em.persist(entity);
+            
+            em.getTransaction().commit();
+            
+            UUID id = entity.getId();
+            assertNotNull(id);
+            
+            em.clear();
+            assertFalse(em.contains(entity));
+
+            UUIDAutoGenEntity findEntity = em.find(UUIDAutoGenEntity.class, id);
+            assertNotNull(findEntity);
+            assertEquals(id, findEntity.getId());
+            assertNotSame(id, findEntity.getId());
+            assertNotSame(entity, findEntity);
+        } catch (AssertionError ae) {
+            throw ae;
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            em.close();
+        }
+    }
+	
+	@Test
+    public void testBasicUUIDIdentity_UUID_Generator() {
+		EntityManager em = uuidEmf.createEntityManager();
+		
+        try {
+            em.getTransaction().begin();
+            
+            UUIDUUIDGenEntity entity = new UUIDUUIDGenEntity();
+            entity.setName("Ultron");
+            em.persist(entity);
+            
+            em.getTransaction().commit();
+            
+            UUID id = entity.getId();
+            assertNotNull(id);
+            
+            em.clear();
+            assertFalse(em.contains(entity));
+
+            UUIDUUIDGenEntity findEntity = em.find(UUIDUUIDGenEntity.class, id);
+            assertNotNull(findEntity);
+            assertEquals(id, findEntity.getId());
+            assertNotSame(id, findEntity.getId());
+            assertNotSame(entity, findEntity);
+        } catch (AssertionError ae) {
+            throw ae;
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            em.close();
+        }
+    }
+	
+	@Test
+    public void testBasicUUIDIdentity_UUID_Generator_XML() {
+		EntityManager em = uuidEmf.createEntityManager();
+		
+        try {
+            em.getTransaction().begin();
+            
+            XMLUUIDUUIDGenEntity entity = new XMLUUIDUUIDGenEntity();
+            entity.setName("Ultron");
+            em.persist(entity);
+            
+            em.getTransaction().commit();
+            
+            UUID id = entity.getId();
+            assertNotNull(id);
+            
+            em.clear();
+            assertFalse(em.contains(entity));
+
+            XMLUUIDUUIDGenEntity findEntity = em.find(XMLUUIDUUIDGenEntity.class, id);
+            assertNotNull(findEntity);
+            assertEquals(id, findEntity.getId());
+            assertNotSame(id, findEntity.getId());
+            assertNotSame(entity, findEntity);
+        } catch (AssertionError ae) {
+            throw ae;
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            em.close();
+        }
+    }
+	
+	
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/uuid/model/EmbeddableUUID_ID.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/uuid/model/EmbeddableUUID_ID.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2022 IBM and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     IBM - initial API and implementation
+
+package org.eclipse.persistence.jpa.test.uuid.model;
+
+import java.util.UUID;
+
+import jakarta.persistence.Embeddable;
+
+/**
+ *
+ */
+@Embeddable
+public class EmbeddableUUID_ID {
+    private UUID id;
+
+    public EmbeddableUUID_ID() {
+
+    }
+
+    public EmbeddableUUID_ID(UUID id) {
+        this.id = id;
+    }
+
+    /**
+     * @return the id
+     */
+    public UUID getId() {
+        return id;
+    }
+
+    /**
+     * @param id the id to set
+     */
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        EmbeddableUUID_ID other = (EmbeddableUUID_ID) obj;
+        if (id == null) {
+            if (other.id != null)
+                return false;
+        } else if (!id.equals(other.id))
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "EmbeddableUUID_ID [id=" + id + "]";
+    }
+
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/uuid/model/UUIDAutoGenEntity.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/uuid/model/UUIDAutoGenEntity.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2022 IBM and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     IBM - initial API and implementation
+
+package org.eclipse.persistence.jpa.test.uuid.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "UUIDAutoGenEntity")
+public class UUIDAutoGenEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
+    private String name;
+
+    public UUIDAutoGenEntity() {
+    }
+
+    public UUIDAutoGenEntity(UUID id) {
+        this.id = id;
+    }
+
+    public UUIDAutoGenEntity(UUID id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "UUIDAutoGenEntity{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                '}';
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/uuid/model/UUIDEmbeddableIdEntity.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/uuid/model/UUIDEmbeddableIdEntity.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2022 IBM and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     IBM - initial API and implementation
+
+package org.eclipse.persistence.jpa.test.uuid.model;
+
+import java.util.UUID;
+
+import jakarta.persistence.Basic;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+
+@Entity
+public class UUIDEmbeddableIdEntity {
+	@EmbeddedId
+    private EmbeddableUUID_ID id;
+
+    private String name;
+
+    public UUIDEmbeddableIdEntity() {
+    }
+
+    public UUIDEmbeddableIdEntity(EmbeddableUUID_ID id) {
+        this.id = id;
+    }
+
+    public UUIDEmbeddableIdEntity(EmbeddableUUID_ID id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public EmbeddableUUID_ID getId() {
+        return id;
+    }
+
+    public void setId(EmbeddableUUID_ID id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "UUIDEmbeddableIdEntity{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                '}';
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/uuid/model/UUIDIdClassEntity.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/uuid/model/UUIDIdClassEntity.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2022 IBM and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     IBM - initial API and implementation
+
+package org.eclipse.persistence.jpa.test.uuid.model;
+import java.util.UUID;
+
+import jakarta.persistence.Basic;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+
+@Entity
+@IdClass(UUID_IDClass.class)
+public class UUIDIdClassEntity {
+    @Id
+    private UUID uuid_id;
+
+    @Id
+    private long l_id;
+
+    @Basic
+    private String name;
+
+    public UUIDIdClassEntity() {
+
+    }
+
+    /**
+     * @return the uuid_id
+     */
+    public UUID getUuid_id() {
+        return uuid_id;
+    }
+
+    /**
+     * @param uuid_id the uuid_id to set
+     */
+    public void setUuid_id(UUID uuid_id) {
+        this.uuid_id = uuid_id;
+    }
+
+    /**
+     * @return the l_id
+     */
+    public long getL_id() {
+        return l_id;
+    }
+
+    /**
+     * @param l_id the l_id to set
+     */
+    public void setL_id(long l_id) {
+        this.l_id = l_id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "UUIDIdClassEntity [uuid_id=" + uuid_id + ", l_id=" + l_id + ", name=" + name + "]";
+    }
+
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/uuid/model/UUIDUUIDGenEntity.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/uuid/model/UUIDUUIDGenEntity.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2022 IBM and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     IBM - initial API and implementation
+
+package org.eclipse.persistence.jpa.test.uuid.model;
+
+import java.util.UUID;
+
+import jakarta.persistence.Basic;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class UUIDUUIDGenEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Basic
+    private String name;
+
+    public UUIDUUIDGenEntity() {
+
+    }
+
+    /**
+     * @return the id
+     */
+    public UUID getId() {
+        return id;
+    }
+
+    /**
+     * @param id the id to set
+     */
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    /**
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "UUIDUUIDGenEntity [id=" + id + ", name=" + name + "]";
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/uuid/model/UUID_IDClass.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/uuid/model/UUID_IDClass.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2022 IBM and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     IBM - initial API and implementation
+
+package org.eclipse.persistence.jpa.test.uuid.model;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+import jakarta.persistence.Id;
+
+/**
+ *
+ */
+public class UUID_IDClass implements Serializable {
+    @Id
+    private UUID uuid_id;
+
+    @Id
+    private long l_id;
+
+    public UUID_IDClass() {
+
+    }
+
+    /**
+     * @return the uuid_id
+     */
+    public UUID getUuid_id() {
+        return uuid_id;
+    }
+
+    /**
+     * @param uuid_id the uuid_id to set
+     */
+    public void setUuid_id(UUID uuid_id) {
+        this.uuid_id = uuid_id;
+    }
+
+    /**
+     * @return the l_id
+     */
+    public long getL_id() {
+        return l_id;
+    }
+
+    /**
+     * @param l_id the l_id to set
+     */
+    public void setL_id(long l_id) {
+        this.l_id = l_id;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + (int) (l_id ^ (l_id >>> 32));
+        result = prime * result + ((uuid_id == null) ? 0 : uuid_id.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        UUID_IDClass other = (UUID_IDClass) obj;
+        if (l_id != other.l_id)
+            return false;
+        if (uuid_id == null) {
+            if (other.uuid_id != null)
+                return false;
+        } else if (!uuid_id.equals(other.uuid_id))
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "UUID_IDClass [uuid_id=" + uuid_id + ", l_id=" + l_id + "]";
+    }
+
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/uuid/model/XMLEmbeddableUUID_ID.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/uuid/model/XMLEmbeddableUUID_ID.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2022 IBM and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     IBM - initial API and implementation
+
+package org.eclipse.persistence.jpa.test.uuid.model;
+
+import java.util.UUID;
+
+/**
+ *
+ */
+public class XMLEmbeddableUUID_ID {
+    private UUID eid;
+
+    public XMLEmbeddableUUID_ID() {
+
+    }
+
+    public XMLEmbeddableUUID_ID(UUID id) {
+        this.eid = id;
+    }
+
+    /**
+     * @return the id
+     */
+    public UUID getEId() {
+        return eid;
+    }
+
+    /**
+     * @param id the id to set
+     */
+    public void setEId(UUID id) {
+        this.eid = id;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((eid == null) ? 0 : eid.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        XMLEmbeddableUUID_ID other = (XMLEmbeddableUUID_ID) obj;
+        if (eid == null) {
+            if (other.eid != null)
+                return false;
+        } else if (!eid.equals(other.eid))
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLEmbeddableUUID_ID [eid=" + eid + "]";
+    }
+
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/uuid/model/XMLUUIDEmbeddableIdEntity.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/uuid/model/XMLUUIDEmbeddableIdEntity.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022 IBM and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     IBM - initial API and implementation
+
+package org.eclipse.persistence.jpa.test.uuid.model;
+
+public class XMLUUIDEmbeddableIdEntity {
+    private XMLEmbeddableUUID_ID id;
+
+    private String name;
+
+    public XMLUUIDEmbeddableIdEntity() {
+
+    }
+
+    /**
+     * @return the id
+     */
+    public XMLEmbeddableUUID_ID getId() {
+        return id;
+    }
+
+    /**
+     * @param id the id to set
+     */
+    public void setId(XMLEmbeddableUUID_ID id) {
+        this.id = id;
+    }
+
+    /**
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param name the name to set
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLUUIDEmbeddableIdEntity [id=" + id + ", name=" + name + "]";
+    }
+
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/uuid/model/XMLUUIDEntity.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/uuid/model/XMLUUIDEntity.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022 IBM and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     IBM - initial API and implementation
+
+package org.eclipse.persistence.jpa.test.uuid.model;
+
+import java.util.UUID;
+
+public class XMLUUIDEntity {
+	private UUID id;
+
+    private String name;
+
+    public XMLUUIDEntity() {
+    }
+
+    public XMLUUIDEntity(UUID id) {
+        this.id = id;
+    }
+
+    public XMLUUIDEntity(UUID id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLUUIDUUIDEntity{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                '}';
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/uuid/model/XMLUUIDIdClassEntity.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/uuid/model/XMLUUIDIdClassEntity.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2022 IBM and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     IBM - initial API and implementation
+
+package org.eclipse.persistence.jpa.test.uuid.model;
+
+import java.util.UUID;
+
+public class XMLUUIDIdClassEntity {
+    private UUID uuid_id;
+
+    private long l_id;
+
+    private String name;
+
+    public XMLUUIDIdClassEntity() {
+
+    }
+
+    /**
+     * @return the uuid_id
+     */
+    public UUID getUuid_id() {
+        return uuid_id;
+    }
+
+    /**
+     * @param uuid_id the uuid_id to set
+     */
+    public void setUuid_id(UUID uuid_id) {
+        this.uuid_id = uuid_id;
+    }
+
+    /**
+     * @return the l_id
+     */
+    public long getL_id() {
+        return l_id;
+    }
+
+    /**
+     * @param l_id the l_id to set
+     */
+    public void setL_id(long l_id) {
+        this.l_id = l_id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLUUIDIdClassEntity [uuid_id=" + uuid_id + ", l_id=" + l_id + ", name=" + name + "]";
+    }
+
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/uuid/model/XMLUUIDUUIDGenEntity.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/uuid/model/XMLUUIDUUIDGenEntity.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022 IBM and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     IBM - initial API and implementation
+
+package org.eclipse.persistence.jpa.test.uuid.model;
+
+import java.util.UUID;
+
+public class XMLUUIDUUIDGenEntity {
+    private UUID id;
+
+    private String name;
+
+    public XMLUUIDUUIDGenEntity() {
+
+    }
+
+    /**
+     * @return the id
+     */
+    public UUID getId() {
+        return id;
+    }
+
+    /**
+     * @param id the id to set
+     */
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLUUIDUUIDGenEntity [id=" + id + ", name=" + name + "]";
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/uuid/model/XMLUUID_IDClass.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/uuid/model/XMLUUID_IDClass.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2022 IBM and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     IBM - initial API and implementation
+
+package org.eclipse.persistence.jpa.test.uuid.model;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+/**
+ *
+ */
+public class XMLUUID_IDClass implements Serializable {
+
+    private UUID uuid_id;
+    private long l_id;
+
+    public XMLUUID_IDClass() {
+
+    }
+
+    /**
+     * @return the uuid_id
+     */
+    public UUID getUuid_id() {
+        return uuid_id;
+    }
+
+    /**
+     * @param uuid_id the uuid_id to set
+     */
+    public void setUuid_id(UUID uuid_id) {
+        this.uuid_id = uuid_id;
+    }
+
+    /**
+     * @return the l_id
+     */
+    public long getL_id() {
+        return l_id;
+    }
+
+    /**
+     * @param l_id the l_id to set
+     */
+    public void setL_id(long l_id) {
+        this.l_id = l_id;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + (int) (l_id ^ (l_id >>> 32));
+        result = prime * result + ((uuid_id == null) ? 0 : uuid_id.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        XMLUUID_IDClass other = (XMLUUID_IDClass) obj;
+        if (l_id != other.l_id)
+            return false;
+        if (uuid_id == null) {
+            if (other.uuid_id != null)
+                return false;
+        } else if (!uuid_id.equals(other.uuid_id))
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLUUID_IDClass [uuid_id=" + uuid_id + ", l_id=" + l_id + "]";
+    }
+
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/resources/META-INF/uuid-orm.xml
+++ b/jpa/eclipselink.jpa.test.jse/src/it/resources/META-INF/uuid-orm.xml
@@ -1,0 +1,42 @@
+<entity-mappings xmlns="https://jakarta.ee/xml/ns/persistence/orm"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence/orm
+    https://jakarta.ee/xml/ns/persistence/orm/orm_3_1.xsd"
+  version="3.1">
+
+  <entity class="org.eclipse.persistence.jpa.test.uuid.model.XMLUUIDEmbeddableIdEntity">
+     <attributes>
+        <embedded-id name="id"/>
+        <basic name="name" />
+     </attributes>
+  </entity>
+  <entity class="org.eclipse.persistence.jpa.test.uuid.model.XMLUUIDEntity">
+     <attributes>
+        <id name="id" />
+        <basic name="name" />
+     </attributes>
+  </entity>
+  <entity class="org.eclipse.persistence.jpa.test.uuid.model.XMLUUIDIdClassEntity">
+     <id-class class="org.eclipse.persistence.jpa.test.uuid.model.XMLUUID_IDClass"/>
+     <attributes>
+        <id name="uuid_id" />
+        <id name="l_id" />
+        <basic name="name" />
+     </attributes>
+  </entity>
+  <entity class="org.eclipse.persistence.jpa.test.uuid.model.XMLUUIDUUIDGenEntity">
+     <attributes>
+        <id name="id">
+            <generated-value strategy="UUID" />
+        </id>
+        <basic name="name" />
+     </attributes>
+  </entity>
+  
+  <embeddable class="org.eclipse.persistence.jpa.test.uuid.model.XMLEmbeddableUUID_ID">
+     <attributes>
+        <basic name="eid" />
+     </attributes>
+  </embeddable>
+
+</entity-mappings>


### PR DESCRIPTION
Adding more detailed testing for the UUID function, including a disabled test (see #1625) .  These tests include the addition of testing the 3.1 ORM XML declaration of UUID generators, to ensure that parsing is exercised.