### PR TITLE
[2.7] Jenkins build - Docker build image revert

### DIFF
--- a/etc/jenkins/build.groovy
+++ b/etc/jenkins/build.groovy
@@ -77,7 +77,7 @@ spec:
         memory: "12Gi"
         cpu: "6"
         cpu: "5.5"
-    image: tkraus/el-build:2.0.2
+    image: tkraus/el-build:2.0.1
     volumeMounts:
     - name: tools
       mountPath: /opt/tools

--- a/etc/jenkins/build.groovy
+++ b/etc/jenkins/build.groovy
@@ -77,7 +77,7 @@ spec:
         memory: "12Gi"
         cpu: "6"
         cpu: "5.5"
-    image: tkraus/el-build:2.0.1
+    image: tkraus/el-build:2.0.2
     volumeMounts:
     - name: tools
       mountPath: /opt/tools

--- a/etc/jenkins/pr_verify.groovy
+++ b/etc/jenkins/pr_verify.groovy
@@ -63,7 +63,7 @@ spec:
       requests:
         memory: "6Gi"
         cpu: "3"
-    image: tkraus/el-build:2.0.2
+    image: tkraus/el-build:2.0.1
     volumeMounts:
     - name: tools
       mountPath: /opt/tools

--- a/etc/jenkins/pr_verify.groovy
+++ b/etc/jenkins/pr_verify.groovy
@@ -63,7 +63,7 @@ spec:
       requests:
         memory: "6Gi"
         cpu: "3"
-    image: tkraus/el-build:2.0.1
+    image: tkraus/el-build:2.0.2
     volumeMounts:
     - name: tools
       mountPath: /opt/tools

--- a/etc/jenkins/promote.groovy
+++ b/etc/jenkins/promote.groovy
@@ -73,7 +73,7 @@ spec:
       requests:
         memory: "2Gi"
         cpu: "1"
-    image: tkraus/el-build:2.0.1
+    image: tkraus/el-build:2.0.2
     volumeMounts:
     - name: tools
       mountPath: /opt/tools

--- a/etc/jenkins/promote.groovy
+++ b/etc/jenkins/promote.groovy
@@ -73,7 +73,7 @@ spec:
       requests:
         memory: "2Gi"
         cpu: "1"
-    image: tkraus/el-build:2.0.2
+    image: tkraus/el-build:1.1.9
     volumeMounts:
     - name: tools
       mountPath: /opt/tools
@@ -123,6 +123,7 @@ spec:
                             """
                         // Prepare and promote EclipseLink artifacts to oss.sonatype.org (staging)
                         sh """
+                            . /etc/profile
                             curl --version
                             $JAVA_HOME/bin/java -version
                             echo JAVA_HOME = ${JAVA_HOME}


### PR DESCRIPTION
Docker build image revert as is unable to create 2.0.2. Promotion pipeline is reverted to 1.1.9 due a zip, unzip tools requirement.