### PR TITLE
FS layers squash turned off (commented out) in Docker build.

### DIFF
--- a/etc/jenkins/docker/pom.xml
+++ b/etc/jenkins/docker/pom.xml
@@ -195,7 +195,7 @@
                             <build>
                                 <contextDir>${project.build.directory}/image</contextDir>
                                 <buildOptions>
-                                    <squash/>
+                                    <!--squash/-->
                                 </buildOptions>
                             </build>
                         </image>


### PR DESCRIPTION
Looks like this feature is broken in current maven Docker plugin.