### PR TITLE
[master] OracleNoSQL platform switch to new driver

### DIFF
--- a/etc/el-test.oracle.properties
+++ b/etc/el-test.oracle.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2022 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at
@@ -40,5 +40,19 @@ logging.level=info
 db.sys.user=sys
 db.sys.pwd=oracle11
 
-# NoSQL properties for test-oracle-nosql target
+# NoSQL properties for test-oracle-nosql target - Deprecated
 nosql.url=nosql://localhost:5000/elstore
+
+# NoSQL properties for test-oracle-nosql-sdk target
+# Local Oracle NoSQL installation (Cloud simulator)
+nosql.sdk.service=cloudsim
+nosql.sdk.endpoint=http://localhost:8080
+
+# Cloud Oracle NoSQL deployment
+#nosql.sdk.service=cloud
+#nosql.sdk.endpoint=eu-frankfurt-1
+#nosql.sdk.compartment=ocid1.tenancy.oc1..*****************
+#nosql.sdk.authprincipal=user
+
+nosql.sdk.target-database=org.eclipse.persistence.nosql.adapters.sdk.OracleNoSQLPlatform
+nosql.sdk.connection-spec=org.eclipse.persistence.nosql.adapters.sdk.OracleNoSQLConnectionSpec

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/eis/EISException.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/eis/EISException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -47,6 +47,12 @@ public class EISException extends org.eclipse.persistence.exceptions.DatabaseExc
     public static final int INVALID_FACTORY_ATTRIBUTES = 17023;
     public static final int COULD_NOT_DELETE_FILE = 17024;
     public static final int GROUPING_ELEMENT_REQUIRED = 17025;
+    public static final int OPERATION_PROPERTY_IS_NOT_SET = 17026;
+    public static final int TABLE_NAME_IS_NOT_SET = 17027;
+    public static final int INVALID_CONSISTENCY_PROPERTY_VALUE = 17028;
+    public static final int INVALID_DURABILITY_PROPERTY_VALUE = 17029;
+    public static final int XML_INTERACTION_IS_VALID_ONLY = 17030;
+    public static final int QUERY_IS_TOO_COMPLEX_FOR_ORACLE_NOSQL_DB = 17031;
     public static final int EIS_EXCEPTION = 91000;
     public static final int RESOURCE_EXCEPTION = 90000;
 
@@ -176,6 +182,30 @@ public class EISException extends org.eclipse.persistence.exceptions.DatabaseExc
 
     public static EISException couldNotDeleteFile(Object[] args) {
         return EISException.createResourceException(args, COULD_NOT_DELETE_FILE);
+    }
+
+    public static EISException operationPropertyIsNotSet() {
+        return EISException.createException(new Object[] {  }, OPERATION_PROPERTY_IS_NOT_SET);
+    }
+
+    public static EISException tableNameIsNotSet() {
+        return EISException.createException(new Object[] {  }, TABLE_NAME_IS_NOT_SET);
+    }
+
+    public static EISException invalidConsistencyPropertyValue(String property) {
+        return EISException.createException(new Object[] { property }, INVALID_CONSISTENCY_PROPERTY_VALUE);
+    }
+
+    public static EISException invalidDurabilityPropertyValue(String property) {
+        return EISException.createException(new Object[] { property }, INVALID_DURABILITY_PROPERTY_VALUE);
+    }
+
+    public static EISException xmlInteractionIsValidOnly(String property) {
+        return EISException.createException(new Object[] { property }, XML_INTERACTION_IS_VALID_ONLY);
+    }
+
+    public static EISException queryIsTooComplexForOracleNoSQLDB(String property) {
+        return EISException.createException(new Object[] { property }, QUERY_IS_TOO_COMPLEX_FOR_ORACLE_NOSQL_DB);
     }
 
     public static EISException incorrectLoginInstanceProvided(Class<?> loginClass) {

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/eis/EISPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/eis/EISPlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -25,12 +25,12 @@ import org.eclipse.persistence.exceptions.*;
 import org.eclipse.persistence.queries.*;
 import org.eclipse.persistence.eis.interactions.*;
 import org.eclipse.persistence.internal.databaseaccess.DatasourceCall;
-import org.eclipse.persistence.internal.databaseaccess.DatasourcePlatform;
 import org.eclipse.persistence.internal.expressions.SQLStatement;
 import org.eclipse.persistence.internal.oxm.XMLConversionManager;
 import org.eclipse.persistence.internal.security.PrivilegedAccessHelper;
 import org.eclipse.persistence.internal.sessions.AbstractRecord;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
+import org.eclipse.persistence.platform.database.DatabasePlatform;
 
 /**
  * <p>An <code>EISPlatform</code> defines any EIS adapter specific behavior.
@@ -52,7 +52,7 @@ import org.eclipse.persistence.internal.sessions.AbstractSession;
  * @author James
  * @since OracleAS TopLink 10<i>g</i> (10.0.3)
  */
-public class EISPlatform extends DatasourcePlatform {
+public class EISPlatform extends DatabasePlatform {
     protected boolean isIndexedRecordSupported;
     protected boolean isMappedRecordSupported;
     protected boolean isDOMRecordSupported;

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/eis/EISPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/eis/EISPlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -25,12 +25,12 @@ import org.eclipse.persistence.exceptions.*;
 import org.eclipse.persistence.queries.*;
 import org.eclipse.persistence.eis.interactions.*;
 import org.eclipse.persistence.internal.databaseaccess.DatasourceCall;
+import org.eclipse.persistence.internal.databaseaccess.DatasourcePlatform;
 import org.eclipse.persistence.internal.expressions.SQLStatement;
 import org.eclipse.persistence.internal.oxm.XMLConversionManager;
 import org.eclipse.persistence.internal.security.PrivilegedAccessHelper;
 import org.eclipse.persistence.internal.sessions.AbstractRecord;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
-import org.eclipse.persistence.platform.database.DatabasePlatform;
 
 /**
  * <p>An <code>EISPlatform</code> defines any EIS adapter specific behavior.
@@ -52,7 +52,7 @@ import org.eclipse.persistence.platform.database.DatabasePlatform;
  * @author James
  * @since OracleAS TopLink 10<i>g</i> (10.0.3)
  */
-public class EISPlatform extends DatabasePlatform {
+public class EISPlatform extends DatasourcePlatform {
     protected boolean isIndexedRecordSupported;
     protected boolean isMappedRecordSupported;
     protected boolean isDOMRecordSupported;

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/eis/interactions/XMLInteraction.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/eis/interactions/XMLInteraction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -259,7 +259,7 @@ public class XMLInteraction extends MappedInteraction {
      */
     protected XMLRecord createXMLRecord(String rootName) {
         XMLRecord xmlRec;
-        if (getQuery().getDescriptor() != null && getQuery().getDescriptor() instanceof EISDescriptor) {
+        if (getQuery().getDescriptor() != null && getQuery().getDescriptor() instanceof EISDescriptor && this.getQuery().getDescriptor().getObjectBuilder() instanceof XMLObjectBuilder) {
             xmlRec = (XMLRecord)((XMLObjectBuilder)this.getQuery().getDescriptor().getObjectBuilder()).createRecord(getInputRootElementName(), getQuery().getSession());
         } else {
             xmlRec = new org.eclipse.persistence.oxm.record.DOMRecord(getInputRootElementName());

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/exceptions/i18n/EISExceptionResource.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/exceptions/i18n/EISExceptionResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -43,7 +43,13 @@ public final class EISExceptionResource extends ListResourceBundle {
                                            { "17022", "Input must contain a single raw element." },
                                            { "17023", "An exception occurred setting MQQueueConnectionFactory attributes." },
                                            { "17024", "Could not delete file: {0}" },
-                                           { "17025", "This mapping requires a foreign key grouping element, as mulitple foreign keys exist." }
+                                           { "17025", "This mapping requires a foreign key grouping element, as multiple foreign keys exist." },
+                                           { "17026", "Operation property must be set on the query's interaction." },
+                                           { "17027", "Target table name is not set. It must be set on the query's interaction." },
+                                           { "17028", "Invalid consistency property value: {0}" },
+                                           { "17029", "Invalid durability property value: {0}" },
+                                           { "17030", "XMLInteraction is only valid for object queries, use MappedInteraction for native queries: {0}" },
+                                           { "17031", "Query too complex for Oracle NoSQL translation, only select queries are supported in query: {0}" }
     };
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sequencing/UUIDSequence.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sequencing/UUIDSequence.java
@@ -45,7 +45,10 @@ public class UUIDSequence extends Sequence {
 
     @Override
     public Object getGeneratedValue(Accessor accessor, AbstractSession writeSession, String seqName) {
-        ValueReadQuery query = getDatasourcePlatform().getUUIDQuery();
+        ValueReadQuery query = null;
+        if (getDatasourcePlatform() != null) {
+            query = getDatasourcePlatform().getUUIDQuery();
+        }
         if (query != null) {
             return writeSession.executeQuery(query);
         } else {

--- a/foundation/org.eclipse.persistence.oracle.nosql/pom.xml
+++ b/foundation/org.eclipse.persistence.oracle.nosql/pom.xml
@@ -62,7 +62,12 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
-        <!--Oracle proprietary dependencies-->
+        <dependency>
+            <groupId>com.oracle.nosql.sdk</groupId>
+            <artifactId>nosqldriver</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
         <dependency>
             <groupId>com.oracle.database.messaging</groupId>
             <artifactId>aqapi</artifactId>
@@ -73,6 +78,14 @@
     </dependencies>
 
     <build>
+        <!--Filtering enables generate/substitute test properties from Maven into *.xml files.-->
+        <testResources>
+            <testResource>
+                <directory>${integration.test.resources.directory}</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
+
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -185,6 +198,20 @@
                             <workingDirectory>${project.build.directory}/test-run</workingDirectory>
                         </configuration>
                         <executions>
+                            <execution>
+                                <id>test-oracle-nosql-sdk</id>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                </goals>
+                                <configuration>
+                                    <skipTests>${test-skip-oracle-nosql}</skipTests>
+                                    <reportNameSuffix>test-oracle-nosql-sdk</reportNameSuffix>
+                                    <includes>
+                                        <include>org.eclipse.persistence.testing.tests.eis.nosql.sdk.NoSQLTestSuite</include>
+                                        <include>org.eclipse.persistence.testing.tests.jpa.nosql.sdk.NoSQLJPATestSuite</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
                             <execution>
                                 <id>test-oracle-nosql</id>
                                 <goals>

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/models/jpa/nosql/Order.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/models/jpa/nosql/Order.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -33,7 +33,7 @@ import org.eclipse.persistence.annotations.UuidGenerator;
 @NoSql
 public class Order {
     @Id
-    @Column(name="@id")
+    @Column(name="id")
     @UuidGenerator(name="uuid")
     @GeneratedValue(generator="uuid")
     public String id;

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/models/jpa/nosql/mapped/Address.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/models/jpa/nosql/mapped/Address.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,6 +14,7 @@
 //     Oracle - initial API and implementation from Oracle TopLink
 package org.eclipse.persistence.testing.models.jpa.nosql.mapped;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 
 import org.eclipse.persistence.nosql.annotations.DataFormatType;
@@ -26,11 +27,17 @@ import org.eclipse.persistence.nosql.annotations.NoSql;
 @Embeddable
 @NoSql(dataFormat=DataFormatType.MAPPED)
 public class Address {
+    @Column(name="addressee")
     public String addressee;
+    @Column(name="street")
     public String street;
+    @Column(name="city")
     public String city;
+    @Column(name="state")
     public String state;
+    @Column(name="country")
     public String country;
+    @Column(name="zipcode")
     public String zipCode;
 
     public String toString() {

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/models/jpa/nosql/mapped/Customer.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/models/jpa/nosql/mapped/Customer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -25,7 +25,7 @@ import org.eclipse.persistence.nosql.annotations.NoSql;
  * Model customer class, maps to CUSTOMER record.
  */
 @Entity
-@NoSql(dataFormat=DataFormatType.MAPPED, dataType="Customer-mapped")
+@NoSql(dataFormat=DataFormatType.MAPPED, dataType="customer_mapped")
 public class Customer {
     @Id
     public String id;

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/models/jpa/nosql/mapped/LineItem.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/models/jpa/nosql/mapped/LineItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -17,21 +17,25 @@ package org.eclipse.persistence.testing.models.jpa.nosql.mapped;
 import java.io.Serializable;
 import java.math.*;
 
-//import jakarta.persistence.Embeddable;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
 
-//import org.eclipse.persistence.annotations.DataFormatType;
-//import org.eclipse.persistence.annotations.NoSql;
+import org.eclipse.persistence.nosql.annotations.DataFormatType;
+import org.eclipse.persistence.nosql.annotations.NoSql;
 
 /**
  * Model line item class, maps to LINE record.
  */
-// The mapped format does not currently support collections.
-//@Embeddable
-//@NoSql(dataFormat=DataFormatType.MAPPED)
+@Embeddable
+@NoSql(dataFormat=DataFormatType.MAPPED)
 public class LineItem implements Serializable {
+    @Column(name="linenumber")
     public long lineNumber;
+    @Column(name="itemname")
     public String itemName;
+    @Column(name="quantity")
     public long quantity;
+    @Column(name="itemprice")
     public BigDecimal itemPrice;
 
     public String toString() {

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/models/jpa/nosql/mapped/Order.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/models/jpa/nosql/mapped/Order.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -17,6 +17,8 @@ package org.eclipse.persistence.testing.models.jpa.nosql.mapped;
 import java.util.*;
 
 import jakarta.persistence.Basic;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -29,19 +31,24 @@ import org.eclipse.persistence.nosql.annotations.NoSql;
  * Model order class, maps to ORDER record.
  */
 @Entity
-@NoSql(dataFormat=DataFormatType.MAPPED, dataType="Order-mapped")
+@NoSql(dataFormat=DataFormatType.MAPPED, dataType="order_mapped")
 public class Order {
     @Id
+    @Column(name="id")
     public long id;
     @Basic
+    @Column(name="orderedby")
     public String orderedBy;
     @Embedded
+    @Column(name="address")
     public Address address;
     @OneToOne
     public Customer customer;
-    @Basic
+    @ElementCollection
+    @Column(name="lineitems")
     public List<LineItem> lineItems = new ArrayList<>();
-    @Basic
+    @ElementCollection
+    @Column(name="comments")
     public List<String> comments = new ArrayList<>();
 
     public String toString() {

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/eis/nosql/sdk/NoSQLModelTest.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/eis/nosql/sdk/NoSQLModelTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.testing.tests.eis.nosql.sdk;
+
+import oracle.nosql.driver.NoSQLHandle;
+import oracle.nosql.driver.ops.TableLimits;
+import oracle.nosql.driver.ops.TableRequest;
+import org.eclipse.persistence.descriptors.ClassDescriptor;
+import org.eclipse.persistence.eis.interactions.XMLInteraction;
+import org.eclipse.persistence.eis.mappings.EISDirectMapping;
+import org.eclipse.persistence.internal.nosql.adapters.sdk.OracleNoSQLConnection;
+import org.eclipse.persistence.internal.nosql.adapters.sdk.OracleNoSQLOperation;
+import org.eclipse.persistence.internal.sessions.AbstractSession;
+import org.eclipse.persistence.logging.AbstractSessionLog;
+import org.eclipse.persistence.logging.SessionLog;
+import org.eclipse.persistence.nosql.adapters.sdk.OracleNoSQLPlatform;
+import org.eclipse.persistence.oxm.XMLField;
+import org.eclipse.persistence.queries.InsertObjectQuery;
+import org.eclipse.persistence.sessions.DatabaseSession;
+import org.eclipse.persistence.sessions.UnitOfWork;
+import org.eclipse.persistence.sessions.factories.SessionManager;
+import org.eclipse.persistence.testing.framework.junit.LogTestExecution;
+import org.eclipse.persistence.testing.models.order.Address;
+import org.eclipse.persistence.testing.models.order.LineItem;
+import org.eclipse.persistence.testing.models.order.Order;
+import org.eclipse.persistence.testing.tests.nosql.ModelHelper;
+import org.eclipse.persistence.testing.tests.nosql.sdk.SessionHelper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Oracle NoSQL database tests with existing data model.
+ */
+public class NoSQLModelTest {
+
+    private final String DROP_TABLE_DDL = "DROP TABLE IF EXISTS order";
+
+    private final String CRATE_TABLE_DDL = "CREATE TABLE IF NOT EXISTS order" +
+            "(id INTEGER, " +
+            "ordered_by STRING, " +
+            "address RECORD(addressee STRING, city STRING, country STRING, state STRING, street STRING, zip STRING), " +
+            "line_item ARRAY(RECORD(name STRING, price DOUBLE, number INTEGER, quantity INTEGER)), " +
+            "PRIMARY KEY(id))";
+
+    /** Log the test being currently executed. */
+    @Rule public LogTestExecution logExecution = new LogTestExecution();
+
+    /** Logger. */
+    private static final SessionLog LOG = AbstractSessionLog.getLog();
+
+    /** Database session shared by tests except first tests which are verifying session creation. */
+    DatabaseSession session;
+
+    /**
+     * Setup {@link Order} class descriptor.
+     * @param session Database session.
+     */
+    private static void setupOrderDescriptor(final DatabaseSession session) {
+        final ClassDescriptor descriptor = session.getDescriptor(Order.class);
+        descriptor.getPrimaryKeyFields().clear();
+
+        XMLField primaryKeyField = new XMLField("id");
+        primaryKeyField.setTable(descriptor.getDefaultTable());
+        descriptor.addPrimaryKeyField(primaryKeyField);
+
+        ((EISDirectMapping)descriptor.getMappingForAttributeName("id")).setFieldName("order.id");
+
+        // Insert
+        final XMLInteraction insertCall = new XMLInteraction();
+        insertCall.setProperty(OracleNoSQLPlatform.OPERATION, OracleNoSQLOperation.PUT);
+        descriptor.getQueryManager().setInsertCall(insertCall);
+
+        // Update
+        final XMLInteraction updateCall = new XMLInteraction();
+        updateCall.setProperty(OracleNoSQLPlatform.OPERATION, OracleNoSQLOperation.PUT);
+        descriptor.getQueryManager().setUpdateCall(updateCall);
+
+        // Read
+        final XMLInteraction readCall = new XMLInteraction();
+        readCall.setProperty(OracleNoSQLPlatform.OPERATION, OracleNoSQLOperation.GET);
+        readCall.addArgument("id");
+        descriptor.getQueryManager().setReadObjectCall(readCall);
+
+        // Delete
+        final XMLInteraction deleteCall = new XMLInteraction();
+        deleteCall.setProperty(OracleNoSQLPlatform.OPERATION, OracleNoSQLOperation.DELETE);
+        deleteCall.addArgument("id");
+        descriptor.getQueryManager().setDeleteCall(deleteCall);
+    }
+
+    /**
+     * Create an instance of MongoDB database test suite.
+     */
+    public NoSQLModelTest() {
+        session = null;
+    }
+
+    /**
+     * Initialize this test suite.
+     */
+    @Before
+    public void setUp() {
+        session = SessionHelper.createDatabaseSession(NoSQLTestSuite.modelProject);
+        SessionManager sessionManager = SessionManager.getManager();
+        sessionManager.setDefaultSession(session);
+        OracleNoSQLConnection oracleNoSQLConnection = (OracleNoSQLConnection)((AbstractSession)session).getAccessor().getDatasourceConnection();
+        LOG.info("Creating order table.");
+        NoSQLHandle noSQLHandle = oracleNoSQLConnection.getNoSQLHandle();
+        TableLimits limits = new TableLimits(1, 2, 1);
+        TableRequest tableRequestDrop = new TableRequest().setStatement(DROP_TABLE_DDL);
+        noSQLHandle.doTableRequest(tableRequestDrop, 60000, 1000);
+        TableRequest tableRequestCreate = new TableRequest().setStatement(CRATE_TABLE_DDL).
+                setTableLimits(limits);
+        noSQLHandle.doTableRequest(tableRequestCreate, 60000, 1000);
+        LOG.info("order table was created.");
+        setupOrderDescriptor((DatabaseSession)session);
+
+    }
+
+    /**
+     * Clean up this test suite.
+     */
+    @After
+    public void tearDown() {
+        session.logout();
+        session = null;
+    }
+
+    /**
+     * Testing reading and writing using {@link DatabaseSession}.
+     */
+    @Test
+    public void testReadWrite() throws Exception {
+        final Address address = ModelHelper.buildAddress();
+        final List<LineItem> lineItems = ModelHelper.buildLineItemsList();
+        final Order order = ModelHelper.buildOrder(address, lineItems);
+
+        //Insert/PUT operation
+        final XMLInteraction insertCall = new XMLInteraction();
+        insertCall.setProperty(OracleNoSQLPlatform.OPERATION, OracleNoSQLOperation.PUT.name());
+        final InsertObjectQuery insert = new InsertObjectQuery(order);
+        insert.setCall(insertCall);
+        insert.storeBypassCache();
+        session.executeQuery(insert);
+
+        final XMLInteraction readCall = new XMLInteraction();
+        readCall.setProperty(OracleNoSQLPlatform.OPERATION, OracleNoSQLOperation.GET.name());
+        readCall.addArgumentValue("id", order.id);
+        session.getIdentityMapAccessor().initializeIdentityMaps();
+
+        final Order dbOrder = (Order)session.readObject(Order.class, readCall);
+
+        assertNotNull("Returned Order instance is null", dbOrder);
+        assertEquals(String.format(
+                "Order not returned properly: %s", dbOrder), order.address.city, dbOrder.address.city);
+    }
+
+    /**
+     * Testing reading and writing using {@link UnitOfWork}.
+     */
+    @Test
+    public void testUnitOfWork() throws Exception {
+        session.getIdentityMapAccessor().initializeIdentityMaps();
+
+        final Address address = ModelHelper.buildAddress();
+        final List<LineItem> lineItems = ModelHelper.buildLineItemsList();
+        final Order order = ModelHelper.buildOrder(address, lineItems);
+
+        final UnitOfWork uow = session.acquireUnitOfWork();
+        uow.registerObject(order);
+        uow.commit();
+
+        session.getIdentityMapAccessor().initializeIdentityMaps();
+
+        final Order dbOrder = (Order)session.readObject(order);
+
+        assertNotNull("Returned Order instance is null", dbOrder);
+        assertEquals(String.format(
+                "Order not returned properly: %s", dbOrder), order.address.city, dbOrder.address.city);
+    }
+
+}

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/eis/nosql/sdk/NoSQLSessionTest.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/eis/nosql/sdk/NoSQLSessionTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.testing.tests.eis.nosql.sdk;
+
+import org.eclipse.persistence.sessions.DatabaseSession;
+import org.eclipse.persistence.sessions.server.Server;
+import org.eclipse.persistence.testing.framework.junit.LogTestExecution;
+import org.eclipse.persistence.testing.tests.nosql.sdk.SessionHelper;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Test EclipseLink EIS sessions creation and login with the Oracle NoSQL database.
+ */
+public class NoSQLSessionTest {
+
+    /** Log the test being currently executed. */
+    @Rule public LogTestExecution logExecution = new LogTestExecution();
+
+    /**
+     * Test {@link DatabaseSession} creation and login.
+     */
+    @Test
+    public void testDatabaseSession() throws Exception {
+        final DatabaseSession session = SessionHelper.createDatabaseSession(NoSQLTestSuite.project);
+        session.logout();
+    }
+
+    /**
+     * Test {@link Server} session creation and login.
+     */
+    @Test
+    public void testServerSession() throws Exception {
+        final Server session = SessionHelper.createServerSession(NoSQLTestSuite.project);
+        session.logout();
+    }
+
+}

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/eis/nosql/sdk/NoSQLSimpleTest.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/eis/nosql/sdk/NoSQLSimpleTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.testing.tests.eis.nosql.sdk;
+
+import oracle.nosql.driver.NoSQLHandle;
+import oracle.nosql.driver.ops.TableLimits;
+import oracle.nosql.driver.ops.TableRequest;
+import org.eclipse.persistence.eis.interactions.MappedInteraction;
+import org.eclipse.persistence.eis.interactions.XMLInteraction;
+import org.eclipse.persistence.expressions.Expression;
+import org.eclipse.persistence.expressions.ExpressionBuilder;
+import org.eclipse.persistence.internal.nosql.adapters.sdk.OracleNoSQLConnection;
+import org.eclipse.persistence.internal.nosql.adapters.sdk.OracleNoSQLOperation;
+import org.eclipse.persistence.internal.sessions.AbstractSession;
+import org.eclipse.persistence.logging.AbstractSessionLog;
+import org.eclipse.persistence.logging.SessionLog;
+import org.eclipse.persistence.nosql.adapters.sdk.OracleNoSQLPlatform;
+import org.eclipse.persistence.queries.InsertObjectQuery;
+import org.eclipse.persistence.queries.ReadObjectQuery;
+import org.eclipse.persistence.sessions.DatabaseSession;
+import org.eclipse.persistence.sessions.factories.SessionManager;
+import org.eclipse.persistence.testing.framework.junit.LogTestExecution;
+import org.eclipse.persistence.testing.models.order.Address;
+import org.eclipse.persistence.testing.models.order.LineItem;
+import org.eclipse.persistence.testing.models.order.Order;
+import org.eclipse.persistence.testing.tests.nosql.ModelHelper;
+import org.eclipse.persistence.testing.tests.nosql.sdk.SessionHelper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Oracle NoSQL database simple tests with no model requirements.
+ */
+public class NoSQLSimpleTest {
+
+    private final String DROP_TABLE_DDL = "DROP TABLE IF EXISTS order";
+
+    private final String CRATE_TABLE_DDL = "CREATE TABLE IF NOT EXISTS order" +
+            "(id INTEGER, " +
+            "ordered_by STRING, " +
+            "address RECORD(addressee STRING, city STRING, country STRING, state STRING, street STRING, zip STRING), " +
+            "line_item ARRAY(RECORD(name STRING, price DOUBLE, number INTEGER, quantity INTEGER)), " +
+            "PRIMARY KEY(id))";
+
+    /** Log the test being currently executed. */
+    @Rule public LogTestExecution logExecution = new LogTestExecution();
+
+    /** Logger. */
+    private static final SessionLog LOG = AbstractSessionLog.getLog();
+
+    /** Database session shared by tests except first tests which are verifying session creation. */
+    DatabaseSession session;
+
+    /**
+     * Create an instance of NoSQL database test suite.
+     */
+    public NoSQLSimpleTest() {
+        session = null;
+    }
+
+    /**
+     * Initialize this test suite.
+     */
+    @Before
+    public void setUp() {
+        session = SessionHelper.createDatabaseSession(NoSQLTestSuite.modelProject);
+        SessionManager sessionManager = SessionManager.getManager();
+        sessionManager.setDefaultSession(session);
+        OracleNoSQLConnection oracleNoSQLConnection = (OracleNoSQLConnection)((AbstractSession)session).getAccessor().getDatasourceConnection();
+        LOG.info("Creating order table.");
+        NoSQLHandle noSQLHandle = oracleNoSQLConnection.getNoSQLHandle();
+        TableLimits limits = new TableLimits(1, 2, 1);
+        TableRequest tableRequestDrop = new TableRequest().setStatement(DROP_TABLE_DDL);
+        noSQLHandle.doTableRequest(tableRequestDrop, 60000, 1000);
+        TableRequest tableRequestCreate = new TableRequest().setStatement(CRATE_TABLE_DDL).
+                setTableLimits(limits);
+        noSQLHandle.doTableRequest(tableRequestCreate, 60000, 1000);
+        LOG.info("order table was created.");
+    }
+
+    /**
+     * Clean up this test suite.
+     */
+    @After
+    public void tearDown() {
+        session.logout();
+        session = null;
+    }
+
+    /**
+     * Test native Oracle NoSQL queries.
+     */
+    @Test
+    public void testNative() throws Exception {
+        final Address address = ModelHelper.buildAddress();
+        final List<LineItem> lineItems = ModelHelper.buildLineItemsList();
+        final Order order = ModelHelper.buildOrder(address, lineItems);
+
+        //Insert/PUT operation
+        final XMLInteraction insertCall = new XMLInteraction();
+        insertCall.setProperty(OracleNoSQLPlatform.OPERATION, OracleNoSQLOperation.PUT.name());
+        final InsertObjectQuery insert = new InsertObjectQuery(order);
+        insert.setCall(insertCall);
+        insert.storeBypassCache();
+        session.executeQuery(insert);
+
+        //Read/GET operation
+        final MappedInteraction readCall = new MappedInteraction();
+        readCall.setProperty(OracleNoSQLPlatform.OPERATION, OracleNoSQLOperation.GET.name());
+        final ReadObjectQuery read = new ReadObjectQuery(Order.class, readCall);
+        ExpressionBuilder bldr = new ExpressionBuilder();
+        Expression exp = bldr.get("id").equal(4321);
+        read.setSelectionCriteria(exp);
+        read.dontCheckCache();
+        final Order result = (Order)session.executeQuery(read);
+        assertEquals(order.id, result.id);
+        assertEquals(order.orderedBy, result.orderedBy);
+        assertEquals(order.address.addressee, result.address.addressee);
+        assertEquals(order.address.city, result.address.city);
+        assertEquals(order.lineItems.size(), result.lineItems.size());
+        Map<Long, LineItem> lineItemMap = new HashMap<>();
+        for (LineItem lineItem: (List<LineItem>)order.lineItems) {
+            lineItemMap.put(lineItem.lineNumber, lineItem);
+        }
+        for (LineItem resultLineItem: (List<LineItem>)result.lineItems) {
+            assertEquals(lineItemMap.get(resultLineItem.lineNumber).lineNumber, resultLineItem.lineNumber);
+            assertEquals(lineItemMap.get(resultLineItem.lineNumber).itemName, resultLineItem.itemName);
+            assertEquals(lineItemMap.get(resultLineItem.lineNumber).quantity, resultLineItem.quantity);
+            assertEquals(lineItemMap.get(resultLineItem.lineNumber).itemPrice, resultLineItem.itemPrice);
+        }
+    }
+}

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/eis/nosql/sdk/NoSQLTestSuite.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/eis/nosql/sdk/NoSQLTestSuite.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.testing.tests.eis.nosql.sdk;
+
+import org.eclipse.persistence.eis.EISLogin;
+import org.eclipse.persistence.nosql.adapters.sdk.OracleNoSQLConnectionSpec;
+import org.eclipse.persistence.nosql.adapters.sdk.OracleNoSQLPlatform;
+import org.eclipse.persistence.sessions.Project;
+import org.eclipse.persistence.testing.tests.nosql.sdk.NoSQLProperties;
+import org.eclipse.persistence.testing.tests.nosql.sdk.SessionHelper;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+/**
+ * Test EclipseLink EIS with the Oracle NoSQL database.
+ */
+@RunWith(Suite.class)
+@SuiteClasses({
+    NoSQLSessionTest.class,
+    NoSQLSimpleTest.class,
+    NoSQLModelTest.class
+})
+public class NoSQLTestSuite {
+
+    /** NoSQL database login information. Shared with whole test suite. */
+    static final EISLogin login = initLogin();
+
+    /** EclipseLink configuration without test model. Shared with whole test suite. */
+    static final Project project  = SessionHelper.createProject(login, NoSQLTestSuite.class);
+
+    /** EclipseLink configuration with test model. Shared with whole test suite. */
+    static final Project modelProject  = SessionHelper.createModelProject(login, NoSQLTestSuite.class);
+
+    /**
+     * Initializes {@link EISLogin} with NoSQL connection specifications for test suite.
+     * Class initialization helper method.
+     * @return {@link EISLogin} with NoSQL connection specifications.
+     */
+    static EISLogin initLogin() {
+        final EISLogin login = new EISLogin(new OracleNoSQLPlatform());
+        login.setConnectionSpec(new OracleNoSQLConnectionSpec());
+        NoSQLProperties.setEISLoginProperties(login);
+        return login;
+    }
+
+}

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/jpa/nosql/sdk/NoSQLJPAMappedTest.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/jpa/nosql/sdk/NoSQLJPAMappedTest.java
@@ -1,0 +1,380 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation.
+package org.eclipse.persistence.testing.tests.jpa.nosql.sdk;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import jakarta.persistence.TypedQuery;
+
+import org.eclipse.persistence.eis.interactions.MappedInteraction;
+import org.eclipse.persistence.eis.interactions.XMLInteraction;
+import org.eclipse.persistence.internal.nosql.adapters.sdk.OracleNoSQLOperation;
+import org.eclipse.persistence.jpa.JpaEntityManager;
+import org.eclipse.persistence.nosql.adapters.sdk.OracleNoSQLPlatform;
+import org.eclipse.persistence.testing.framework.junit.LogTestExecution;
+import org.eclipse.persistence.testing.models.jpa.nosql.mapped.Address;
+import org.eclipse.persistence.testing.models.jpa.nosql.mapped.Customer;
+import org.eclipse.persistence.testing.models.jpa.nosql.mapped.Order;
+import org.eclipse.persistence.testing.tests.nosql.sdk.EntityManagerHelper;
+import org.eclipse.persistence.testing.tests.nosql.sdk.JPAModelHelper;
+import org.eclipse.persistence.testing.tests.nosql.sdk.MappedJPAModelHelper;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Oracle NoSQL mapped database JPA database tests.
+ */
+public class NoSQLJPAMappedTest {
+
+    /** Log the test being currently executed. */
+    @Rule public LogTestExecution logExecution = new LogTestExecution();
+
+    /** The persistence unit name. */
+    private static final String PU_NAME = "nosql-mapped-sdk";
+
+    /** Stored {@link Order} instances count. */
+    private static final int ORDERS_COUNT = 10;
+
+    /** Stored {@link Order} instances. */
+    private static Order[] orders;
+
+    /** Last Order primary key value. */
+    private static long lastId = 0;
+
+    /** Entity manager used by tests. */
+    EntityManager em;
+
+    /**
+     * Local shortcut for entity manager with mapped property for database host and port pair.
+     * @return New {@link EntityManager} instance.
+     */
+    private static EntityManager createEntityManager() {
+        return EntityManagerHelper.createEntityManager(PU_NAME, true);
+    }
+
+    /**
+     * Get random order instance from test setup.
+     * @return Random order instance from test setup.
+     */
+    private static Order getRandomOrder() {
+        final int index = (int)(Math.random() * ORDERS_COUNT);
+        return orders[index];
+    }
+
+    /**
+     * Initialize data model for tests.
+     */
+    @BeforeClass
+    public static void initModel() {
+        EntityManager em = createEntityManager();
+        try {
+            JPAModelHelper.deleteModel(em);
+            orders = MappedJPAModelHelper.buildModel(em, ORDERS_COUNT, lastId);
+            lastId = orders[orders.length-1].id;
+        } finally {
+            EntityManagerHelper.clearCache(em);
+            EntityManagerHelper.closeEntityManagerAndTransaction(em);
+        }
+    }
+
+    /**
+     * Delete data model after tests.
+     */
+    @AfterClass
+    public static void deleteModel() {
+        EntityManager em = createEntityManager();
+        try {
+            MappedJPAModelHelper.deleteModel(em);
+        } finally {
+            EntityManagerHelper.clearCache(em);
+            EntityManagerHelper.closeEntityManagerAndTransaction(em);
+        }
+    }
+
+    /**
+     * Setup test.
+     */
+    @Before
+    public void setUp() {
+        em = createEntityManager();
+    }
+
+    /**
+     * Cleanup test.
+     */
+    @After
+    public void tearDown() {
+        EntityManagerHelper.closeEntityManagerAndTransaction(em);
+    }
+
+    /**
+     * Test inserts.
+     */
+    @Test
+    public void testInsert() {
+        Order order = new Order();
+        Customer customer = new Customer();
+        EntityManagerHelper.beginTransaction(em);
+        try {
+            order.id = ++lastId;
+            order.orderedBy = "ACME";
+            order.address = new Address();
+            order.address.city = "Ottawa";
+            em.persist(order);
+            order.customer = customer;
+            order.customer.id = Long.toString(++lastId);
+            order.customer.name = "ACME";
+            em.persist(order.customer);
+            EntityManagerHelper.commitTransaction(em);
+        } finally {
+            EntityManagerHelper.clearCache(em);
+            EntityManagerHelper.closeEntityManagerAndTransaction(em);
+        }
+        em = createEntityManager();
+        EntityManagerHelper.beginTransaction(em);
+        Order fromDatabase = null;
+        Customer customerFromDatabase = null;
+        try {
+            order.customer = null;
+            fromDatabase = em.find(Order.class, order.id);
+            EntityManagerHelper.compareObjects(order, fromDatabase, em);
+            customerFromDatabase = em.find(Customer.class, customer.id);
+            EntityManagerHelper.compareObjects(customer, customerFromDatabase, em);
+        } finally {
+            if (fromDatabase != null) {
+                em.remove(fromDatabase);
+            }
+             if (customerFromDatabase != null) {
+                em.remove(customerFromDatabase);
+            }
+        }
+    }
+
+    /**
+     * Test find.
+     */
+    @Test
+    public void testFind() {
+        EntityManagerHelper.beginTransaction(em);
+        final Order existingOrder = getRandomOrder();
+        Order order = em.find(Order.class, existingOrder.id);
+        EntityManagerHelper.compareObjects(existingOrder, order, em);
+    }
+
+    /**
+     * Test updates.
+     */
+    @Test
+    public void testUpdate() {
+        EntityManagerHelper.beginTransaction(em);
+        Order order = new Order();
+        long orderId = ++lastId;
+        try {
+            order.id = orderId;
+            order.orderedBy = "ACME";
+            order.address = new Address();
+            order.address.city = "Ottawa";
+            em.persist(order);
+            EntityManagerHelper.commitTransaction(em);
+        } finally {
+            EntityManagerHelper.clearCache(em);
+            EntityManagerHelper.closeEntityManagerAndTransaction(em);
+        }
+        em = createEntityManager();
+        EntityManagerHelper.beginTransaction(em);
+        try {
+            final Order existingOrder = getRandomOrder();
+            order = em.find(Order.class, existingOrder.id);
+            order.orderedBy = "Fred Jones";
+            order.address.addressee = "Fred Jones";
+            EntityManagerHelper.commitTransaction(em);
+        } finally {
+            EntityManagerHelper.clearCache(em);
+            EntityManagerHelper.closeEntityManagerAndTransaction(em);
+        }
+        em = createEntityManager();
+        EntityManagerHelper.beginTransaction(em);
+        try {
+            Order fromDatabase = em.find(Order.class, order.id);
+            EntityManagerHelper.compareObjects(order, fromDatabase, em);
+        } finally {
+            Order toDelete = em.find(Order.class, orderId);
+            em.remove(toDelete);
+        }
+    }
+
+    /**
+     * Test merge.
+     */
+    @Test
+    public void testMerge() {
+        EntityManagerHelper.beginTransaction(em);
+        Order order = new Order();
+        long orderId = ++lastId;
+        try {
+            order.id = orderId;
+            order.orderedBy = "ACME";
+            order.address = new Address();
+            order.address.city = "Ottawa";
+            em.persist(order);
+            EntityManagerHelper.commitTransaction(em);
+        } finally {
+            EntityManagerHelper.clearCache(em);
+            EntityManagerHelper.closeEntityManagerAndTransaction(em);
+        }
+        em = createEntityManager();
+        EntityManagerHelper.beginTransaction(em);
+        try {
+            order = em.find(Order.class, order.id);
+            order.orderedBy = "Fred Jones";
+            order.address.addressee = "Fred Jones";
+        } finally {
+            EntityManagerHelper.closeEntityManagerAndTransaction(em);
+        }
+        em = createEntityManager();
+        EntityManagerHelper.beginTransaction(em);
+        try {
+            em.merge(order);
+            EntityManagerHelper.commitTransaction(em);
+        } finally {
+            EntityManagerHelper.clearCache(em);
+            EntityManagerHelper.closeEntityManagerAndTransaction(em);
+        }
+        em = createEntityManager();
+        EntityManagerHelper.beginTransaction(em);
+        try {
+            Order fromDatabase = em.find(Order.class, order.id);
+            EntityManagerHelper.compareObjects(order, fromDatabase, em);
+        } finally {
+            Order toDelete = em.find(Order.class, orderId);
+            em.remove(toDelete);
+        }
+    }
+
+    /**
+     * Test refresh.
+     */
+    @Test
+    public void testRefresh() {
+        EntityManagerHelper.beginTransaction(em);
+        long orderId = ++lastId;
+        Order order = new Order();
+        try {
+            order.id = orderId++;
+            order.orderedBy = "ACME";
+            order.address = new Address();
+            order.address.city = "Ottawa";
+            em.persist(order);
+            EntityManagerHelper.commitTransaction(em);
+        } finally {
+            EntityManagerHelper.clearCache(em);
+            EntityManagerHelper.closeEntityManagerAndTransaction(em);
+        }
+        em = createEntityManager();
+        EntityManagerHelper.beginTransaction(em);
+        try {
+            order = em.find(Order.class, order.id);
+            order.orderedBy = "Fred Jones";
+            em.refresh(order);
+            assertEquals(String.format("Refresh failed: %s", order.orderedBy), "ACME", order.orderedBy);
+        } finally {
+            em.remove(order);
+        }
+    }
+
+    /**
+     * Test JPQL.
+     */
+    @Test
+    public void testJPQL() {
+        // We need known amount of records in DB.
+        initModel();
+        final TypedQuery<Order> query1 = em.createQuery("Select o from Order o", Order.class);
+        final int count1 = query1.getResultList().size();
+        assertEquals(String.format("Find all did not work, expected 10 got: %d", count1), 10, count1);
+        final Order existingOrder = getRandomOrder();
+        final TypedQuery<Order> query2 = em.createQuery("Select o from Order o where o.id = :id", Order.class);
+        query2.setParameter("id", existingOrder.id);
+        final int count2 = query2.getResultList().size();
+        assertEquals(String.format("Find all did not work, expected 1 got: %d", count2), 1, count2);
+    }
+
+    /**
+     * Test native query.
+     */
+    @Test
+    public void testNativeQuery() {
+        MappedInteraction interaction = new XMLInteraction();
+        final Order existingOrder = getRandomOrder();
+        interaction.setProperty(OracleNoSQLPlatform.OPERATION, OracleNoSQLOperation.ITERATOR_QUERY.name());
+        interaction.addArgumentValue(OracleNoSQLPlatform.QUERY, "DECLARE $id INTEGER; " +
+                                                                              "SELECT * FROM order_mapped WHERE id = $id");
+        interaction.addArgumentValue(OracleNoSQLPlatform.QUERY_ARGUMENTS, "id");
+        interaction.addArgumentValue("id" + OracleNoSQLPlatform.QUERY_ARGUMENT_TYPE_SUFFIX, "java.lang.Long");
+        interaction.addArgumentValue("id" + OracleNoSQLPlatform.QUERY_ARGUMENT_VALUE_SUFFIX, existingOrder.id);
+
+        final Query query = em.unwrap(JpaEntityManager.class).createQuery(interaction, Order.class);
+        @SuppressWarnings("unchecked")
+        final List<Object> result2 = query.getResultList();
+        assertEquals(String.format("Expected result of size 1, got %d", result2.size()), 1, result2.size());
+        assertTrue(String.format("Result is not instance of Order but %s", result2.get(0).getClass().getSimpleName()),
+                (result2.get(0) instanceof Order));
+    }
+
+    /**
+     * Test deletes.
+     */
+    @Test
+    public void testDelete() {
+        EntityManagerHelper.beginTransaction(em);
+        long orderId = ++lastId;
+        Order order = new Order();
+        try {
+            order.id = orderId;
+            order.orderedBy = "ACME";
+            order.address = new Address();
+            order.address.city = "Ottawa";
+            em.persist(order);
+            EntityManagerHelper.commitTransaction(em);
+        } finally {
+            EntityManagerHelper.clearCache(em);
+            EntityManagerHelper.closeEntityManagerAndTransaction(em);
+        }
+        em = createEntityManager();
+        EntityManagerHelper.beginTransaction(em);
+        try {
+            order = em.find(Order.class, order.id);
+            em.remove(order);
+            EntityManagerHelper.commitTransaction(em);
+        } finally {
+            EntityManagerHelper.clearCache(em);
+            EntityManagerHelper.closeEntityManagerAndTransaction(em);
+        }
+        em = createEntityManager();
+        EntityManagerHelper.beginTransaction(em);
+        final Order fromDatabase = em.find(Order.class, order.id);
+        assertNull(String.format("Object not deleted: %s", fromDatabase), fromDatabase);
+    }
+}

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/jpa/nosql/sdk/NoSQLJPATest.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/jpa/nosql/sdk/NoSQLJPATest.java
@@ -1,0 +1,362 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation.
+package org.eclipse.persistence.testing.tests.jpa.nosql.sdk;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import jakarta.persistence.TypedQuery;
+
+import org.eclipse.persistence.eis.interactions.MappedInteraction;
+import org.eclipse.persistence.eis.interactions.XMLInteraction;
+import org.eclipse.persistence.internal.nosql.adapters.sdk.OracleNoSQLOperation;
+import org.eclipse.persistence.jpa.JpaEntityManager;
+import org.eclipse.persistence.nosql.adapters.sdk.OracleNoSQLPlatform;
+import org.eclipse.persistence.testing.framework.junit.LogTestExecution;
+import org.eclipse.persistence.testing.models.jpa.nosql.Address;
+import org.eclipse.persistence.testing.models.jpa.nosql.Customer;
+import org.eclipse.persistence.testing.models.jpa.nosql.Order;
+import org.eclipse.persistence.testing.tests.nosql.sdk.EntityManagerHelper;
+import org.eclipse.persistence.testing.tests.nosql.sdk.JPAModelHelper;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Oracle NoSQL JPA database tests.
+ */
+public class NoSQLJPATest {
+
+    /** Log the test being currently executed. */
+    @Rule public LogTestExecution logExecution = new LogTestExecution();
+
+    /** The persistence unit name. */
+    private static final String PU_NAME = "nosql-sdk";
+
+    /** Stored {@link Order} instances count. */
+    private static final int ORDERS_COUNT = 10;
+
+    /** Stored {@link Order} instances. */
+    private static Order[] orders;
+
+    /** Entity manager used by tests. */
+    EntityManager em;
+
+    /**
+     * Get random order instance from test setup.
+     * @return Random order instance from test setup.
+     */
+    private static Order getRandomOrder() {
+        final int index = (int)(Math.random() * ORDERS_COUNT);
+        return orders[index];
+    }
+
+    /**
+     * Initialize data model for tests.
+     */
+    @BeforeClass
+    public static void initModel() {
+        EntityManager em = EntityManagerHelper.createEntityManager(PU_NAME);
+        try {
+            JPAModelHelper.deleteModel(em);
+            orders = JPAModelHelper.buildModel(em, ORDERS_COUNT);
+        } finally {
+            EntityManagerHelper.clearCache(em);
+            EntityManagerHelper.closeEntityManagerAndTransaction(em);
+        }
+    }
+
+    /**
+     * Delete data model after tests.
+     */
+    @AfterClass
+    public static void deleteModel() {
+        EntityManager em = EntityManagerHelper.createEntityManager(PU_NAME);
+        try {
+            JPAModelHelper.deleteModel(em);
+        } finally {
+            EntityManagerHelper.clearCache(em);
+            EntityManagerHelper.closeEntityManagerAndTransaction(em);
+        }
+    }
+
+    /**
+     * Setup test.
+     */
+    @Before
+    public void setUp() {
+        em = EntityManagerHelper.createEntityManager(PU_NAME);
+    }
+
+    /**
+     * Cleanup test.
+     */
+    @After
+    public void tearDown() {
+        EntityManagerHelper.closeEntityManagerAndTransaction(em);
+    }
+
+    /**
+     * Test inserts.
+     */
+    @Test
+    public void testInsert() {
+        final Order order = new Order();
+        Customer customer = new Customer();
+        EntityManagerHelper.beginTransaction(em);
+        try {
+            order.orderedBy = "ACME";
+            order.address = new Address();
+            order.address.city = "Ottawa";
+            em.persist(order);
+            order.customer = customer;
+            order.customer.name = "ACME";
+            em.persist(order.customer);
+            EntityManagerHelper.commitTransaction(em);
+        } finally {
+            EntityManagerHelper.clearCache(em);
+            EntityManagerHelper.closeEntityManagerAndTransaction(em);
+        }
+        em = EntityManagerHelper.createEntityManager(PU_NAME);
+        EntityManagerHelper.beginTransaction(em);
+        Order orderFromDatabase = null;
+        Customer customerFromDatabase = null;
+        try {
+            order.customer = null;
+            orderFromDatabase = em.find(Order.class, order.id);
+            EntityManagerHelper.compareObjects(order, orderFromDatabase, em);
+            customerFromDatabase = em.find(Customer.class, customer.id);
+            EntityManagerHelper.compareObjects(customer, customerFromDatabase, em);
+        } finally {
+            if (orderFromDatabase != null) {
+                em.remove(orderFromDatabase);
+            }
+            if (customerFromDatabase != null) {
+                em.remove(customerFromDatabase);
+            }
+        }
+    }
+
+    /**
+     * Test find on random {@link Order} key.
+     */
+    @Test
+    public void testFind() {
+        EntityManagerHelper.beginTransaction(em);
+        final Order existingOrder = getRandomOrder();
+        final Order order = em.find(Order.class, existingOrder.id);
+        EntityManagerHelper.compareObjects(existingOrder, order, em);
+    }
+
+    /**
+     * Test updates.
+     */
+    @Test
+    public void testUpdate() {
+        EntityManagerHelper.beginTransaction(em);
+        Order order = new Order();
+        String orderId = null;
+        try {
+            order.orderedBy = "ACME";
+            order.address = new Address();
+            order.address.city = "Ottawa";
+            em.persist(order);
+            EntityManagerHelper.commitTransaction(em);
+            orderId = order.id;
+        } finally {
+            EntityManagerHelper.clearCache(em);
+            EntityManagerHelper.closeEntityManagerAndTransaction(em);
+        }
+        em = EntityManagerHelper.createEntityManager(PU_NAME);
+        EntityManagerHelper.beginTransaction(em);
+        try {
+            final Order existingOrder = getRandomOrder();
+            order = em.find(Order.class, existingOrder.id);
+            order.orderedBy = "Fred Jones";
+            order.address.addressee = "Fred Jones";
+            EntityManagerHelper.commitTransaction(em);
+        } finally {
+            EntityManagerHelper.clearCache(em);
+            EntityManagerHelper.closeEntityManagerAndTransaction(em);
+        }
+        em = EntityManagerHelper.createEntityManager(PU_NAME);
+        EntityManagerHelper.beginTransaction(em);
+        try {
+            Order fromDatabase = em.find(Order.class, order.id);
+            EntityManagerHelper.compareObjects(order, fromDatabase, em);
+        } finally {
+            Order toDelete = em.find(Order.class, orderId);
+            em.remove(toDelete);
+        }
+    }
+
+    /**
+     * Test merge.
+     */
+    @Test
+    public void testMerge() {
+        EntityManagerHelper.beginTransaction(em);
+        Order order = new Order();
+        String orderId = null;
+        try {
+            order.orderedBy = "ACME";
+            order.address = new Address();
+            order.address.city = "Ottawa";
+            em.persist(order);
+            EntityManagerHelper.commitTransaction(em);
+            orderId = order.id;
+        } finally {
+            EntityManagerHelper.clearCache(em);
+            EntityManagerHelper.closeEntityManagerAndTransaction(em);
+        }
+        em = EntityManagerHelper.createEntityManager(PU_NAME);
+        EntityManagerHelper.beginTransaction(em);
+        try {
+            order = em.find(Order.class, order.id);
+            order.orderedBy = "Fred Jones";
+            order.address.addressee = "Fred Jones";
+        } finally {
+            EntityManagerHelper.closeEntityManagerAndTransaction(em);
+        }
+        em = EntityManagerHelper.createEntityManager(PU_NAME);
+        EntityManagerHelper.beginTransaction(em);
+        try {
+            em.merge(order);
+            EntityManagerHelper.commitTransaction(em);
+        } finally {
+            EntityManagerHelper.clearCache(em);
+            EntityManagerHelper.closeEntityManagerAndTransaction(em);
+        }
+        em = EntityManagerHelper.createEntityManager(PU_NAME);
+        EntityManagerHelper.beginTransaction(em);
+        try {
+            Order fromDatabase = em.find(Order.class, order.id);
+            EntityManagerHelper.compareObjects(order, fromDatabase, em);
+        } finally {
+            Order toDelete = em.find(Order.class, orderId);
+            em.remove(toDelete);
+        }
+    }
+
+    /**
+     * Test refresh.
+     */
+    @Test
+    public void testRefresh() {
+        EntityManagerHelper.beginTransaction(em);
+        Order order = new Order();
+        try {
+            order.orderedBy = "ACME";
+            order.address = new Address();
+            order.address.city = "Ottawa";
+            em.persist(order);
+            EntityManagerHelper.commitTransaction(em);
+        } finally {
+            EntityManagerHelper.clearCache(em);
+            EntityManagerHelper.closeEntityManagerAndTransaction(em);
+        }
+        em = EntityManagerHelper.createEntityManager(PU_NAME);
+        EntityManagerHelper.beginTransaction(em);
+        try {
+            order = em.find(Order.class, order.id);
+            order.orderedBy = "Fred Jones";
+            em.refresh(order);
+            assertEquals(String.format("Refresh failed: %s", order.orderedBy), "ACME", order.orderedBy);
+        } finally {
+            em.remove(order);
+        }
+    }
+
+    /**
+     * Test JPQL.
+     */
+    @Test
+    public void testJPQL() {
+        // We need known amount of records in DB.
+        initModel();
+        final TypedQuery<Order> query1 = em.createQuery("Select o from Order o", Order.class);
+        final int count1 = query1.getResultList().size();
+        assertEquals(String.format("Find all did not work, expected 10 got: %d", count1), ORDERS_COUNT, count1);
+        final Order existingOrder = getRandomOrder();
+        final TypedQuery<Order> query2 = em.createQuery("Select o from Order o where o.id = :id", Order.class);
+        query2.setParameter("id", existingOrder.id);
+        final int count2 = query2.getResultList().size();
+        assertEquals(String.format("Find all did not work, expected 1 got: %d", count2), 1, count2);
+    }
+
+    /**
+     * Test native query.
+     */
+    @Test
+    public void testNativeQuery() {
+        MappedInteraction interaction = new XMLInteraction();
+        final Order existingOrder = getRandomOrder();
+        interaction.setProperty(OracleNoSQLPlatform.OPERATION, OracleNoSQLOperation.ITERATOR_QUERY.name());
+        interaction.addArgumentValue(OracleNoSQLPlatform.QUERY, "DECLARE $id STRING; " +
+                                                                              "SELECT * FROM order WHERE id = $id");
+        interaction.addArgumentValue(OracleNoSQLPlatform.QUERY_ARGUMENTS, "id");
+        interaction.addArgumentValue("id" + OracleNoSQLPlatform.QUERY_ARGUMENT_TYPE_SUFFIX, "java.lang.String");
+        interaction.addArgumentValue("id" + OracleNoSQLPlatform.QUERY_ARGUMENT_VALUE_SUFFIX, existingOrder.id);
+
+        final Query query = em.unwrap(JpaEntityManager.class).createQuery(interaction, Order.class);
+        @SuppressWarnings("unchecked")
+        final List<Object> result2 = query.getResultList();
+        assertEquals(String.format("Expected result of size 1, got %d", result2.size()), 1, result2.size());
+        assertTrue(String.format("Result is not instance of Order but %s", result2.get(0).getClass().getSimpleName()),
+                (result2.get(0) instanceof Order));
+    }
+
+    /**
+     * Test deletes.
+     */
+    @Test
+    public void testDelete() {
+        EntityManagerHelper.beginTransaction(em);
+        Order order = new Order();
+        try {
+            order.orderedBy = "ACME";
+            order.address = new Address();
+            order.address.city = "Ottawa";
+            em.persist(order);
+            EntityManagerHelper.commitTransaction(em);
+        } finally {
+            EntityManagerHelper.clearCache(em);
+            EntityManagerHelper.closeEntityManagerAndTransaction(em);
+        }
+        em = EntityManagerHelper.createEntityManager(PU_NAME);
+        EntityManagerHelper.beginTransaction(em);
+        try {
+            order = em.find(Order.class, order.id);
+            em.remove(order);
+            EntityManagerHelper.commitTransaction(em);
+        } finally {
+            EntityManagerHelper.clearCache(em);
+            EntityManagerHelper.closeEntityManagerAndTransaction(em);
+        }
+        em = EntityManagerHelper.createEntityManager(PU_NAME);
+        EntityManagerHelper.beginTransaction(em);
+        final Order fromDatabase = em.find(Order.class, order.id);
+        assertNull(String.format("Object not deleted: %s", fromDatabase), fromDatabase);
+    }
+
+}

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/jpa/nosql/sdk/NoSQLJPATestSuite.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/jpa/nosql/sdk/NoSQLJPATestSuite.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation.
+package org.eclipse.persistence.testing.tests.jpa.nosql.sdk;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+/**
+ * Oracle NoSQL JPA database tests suite.
+ */
+@RunWith(Suite.class)
+@SuiteClasses({
+    NoSQLJPATest.class,
+    NoSQLJPAMappedTest.class
+})
+public class NoSQLJPATestSuite {
+
+}

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/nosql/sdk/EntityManagerHelper.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/nosql/sdk/EntityManagerHelper.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation.
+package org.eclipse.persistence.testing.tests.nosql.sdk;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+
+import org.eclipse.persistence.descriptors.ClassDescriptor;
+import org.eclipse.persistence.internal.sessions.AbstractSession;
+import org.eclipse.persistence.internal.sessions.DatabaseSessionImpl;
+import org.eclipse.persistence.logging.AbstractSessionLog;
+import org.eclipse.persistence.logging.SessionLog;
+import org.eclipse.persistence.sessions.DatabaseSession;
+import org.eclipse.persistence.sessions.IdentityMapAccessor;
+import org.eclipse.persistence.testing.framework.jpa.junit.JUnitTestCase;
+import org.eclipse.persistence.testing.framework.jpa.server.JEEPlatform;
+import org.eclipse.persistence.testing.framework.jpa.server.ServerPlatform;
+
+public class EntityManagerHelper {
+
+    /** Logger. */
+    private static final SessionLog LOG = AbstractSessionLog.getLog();
+
+    /** Stores an information if this test is running on a JEE server, or in JSE. */
+    static final boolean isOnServer = System.getProperty("TEST_SERVER_PLATFORM") != null;
+
+    /** Stores an information if the data source is JTA or not. */
+    static final boolean isJTA = Boolean.getBoolean(System.getProperty("is.JTA"));
+
+    /** Application server platform. */
+    static final ServerPlatform serverPlatform = isOnServer ? initServerPlatform() : null;
+
+    /**
+     * Initialize application server platform instance.
+     * @return Application server platform instance or {@code null} if instance could not be initialized.
+     */
+    private static ServerPlatform initServerPlatform() {
+        final String platformClass = System.getProperty("TEST_SERVER_PLATFORM");
+        if (platformClass == null) {
+            return new JEEPlatform();
+        } else {
+            try {
+                return (ServerPlatform)Class.forName(platformClass).getConstructor().newInstance();
+            } catch (Exception ex) {
+                LOG.log(SessionLog.WARNING, String.format(
+                        "Could not initiaize ServerPlatform: %s", ex.getLocalizedMessage()));
+                return null;
+            }
+        }
+    }
+
+    /**
+     * Create a new entity manager for the persistence unit using the properties. The properties will only be used
+     * the first time this entity manager is accessed. If in JEE this will create or return the active managed entity
+     * manager.
+     * @param puName      Name of persistence unit used to create {@link EntityManager}.
+     * @param descriptors Additional persistent classes descriptors. Will not be added when running on application
+     *                    server.
+     * @param mapped      Build mapped property for database host and port pair.
+     * @return New {@link EntityManager} instance.
+     */
+    public static EntityManager createEntityManager(
+            final String puName, final List<ClassDescriptor> descriptors, final boolean mapped) {
+        final Map<String, String> emProperties = NoSQLProperties.createEMProperties(mapped);
+        if (isOnServer && isJTA) {
+            if (serverPlatform != null) {
+                final EntityManagerFactory emf = serverPlatform.getEntityManagerFactory(puName);
+                return emf.createEntityManager(emProperties);
+            } else {
+                LOG.log(SessionLog.WARNING, String.format(
+                        "ServerPlatform is unknown, using default EntityManagerFactory to create EntityManager"));
+                return JUnitTestCase.getEntityManagerFactory(puName, emProperties, descriptors)
+                        .createEntityManager(null, emProperties);            }
+        } else {
+            return JUnitTestCase.getEntityManagerFactory(puName, emProperties, descriptors)
+                    .createEntityManager(null, emProperties);
+        }
+    }
+
+    /**
+     * Create a new entity manager for the persistence unit using the properties. The properties will only be used
+     * the first time this entity manager is accessed. If in JEE this will create or return the active managed entity
+     * manager.
+     * @param puName      Name of persistence unit used to create {@link EntityManager}.
+     * @param mapped      Build mapped property for database host and port pair.
+     * @return New {@link EntityManager} instance.
+     */
+    public static EntityManager createEntityManager(final String puName, final boolean mapped) {
+        return createEntityManager(puName, null, mapped);
+    }
+
+    /**
+     * Create a new entity manager for the persistence unit using the properties. The properties will only be used
+     * the first time this entity manager is accessed. If in JEE this will create or return the active managed entity
+     * manager.
+     * @param puName      Name of persistence unit used to create {@link EntityManager}.
+     * @return New {@link EntityManager} instance.
+     */
+    public static EntityManager createEntityManager(final String puName) {
+        return createEntityManager(puName, null, false);
+    }
+
+    /**
+     * Get database session from entity manager.
+     * @param entityManager Entity manager holding the database session.
+     * @return Database session from entity manager.
+     */
+    public static DatabaseSessionImpl getDatabaseSession(final EntityManager entityManager) {
+        return ((org.eclipse.persistence.jpa.JpaEntityManager)entityManager).getDatabaseSession();
+    }
+
+    /**
+     * Begin a transaction on the entity manager. This allows the same code to be used on the server where JTA is used,
+     * and will join the EntityManager to the transaction.
+     * @param entityManager Entity manager holding the transaction.
+     */
+    public static void beginTransaction(final EntityManager entityManager) {
+        if (serverPlatform != null) {
+            serverPlatform.beginTransaction();
+            serverPlatform.joinTransaction(entityManager);
+        } else {
+            entityManager.getTransaction().begin();
+        }
+    }
+
+    /**
+     * Commit a transaction on the entity manager. This allows the same code to be used on the server where JTA is used.
+     * @param entityManager Entity manager holding the transaction.
+     */
+    public static void commitTransaction(final EntityManager entityManager) {
+        if (serverPlatform != null) {
+            serverPlatform.commitTransaction();
+        } else {
+            entityManager.getTransaction().commit();
+        }
+    }
+
+    /**
+     * Roll back a transaction on the entity manager. This allows the same code to be used on the server where JTA
+     * is used.
+     * @param entityManager Entity manager holding the transaction.
+     */
+    public static void rollbackTransaction(final EntityManager entityManager) {
+        if (serverPlatform != null) {
+            serverPlatform.rollbackTransaction();
+        } else {
+            entityManager.getTransaction().rollback();
+        }
+    }
+
+    /**
+     * Check if the transaction in provided entity manager is active.
+     * This allows the same code to be used on the server where JTA is used.
+     * @param entityManager Entity manager holding the transaction.
+     */
+    public static boolean isTransactionActive(EntityManager entityManager) {
+        if (serverPlatform != null) {
+            return serverPlatform.isTransactionActive();
+        } else {
+            return entityManager.getTransaction().isActive();
+        }
+    }
+
+    /**
+     * Close the entity manager.
+     * This allows the same code to be used on the server where managed entity managers are not closed.
+     * @param entityManager Entity manager to be closed.
+     */
+    public static void closeEntityManager(EntityManager entityManager) {
+        if (!isOnServer) {
+            if (entityManager.isOpen()) {
+                entityManager.close();
+            }
+        }
+    }
+
+    /**
+     * Close the entity manager.
+     * If a transaction is active, then roll it back.
+     * @param entityManager Entity manager to be closed.
+     */
+    public static void closeEntityManagerAndTransaction(EntityManager entityManager) {
+        if (isTransactionActive(entityManager)) {
+            rollbackTransaction(entityManager);
+        }
+        closeEntityManager(entityManager);
+    }
+
+    /**
+     * Clear cache for current database session.
+     * @param entityManager Entity manager holding the the database session.
+     */
+    public static void clearCache(final EntityManager entityManager) {
+        DatabaseSession session = getDatabaseSession(entityManager);
+        if (session != null) {
+            IdentityMapAccessor accessor = session.getIdentityMapAccessor();
+            if (accessor != null) {
+                accessor.initializeAllIdentityMaps();
+            } else {
+                LOG.log(SessionLog.WARNING, "Could not get IdentityMapAccessor from session");
+            }
+        } else {
+            LOG.log(SessionLog.WARNING, "Could not get session from EntityManager");
+        }
+    }
+
+    /**
+     * Compare persistence objects.
+     * Test will fail when compared objects differ.
+     * @param obj1 First persistence object.
+     * @param obj2 Second persistence object.
+     * @param entityManager Entity manager holding the the database session.
+     */
+    public static void compareObjects(Object obj1, Object obj2, final EntityManager entityManager) {
+        AbstractSession dbs = getDatabaseSession(entityManager);
+        assertTrue("Objects " + obj1 + " and " + obj2 + " are not equal", dbs.compareObjects(obj1, obj2));
+    }
+}

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/nosql/sdk/JPAModelHelper.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/nosql/sdk/JPAModelHelper.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation.
+package org.eclipse.persistence.testing.tests.nosql.sdk;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.EntityManager;
+
+import oracle.nosql.driver.NoSQLHandle;
+import oracle.nosql.driver.ops.TableLimits;
+import oracle.nosql.driver.ops.TableRequest;
+import org.eclipse.persistence.internal.sessions.AbstractSession;
+import org.eclipse.persistence.jpa.JpaEntityManager;
+import org.eclipse.persistence.logging.AbstractSessionLog;
+import org.eclipse.persistence.logging.SessionLog;
+import org.eclipse.persistence.sessions.DatabaseSession;
+import org.eclipse.persistence.sessions.factories.SessionManager;
+import org.eclipse.persistence.testing.models.jpa.nosql.Address;
+import org.eclipse.persistence.testing.models.jpa.nosql.LineItem;
+import org.eclipse.persistence.testing.models.jpa.nosql.Order;
+
+/**
+ * JPA test model helper methods.
+ */
+public class JPAModelHelper {
+
+    private static final String DROP_CUSTOMER_TABLE_DDL = "DROP TABLE IF EXISTS customer";
+    private static final String DROP_ORDER_TABLE_DDL = "DROP TABLE IF EXISTS order";
+    private static final String CRATE_CUSTOMER_TABLE_DDL = "CREATE TABLE IF NOT EXISTS customer" +
+            "(id STRING, " +
+            "name STRING, " +
+            "PRIMARY KEY(id))";
+    private static final String CRATE_ORDER_TABLE_DDL = "CREATE TABLE IF NOT EXISTS order" +
+            "(id STRING, " +
+            "orderedby STRING, " +
+            "address RECORD(addressee STRING, city STRING, country STRING, state STRING, street STRING, zipcode STRING), " +
+            "lineitems ARRAY(RECORD(itemname STRING, itemprice DOUBLE, linenumber INTEGER, quantity INTEGER)), " +
+            "comments ARRAY(STRING), " +
+            "PRIMARY KEY(id))";
+
+    /** Logger. */
+    private static final SessionLog LOG = AbstractSessionLog.getLog();
+
+    /**
+     * Build {@link Address} instance.
+     * @return {@link Address} instance.
+     */
+    public static Address buildAddress() {
+        final Address address = new Address();
+        address.city = "Ottawa";
+        address.addressee = "Bob Jones";
+        address.state = "CA";
+        address.country = "Mexico";
+        address.zipCode = "12345";
+        return address;
+    }
+
+    /**
+     * Build list of {@link LineItem} instances.
+     * @return List of {@link LineItem} instances.
+     */
+    public static List<LineItem> buildLineItemsList() {
+        final List<LineItem> lineItems = new ArrayList<>();
+        final LineItem line1 = new LineItem();
+        line1.itemName = "stuff";
+        line1.itemPrice = new BigDecimal("10.99");
+        line1.lineNumber = 1;
+        line1.quantity = 100;
+        lineItems.add(line1);
+        final LineItem line2 = new LineItem();
+        line2.itemName = "more stuff";
+        line2.itemPrice = new BigDecimal("20.99");
+        line2.lineNumber = 2;
+        line2.quantity = 50;
+        lineItems.add(line2);
+        return lineItems;
+    }
+
+    /**
+     * Build {@link Order} instance.
+     * @param address {@link Address} instance to be attached.
+     * @param lineItems List of {@link LineItem} instances to be attached.
+     * @return {@link Order} instance.
+     */
+    public static Order buildOrder(final Address address, final List<LineItem> lineItems) {
+        final Order order = new Order();
+        order.orderedBy = "ACME";
+        order.comments.add("priority order");
+        order.comments.add("next day");
+        order.address = address;
+        order.lineItems = lineItems;
+        return order;
+    }
+
+    private static void dropCreateTable(final EntityManager em, boolean justDrop) {
+        DatabaseSession session = ((JpaEntityManager)em).getDatabaseSession();
+        SessionManager sessionManager = SessionManager.getManager();
+        sessionManager.setDefaultSession(session);
+        org.eclipse.persistence.internal.nosql.adapters.sdk.OracleNoSQLConnection oracleNoSQLConnection = (org.eclipse.persistence.internal.nosql.adapters.sdk.OracleNoSQLConnection)((AbstractSession)session).getAccessor().getDatasourceConnection();
+        NoSQLHandle noSQLHandle = oracleNoSQLConnection.getNoSQLHandle();
+        TableLimits limits = new TableLimits(1, 2, 1);
+        LOG.info("Droping order table.");
+        TableRequest tableRequestOrderDrop = new TableRequest().setStatement(DROP_ORDER_TABLE_DDL);
+        noSQLHandle.doTableRequest(tableRequestOrderDrop, 60000, 1000);
+        LOG.info("Droping customer table.");
+        TableRequest tableRequestCustomerDrop = new TableRequest().setStatement(DROP_CUSTOMER_TABLE_DDL);
+        noSQLHandle.doTableRequest(tableRequestCustomerDrop, 60000, 1000);
+        if (!justDrop) {
+            LOG.info("Creating order table.");
+            TableRequest tableRequestOrderCreate = new TableRequest().setStatement(CRATE_ORDER_TABLE_DDL).setTableLimits(limits);
+            noSQLHandle.doTableRequest(tableRequestOrderCreate, 60000, 1000);
+            LOG.info("Creating customer table.");
+            TableRequest tableRequestCustomerCreate = new TableRequest().setStatement(CRATE_CUSTOMER_TABLE_DDL).setTableLimits(limits);
+            noSQLHandle.doTableRequest(tableRequestCustomerCreate, 60000, 1000);
+        }
+        LOG.info("order and customer table was created.");
+    }
+
+    /**
+     * Build data model for tests.
+     * @param em    {@link EntityManager} used to access database.
+     * @param count Number of {@link Order} instances to store.
+     * @return An array of stored {@link Order} instances.
+     */
+    public static Order[] buildModel(final EntityManager em, final int count) {
+        dropCreateTable(em, false);
+        final Order[] orders = new Order[count];
+        EntityManagerHelper.beginTransaction(em);
+        for (int index = 0; index < count; index++) {
+            final Address address = buildAddress();
+            final List<LineItem> lineItems = buildLineItemsList();
+            final Order order = buildOrder(address, lineItems);
+            em.persist(order);
+            orders[index] = order;
+        }
+        EntityManagerHelper.commitTransaction(em);
+        return orders;
+    }
+
+    /**
+     * Delete data model for tests.
+     */
+    public static void deleteModel(final EntityManager em) {
+        dropCreateTable(em, true);
+    }
+}

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/nosql/sdk/MappedJPAModelHelper.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/nosql/sdk/MappedJPAModelHelper.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2016, 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation.
+package org.eclipse.persistence.testing.tests.nosql.sdk;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.EntityManager;
+
+import oracle.nosql.driver.NoSQLHandle;
+import oracle.nosql.driver.ops.TableLimits;
+import oracle.nosql.driver.ops.TableRequest;
+import org.eclipse.persistence.internal.sessions.AbstractSession;
+import org.eclipse.persistence.jpa.JpaEntityManager;
+import org.eclipse.persistence.logging.AbstractSessionLog;
+import org.eclipse.persistence.logging.SessionLog;
+import org.eclipse.persistence.sessions.DatabaseSession;
+import org.eclipse.persistence.sessions.factories.SessionManager;
+import org.eclipse.persistence.testing.models.jpa.nosql.mapped.Address;
+import org.eclipse.persistence.testing.models.jpa.nosql.mapped.LineItem;
+import org.eclipse.persistence.testing.models.jpa.nosql.mapped.Order;
+
+/**
+ * JPA with mapped database test model helper methods.
+ */
+public class MappedJPAModelHelper {
+
+    private static final String DROP_CUSTOMER_TABLE_DDL = "DROP TABLE IF EXISTS customer_mapped";
+    private static final String DROP_ORDER_TABLE_DDL = "DROP TABLE IF EXISTS order_mapped";
+    private static final String CRATE_CUSTOMER_TABLE_DDL = "CREATE TABLE IF NOT EXISTS customer_mapped" +
+            "(id STRING, " +
+            "name STRING, " +
+            "PRIMARY KEY(id))";
+    private static final String CRATE_ORDER_TABLE_DDL = "CREATE TABLE IF NOT EXISTS order_mapped" +
+            "(id INTEGER, " +
+            "orderedby STRING, " +
+            "address RECORD(addressee STRING, city STRING, country STRING, state STRING, street STRING, zipcode STRING), " +
+            "lineitems ARRAY(RECORD(itemname STRING, itemprice DOUBLE, linenumber INTEGER, quantity INTEGER)), " +
+            "comments ARRAY(STRING), " +
+            "PRIMARY KEY(id))";
+
+    /** Logger. */
+    private static final SessionLog LOG = AbstractSessionLog.getLog();
+
+    /**
+     * Build {@link Address} instance.
+     * @return {@link Address} instance.
+     */
+    public static Address buildAddress() {
+        final Address address = new Address();
+        address.city = "Ottawa";
+        address.addressee = "Bob Jones";
+        address.state = "CA";
+        address.country = "Mexico";
+        address.zipCode = "12345";
+        return address;
+    }
+
+    /**
+     * Build list of {@link LineItem} instances.
+     * @return List of {@link LineItem} instances.
+     */
+    public static List<LineItem> buildLineItemsList() {
+        final List<LineItem> lineItems = new ArrayList<>();
+        final LineItem line1 = new LineItem();
+        line1.itemName = "stuff";
+        line1.itemPrice = new BigDecimal("10.99");
+        line1.lineNumber = 1;
+        line1.quantity = 100;
+        lineItems.add(line1);
+        final LineItem line2 = new LineItem();
+        line2.itemName = "more stuff";
+        line2.itemPrice = new BigDecimal("20.99");
+        line2.lineNumber = 2;
+        line2.quantity = 50;
+        lineItems.add(line2);
+        return lineItems;
+    }
+
+    /**
+     * Build {@link Order} instance.
+     * @param id        Database record primary key value.
+     * @param address   {@link Address} instance to be attached.
+     * @param lineItems List of {@link LineItem} instances to be attached.
+     * @return {@link Order} instance.
+     */
+    public static Order buildOrder(final long id, final Address address, final List<LineItem> lineItems) {
+        final Order order = new Order();
+        order.id = id;
+        order.orderedBy = "ACME";
+        order.comments.add("priority order");
+        order.comments.add("next day");
+        order.address = address;
+        order.lineItems = lineItems;
+        return order;
+    }
+
+    private static void dropCreateTable(final EntityManager em, boolean justDrop) {
+        DatabaseSession session = ((JpaEntityManager)em).getDatabaseSession();
+        SessionManager sessionManager = SessionManager.getManager();
+        sessionManager.setDefaultSession(session);
+        org.eclipse.persistence.internal.nosql.adapters.sdk.OracleNoSQLConnection oracleNoSQLConnection = (org.eclipse.persistence.internal.nosql.adapters.sdk.OracleNoSQLConnection)((AbstractSession)session).getAccessor().getDatasourceConnection();
+        NoSQLHandle noSQLHandle = oracleNoSQLConnection.getNoSQLHandle();
+        TableLimits limits = new TableLimits(1, 2, 1);
+        LOG.info("Droping order table.");
+        TableRequest tableRequestOrderDrop = new TableRequest().setStatement(DROP_ORDER_TABLE_DDL);
+        noSQLHandle.doTableRequest(tableRequestOrderDrop, 60000, 1000);
+        LOG.info("Droping customer table.");
+        TableRequest tableRequestCustomerDrop = new TableRequest().setStatement(DROP_CUSTOMER_TABLE_DDL);
+        noSQLHandle.doTableRequest(tableRequestCustomerDrop, 60000, 1000);
+        if (!justDrop) {
+            LOG.info("Creating order table.");
+            TableRequest tableRequestOrderCreate = new TableRequest().setStatement(CRATE_ORDER_TABLE_DDL).setTableLimits(limits);
+            noSQLHandle.doTableRequest(tableRequestOrderCreate, 60000, 1000);
+            LOG.info("Creating customer table.");
+            TableRequest tableRequestCustomerCreate = new TableRequest().setStatement(CRATE_CUSTOMER_TABLE_DDL).setTableLimits(limits);
+            noSQLHandle.doTableRequest(tableRequestCustomerCreate, 60000, 1000);
+        }
+        LOG.info("order and customer table was created.");
+    }
+
+    /**
+     * Build data model for tests.
+     * Last used id is stored in {@code orders[orders.length-1].id}.
+     * @param em    {@link EntityManager} used to access database.
+     * @param count Number of {@link Order} instances to store.
+     * @return An array of stored {@link Order} instances.
+     */
+
+    public static Order[] buildModel(final EntityManager em, final int count, final long lastId) {
+        dropCreateTable(em, false);
+        long id = lastId + 1;
+        final Order[] orders = new Order[count];
+        EntityManagerHelper.beginTransaction(em);
+        for (int index = 0; index < count; index++) {
+            final Address address = buildAddress();
+            final List<LineItem> lineItems = buildLineItemsList();
+            final Order order = buildOrder(id++, address, lineItems);
+            em.persist(order);
+            orders[index] = order;
+        }
+        EntityManagerHelper.commitTransaction(em);
+        return orders;
+    }
+
+    /**
+     * Delete data model for tests.
+     */
+    public static void deleteModel(final EntityManager em) {
+        dropCreateTable(em, true);
+    }
+}

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/nosql/sdk/NoSQLProperties.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/nosql/sdk/NoSQLProperties.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.testing.tests.nosql.sdk;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.persistence.config.PersistenceUnitProperties;
+import org.eclipse.persistence.eis.EISLogin;
+import org.eclipse.persistence.logging.AbstractSessionLog;
+import org.eclipse.persistence.logging.SessionLog;
+import org.eclipse.persistence.nosql.adapters.sdk.OracleNoSQLConnectionSpec;
+import org.eclipse.persistence.testing.framework.junit.JUnitTestCaseHelper;
+
+/**
+ * NoSQL test suite properties.
+ */
+public class NoSQLProperties {
+
+    /** Logger. */
+    private static final SessionLog LOG = AbstractSessionLog.getLog();
+
+    /** NoSQL database service build property name. */
+    private static final String NOSQL_BUILD_PROPERTY_PREFIX = "nosql.sdk.";
+    public static final String NOSQL_SERVICE_BUILD_KEY = JUnitTestCaseHelper.insertIndex(NOSQL_BUILD_PROPERTY_PREFIX + "service", null);
+    public static final String NOSQL_ENDPOINT_BUILD_KEY = JUnitTestCaseHelper.insertIndex(NOSQL_BUILD_PROPERTY_PREFIX + "endpoint", null);
+    public static final String NOSQL_COMPARTMENT_BUILD_KEY = JUnitTestCaseHelper.insertIndex(NOSQL_BUILD_PROPERTY_PREFIX + "compartment", null);
+    public static final String NOSQL_AUTH_PRINCIPAL_BUILD_KEY = JUnitTestCaseHelper.insertIndex(NOSQL_BUILD_PROPERTY_PREFIX + "authprincipal", null);
+
+    /** Relational database platform class build property name. */
+    private static final String DB_PLATFORM_KEY = JUnitTestCaseHelper.insertIndex(JUnitTestCaseHelper.DB_PLATFORM_KEY, null);
+
+    // NoSQL related persistence unit property names.
+    /** The persistence unit property key for the Oracle NoSQL service (cloud | onprem | cloudsim). */
+    public static final String NOSQL_SERVICE_PROPERTY_KEY = PersistenceUnitProperties.NOSQL_PROPERTY + "nosql.service";
+    /** The persistence unit property key for the Oracle NoSQL endpoint (e.g. eu-frankfurt-1 (for cloud) | http://localhost:8080 (for onprem) | http://localhost:8080 (for cloudsim)). */
+    public static final String NOSQL_ENDPOINT_PROPERTY_KEY = PersistenceUnitProperties.NOSQL_PROPERTY + "nosql.endpoint";
+    /** The persistence unit property key for the Oracle NoSQL compartment. */
+    public static final String NOSQL_COMPARTMENT_PROPERTY_KEY = PersistenceUnitProperties.NOSQL_PROPERTY + "nosql.compartment";
+    /** The persistence unit property key for the Oracle NoSQL authorization principal (user | instance | resource). */
+    public static final String NOSQL_AUTH_PRINCIPAL_PROPERTY_KEY = PersistenceUnitProperties.NOSQL_PROPERTY + "nosql.authprincipal";
+
+
+    /** Database PU properties {@link Map} from the build properties. Shared for whole test suite. */
+    public static final Map<String, String> properties = buildProperties();
+
+
+    /**
+     * Get database platform class name from configuration properties.
+     * @return Database platform class name.
+     */
+    public static String getDBPlatform() {
+        return properties.get(PersistenceUnitProperties.TARGET_DATABASE);
+    }
+
+    /**
+     * Process and add simple build property.
+     * @param properties Test properties {@link Map} being built.
+     * @param buildKey   Property key in build properties.
+     * @param testKey      Property key in jUnit test.
+     */
+    private static void processProperty(
+            final Map<String, String> properties, final String buildKey, final String testKey) {
+        final String value = JUnitTestCaseHelper.getProperty(buildKey);
+        LOG.log(SessionLog.FINER,
+                String.format("Property %s -> %s :: %s", buildKey, testKey, value != null ? value : "N/A"));
+        if (value != null) {
+            properties.put(testKey, value);
+        }
+    }
+
+    /**
+     * Create test properties {@link Map} from build properties.
+     * @return Persistence unit properties {@link Map}.
+     */
+    private static Map<String, String> buildProperties() {
+        final Map<String, String> properties = new HashMap<>();
+        processProperty(properties, NOSQL_SERVICE_BUILD_KEY, NOSQL_SERVICE_PROPERTY_KEY);
+        processProperty(properties, NOSQL_ENDPOINT_BUILD_KEY, NOSQL_ENDPOINT_PROPERTY_KEY);
+        processProperty(properties, NOSQL_COMPARTMENT_BUILD_KEY, NOSQL_COMPARTMENT_PROPERTY_KEY);
+        processProperty(properties, NOSQL_AUTH_PRINCIPAL_BUILD_KEY, NOSQL_AUTH_PRINCIPAL_PROPERTY_KEY);
+        processProperty(properties, DB_PLATFORM_KEY, PersistenceUnitProperties.TARGET_DATABASE);
+        return properties;
+    }
+
+    /**
+     * Set EIS login connection information for NoSQL database.
+     * @param login      Target {@link EISLogin} instance.
+     */
+    public static void setEISLoginProperties(final EISLogin login) {
+        final String service = properties.get(NOSQL_SERVICE_PROPERTY_KEY);
+        final String endpoint = properties.get(NOSQL_ENDPOINT_PROPERTY_KEY);
+        final String compartment = properties.get(NOSQL_COMPARTMENT_PROPERTY_KEY);
+        final String authPrincipal = properties.get(NOSQL_AUTH_PRINCIPAL_PROPERTY_KEY);
+        LOG.log(SessionLog.FINE, String.format("NoSQL service:%s\tendpoint:%s\tcompartment:%s\tauthorization principal:%s", service, endpoint, compartment, authPrincipal));
+        if (service != null) {
+            login.setProperty(OracleNoSQLConnectionSpec.SERVICE, service);
+        }
+        if (endpoint != null) {
+            login.setProperty(OracleNoSQLConnectionSpec.END_POINT, endpoint);
+        }
+        if (compartment != null) {
+            login.setProperty(OracleNoSQLConnectionSpec.COMPARTMENT, compartment);
+        }
+        if (authPrincipal != null) {
+            login.setProperty(OracleNoSQLConnectionSpec.AUTHORIZATION_PRINCIPAL, authPrincipal);
+        }
+    }
+
+    /**
+     * Build EIS login connection information for {@code EntityManager} NoSQL database connection.
+     * @param mapped Build mapped property for the same host and port pair when {@code true} or normal property
+     *               otherwise.
+     * @return {@code EntityManager} NoSQL database connection properties.
+     */
+    public static Map<String, String> createEMProperties(final boolean mapped) {
+        final String service = properties.get(NOSQL_SERVICE_PROPERTY_KEY);
+        final String endpoint = properties.get(NOSQL_ENDPOINT_PROPERTY_KEY);
+        final String compartment = properties.get(NOSQL_COMPARTMENT_PROPERTY_KEY);
+        final String authPrincipal = properties.get(NOSQL_AUTH_PRINCIPAL_PROPERTY_KEY);
+        final Map<String, String> emProperties = new HashMap<>(2);
+        LOG.log(SessionLog.FINE, String.format("NoSQL service:%s\tendpoint:%s\tcompartment:%s\tauthorization principal:%s", service, endpoint, compartment, authPrincipal));
+        if (service != null) {
+            emProperties.put(NOSQL_SERVICE_PROPERTY_KEY, service);
+        }
+        if (endpoint != null) {
+            emProperties.put(NOSQL_ENDPOINT_PROPERTY_KEY, endpoint);
+        }
+        if (compartment != null) {
+            emProperties.put(NOSQL_COMPARTMENT_PROPERTY_KEY, compartment);
+        }
+        if (authPrincipal != null) {
+            emProperties.put(NOSQL_AUTH_PRINCIPAL_PROPERTY_KEY, authPrincipal);
+        }
+        return emProperties;
+    }
+}

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/nosql/sdk/SessionHelper.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/nosql/sdk/SessionHelper.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.testing.tests.nosql.sdk;
+
+import org.eclipse.persistence.logging.AbstractSessionLog;
+import org.eclipse.persistence.logging.SessionLog;
+import org.eclipse.persistence.sessions.DatabaseSession;
+import org.eclipse.persistence.sessions.DatasourceLogin;
+import org.eclipse.persistence.sessions.Project;
+import org.eclipse.persistence.sessions.factories.XMLProjectReader;
+import org.eclipse.persistence.sessions.server.Server;
+import org.eclipse.persistence.testing.framework.TestProblemException;
+
+/**
+ * Session initialization helper methods.
+ * Keeps database configuration properties in static context.
+ */
+public class SessionHelper {
+
+    /** Logger. */
+    private static final SessionLog LOG = AbstractSessionLog.getLog();
+
+    /** Database model descriptor file. */
+    public static final String MODEL_FILE = "org/eclipse/persistence/testing/models/order/eis/nosql/sdk/order-project.xml";
+
+    /**
+     * Creates EclipseLink configuration {@link Project} without testing model and with provided connection
+     *  specifications.
+     * @param login Database connection specifications.
+     * @param loaderClass Class used to retrieve {@link ClassLoader}.
+     */
+    public static Project createProject(final DatasourceLogin login, final Class<?> loaderClass) {
+        return new Project(login);
+    }
+
+    /**
+     * Creates EclipseLink configuration {@link Project} with testing model and provided connection specifications.
+     * @param login Database connection specifications.
+     * @param loaderClass Class used to retrieve {@link ClassLoader}.
+     */
+    public static Project createModelProject(final DatasourceLogin login, final Class<?> loaderClass) {
+        final Project project = XMLProjectReader.read(MODEL_FILE, loaderClass.getClassLoader());
+        project.setLogin(login);
+        return project;
+    }
+
+    /**
+     * Creates {@link DatabaseSession} from project and connect it to database.
+     * {@link DatabaseSession#logout()} must be called before session instance is disposed.
+     */
+    public static DatabaseSession createDatabaseSession(final Project project) {
+        DatabaseSession session = project.createDatabaseSession();
+        session.setSessionLog(LOG);
+        try {
+            session.login();
+        } catch (Exception ex) {
+            throw new TestProblemException(
+                    "Database needs to be setup for Oracle NoSQL database.", ex);
+        }
+        return session;
+    }
+
+    /**
+     * Creates {@link DatabaseSession} from project and connect it to database.
+     * {@link DatabaseSession#logout()} must be called before session instance is disposed.
+     */
+    public static Server createServerSession(final Project project) {
+        Server session = project.createServerSession();
+        session.setSessionLog(LOG);
+        try {
+            session.login();
+        } catch (Exception ex) {
+            throw new TestProblemException(
+                    "Database needs to be setup for Oracle NoSQL database.", ex);
+        }
+        return session;
+    }
+
+}

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/it/resources/META-INF/persistence.xml
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/it/resources/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -33,6 +33,48 @@
         <properties>
             <property name="eclipselink.target-database" value="org.eclipse.persistence.nosql.adapters.nosql.OracleNoSQLPlatform"/>
             <property name="eclipselink.nosql.connection-spec" value="org.eclipse.persistence.nosql.adapters.nosql.OracleNoSQLConnectionSpec"/>
+            <!--property name="eclipselink.logging.level" value="FINEST"/-->
+        </properties>
+    </persistence-unit>
+    <persistence-unit name="nosql-sdk" transaction-type="RESOURCE_LOCAL">
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+        <class>org.eclipse.persistence.testing.models.jpa.nosql.Order</class>
+        <class>org.eclipse.persistence.testing.models.jpa.nosql.Customer</class>
+        <class>org.eclipse.persistence.testing.models.jpa.nosql.LineItem</class>
+        <class>org.eclipse.persistence.testing.models.jpa.nosql.Address</class>
+        <properties>
+            <property name="eclipselink.nosql.property.nosql.service" value="@nosql.sdk.service@"/>
+            <property name="eclipselink.nosql.property.nosql.endpoint" value="@nosql.sdk.endpoint@"/>
+
+<!--
+            Needed for Oracle NoSQL database deployed in the cloud (additionally to ...nosql.service and ...nosql.endpoint properties)
+            <property name="eclipselink.nosql.property.nosql.compartment" value="@nosql.sdk.compartment@"/>
+            <property name="eclipselink.nosql.property.nosql.authprincipal" value="@nosql.sdk.authprincipal@"/>
+-->
+
+            <property name="eclipselink.target-database" value="@nosql.sdk.target-database@"/>
+            <property name="eclipselink.nosql.connection-spec" value="@nosql.sdk.connection-spec@"/>
+            <!--property name="eclipselink.logging.level" value="FINEST"/-->
+        </properties>
+    </persistence-unit>
+    <persistence-unit name="nosql-mapped-sdk" transaction-type="RESOURCE_LOCAL">
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+        <class>org.eclipse.persistence.testing.models.jpa.nosql.mapped.Order</class>
+        <class>org.eclipse.persistence.testing.models.jpa.nosql.mapped.Customer</class>
+        <class>org.eclipse.persistence.testing.models.jpa.nosql.mapped.LineItem</class>
+        <class>org.eclipse.persistence.testing.models.jpa.nosql.mapped.Address</class>
+        <properties>
+            <property name="eclipselink.nosql.property.nosql.service" value="@nosql.sdk.service@"/>
+            <property name="eclipselink.nosql.property.nosql.endpoint" value="@nosql.sdk.endpoint@"/>
+
+            <!--
+            Needed for Oracle NoSQL database deployed in the cloud (additionally to ...nosql.service and ...nosql.endpoint properties)
+            <property name="eclipselink.nosql.property.nosql.compartment" value="@nosql.sdk.compartment@"/>
+            <property name="eclipselink.nosql.property.nosql.authprincipal" value="@nosql.sdk.authprincipal@"/>
+            -->
+
+            <property name="eclipselink.target-database" value="@nosql.sdk.target-database@"/>
+            <property name="eclipselink.nosql.connection-spec" value="@nosql.sdk.connection-spec@"/>
             <!--property name="eclipselink.logging.level" value="FINEST"/-->
         </properties>
     </persistence-unit>

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/it/resources/org/eclipse/persistence/testing/models/order/eis/nosql/sdk/order-project.xml
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/it/resources/org/eclipse/persistence/testing/models/order/eis/nosql/sdk/order-project.xml
@@ -1,0 +1,197 @@
+<?xml version = '1.0' encoding = 'UTF-8'?>
+<!--
+
+    Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0,
+    or the Eclipse Distribution License v. 1.0 which is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+
+    SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+-->
+
+<object-persistence version="Eclipse Persistence Services - 0.1-incubation" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://www.eclipse.org/eclipselink/xsds/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+   <name>OrderProject</name>
+   <class-mapping-descriptors>
+      <class-mapping-descriptor xsi:type="eis-class-mapping-descriptor">
+         <class>org.eclipse.persistence.testing.models.order.Address</class>
+         <alias>Address</alias>
+         <events xsi:type="event-policy"/>
+         <querying xsi:type="query-policy"/>
+         <attribute-mappings>
+            <attribute-mapping xsi:type="eis-direct-mapping">
+               <attribute-name>addressee</attribute-name>
+               <field name="@addressee" xsi:type="node">
+                  <schema-type>{http://www.w3.org/2001/XMLSchema}anySimpleType</schema-type>
+               </field>
+            </attribute-mapping>
+            <attribute-mapping xsi:type="eis-direct-mapping">
+               <attribute-name>city</attribute-name>
+               <field name="@city" xsi:type="node">
+                  <schema-type>{http://www.w3.org/2001/XMLSchema}anySimpleType</schema-type>
+               </field>
+            </attribute-mapping>
+            <attribute-mapping xsi:type="eis-direct-mapping">
+               <attribute-name>country</attribute-name>
+               <field name="@country" xsi:type="node">
+                  <schema-type>{http://www.w3.org/2001/XMLSchema}anySimpleType</schema-type>
+               </field>
+            </attribute-mapping>
+            <attribute-mapping xsi:type="eis-direct-mapping">
+               <attribute-name>state</attribute-name>
+               <field name="@state" xsi:type="node">
+                  <schema-type>{http://www.w3.org/2001/XMLSchema}anySimpleType</schema-type>
+               </field>
+            </attribute-mapping>
+            <attribute-mapping xsi:type="eis-direct-mapping">
+               <attribute-name>street</attribute-name>
+               <field name="@street" xsi:type="node">
+                  <schema-type>{http://www.w3.org/2001/XMLSchema}anySimpleType</schema-type>
+               </field>
+            </attribute-mapping>
+            <attribute-mapping xsi:type="eis-direct-mapping">
+               <attribute-name>zipCode</attribute-name>
+               <field name="@zip" xsi:type="node">
+                  <schema-type>{http://www.w3.org/2001/XMLSchema}anySimpleType</schema-type>
+               </field>
+            </attribute-mapping>
+         </attribute-mappings>
+         <descriptor-type>aggregate</descriptor-type>
+         <instantiation/>
+         <copying xsi:type="instantiation-copy-policy"/>
+         <datatype>address</datatype>
+         <namespace-resolver>
+            <namespaces>
+               <namespace>
+                  <prefix>xsd</prefix>
+                  <namespace-uri>http://www.w3.org/2001/XMLSchema</namespace-uri>
+               </namespace>
+               <namespace>
+                  <prefix>xsi</prefix>
+                  <namespace-uri>http://www.w3.org/2001/XMLSchema-instance</namespace-uri>
+               </namespace>
+            </namespaces>
+         </namespace-resolver>
+      </class-mapping-descriptor>
+      <class-mapping-descriptor xsi:type="eis-class-mapping-descriptor">
+         <class>org.eclipse.persistence.testing.models.order.LineItem</class>
+         <alias>LineItem</alias>
+         <events xsi:type="event-policy"/>
+         <querying xsi:type="query-policy"/>
+         <attribute-mappings>
+            <attribute-mapping xsi:type="eis-direct-mapping">
+               <attribute-name>itemName</attribute-name>
+               <field name="@name" xsi:type="node">
+                  <schema-type>{http://www.w3.org/2001/XMLSchema}anySimpleType</schema-type>
+               </field>
+            </attribute-mapping>
+            <attribute-mapping xsi:type="eis-direct-mapping">
+               <attribute-name>itemPrice</attribute-name>
+               <field name="@price" xsi:type="node">
+                  <schema-type>{http://www.w3.org/2001/XMLSchema}double</schema-type>
+               </field>
+            </attribute-mapping>
+            <attribute-mapping xsi:type="eis-direct-mapping">
+               <attribute-name>lineNumber</attribute-name>
+               <field name="@number" xsi:type="node">
+                  <schema-type>{http://www.w3.org/2001/XMLSchema}integer</schema-type>
+               </field>
+            </attribute-mapping>
+            <attribute-mapping xsi:type="eis-direct-mapping">
+               <attribute-name>quantity</attribute-name>
+               <field name="@quantity" xsi:type="node">
+                  <schema-type>{http://www.w3.org/2001/XMLSchema}integer</schema-type>
+               </field>
+            </attribute-mapping>
+         </attribute-mappings>
+         <descriptor-type>aggregate</descriptor-type>
+         <instantiation/>
+         <copying xsi:type="instantiation-copy-policy"/>
+         <datatype>line_item</datatype>
+         <namespace-resolver>
+            <namespaces>
+               <namespace>
+                  <prefix>xsd</prefix>
+                  <namespace-uri>http://www.w3.org/2001/XMLSchema</namespace-uri>
+               </namespace>
+               <namespace>
+                  <prefix>xsi</prefix>
+                  <namespace-uri>http://www.w3.org/2001/XMLSchema-instance</namespace-uri>
+               </namespace>
+            </namespaces>
+         </namespace-resolver>
+      </class-mapping-descriptor>
+      <class-mapping-descriptor xsi:type="eis-class-mapping-descriptor">
+         <class>org.eclipse.persistence.testing.models.order.Order</class>
+         <alias>Order</alias>
+         <primary-key>
+            <field name="id" xsi:type="node">
+               <schema-type>{http://www.w3.org/2001/XMLSchema}integer</schema-type>
+            </field>
+         </primary-key>
+         <events xsi:type="event-policy"/>
+         <querying xsi:type="query-policy">
+            <timeout>0</timeout>
+            <insert-query xsi:type="insert-object-query">
+               <call xsi:type="xml-interaction">
+                  <function-name>insert-order</function-name>
+                  <input-record-name>insert-order</input-record-name>
+                  <input-root-element-name>insert-order</input-root-element-name>
+               </call>
+            </insert-query>
+         </querying>
+         <attribute-mappings>
+            <attribute-mapping xsi:type="eis-direct-mapping">
+               <attribute-name>id</attribute-name>
+               <field name="id" xsi:type="node">
+                  <schema-type>{http://www.w3.org/2001/XMLSchema}integer</schema-type>
+               </field>
+            </attribute-mapping>
+            <attribute-mapping xsi:type="eis-direct-mapping">
+               <attribute-name>orderedBy</attribute-name>
+               <field name="ordered_by" xsi:type="node">
+                  <schema-type>{http://www.w3.org/2001/XMLSchema}anySimpleType</schema-type>
+               </field>
+            </attribute-mapping>
+            <attribute-mapping xsi:type="eis-composite-object-mapping">
+               <attribute-name>address</attribute-name>
+               <reference-class>org.eclipse.persistence.testing.models.order.Address</reference-class>
+               <field name="address" xsi:type="node"/>
+            </attribute-mapping>
+            <attribute-mapping xsi:type="eis-composite-collection-mapping">
+               <attribute-name>lineItems</attribute-name>
+               <reference-class>org.eclipse.persistence.testing.models.order.LineItem</reference-class>
+               <field name="line_item" xsi:type="node"/>
+               <container xsi:type="list-container-policy">
+                  <collection-type>java.util.Vector</collection-type>
+               </container>
+            </attribute-mapping>
+         </attribute-mappings>
+         <descriptor-type>independent</descriptor-type>
+         <instantiation/>
+         <copying xsi:type="instantiation-copy-policy"/>
+         <datatype>order</datatype>
+         <namespace-resolver>
+            <namespaces>
+               <namespace>
+                  <prefix>xsd</prefix>
+                  <namespace-uri>http://www.w3.org/2001/XMLSchema</namespace-uri>
+               </namespace>
+               <namespace>
+                  <prefix>xsi</prefix>
+                  <namespace-uri>http://www.w3.org/2001/XMLSchema-instance</namespace-uri>
+               </namespace>
+            </namespaces>
+         </namespace-resolver>
+      </class-mapping-descriptor>
+   </class-mapping-descriptors>
+   <login xsi:type="eis-login">
+      <platform-class>org.eclipse.persistence.nosql.adapters.sdk.OracleNoSQLPlatform</platform-class>
+      <user-name></user-name>
+      <password></password>
+      <connection-spec-class>org.eclipse.persistence.nosql.adapters.sdk.OracleNoSQLConnectionSpec</connection-spec-class>
+   </login>
+</object-persistence>

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/module-info.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -18,10 +18,14 @@ module org.eclipse.persistence.oracle.nosql {
     requires transitive jakarta.resource;
 
     requires transitive org.eclipse.persistence.core;
+    requires oracle.nosql.client;
+    requires nosqldriver;
 
     exports org.eclipse.persistence.eis.adapters.aq;
     exports org.eclipse.persistence.nosql.adapters.nosql;
+    exports org.eclipse.persistence.nosql.adapters.sdk;
 
     //exported through PUBLIC API
     exports org.eclipse.persistence.internal.nosql.adapters.nosql;
+    exports org.eclipse.persistence.internal.nosql.adapters.sdk;
 }

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLAdapterMetaData.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLAdapterMetaData.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.internal.nosql.adapters.sdk;
+
+import jakarta.resource.cci.ResourceAdapterMetaData;
+import org.eclipse.persistence.Version;
+
+/**
+ * Defines the meta-data for the Oracle NoSQL SDK adapter
+ *
+ * @author Radek Felcman
+ * @since EclipseLink 4.0
+ */
+public class OracleNoSQLAdapterMetaData implements ResourceAdapterMetaData {
+
+    /**
+     * Default constructor.
+     */
+    public OracleNoSQLAdapterMetaData() {
+    }
+
+    @Override
+    public String getAdapterName() {
+        return "Oracle NoSQL SDK Adapter";
+    }
+
+    @Override
+    public String getAdapterShortDescription() {
+        return "Oracle NoSQL SDK JCA adapter.";
+    }
+
+    @Override
+    public String getAdapterVendorName() {
+        return "Oracle";
+    }
+
+    @Override
+    public String getAdapterVersion() {
+        return Version.getVersion();
+    }
+
+    @Override
+    public String[] getInteractionSpecsSupported() {
+        String[] specs = new String[1];
+        specs[0] = "org.eclipse.persistence.internal.nosql.adapters.sdk.OracleNoSQLInteractionSpec";
+        return specs;
+    }
+
+    @Override
+    public String getSpecVersion() {
+        return "1.5";
+    }
+
+    @Override
+    public boolean supportsExecuteWithInputAndOutputRecord() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsExecuteWithInputRecordOnly() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsLocalTransactionDemarcation() {
+        return true;
+    }
+}

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLConnection.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLConnection.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.internal.nosql.adapters.sdk;
+
+import jakarta.resource.ResourceException;
+import jakarta.resource.cci.Connection;
+import jakarta.resource.cci.ConnectionMetaData;
+import jakarta.resource.cci.Interaction;
+import jakarta.resource.cci.LocalTransaction;
+import jakarta.resource.cci.ResultSetInfo;
+
+import oracle.nosql.driver.NoSQLHandle;
+
+import org.eclipse.persistence.exceptions.ValidationException;
+
+/**
+ * Connection to Oracle NoSQL
+ * This connection wraps a NoSQLHandle.
+ *
+ * @author Radek Felcman
+ * @since EclipseLink 4.0
+ */
+public class OracleNoSQLConnection implements Connection {
+    private OracleNoSQLJCAConnectionSpec spec;
+    private OracleNoSQLTransaction transaction;
+
+    private NoSQLHandle noSQLHandle = null;
+
+    /**
+     * Create the connection on a native AQ session.
+     * The session must be connected to a JDBC connection.
+     */
+    public OracleNoSQLConnection(NoSQLHandle noSQLHandle, OracleNoSQLJCAConnectionSpec spec) {
+        this.noSQLHandle = noSQLHandle;
+        this.transaction = new OracleNoSQLTransaction(this);
+        this.spec = spec;
+    }
+
+    /**
+     * Close the AQ native session and the database connection.
+     */
+    @Override
+    public void close() throws ResourceException {
+        try {
+            this.noSQLHandle.close();
+        } catch (Exception exception) {
+            ResourceException resourceException = new ResourceException(exception.toString());
+            resourceException.initCause(exception);
+            throw resourceException;
+        }
+    }
+
+    @Override
+    public Interaction createInteraction() {
+        return new OracleNoSQLInteraction(this);
+    }
+
+    public OracleNoSQLJCAConnectionSpec getConnectionSpec() {
+        return spec;
+    }
+
+    @Override
+    public LocalTransaction getLocalTransaction() {
+        return transaction;
+    }
+
+    public OracleNoSQLTransaction getOracleNoSQLTransaction() {
+        return transaction;
+    }
+
+    @Override
+    public ConnectionMetaData getMetaData() {
+        return new OracleNoSQLConnectionMetaData(this);
+    }
+
+    /**
+     * TODO check if Result sets are not supported.
+     */
+    @Override
+    public ResultSetInfo getResultSetInfo() {
+        throw ValidationException.operationNotSupported("getResultSetInfo");
+    }
+
+    public NoSQLHandle getNoSQLHandle() {
+        return noSQLHandle;
+    }
+}

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLConnection.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLConnection.java
@@ -39,8 +39,7 @@ public class OracleNoSQLConnection implements Connection {
     private NoSQLHandle noSQLHandle = null;
 
     /**
-     * Create the connection on a native AQ session.
-     * The session must be connected to a JDBC connection.
+     * Create the connection on a native OracleNoSQLHandle (connection).
      */
     public OracleNoSQLConnection(NoSQLHandle noSQLHandle, OracleNoSQLJCAConnectionSpec spec) {
         this.noSQLHandle = noSQLHandle;
@@ -49,7 +48,7 @@ public class OracleNoSQLConnection implements Connection {
     }
 
     /**
-     * Close the AQ native session and the database connection.
+     * Close the native OracleNoSQLHandle (connection).
      */
     @Override
     public void close() throws ResourceException {

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLConnectionFactory.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLConnectionFactory.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.internal.nosql.adapters.sdk;
+
+import jakarta.resource.ResourceException;
+import jakarta.resource.cci.Connection;
+import jakarta.resource.cci.ConnectionFactory;
+import jakarta.resource.cci.ConnectionSpec;
+import jakarta.resource.cci.RecordFactory;
+import jakarta.resource.cci.ResourceAdapterMetaData;
+import oracle.nosql.driver.AuthorizationProvider;
+import oracle.nosql.driver.NoSQLHandle;
+import oracle.nosql.driver.NoSQLHandleConfig;
+import oracle.nosql.driver.NoSQLHandleFactory;
+import oracle.nosql.driver.iam.SignatureProvider;
+import oracle.nosql.driver.kv.StoreAccessTokenProvider;
+import oracle.nosql.driver.ops.Request;
+
+import javax.naming.Reference;
+import java.io.IOException;
+
+/**
+ * Connection factory for Oracle NoSQL SDK JCA adapter.
+ *
+ * @author Radek Felcman
+ * @since EclipseLink 4.0
+ */
+public class OracleNoSQLConnectionFactory implements ConnectionFactory {
+
+    /**
+     * Default constructor.
+     */
+    public OracleNoSQLConnectionFactory() {
+    }
+
+    @Override
+    public Connection getConnection() throws ResourceException {
+        return getConnection(new OracleNoSQLJCAConnectionSpec());
+    }
+
+    @Override
+    public Connection getConnection(ConnectionSpec spec) throws ResourceException {
+        OracleNoSQLJCAConnectionSpec connectionSpec = (OracleNoSQLJCAConnectionSpec) spec;
+        NoSQLHandle noSQLHandle = null;
+        try {
+            //TODO Extend this from Cloud Simulator into all available stores
+            //TODO handle all available properties in NoSQLHandleConfig
+            NoSQLHandleConfig config = new NoSQLHandleConfig(connectionSpec.getEndPoint());
+            config.setAuthorizationProvider(getAuthorizationProvider(config, connectionSpec));
+
+            noSQLHandle = NoSQLHandleFactory.createNoSQLHandle(config);
+        } catch (Exception exception) {
+            ResourceException resourceException = new ResourceException(exception.toString(), exception);
+            throw resourceException;
+        }
+        return new OracleNoSQLConnection(noSQLHandle, connectionSpec);
+    }
+
+    @Override
+    public ResourceAdapterMetaData getMetaData() {
+        return new OracleNoSQLAdapterMetaData();
+    }
+
+    @Override
+    public RecordFactory getRecordFactory() {
+        return new OracleNoSQLRecordFactory();
+    }
+
+    @Override
+    public Reference getReference() {
+        return new Reference(getClass().getName());
+    }
+
+    @Override
+    public void setReference(Reference reference) {
+    }
+
+    private AuthorizationProvider getAuthorizationProvider(NoSQLHandleConfig config, OracleNoSQLJCAConnectionSpec connectionSpec) {
+        AuthorizationProvider authorizationProvider = null;
+        try {
+            switch (connectionSpec.getService()) {
+                case CLOUD: {
+                    switch (connectionSpec.getAuthPrincipalType()) {
+                        case USER:
+                            authorizationProvider = new SignatureProvider();
+                            break;
+                        case INSTANCE:
+                            if (connectionSpec.getCompartment() == null) {
+                                throw new IllegalArgumentException("Compartment is required for Instance/Resource " + "Principal authorization");
+                            }
+                            authorizationProvider = SignatureProvider.createWithInstancePrincipal();
+                            break;
+                        case RESOURCE:
+                            if (connectionSpec.getCompartment() == null) {
+                                throw new IllegalArgumentException("Compartment is required for Instance/Resource " + "Principal authorization");
+                            }
+                            authorizationProvider = SignatureProvider.createWithResourcePrincipal();
+                            break;
+                    }
+                    break;
+                }
+                case ON_PREMISE:
+                    authorizationProvider = new StoreAccessTokenProvider();
+                    break;
+                case CLOUD_SIMULATOR:
+                    authorizationProvider = new AuthorizationProvider() {
+                        @Override
+                        public String getAuthorizationString(Request request) {
+                            return "Bearer cloudsim";
+                        }
+
+                        @Override
+                        public void close() {
+                        }
+                    };
+                    break;
+            }
+        } catch (IOException ioe) {
+            System.err.println("Unable to configure authentication: " + ioe);
+        }
+        return authorizationProvider;
+    }
+}

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLConnectionFactory.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLConnectionFactory.java
@@ -62,8 +62,7 @@ public class OracleNoSQLConnectionFactory implements ConnectionFactory {
 
             noSQLHandle = NoSQLHandleFactory.createNoSQLHandle(config);
         } catch (Exception exception) {
-            ResourceException resourceException = new ResourceException(exception.toString(), exception);
-            throw resourceException;
+            throw new ResourceException(exception.toString(), exception);
         }
         return new OracleNoSQLConnection(noSQLHandle, connectionSpec);
     }

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLConnectionMetaData.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLConnectionMetaData.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.internal.nosql.adapters.sdk;
+
+import jakarta.resource.ResourceException;
+import jakarta.resource.cci.ConnectionMetaData;
+import oracle.nosql.driver.DriverMain;
+
+
+/**
+ * Defines the meta-data for the Oracle NoSQL adaptor
+ *
+ * @author Radek Felcman
+ * @since EclipseLink 4.0
+ */
+public class OracleNoSQLConnectionMetaData implements ConnectionMetaData {
+    protected OracleNoSQLConnection connection;
+
+    /**
+     * Default constructor.
+     */
+    public OracleNoSQLConnectionMetaData(OracleNoSQLConnection connection) {
+        this.connection = connection;
+    }
+
+    @Override
+    public String getEISProductName() throws ResourceException {
+        try {
+            return "Oracle NoSQL Database";
+        } catch (Exception exception) {
+            throw new ResourceException(exception.toString());
+        }
+    }
+
+    @Override
+    public String getEISProductVersion() throws ResourceException {
+        try {
+            return DriverMain.getLibraryVersion();
+        } catch (Exception exception) {
+            throw new ResourceException(exception.toString());
+        }
+    }
+
+    @Override
+    public String getUserName() throws ResourceException {
+        return "";
+    }
+}

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLInteraction.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLInteraction.java
@@ -307,7 +307,7 @@ public class OracleNoSQLInteraction implements Interaction {
                 }
             } else if (mapping instanceof EISCompositeDirectCollectionMapping) {
                 ArrayValue arrayValue = new ArrayValue();
-                List<DOMRecord> domRecordList = (List) domRecord.getValues(key);
+                List<DOMRecord> domRecordList = (List<DOMRecord>) domRecord.getValues(key);
                 for (DOMRecord domRecordListItem : domRecordList) {
                     StringValue recordValue = null;
                     for (Node domRecordListItemValue : (List<Node>) domRecordListItem.getValues()) {

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLInteraction.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLInteraction.java
@@ -1,0 +1,586 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.internal.nosql.adapters.sdk;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringTokenizer;
+
+import jakarta.resource.ResourceException;
+import jakarta.resource.cci.Connection;
+import jakarta.resource.cci.Interaction;
+import jakarta.resource.cci.InteractionSpec;
+import jakarta.resource.cci.ResourceWarning;
+
+import oracle.nosql.driver.ops.DeleteRequest;
+import oracle.nosql.driver.ops.DeleteResult;
+import oracle.nosql.driver.ops.GetRequest;
+import oracle.nosql.driver.ops.GetResult;
+import oracle.nosql.driver.ops.PrepareRequest;
+import oracle.nosql.driver.ops.PrepareResult;
+import oracle.nosql.driver.ops.PreparedStatement;
+import oracle.nosql.driver.ops.PutRequest;
+import oracle.nosql.driver.ops.PutResult;
+import oracle.nosql.driver.ops.QueryRequest;
+import oracle.nosql.driver.ops.QueryResult;
+import oracle.nosql.driver.values.ArrayValue;
+import oracle.nosql.driver.values.BinaryValue;
+import oracle.nosql.driver.values.BooleanValue;
+import oracle.nosql.driver.values.DoubleValue;
+import oracle.nosql.driver.values.FieldValue;
+import oracle.nosql.driver.values.IntegerValue;
+import oracle.nosql.driver.values.LongValue;
+import oracle.nosql.driver.values.MapValue;
+import oracle.nosql.driver.values.NullValue;
+import oracle.nosql.driver.values.NumberValue;
+import oracle.nosql.driver.values.StringValue;
+
+import oracle.nosql.driver.values.TimestampValue;
+import org.eclipse.persistence.descriptors.ClassDescriptor;
+import org.eclipse.persistence.eis.EISException;
+import org.eclipse.persistence.eis.mappings.EISCompositeCollectionMapping;
+import org.eclipse.persistence.eis.mappings.EISCompositeDirectCollectionMapping;
+import org.eclipse.persistence.eis.mappings.EISCompositeObjectMapping;
+import org.eclipse.persistence.eis.mappings.EISDirectMapping;
+import org.eclipse.persistence.exceptions.ValidationException;
+import org.eclipse.persistence.internal.helper.DatabaseField;
+import org.eclipse.persistence.mappings.DatabaseMapping;
+import org.eclipse.persistence.mappings.converters.Converter;
+import org.eclipse.persistence.nosql.adapters.sdk.OracleNoSQLPlatform;
+import org.eclipse.persistence.oxm.record.DOMRecord;
+
+import org.eclipse.persistence.sessions.Session;
+import org.eclipse.persistence.sessions.factories.SessionManager;
+import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+
+/**
+ * Interaction to Oracle NoSQL JCA adapter.
+ *
+ * @author Radek Felcman
+ * @since EclipseLink 4.0
+ */
+public class OracleNoSQLInteraction implements Interaction {
+
+    /**
+     * Store the connection the interaction was created from.
+     */
+    protected OracleNoSQLConnection connection;
+
+    /**
+     * Default constructor.
+     */
+    public OracleNoSQLInteraction(OracleNoSQLConnection connection) {
+        this.connection = connection;
+    }
+
+    @Override
+    public void clearWarnings() {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    /**
+     * Output records are not supported/required.
+     */
+    @Override
+    public boolean execute(InteractionSpec spec, jakarta.resource.cci.Record input, jakarta.resource.cci.Record output) throws ResourceException {
+        throw ValidationException.operationNotSupported("execute(InteractionSpec, jakarta.resource.cci.Record, jakarta.resource.cci.Record)");
+    }
+
+    /**
+     * Execute the interaction and return output record.
+     * The spec is either GET, PUT or DELETE interaction.
+     */
+    @Override
+    @SuppressWarnings({"unchecked"})
+    public jakarta.resource.cci.Record execute(InteractionSpec spec, jakarta.resource.cci.Record record) throws ResourceException {
+        if (!(spec instanceof OracleNoSQLInteractionSpec)) {
+            throw EISException.invalidInteractionSpecType();
+        }
+        if (!(record instanceof OracleNoSQLRecord)) {
+            throw EISException.invalidRecordType();
+        }
+        OracleNoSQLInteractionSpec noSqlSpec = (OracleNoSQLInteractionSpec) spec;
+        OracleNoSQLRecord input = (OracleNoSQLRecord) record;
+        try {
+            OracleNoSQLOperation operation = noSqlSpec.getOperation();
+            if (operation == OracleNoSQLOperation.GET) {
+                OracleNoSQLRecord output = new OracleNoSQLRecord();
+                for (Map.Entry<?, ?> entry : (Set<Map.Entry<?, ?>>) input.entrySet()) {
+                    MapValue key = null;
+                    if (entry.getValue() instanceof byte[]) {
+                        key = createMapValue(createDOMRecord((byte[]) entry.getValue()), noSqlSpec.getDescriptor());
+                    } else if (entry.getValue() instanceof Map) {
+                        key = createMapValue((Map) entry.getValue(), noSqlSpec.getDescriptor());
+                    }
+                    GetRequest getRequest = new GetRequest().setKey(key).setTableName(noSqlSpec.getTableName());
+                    if (noSqlSpec.getTimeout() > 0) {
+                        getRequest.setTimeout(noSqlSpec.getTimeout());
+                    }
+                    if (noSqlSpec.getConsistency() != null) {
+                        getRequest.setConsistency(noSqlSpec.getConsistency());
+                    }
+                    GetResult getResult = this.connection.getNoSQLHandle().get(getRequest);
+                    MapValue values = getResult.getValue();
+                    if (values != null) {
+                        for (Map.Entry<String, FieldValue> outputEntry : values.entrySet()) {
+                            output.put(outputEntry.getKey(), unboxFieldValue(outputEntry.getValue(), spec));
+                        }
+                    }
+                }
+                if (output.isEmpty()) {
+                    return null;
+                }
+                return output;
+            } else if ((operation == OracleNoSQLOperation.PUT) || (operation == OracleNoSQLOperation.PUT_IF_ABSENT)
+                    || (operation == OracleNoSQLOperation.PUT_IF_PRESENT) || (operation == OracleNoSQLOperation.PUT_IF_VERSION)) {
+                for (Map.Entry<?, ?> entry : (Set<Map.Entry<?, ?>>) input.entrySet()) {
+                    PutRequest putRequest = null;
+                    if (entry.getValue() instanceof byte[]) {
+                        DOMRecord domRecord = createDOMRecord((byte[]) entry.getValue());
+                        putRequest = createPutRequest(domRecord, noSqlSpec.getTableName(), noSqlSpec.getDescriptor());
+                    } else if (entry.getValue() instanceof Map) {
+                        putRequest = createPutRequest((Map) entry.getValue(), noSqlSpec.getTableName(), noSqlSpec.getDescriptor());
+                    }
+                    if (noSqlSpec.getTimeout() > 0) {
+                        putRequest.setTimeout(noSqlSpec.getTimeout());
+                    }
+                    if (noSqlSpec.getDurability() != null) {
+                        putRequest.setDurability(noSqlSpec.getDurability());
+                    }
+                    PutResult putResult = this.connection.getNoSQLHandle().put(putRequest);
+                    if (putResult.getVersion() == null) {
+                        throw new ResourceException("Attempt to put failed:" + input);
+                    }
+                }
+            } else if (operation == OracleNoSQLOperation.DELETE) {
+                for (Map.Entry<?, ?> entry : (Set<Map.Entry<?, ?>>) input.entrySet()) {
+                    MapValue key = null;
+                    if (entry.getValue() instanceof byte[]) {
+                        key = createMapValue(createDOMRecord((byte[]) entry.getValue()), noSqlSpec.getDescriptor());
+                    } else if (entry.getValue() instanceof Map) {
+                        key = createMapValue((Map) entry.getValue(), noSqlSpec.getDescriptor());
+                    }
+                    DeleteRequest deleteRequest = new DeleteRequest().setKey(key).setTableName(noSqlSpec.getTableName());
+                    if (noSqlSpec.getTimeout() > 0) {
+                        deleteRequest.setTimeout(noSqlSpec.getTimeout());
+                    }
+                    if (noSqlSpec.getDurability() != null) {
+                        deleteRequest.setDurability(noSqlSpec.getDurability());
+                    }
+                    DeleteResult deleteResult = this.connection.getNoSQLHandle().delete(deleteRequest);
+                }
+            } else if (operation == OracleNoSQLOperation.ITERATOR) {
+                OracleNoSQLRecord output = new OracleNoSQLRecord();
+                //Handle ReadAll query like SELECT * FROM TEST_TABLE
+                QueryRequest queryRequest = new QueryRequest().setStatement("SELECT * FROM " + noSqlSpec.getTableName());
+                if (noSqlSpec.getTimeout() > 0) {
+                    queryRequest.setTimeout(noSqlSpec.getTimeout());
+                }
+                if (noSqlSpec.getConsistency() != null) {
+                    queryRequest.setConsistency(noSqlSpec.getConsistency());
+                }
+                do {
+                    QueryResult queryResult = this.connection.getNoSQLHandle().query(queryRequest);
+                    List<MapValue> results = queryResult.getResults();
+                    int rowId = 1;
+                    OracleNoSQLRecord outputRow;
+                    for (MapValue values : results) {
+                        outputRow = new OracleNoSQLRecord();
+                        for (Map.Entry<String, FieldValue> outputEntry : values.entrySet()) {
+                            outputRow.put(outputEntry.getKey(), unboxFieldValue(outputEntry.getValue(), spec));
+                        }
+                        output.put(rowId++, outputRow);
+                    }
+                } while (!queryRequest.isDone());
+                if (output.isEmpty()) {
+                    return null;
+                }
+                return output;
+            } else if (operation == OracleNoSQLOperation.ITERATOR_QUERY) {
+                OracleNoSQLRecord output = new OracleNoSQLRecord();
+                Map<String, String> inputRecord = null;
+                for (Map.Entry<?, ?> entry : (Set<Map.Entry<?, ?>>) input.entrySet()) {
+                    DOMRecord domRecord = createDOMRecord((byte[]) entry.getValue());
+                    inputRecord = createMapFromDOMRecord(createDOMRecord((byte[]) entry.getValue()));
+                    System.out.println(inputRecord);
+                }
+                //Handle Find queries like SELECT * FROM TEST_TABLE WHERE NAME = :name
+                String sqlString = inputRecord.get(OracleNoSQLPlatform.QUERY);
+                PrepareRequest prepareRequest = new PrepareRequest().setStatement(sqlString);
+                if (noSqlSpec.getTimeout() > 0) {
+                    prepareRequest.setTimeout(noSqlSpec.getTimeout());
+                }
+                PrepareResult prepareResult = this.connection.getNoSQLHandle().prepare(prepareRequest);
+                PreparedStatement preparedStatement = prepareResult.getPreparedStatement();
+                if (inputRecord.get(OracleNoSQLPlatform.QUERY_ARGUMENTS) != null) {
+                    StringTokenizer st = new StringTokenizer(inputRecord.get(OracleNoSQLPlatform.QUERY_ARGUMENTS), ";");
+                    while (st.hasMoreTokens()) {
+                        String argumentName = st.nextToken();
+                        preparedStatement.setVariable("$" + argumentName, OracleNoSQLPlatform.getFieldValue(argumentName + (String) inputRecord.get(OracleNoSQLPlatform.QUERY_ARGUMENT_TYPE_SUFFIX), (String) inputRecord.get(argumentName + OracleNoSQLPlatform.QUERY_ARGUMENT_VALUE_SUFFIX), false));
+                    }
+                }
+                QueryRequest queryRequest = new QueryRequest().setPreparedStatement(preparedStatement);
+                do {
+                    QueryResult queryResult = this.connection.getNoSQLHandle().query(queryRequest);
+                    List<MapValue> results = queryResult.getResults();
+                    int rowId = 1;
+                    OracleNoSQLRecord outputRow;
+                    for (MapValue values : results) {
+                        outputRow = new OracleNoSQLRecord();
+                        for (Map.Entry<String, FieldValue> outputEntry : values.entrySet()) {
+                            outputRow.put(outputEntry.getKey(), unboxFieldValue(outputEntry.getValue(), spec));
+                        }
+                        output.put(rowId++, outputRow);
+                    }
+                } while (!queryRequest.isDone());
+                if (output.isEmpty()) {
+                    return null;
+                }
+                return output;
+            } else {
+                throw new ResourceException("Invalid NoSQL operation:" + operation);
+            }
+        } catch (Exception exception) {
+            throw new ResourceException(exception);
+        }
+        return null;
+    }
+
+    @Override
+    public Connection getConnection() {
+        return connection;
+    }
+
+    @Override
+    public ResourceWarning getWarnings() {
+        return null;
+    }
+
+    private DOMRecord createDOMRecord(byte[] byteArray) {
+        DOMRecord domRecord = new DOMRecord();
+        domRecord.transformFromXML(new String(byteArray));
+        return domRecord;
+    }
+
+    private MapValue createMapValue(DOMRecord domRecord, ClassDescriptor descriptor) {
+        Map<String, DatabaseMapping> fieldNameMapping = createFieldNameMappingMap(descriptor);
+        MapValue mapValue = new MapValue();
+        for (Map.Entry<DatabaseField, Element> entry : (Set<Map.Entry<DatabaseField, Element>>) domRecord.entrySet()) {
+            String key = entry.getKey().getName();
+            String typesKey = descriptor.buildField(entry.getKey()).toString();
+            DatabaseMapping mapping = fieldNameMapping.get(typesKey);
+            if (mapping == null) {
+                mapping = fieldNameMapping.get(typesKey.replace("/text()", ""));
+            }
+            if (mapping instanceof EISDirectMapping) {
+                Converter converter = ((EISDirectMapping) mapping).getConverter();
+                String fieldClassificationName = ((EISDirectMapping) mapping).getFieldClassificationClassName();
+                String typeName = mapping.getAttributeClassification().getTypeName();
+                String value = entry.getValue().getFirstChild().getNodeValue();
+                if (converter == null) {
+                    mapValue.put(key, OracleNoSQLPlatform.getFieldValue(typeName, value, OracleNoSQLPlatform.isLob(fieldClassificationName)));
+                } else {
+                    Session session = SessionManager.getManager().getSession(descriptor.getSessionName());
+                    Object convertedValue = converter.convertDataValueToObjectValue(value, session);
+                    mapValue.put(key, OracleNoSQLPlatform.getFieldValue(typeName, convertedValue, OracleNoSQLPlatform.isLob(fieldClassificationName)));
+                }
+            } else if (mapping instanceof EISCompositeDirectCollectionMapping) {
+                ArrayValue arrayValue = new ArrayValue();
+                List<DOMRecord> domRecordList = (List) domRecord.getValues(key);
+                for (DOMRecord domRecordListItem : domRecordList) {
+                    StringValue recordValue = null;
+                    for (Node domRecordListItemValue : (List<Node>) domRecordListItem.getValues()) {
+                        recordValue = new StringValue(domRecordListItemValue.getNodeValue());
+                        arrayValue.add(recordValue);
+                    }
+                }
+                mapValue.put(key, arrayValue);
+            } else if (mapping instanceof EISCompositeObjectMapping) {
+                MapValue recordValue = new MapValue();
+                Map<String, DatabaseMapping> fieldNameMappingCollection = createFieldNameMappingMap(mapping.getReferenceDescriptor());
+                //Check DOM Element attributes first
+                NamedNodeMap namedNodeMap = entry.getValue().getAttributes();
+                for (int i = 0; i < namedNodeMap.getLength(); i++) {
+                    Node item = namedNodeMap.item(i);
+                    DatabaseMapping mappingCollection = fieldNameMappingCollection.get("@" + item.getLocalName());
+                    Converter converter = ((EISDirectMapping) mappingCollection).getConverter();
+                    String fieldClassificationName = ((EISDirectMapping) mappingCollection).getFieldClassificationClassName();
+                    String typeName = mappingCollection.getAttributeClassification().getTypeName();
+                    String value = item.getNodeValue();
+                    if (converter == null) {
+                        recordValue.put(item.getLocalName(), OracleNoSQLPlatform.getFieldValue(typeName, value, OracleNoSQLPlatform.isLob(typeName)));
+                    } else {
+                        Session session = SessionManager.getManager().getSession(descriptor.getSessionName());
+                        Object convertedValue = converter.convertDataValueToObjectValue(value, session);
+                        recordValue.put(item.getLocalName(), OracleNoSQLPlatform.getFieldValue(typeName, convertedValue, OracleNoSQLPlatform.isLob(fieldClassificationName)));
+                    }
+                }
+                //Check DOM Element sub elements
+                Node firstChild = entry.getValue().getFirstChild();
+                if (firstChild != null && firstChild.getFirstChild() != null) {
+                    Node item = firstChild;
+                    do {
+                        DatabaseMapping mappingCollection = fieldNameMappingCollection.get(item.getLocalName()) != null ? fieldNameMappingCollection.get(item.getLocalName()) : fieldNameMappingCollection.get(item.getLocalName() + "/text()");
+                        Converter converter = ((EISDirectMapping) mappingCollection).getConverter();
+                        String fieldClassificationName = ((EISDirectMapping) mappingCollection).getFieldClassificationClassName();
+                        String typeName = mappingCollection.getAttributeClassification().getTypeName();
+                        String value = item.getFirstChild().getNodeValue();
+                        if (converter == null) {
+                            recordValue.put(item.getLocalName(), OracleNoSQLPlatform.getFieldValue(typeName, value, OracleNoSQLPlatform.isLob(typeName)));
+                        } else {
+                            Session session = SessionManager.getManager().getSession(descriptor.getSessionName());
+                            Object convertedValue = converter.convertDataValueToObjectValue(value, session);
+                            recordValue.put(item.getLocalName(), OracleNoSQLPlatform.getFieldValue(typeName, convertedValue, OracleNoSQLPlatform.isLob(fieldClassificationName)));
+                        }
+                        item = item.getNextSibling();
+                    } while (item != null);
+                }
+                if (recordValue.size() > 0) {
+                    mapValue.put(key, recordValue);
+                }
+            } else if (mapping instanceof EISCompositeCollectionMapping) {
+                ArrayValue arrayValue = new ArrayValue();
+                Map<String, DatabaseMapping> fieldNameMappingCollection = createFieldNameMappingMap(mapping.getReferenceDescriptor());
+                List<DOMRecord> domRecordList = (List) domRecord.getValues(key);
+                for (DOMRecord domRecordListItem : domRecordList) {
+                    MapValue recordValue = new MapValue();
+                    //Check DOM Element attributes first
+                    NamedNodeMap attributes = domRecordListItem.getDOM().getAttributes();
+                    for (int i = 0; i < attributes.getLength(); i++) {
+                        Node item = attributes.item(i);
+                        DatabaseMapping mappingCollection = fieldNameMappingCollection.get("@" + item.getLocalName());
+                        Converter converter = ((EISDirectMapping) mappingCollection).getConverter();
+                        String fieldClassificationName = ((EISDirectMapping) mappingCollection).getFieldClassificationClassName();
+                        String typeName = mappingCollection.getAttributeClassification().getTypeName();
+                        String value = item.getNodeValue();
+                        if (converter == null) {
+                            recordValue.put(item.getLocalName(), OracleNoSQLPlatform.getFieldValue(typeName, value, OracleNoSQLPlatform.isLob(typeName)));
+                        } else {
+                            Session session = SessionManager.getManager().getSession(descriptor.getSessionName());
+                            Object convertedValue = converter.convertDataValueToObjectValue(value, session);
+                            recordValue.put(item.getLocalName(), OracleNoSQLPlatform.getFieldValue(typeName, convertedValue, OracleNoSQLPlatform.isLob(fieldClassificationName)));
+                        }
+                    }
+                    //Check DOM Element sub elements
+                    if (domRecordListItem.getValues().size() > 0) {
+                        for (Map.Entry<DatabaseField, Element> listItemEntry : (Set<Map.Entry<DatabaseField, Element>>) domRecordListItem.entrySet()) {
+                            DatabaseMapping mappingCollection = fieldNameMappingCollection.get(listItemEntry.getValue().getLocalName()) != null ? fieldNameMappingCollection.get(listItemEntry.getValue().getLocalName()) : fieldNameMappingCollection.get(listItemEntry.getValue().getLocalName() + "/text()");
+                            Converter converter = ((EISDirectMapping) mappingCollection).getConverter();
+                            String fieldClassificationName = ((EISDirectMapping) mappingCollection).getFieldClassificationClassName();
+                            String typeName = mappingCollection.getAttributeClassification().getTypeName();
+                            String value = listItemEntry.getValue().getFirstChild().getNodeValue();
+                            if (converter == null) {
+                                recordValue.put(listItemEntry.getValue().getLocalName(), OracleNoSQLPlatform.getFieldValue(typeName, value, OracleNoSQLPlatform.isLob(typeName)));
+                            } else {
+                                Session session = SessionManager.getManager().getSession(descriptor.getSessionName());
+                                Object convertedValue = converter.convertDataValueToObjectValue(value, session);
+                                recordValue.put(listItemEntry.getValue().getLocalName(), OracleNoSQLPlatform.getFieldValue(typeName, convertedValue, OracleNoSQLPlatform.isLob(fieldClassificationName)));
+                            }
+                        }
+                    }
+                    if (recordValue.size() > 0) {
+                        arrayValue.add(recordValue);
+                    }
+                }
+                mapValue.put(key, arrayValue);
+            }
+        }
+        return mapValue;
+    }
+
+    private MapValue createMapValue(Map recordEntry, ClassDescriptor descriptor) {
+        Map<String, DatabaseMapping> fieldNameMapping = createFieldNameMappingMap(descriptor);
+        MapValue mapValue = new MapValue();
+        for (Map.Entry<String, Object> entry : (Set<Map.Entry<String, Object>>) recordEntry.entrySet()) {
+            if (entry.getValue() != null) {
+                String key = entry.getKey();
+                String typesKey = descriptor.buildField(entry.getKey()).toString();
+                DatabaseMapping mapping = fieldNameMapping.get(typesKey);
+                if (mapping == null) {
+                    mapping = fieldNameMapping.get(typesKey.replace("/text()", ""));
+                }
+                if (mapping == null) {
+                    mapping = fieldNameMapping.get(descriptor.getTableName() + "." + typesKey.replace("/text()", ""));
+                }
+                if (mapping instanceof EISDirectMapping) {
+                    Converter converter = ((EISDirectMapping) mapping).getConverter();
+                    String fieldClassificationName = ((EISDirectMapping) mapping).getFieldClassificationClassName();
+                    String typeName = mapping.getAttributeClassification().getTypeName();
+                    String value = entry.getValue().toString();
+                    if (converter == null) {
+                        mapValue.put(key, OracleNoSQLPlatform.getFieldValue(typeName, value, OracleNoSQLPlatform.isLob(fieldClassificationName)));
+                    } else {
+                        Session session = SessionManager.getManager().getSession(descriptor.getSessionName());
+                        Object convertedValue = converter.convertDataValueToObjectValue(value, session);
+                        mapValue.put(key, OracleNoSQLPlatform.getFieldValue(typeName, convertedValue, OracleNoSQLPlatform.isLob(fieldClassificationName)));
+                    }
+                } else if (mapping instanceof EISCompositeDirectCollectionMapping) {
+                    ArrayValue arrayValue = new ArrayValue();
+                    for (Object collectionItem : (List<Object>) entry.getValue()) {
+                        StringValue recordValue;
+                        if (collectionItem instanceof String) {
+                            recordValue = new StringValue((String)collectionItem);
+                            arrayValue.add(recordValue);
+                        } else if (collectionItem instanceof String[]) {
+                            for (String collectionSubItem : (String[]) collectionItem) {
+                                recordValue = new StringValue(collectionSubItem);
+                                arrayValue.add(recordValue);
+                            }
+                        }
+                    }
+                    mapValue.put(key, arrayValue);
+                } else if (mapping instanceof EISCompositeObjectMapping) {
+                    MapValue recordValue = new MapValue();
+                    Map<String, DatabaseMapping> fieldNameMappingCollection = createFieldNameMappingMap(mapping.getReferenceDescriptor());
+                    for (Map<String, String> compositeObject : (List<Map>) entry.getValue()) {
+                        for (Map.Entry<String, String> compositeObjectEntry : compositeObject.entrySet()) {
+                            DatabaseMapping mappingCollection = fieldNameMappingCollection.get(compositeObjectEntry.getKey());
+                            Converter converter = ((EISDirectMapping) mappingCollection).getConverter();
+                            String fieldClassificationName = ((EISDirectMapping) mappingCollection).getFieldClassificationClassName();
+                            String typeName = mappingCollection.getAttributeClassification().getTypeName();
+                            String value = compositeObjectEntry.getValue();
+                            if (value != null) {
+                                if (converter == null) {
+                                    recordValue.put(compositeObjectEntry.getKey(), OracleNoSQLPlatform.getFieldValue(typeName, value, OracleNoSQLPlatform.isLob(typeName)));
+                                } else {
+                                    Session session = SessionManager.getManager().getSession(descriptor.getSessionName());
+                                    Object convertedValue = converter.convertDataValueToObjectValue(value, session);
+                                    recordValue.put(compositeObjectEntry.getKey(), OracleNoSQLPlatform.getFieldValue(typeName, convertedValue, OracleNoSQLPlatform.isLob(fieldClassificationName)));
+                                }
+                            }
+                        }
+                    }
+                    if (recordValue.size() > 0) {
+                        mapValue.put(key, recordValue);
+                    }
+                } else if (mapping instanceof EISCompositeCollectionMapping) {
+                    ArrayValue arrayValue = new ArrayValue();
+                    Map<String, DatabaseMapping> fieldNameMappingCollection = createFieldNameMappingMap(mapping.getReferenceDescriptor());
+                    for (Map<String, Object> compositeObjectList : (List<Map<String, Object>>) entry.getValue()) {
+                        MapValue recordValue = new MapValue();
+                        for (Map.Entry<String, Object> compositeObjectEntry : compositeObjectList.entrySet()) {
+                            DatabaseMapping mappingCollection = fieldNameMappingCollection.get(compositeObjectEntry.getKey());
+                            Converter converter = ((EISDirectMapping) mappingCollection).getConverter();
+                            String fieldClassificationName = ((EISDirectMapping) mappingCollection).getFieldClassificationClassName();
+                            String typeName = mappingCollection.getAttributeClassification().getTypeName();
+                            Object value = compositeObjectEntry.getValue();
+                            if (value != null) {
+                                if (converter == null) {
+                                    recordValue.put(compositeObjectEntry.getKey(), OracleNoSQLPlatform.getFieldValue(typeName, value, OracleNoSQLPlatform.isLob(typeName)));
+                                } else {
+                                    Session session = SessionManager.getManager().getSession(descriptor.getSessionName());
+                                    Object convertedValue = converter.convertDataValueToObjectValue(value, session);
+                                    recordValue.put(compositeObjectEntry.getKey(), OracleNoSQLPlatform.getFieldValue(typeName, convertedValue, OracleNoSQLPlatform.isLob(fieldClassificationName)));
+                                }
+                            }
+                        }
+                        arrayValue.add(recordValue);
+                    }
+                    mapValue.put(key, arrayValue);
+                }
+            }
+        }
+        return mapValue;
+    }
+
+    private Map<String, String> createMapFromDOMRecord(DOMRecord domRecord) {
+        Map<String, String> map = new HashMap<>();
+        for (Map.Entry<DatabaseField, Element> entry : (Set<Map.Entry<DatabaseField, Element>>) domRecord.entrySet()) {
+            String key = entry.getKey().getName();
+            String value = entry.getValue().getFirstChild().getNodeValue();
+            map.put(key, value);
+        }
+        return map;
+    }
+
+    private Object unboxFieldValue(FieldValue value, InteractionSpec spec) {
+        Object result = null;
+        if (value instanceof ArrayValue) {
+            if (((OracleNoSQLInteractionSpec)spec).getInteractionType() == OracleNoSQLInteractionSpec.InteractionType.XML) {
+                //Output as an array works for XMLInteraction
+                result = new int[((ArrayValue) value).size()];
+                if (((ArrayValue) value).size() > 0) {
+                    result = Array.newInstance((unboxFieldValue(((ArrayValue) value).get(0), spec).getClass()), ((ArrayValue) value).size());
+                }
+                for (int i = 0; i < ((ArrayValue) value).size(); i++) {
+                    ((Object[]) result)[i] = unboxFieldValue(((ArrayValue) value).get(i), spec);
+                }
+            } else if (((OracleNoSQLInteractionSpec)spec).getInteractionType() == OracleNoSQLInteractionSpec.InteractionType.MAPPED) {
+                //Output as a collection (List) works for MappedInteraction
+                if (((ArrayValue) value).size() > 0) {
+                    result = new ArrayList(((ArrayValue) value).size());
+                    for (int i = 0; i < ((ArrayValue) value).size(); i++) {
+                        ((List) result).add(unboxFieldValue(((ArrayValue) value).get(i), spec));
+                    }
+                }
+            }
+        } else if (value instanceof BinaryValue) {
+            result = value.getBinary();
+        } else if (value instanceof BooleanValue) {
+            result = value.getBoolean();
+        } else if (value instanceof DoubleValue) {
+            result = value.getDouble();
+        } else if (value instanceof IntegerValue) {
+            result = value.getInt();
+        } else if (value instanceof LongValue) {
+            result = value.getLong();
+        } else if (value instanceof MapValue) {
+            Map<String, FieldValue> mapValue = ((MapValue) value).getMap();
+            Map<String, Object> resultMap = new HashMap<>();
+            for (Map.Entry<String, FieldValue> entry : mapValue.entrySet()) {
+                resultMap.put(entry.getKey(), unboxFieldValue(entry.getValue(), spec));
+            }
+            result = resultMap;
+        } else if (value instanceof NullValue) {
+            result = null;
+        } else if (value instanceof NumberValue) {
+            result = value.getNumber();
+        } else if (value instanceof StringValue) {
+            result = value.getString();
+        } else if (value instanceof TimestampValue) {
+            result = value.getTimestamp();
+        }
+        return result;
+    }
+
+    private PutRequest createPutRequest(DOMRecord domRecord, String tableName, ClassDescriptor descriptor) {
+        MapValue mapValue = createMapValue(domRecord, descriptor);
+        return new PutRequest().setValue(mapValue).setTableName(tableName);
+    }
+
+    private PutRequest createPutRequest(Map input, String tableName, ClassDescriptor descriptor) {
+        MapValue mapValue = createMapValue(input, descriptor);
+        return new PutRequest().setValue(mapValue).setTableName(tableName);
+    }
+
+    private Map<String, DatabaseMapping> createFieldNameMappingMap(ClassDescriptor descriptor) {
+        Map<String, DatabaseMapping> result = new HashMap<>();
+        for (DatabaseMapping mapping : descriptor.getMappings()) {
+            for (DatabaseField field : mapping.getFields()) {
+                result.put(field.getQualifiedName(), mapping);
+            }
+        }
+        return result;
+    }
+}

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLInteractionSpec.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLInteractionSpec.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.internal.nosql.adapters.sdk;
+
+import jakarta.resource.cci.InteractionSpec;
+
+import oracle.nosql.driver.Consistency;
+import oracle.nosql.driver.Durability;
+import oracle.nosql.driver.Version;
+import org.eclipse.persistence.descriptors.ClassDescriptor;
+import org.eclipse.persistence.eis.interactions.EISInteraction;
+import org.eclipse.persistence.eis.interactions.MappedInteraction;
+
+/**
+ * Interaction spec for Oracle NoSQL JCA adapter.
+ *
+ * @author Radek Felcman
+ * @since EclipseLink 4.0
+ */
+public class OracleNoSQLInteractionSpec implements InteractionSpec {
+
+    public enum InteractionType {
+        XML, MAPPED
+    }
+
+    private OracleNoSQLOperation operation;
+    private Consistency consistency;
+    private Durability durability;
+    private int timeout;
+    private String key;
+    private Version version;
+    private String tableName;
+    private ClassDescriptor descriptor;
+    private InteractionType interactionType;
+
+    /**
+     * Default constructor.
+     */
+    public OracleNoSQLInteractionSpec(EISInteraction interaction) {
+        if (interaction instanceof MappedInteraction) {
+            this.interactionType = InteractionType.MAPPED;
+        } else {
+            this.interactionType = InteractionType.XML;
+        }
+    }
+
+    public OracleNoSQLOperation getOperation() {
+        return operation;
+    }
+
+    public void setOperation(OracleNoSQLOperation operation) {
+        this.operation = operation;
+    }
+
+    public Version getVersion() {
+        return version;
+    }
+
+    public void setVersion(Version version) {
+        this.version = version;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public Consistency getConsistency() {
+        return consistency;
+    }
+
+    public void setConsistency(Consistency consistency) {
+        this.consistency = consistency;
+    }
+
+    public Durability getDurability() {
+        return durability;
+    }
+
+    public void setDurability(Durability durability) {
+        this.durability = durability;
+    }
+
+    public int getTimeout() {
+        return timeout;
+    }
+
+    public void setTimeout(int timeout) {
+        this.timeout = timeout;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public void setTableName(String tableName) {
+        this.tableName = tableName;
+    }
+
+    public ClassDescriptor getDescriptor() {
+        return descriptor;
+    }
+
+    public void setDescriptor(ClassDescriptor descriptor) {
+        this.descriptor = descriptor;
+    }
+
+    public InteractionType getInteractionType() {
+        return interactionType;
+    }
+
+    public void setInteractionType(InteractionType interactionType) {
+        this.interactionType = interactionType;
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getName() + "(" + getOperation() + ")";
+    }
+}

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLJCAConnectionSpec.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLJCAConnectionSpec.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.internal.nosql.adapters.sdk;
+
+import jakarta.resource.cci.ConnectionSpec;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+/**
+ * Defines connection information for connecting to Oracle NoSQL.
+ *
+ * @author Radek Felcman
+ * @since EclipseLink 4.0
+ */
+public class OracleNoSQLJCAConnectionSpec implements ConnectionSpec {
+
+    /** Cloud authorization mechanisms.
+     * <ul>
+     * <li>user - Use User Principal authorization using a config file in $HOME/.oci/config</li>
+     * <li>instance - Create a SignatureProvider using an instance principal.</li>
+     * <li>resource - Create a SignatureProvider using a resource principal.</li>
+     * </ul>
+     **/
+    public enum AuthPrincipalType {
+        USER("user"),
+        INSTANCE("instance"),
+        RESOURCE("resource");
+
+        private String authPrincipalName;
+
+        AuthPrincipalType(String authPrincipalName) {
+            this.authPrincipalName = authPrincipalName;
+        }
+
+        public String getAuthPrincipalName() {
+            return this.authPrincipalName;
+        }
+
+        public static Optional<AuthPrincipalType> get(String authPrincipalName) {
+            return Arrays.stream(AuthPrincipalType.values())
+                    .filter(authPrincipalType -> authPrincipalType.authPrincipalName.equals(authPrincipalName))
+                    .findFirst();
+        }
+    };
+
+
+    /** NoSQL service type.
+     * <ul>
+     * <li>cloud - Cloud service</li>
+     * <li>onprem - On-premise proxy and Oracle NoSQL Database instance</li>
+     * <li>cloudsim - Cloud simulator (for development)</li>
+     * </ul>
+     **/
+    public enum ServiceType {
+        CLOUD("cloud"),
+        ON_PREMISE("onpremise"),
+        CLOUD_SIMULATOR("cloudsim");
+
+        private String serviceName;
+
+        ServiceType(String serviceName) {
+            this.serviceName = serviceName;
+        }
+
+        public String getServiceName() {
+            return this.serviceName;
+        }
+
+        public static Optional<ServiceType> get(String serviceName) {
+            return Arrays.stream(ServiceType.values())
+                    .filter(service -> service.serviceName.equals(serviceName))
+                    .findFirst();
+        }
+    };
+
+    private ServiceType service;
+
+    /** NoSQL endpoint e.g.
+     * <ul>
+     * <li>eu-frankfurt-1 (for cloud))</li>
+     * <li>http://localhost:8080 (for onprem))</li>
+     * <li>http://localhost:8080 (for cloudsim))</li>
+     * </ul>
+     **/
+    private String endPoint;
+
+    private AuthPrincipalType authPrincipalType;
+
+    /* required for Instance/Resource Principal auth */
+    private String compartment = null; // an OCID
+
+    /**
+     * PUBLIC:
+     * Default constructor.
+     */
+    public OracleNoSQLJCAConnectionSpec() {
+        this.service = ServiceType.CLOUD_SIMULATOR;
+    }
+
+    public ServiceType getService() {
+        return service;
+    }
+
+    public void setService(ServiceType service) {
+        this.service = service;
+    }
+
+    public String getEndPoint() {
+        return endPoint;
+    }
+
+    public void setEndPoint(String endPoint) {
+        this.endPoint = endPoint;
+    }
+
+    public AuthPrincipalType getAuthPrincipalType() {
+        return authPrincipalType;
+    }
+
+    public void setAuthPrincipalType(AuthPrincipalType authPrincipalType) {
+        this.authPrincipalType = authPrincipalType;
+    }
+
+    public String getCompartment() {
+        return compartment;
+    }
+
+    public void setCompartment(String compartment) {
+        this.compartment = compartment;
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "(" + this.service + ", " + this.endPoint + ")";
+    }
+}

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLJCAConnectionSpec.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLJCAConnectionSpec.java
@@ -39,7 +39,7 @@ public class OracleNoSQLJCAConnectionSpec implements ConnectionSpec {
         INSTANCE("instance"),
         RESOURCE("resource");
 
-        private String authPrincipalName;
+        private final String authPrincipalName;
 
         AuthPrincipalType(String authPrincipalName) {
             this.authPrincipalName = authPrincipalName;
@@ -69,7 +69,7 @@ public class OracleNoSQLJCAConnectionSpec implements ConnectionSpec {
         ON_PREMISE("onpremise"),
         CLOUD_SIMULATOR("cloudsim");
 
-        private String serviceName;
+        private final String serviceName;
 
         ServiceType(String serviceName) {
             this.serviceName = serviceName;

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLOperation.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLOperation.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.internal.nosql.adapters.sdk;
+
+/**
+ * Defines the valid Oracle NoSQL operations.
+ *
+ * @author Radek Felcman
+ * @since EclipseLink 4.0
+ */
+public enum OracleNoSQLOperation {
+    GET, PUT, PUT_IF_ABSENT, PUT_IF_PRESENT, PUT_IF_VERSION, DELETE, DELETE_IF_VERSION, ITERATOR, ITERATOR_QUERY
+}

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLRecord.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLRecord.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.internal.nosql.adapters.sdk;
+
+import java.util.HashMap;
+
+import jakarta.resource.cci.MappedRecord;
+
+/**
+ * Simple mapped record.
+ *
+ * @author Radek Felcman
+ * @since EclipseLink 4.0
+ */
+public class OracleNoSQLRecord extends HashMap implements MappedRecord {
+
+    public static final String SORT = "$sort";
+
+    protected String description;
+    protected String name;
+
+    /**
+     * Default constructor.
+     */
+    public OracleNoSQLRecord() {
+        super();
+        this.name = "Oracle NoSQL record";
+        this.description = "Oracle NoSQL key/value data";
+    }
+
+    public OracleNoSQLRecord(String name) {
+        super();
+        this.name = name;
+        this.description = "Oracle NoSQL key/value data";
+    }
+
+    @Override
+    public String getRecordShortDescription() {
+        return description;
+    }
+
+    @Override
+    public void setRecordShortDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public String getRecordName() {
+        return name;
+    }
+
+    @Override
+    public void setRecordName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public Object get(Object key) {
+        Object result = super.get(key);
+        if (result == null) {
+            result = super.get(((String)key).toUpperCase());
+        }
+        if (result == null) {
+            result = super.get(((String)key).toLowerCase());
+        }
+        return result;
+    }
+
+}

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLRecordFactory.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLRecordFactory.java
@@ -34,11 +34,13 @@ public class OracleNoSQLRecordFactory implements RecordFactory {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public IndexedRecord createIndexedRecord(String recordName) {
         throw ValidationException.operationNotSupported("createIndexedRecord");
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public MappedRecord createMappedRecord(String recordName) {
         return new OracleNoSQLRecord(recordName);
     }

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLRecordFactory.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLRecordFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.internal.nosql.adapters.sdk;
+
+import jakarta.resource.cci.IndexedRecord;
+import jakarta.resource.cci.MappedRecord;
+import jakarta.resource.cci.RecordFactory;
+import org.eclipse.persistence.exceptions.ValidationException;
+
+/**
+ * Record factory for Oracle NoSQL JCA adapter.
+ *
+ * @author Radek Felcman
+ * @since EclipseLink 4.0
+ */
+public class OracleNoSQLRecordFactory implements RecordFactory {
+
+    /**
+     * Default constructor.
+     */
+    public OracleNoSQLRecordFactory() {
+    }
+
+    @Override
+    public IndexedRecord createIndexedRecord(String recordName) {
+        throw ValidationException.operationNotSupported("createIndexedRecord");
+    }
+
+    @Override
+    public MappedRecord createMappedRecord(String recordName) {
+        return new OracleNoSQLRecord(recordName);
+    }
+}

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLTransaction.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLTransaction.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.internal.nosql.adapters.sdk;
+
+import jakarta.resource.ResourceException;
+import jakarta.resource.cci.LocalTransaction;
+
+/**
+ * Transaction to Oracle NoSQL JCA adapter.
+ * Oracle NoSQL does not currently support transactions.
+ *
+ * @author James
+ * @since EclipseLink 2.4
+ */
+public class OracleNoSQLTransaction implements LocalTransaction {
+    protected boolean isInTransaction;
+    protected OracleNoSQLConnection connection;
+
+    /**
+     * Default constructor.
+     */
+    public OracleNoSQLTransaction(OracleNoSQLConnection connection) {
+        this.connection = connection;
+        this.isInTransaction = false;
+    }
+
+    /**
+     * Record that a transaction has begun.
+     */
+    @Override
+    public void begin() {
+        this.isInTransaction = true;
+    }
+
+    /**
+     * Return if currently within a transaction.
+     */
+    public boolean isInTransaction() {
+        return isInTransaction;
+    }
+
+    /**
+     * Rollback.  Not currently supported.
+     */
+    @Override
+    public void commit() throws ResourceException {
+        try {
+            //this.connection.getDatabaseConnection().commit();
+        } catch (Exception exception) {
+            throw new ResourceException(exception.toString());
+        }
+        this.isInTransaction = false;
+    }
+
+    /**
+     * Rollback.  Not currently supported.
+     */
+    @Override
+    public void rollback() throws ResourceException {
+        try {
+            //this.connection.getDatabaseConnection().rollback();
+        } catch (Exception exception) {
+            throw new ResourceException(exception.toString());
+        }
+        this.isInTransaction = false;
+    }
+}

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/nosql/adapters/sdk/OracleNoSQLConnectionSpec.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/nosql/adapters/sdk/OracleNoSQLConnectionSpec.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.nosql.adapters.sdk;
+
+import java.util.Properties;
+
+import jakarta.resource.cci.Connection;
+
+import org.eclipse.persistence.internal.nosql.adapters.sdk.OracleNoSQLConnectionFactory;
+import org.eclipse.persistence.internal.nosql.adapters.sdk.OracleNoSQLJCAConnectionSpec;
+import org.eclipse.persistence.eis.EISAccessor;
+import org.eclipse.persistence.eis.EISConnectionSpec;
+import org.eclipse.persistence.exceptions.DatabaseException;
+import org.eclipse.persistence.exceptions.ValidationException;
+
+/**
+ * Provides connection information to the Oracle NoSQL database.
+ *
+ * @author Radek Felcman
+ * @since EclipseLink 4.0
+ */
+public class OracleNoSQLConnectionSpec extends EISConnectionSpec {
+
+    /**
+     * Connection spec properties.
+     * NoSQL service type.
+     * <ul>
+     * <li>cloud - Cloud service</li>
+     * <li>onprem - On-premise proxy and Oracle NoSQL Database instance</li>
+     * <li>cloudsim - Cloud simulator (for development)</li>
+     * </ul>
+     **/
+    public static String SERVICE = "nosql.service";
+
+    /**
+     * NoSQL endpoint e.g.
+     * <ul>
+     * <li>eu-frankfurt-1 (for cloud nosql.service))</li>
+     * <li>http://localhost:8080 (for onprem nosql.service))</li>
+     * <li>http://localhost:8080 (for cloudsim nosql.service))</li>
+     * </ul>
+     **/
+    public static String END_POINT = "nosql.endpoint";
+
+    /**
+     * Compartment is an OCID. This is required if using Instance Principal or Resource Principal authorization.
+     * It's walid for cloud, onprem nosql.service types.
+     */
+    public static String COMPARTMENT = "nosql.compartment";
+
+    /** Cloud authorization mechanisms. Possible values are.
+     * <ul>
+     * <li>user - Use User Principal authorization using a config file in $HOME/.oci/config</li>
+     * <li>instance - Create a SignatureProvider using an instance principal.</li>
+     * <li>resource - Create a SignatureProvider using a resource principal.</li>
+     * </ul>
+     **/
+    public static String AUTHORIZATION_PRINCIPAL = "nosql.authprincipal";
+
+    /**
+     * PUBLIC:
+     * Default constructor.
+     */
+    public OracleNoSQLConnectionSpec() {
+        super();
+    }
+
+    /**
+     * Connect with the specified properties and return the Connection.
+     */
+    @Override
+    public Connection connectToDataSource(EISAccessor accessor, Properties properties) throws DatabaseException, ValidationException {
+        if ((this.connectionFactory == null) && (this.name == null)) {
+            this.connectionFactory = new OracleNoSQLConnectionFactory();
+        }
+        if (!properties.isEmpty()) {
+            if (this.connectionSpec == null) {
+                this.connectionSpec = new OracleNoSQLJCAConnectionSpec();
+            }
+            OracleNoSQLJCAConnectionSpec spec = (OracleNoSQLJCAConnectionSpec)this.connectionSpec;
+            String serviceName = (String)properties.get(SERVICE);
+            if (serviceName != null) {
+                spec.setService(OracleNoSQLJCAConnectionSpec.ServiceType.get(serviceName).get());
+            }
+            String endPoint = (String)properties.get(END_POINT);
+            if (endPoint != null) {
+                spec.setEndPoint(endPoint);
+            }
+            String compartment = (String)properties.get(COMPARTMENT);
+            if (compartment  != null) {
+                spec.setCompartment(compartment);
+            }
+            String authPrincipalType = (String)properties.get(AUTHORIZATION_PRINCIPAL);
+            if (authPrincipalType  != null) {
+                spec.setAuthPrincipalType(OracleNoSQLJCAConnectionSpec.AuthPrincipalType.get(authPrincipalType).get());
+            }
+        }
+        return super.connectToDataSource(accessor, properties);
+    }
+}

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/nosql/NoSqlMetadata.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/nosql/NoSqlMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,6 +14,8 @@
 //     Oracle - initial implementation
 package org.eclipse.persistence.internal.jpa.metadata.nosql;
 
+import jakarta.persistence.Table;
+
 import org.eclipse.persistence.descriptors.ClassDescriptor;
 import org.eclipse.persistence.eis.EISDescriptor;
 import org.eclipse.persistence.internal.helper.Helper;
@@ -21,6 +23,7 @@ import org.eclipse.persistence.internal.jpa.metadata.MetadataDescriptor;
 import org.eclipse.persistence.internal.jpa.metadata.ORMetadata;
 import org.eclipse.persistence.internal.jpa.metadata.accessors.MetadataAccessor;
 import org.eclipse.persistence.internal.jpa.metadata.accessors.objects.MetadataAnnotation;
+import org.eclipse.persistence.internal.jpa.metadata.tables.TableMetadata;
 
 /**
  * Defines the metadata for the @EIS annotation for mapping an EISDescriptor.
@@ -115,7 +118,15 @@ public class NoSqlMetadata extends ORMetadata {
         } else {
             String defaultName = Helper.getShortClassName(descriptor.getJavaClassName());
             defaultName = getProject().useDelimitedIdentifier() ? defaultName : defaultName.toUpperCase();
-            newDescriptor.setDataTypeName(defaultName);
+            if (!descriptor.isEmbeddable()) {
+                MetadataAnnotation tableAnnotation = descriptor.getEntityAccessor().getAnnotation(Table.class);
+                if (tableAnnotation != null) {
+                    TableMetadata tableMetadata = new TableMetadata(tableAnnotation, descriptor.getEntityAccessor());
+                    newDescriptor.setDataTypeName(tableMetadata.getName());
+                } else {
+                    newDescriptor.setDataTypeName(defaultName);
+                }
+            }
         }
         if (this.dataFormat != null) {
             if (this.dataFormat.equals("XML")) {

--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,8 @@
         <oracle.fmw.version>12.2.1-2-0</oracle.fmw.version>
         <!-- CQ #21141 -->
         <oracle.nosql.version>18.3.10</oracle.nosql.version>
+        <!-- CQ #24195 -->
+        <oracle.nosql.sdk.version>5.3.5</oracle.nosql.sdk.version>
         <!-- CQ #21142 -->
         <osgi.version>6.0.0</osgi.version>
         <!-- CQ #21143 -->
@@ -829,6 +831,12 @@
                 <groupId>com.oracle.kv</groupId>
                 <artifactId>oracle-nosql-client</artifactId>
                 <version>${oracle.nosql.version}</version>
+            </dependency>
+            <!--Oracle NoSQL SDK Driver-->
+            <dependency>
+                <groupId>com.oracle.nosql.sdk</groupId>
+                <artifactId>nosqldriver</artifactId>
+                <version>${oracle.nosql.sdk.version}</version>
             </dependency>
             <!-- All files as a Oracle JDBC driver CQ #21154 -->
             <dependency>


### PR DESCRIPTION
This is major change in OracleNoSQL platform. It changes OracleNoSQL driver/API from 
`com.oracle.kv:oracle-nosql-client` into new OracleNoSQL SDK `com.oracle.nosql.sdk:nosqldriver`.
New platform should be enabled by following _persistence.xml_ properties:

```
<property name="eclipselink.target-database" value="org.eclipse.persistence.nosql.adapters.sdk.OracleNoSQLPlatform"/>
<property name="eclipselink.nosql.connection-spec" value="org.eclipse.persistence.nosql.adapters.sdk.OracleNoSQLConnectionSpec"/>
```

New OracleNoSQL SDK additionally offers proceed some simple SQL queries and supports following three Oracle NoSQL Database deployments (new _persistence.xml_ properties):

- Cloud simulator (locally installed database)

```
...
<property name="eclipselink.nosql.property.nosql.service" value="cloudsim"/>
<property name="eclipselink.nosql.property.nosql.endpoint" value="http://localhost:8080"/>
...

```

- Cloud service on region (DB cloud deployment e.g. eu-frankfurt-1)

```
...

<property name="eclipselink.nosql.property.nosql.service" value="cloud"/>
<property name="eclipselink.nosql.property.nosql.endpoint" value="eu-frankfurt-1"/>
<property name="eclipselink.nosql.property.nosql.compartment" value="ocid1.tenancy.oc1..****************"/>
<property name="eclipselink.nosql.property.nosql.authprincipal" value="user"/>
...

```

- On-premise instance on endpoint (customer hardware e.g. URL http://company.domain.com:8090)

```
...

<property name="eclipselink.nosql.property.nosql.service" value="onprem"/>
<property name="eclipselink.nosql.property.nosql.endpoint" value="[eu-frankfurt-1](http://company.domain.com:8090)"/>
<property name="eclipselink.nosql.property.nosql.compartment" value="ocid1.tenancy.oc1..****************"/>
<property name="eclipselink.nosql.property.nosql.authprincipal" value="user"/>
...

```

Legacy ORM access or JPA access remains same. JCA XMLInteraction and MapedInteraction are supported by new adapter. Previous platform `org.eclipse.persistence.nosql.adapters.nosql.OracleNoSQLPlatform` is marked as a `Deprecated`.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>