### PR TITLE
[master] JPA Test Framework - distribution bundle fix

### DIFF
--- a/bundles/others/pom.xml
+++ b/bundles/others/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -225,7 +225,13 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
-        <!--EclipseLink JPA test classes (test framework) additional classes-->
+        <!--EclipseLink JPA test framework-->
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.jpa.test.framework</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!--EclipseLink JPA test classes-->
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>org.eclipse.persistence.jpa.test</artifactId>

--- a/bundles/others/src/main/assembly/eclipselink-jpatest-framework.jar.xml
+++ b/bundles/others/src/main/assembly/eclipselink-jpatest-framework.jar.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -24,7 +24,7 @@
     <dependencySets>
         <dependencySet>
             <includes>
-                <include>org.eclipse.persistence:org.eclipse.persistence.jpa.test:test-jar</include>
+                <include>org.eclipse.persistence:org.eclipse.persistence.jpa.test.framework</include>
             </includes>
             <scope>test</scope>
             <unpack>true</unpack>


### PR DESCRIPTION
This fixes missing files in _eclipselink-jpatest-framework.jar_ bundle.
Backport from 3.0 branch.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>