### PR TITLE
#1648: SchemaManager should consistently suppress logging on schema generation

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/tools/schemaframework/SequenceDefinition.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/tools/schemaframework/SequenceDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -84,7 +84,15 @@ public abstract class SequenceDefinition extends DatabaseObjectDefinition {
      */
     @Override
     public void createOnDatabase(AbstractSession session) throws EclipseLinkException {
-        if (checkIfExist(session)) {
+        boolean exists = false;
+        final boolean loggingOff = session.isLoggingOff();
+        try {
+            session.setLoggingOff(true);
+            exists = checkIfExist(session);
+        } finally {
+            session.setLoggingOff(loggingOff);
+        }
+        if (exists) {
             if (this.isAlterSupported(session)) {
                 alterOnDatabase(session);
             }


### PR DESCRIPTION
fixes #1648 

Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>