### PR TITLE
[master] PrintInnerJoinInWhereClause as query hint

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/QueryHints.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/QueryHints.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2021 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -920,6 +920,15 @@ public class QueryHints {
      * @see org.eclipse.persistence.queries.ResultSetMappingQuery#shouldReturnNameValuePairs()
      */
     public static final String RETURN_NAME_VALUE_PAIRS = "eclipselink.query-return-name-value-pairs";
+
+    /**
+     * "eclipselink.print-inner-join-in-where-clause"
+     * <p>Changes the way that inner joins are printed in generated SQL for the database.
+     * With a value of true, inner joins are printed in the WHERE clause, if false, inner joins are printed in the FROM clause.
+     * This query hint should override global/session switch {@link org.eclipse.persistence.internal.databaseaccess.DatabasePlatform#setPrintInnerJoinInWhereClause(boolean)}
+     * @see org.eclipse.persistence.internal.databaseaccess.DatabasePlatform#setPrintInnerJoinInWhereClause(boolean)
+     */
+    public static final String PRINT_INNER_JOIN_IN_WHERE_CLAUSE = "eclipselink.print-inner-join-in-where-clause";
 
     private QueryHints() {
         // no instance please

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/QueryHints.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/QueryHints.java
@@ -922,13 +922,13 @@ public class QueryHints {
     public static final String RETURN_NAME_VALUE_PAIRS = "eclipselink.query-return-name-value-pairs";
 
     /**
-     * "eclipselink.print-inner-join-in-where-clause"
+     * "eclipselink.inner-join-in-where-clause"
      * <p>Changes the way that inner joins are printed in generated SQL for the database.
      * With a value of true, inner joins are printed in the WHERE clause, if false, inner joins are printed in the FROM clause.
      * This query hint should override global/session switch {@link org.eclipse.persistence.internal.databaseaccess.DatabasePlatform#setPrintInnerJoinInWhereClause(boolean)}
      * @see org.eclipse.persistence.internal.databaseaccess.DatabasePlatform#setPrintInnerJoinInWhereClause(boolean)
      */
-    public static final String PRINT_INNER_JOIN_IN_WHERE_CLAUSE = "eclipselink.print-inner-join-in-where-clause";
+    public static final String INNER_JOIN_IN_WHERE_CLAUSE = "eclipselink.inner-join-in-where-clause";
 
     private QueryHints() {
         // no instance please

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/expressions/ExpressionBuilder.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/expressions/ExpressionBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -278,7 +278,7 @@ public class ExpressionBuilder extends ObjectExpression {
         // Normalize the ON clause if present.  Need to use rebuild, not twist as parameters are real parameters.
         if (this.onClause != null) {
             this.onClause = this.onClause.normalize(normalizer);
-            if (shouldUseOuterJoin() || (!getSession().getPlatform().shouldPrintInnerJoinInWhereClause())) {
+            if (shouldUseOuterJoin() || (!getSession().getPlatform().shouldPrintInnerJoinInWhereClause((normalizer.getStatement().getParentStatement() != null ? normalizer.getStatement().getParentStatement().getQuery() : normalizer.getStatement().getQuery())))) {
                 normalizer.getStatement().addOuterJoinExpressionsHolders(this, null, null, null);
                 if ((getDescriptor() != null) && (getDescriptor().getHistoryPolicy() != null)) {
                     Expression historyCriteria = getDescriptor().getHistoryPolicy().additionalHistoryExpression(this, this);

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
@@ -63,7 +63,6 @@ import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.UUID;
 import java.util.Vector;
 
@@ -101,6 +100,8 @@ import org.eclipse.persistence.platform.database.partitioning.DataPartitioningCa
 import org.eclipse.persistence.queries.Call;
 import org.eclipse.persistence.queries.DataReadQuery;
 import org.eclipse.persistence.queries.DatabaseQuery;
+import org.eclipse.persistence.queries.ObjectBuildingQuery;
+import org.eclipse.persistence.queries.ReadQuery;
 import org.eclipse.persistence.queries.ReportQuery;
 import org.eclipse.persistence.queries.SQLCall;
 import org.eclipse.persistence.queries.StoredProcedureCall;
@@ -2104,11 +2105,16 @@ public class DatabasePlatform extends DatasourcePlatform {
      * By default most platforms put inner joins in the WHERE clause.
      * If set to false, inner joins will be printed in the FROM clause.
      */
-    public boolean shouldPrintInnerJoinInWhereClause() {
-        if (this.printInnerJoinInWhereClause == null) {
-            return true;
+    public boolean shouldPrintInnerJoinInWhereClause(ReadQuery query) {
+        Boolean printInnerJoinInWhereClauseQueryHint = ((query != null) && (query instanceof ObjectBuildingQuery)) ? ((ObjectBuildingQuery)query).printInnerJoinInWhereClause() : null;
+        if (printInnerJoinInWhereClauseQueryHint != null) {
+            return printInnerJoinInWhereClauseQueryHint;
+        } else {
+            if (this.printInnerJoinInWhereClause == null) {
+                return true;
+            }
+            return this.printInnerJoinInWhereClause;
         }
-        return this.printInnerJoinInWhereClause;
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/QueryKeyExpression.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/QueryKeyExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -191,7 +191,7 @@ public class QueryKeyExpression extends ObjectExpression {
         Vector<DatabaseTable> tables = getDescriptor().getTables();
         // skip the main table - start with i=1
         int tablesSize = tables.size();
-        if (shouldUseOuterJoin() || (!getSession().getPlatform().shouldPrintInnerJoinInWhereClause())) {
+        if (shouldUseOuterJoin() || (!getSession().getPlatform().shouldPrintInnerJoinInWhereClause(getDescriptor().getQueryManager().getReadAllQuery()))) {
             for (int i=1; i < tablesSize; i++) {
                 DatabaseTable table = tables.elementAt(i);
                 Expression joinExpression = getDescriptor().getQueryManager().getTablesJoinExpressions().get(table);
@@ -839,7 +839,7 @@ public class QueryKeyExpression extends ObjectExpression {
                 normalizer.addAdditionalExpression(mappingExpression.and(additionalExpressionCriteria()));
                 return this;
             } else if ((shouldUseOuterJoin() && (!getSession().getPlatform().shouldPrintOuterJoinInWhereClause()))
-                    || (!getSession().getPlatform().shouldPrintInnerJoinInWhereClause())) {
+                    || (!getSession().getPlatform().shouldPrintInnerJoinInWhereClause((normalizer.getStatement().getParentStatement() != null ? normalizer.getStatement().getParentStatement().getQuery() : normalizer.getStatement().getQuery())))) {
                 setOuterJoinExpIndex(statement.addOuterJoinExpressionsHolders(this, mappingExpression, additionalExpressionCriteriaMap(), null));
                 if ((getDescriptor() != null) && (getDescriptor().getHistoryPolicy() != null)) {
                     Expression historyOnClause = getDescriptor().getHistoryPolicy().additionalHistoryExpression(this, this, 0);

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/RelationExpression.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/RelationExpression.java
@@ -796,7 +796,7 @@ public class RelationExpression extends CompoundExpression {
             //.equal(anyOf() or get())
             (first.isExpressionBuilder() && second.isQueryKeyExpression()
                     &&  (!((QueryKeyExpression)second).hasDerivedExpressions()) // The right side is not used for anything else.
-                    && normalizer.getSession().getPlatform().shouldPrintInnerJoinInWhereClause()) {
+                    && normalizer.getSession().getPlatform().shouldPrintInnerJoinInWhereClause((normalizer.getStatement().getParentStatement() != null ? normalizer.getStatement().getParentStatement().getQuery() : normalizer.getStatement().getQuery()))) {
             first = (ExpressionBuilder)first.normalize(normalizer);
 
             // If FK joins go in the WHERE clause, want to get hold of it and

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/SQLSelectStatement.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/SQLSelectStatement.java
@@ -571,7 +571,7 @@ public class SQLSelectStatement extends SQLStatement {
         if (hasOuterJoinExpressions()) {
             if (session.getPlatform().isInformixOuterJoin()) {
                 appendFromClauseForInformixOuterJoin(printer, outerJoinedAliases);
-            } else if (!session.getPlatform().shouldPrintOuterJoinInWhereClause() || !session.getPlatform().shouldPrintInnerJoinInWhereClause()) {
+            } else if (!session.getPlatform().shouldPrintOuterJoinInWhereClause() || !session.getPlatform().shouldPrintInnerJoinInWhereClause(query)) {
                 appendFromClauseForOuterJoin(printer, outerJoinedAliases, aliasesOfTablesToBeLocked, shouldPrintUpdateClauseForAllTables);
             }
             firstTable = false;

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/TreatAsExpression.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/TreatAsExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -621,7 +621,7 @@ public class TreatAsExpression extends QueryKeyExpression {
                 normalizer.addAdditionalLocalExpression(typeExpression.and(additionalTreatExpressionCriteria()).and(this.onClause));
                 return this;
             } else if (((!getSession().getPlatform().shouldPrintOuterJoinInWhereClause()))
-                    || (!getSession().getPlatform().shouldPrintInnerJoinInWhereClause())) {
+                    || (!getSession().getPlatform().shouldPrintInnerJoinInWhereClause((normalizer.getStatement().getParentStatement() != null ? normalizer.getStatement().getParentStatement().getQuery() : normalizer.getStatement().getQuery())))) {
 
                 //Adds the left joins from treat to the base QKE joins.
                 Map<DatabaseTable, Expression> map = statement.getOuterJoinExpressionsHolders().get(postition).outerJoinedAdditionalJoinCriteria;
@@ -633,7 +633,7 @@ public class TreatAsExpression extends QueryKeyExpression {
                 return this;
             }
         } else if (!getSession().getPlatform().shouldPrintOuterJoinInWhereClause()
-                || (!getSession().getPlatform().shouldPrintInnerJoinInWhereClause())) {
+                || (!getSession().getPlatform().shouldPrintInnerJoinInWhereClause((normalizer.getStatement().getParentStatement() != null ? normalizer.getStatement().getParentStatement().getQuery() : normalizer.getStatement().getQuery())))) {
             //the base is not using an outer join, so we add a new one for this class' tables.
             Map additionalExpMap = additionalTreatExpressionCriteriaMap();
             if (additionalExpMap!=null && !additionalExpMap.isEmpty()) {

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/ObjectBuildingQuery.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/ObjectBuildingQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -103,6 +103,13 @@ public abstract class ObjectBuildingQuery extends ReadQuery {
     protected boolean isCacheCheckComplete;
 
     protected Map<Object, CacheKey> prefetchedCacheKeys;
+
+    /** Indicates whether the query printer/normalizer changes the way that inner joins are printed
+     * in generated SQL for the database. With a value of true, inner joins are printed in the WHERE clause,
+     * if false, inner joins are printed in the FROM clause.
+     * If value is set it overrides printInnerJoinInWhereClause persistence unit property.
+     * Default value null - value from printInnerJoinInWhereClause persistence unit property is used*/
+    protected Boolean printInnerJoinInWhereClause;
 
     /**
      * INTERNAL:
@@ -798,5 +805,26 @@ public abstract class ObjectBuildingQuery extends ReadQuery {
      */
     public boolean shouldUseSerializedObjectPolicy() {
         return false;
+    }
+
+    /**
+     * INTERNAL:
+     * Indicates whether the query will change the way that inner joins are printed in generated SQL for the database.
+     * With a value of true, inner joins are printed in the WHERE clause, if false, inner joins are printed in the FROM clause.
+     */
+    public Boolean printInnerJoinInWhereClause() {
+        return this.printInnerJoinInWhereClause;
+    }
+
+    /**
+     * INTERNAL:
+     * Set a flag that indicates whether the query will change the way that inner joins are printed in generated SQL for the database.
+     * With a value of true, inner joins are printed in the WHERE clause, if false, inner joins are printed in the FROM clause.
+     */
+    public void setPrintInnerJoinInWhereClause(boolean printInnerJoinInWhereClause) {
+        if (this.printInnerJoinInWhereClause == null || this.printInnerJoinInWhereClause != printInnerJoinInWhereClause) {
+            this.printInnerJoinInWhereClause = printInnerJoinInWhereClause;
+            setIsPrepared(false);
+        }
     }
 }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/ObjectLevelReadQuery.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/ObjectLevelReadQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2018 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/TestQueryHints.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/TestQueryHints.java
@@ -335,7 +335,7 @@ public class TestQueryHints implements PUPropertiesProvider {
             //JPQL Query test
             String jpql = "SELECT o FROM QueryOrder o WHERE o.queryOrderLines IS EMPTY";
             Query query4 = em.createQuery(jpql, QueryOrder.class);
-            query4.setHint(QueryHints.PRINT_INNER_JOIN_IN_WHERE_CLAUSE, "false");
+            query4.setHint(QueryHints.INNER_JOIN_IN_WHERE_CLAUSE, "false");
             List<QueryOrder> result4 = query4.getResultList();
             assertEquals(0, result4.size());
 

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/TestQueryHints.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/TestQueryHints.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2017, 2019 IBM Corporation. All rights reserved.
+ * Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -26,6 +26,7 @@ import java.lang.reflect.Proxy;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -42,6 +43,8 @@ import org.eclipse.persistence.jpa.test.framework.Emf;
 import org.eclipse.persistence.jpa.test.framework.EmfRunner;
 import org.eclipse.persistence.jpa.test.framework.PUPropertiesProvider;
 import org.eclipse.persistence.jpa.test.query.model.QueryEmployee;
+import org.eclipse.persistence.jpa.test.query.model.QueryOrder;
+import org.eclipse.persistence.jpa.test.query.model.QueryOrderLine;
 import org.eclipse.persistence.queries.ScrollableCursor;
 import org.eclipse.persistence.sessions.Connector;
 import org.eclipse.persistence.sessions.DatabaseLogin;
@@ -49,9 +52,10 @@ import org.eclipse.persistence.sessions.Session;
 import org.eclipse.persistence.sessions.SessionEvent;
 import org.eclipse.persistence.sessions.SessionEventAdapter;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
 
 @RunWith(EmfRunner.class)
 public class TestQueryHints implements PUPropertiesProvider {
@@ -60,8 +64,38 @@ public class TestQueryHints implements PUPropertiesProvider {
 
     private final static int propertyTimeout = 3099;
 
-    @Emf(name = "queryhintsEMF", classes = { QueryEmployee.class }, createTables = DDLGen.DROP_CREATE)
+    @Emf(name = "queryhintsEMF", classes = { QueryEmployee.class, QueryOrder.class, QueryOrderLine.class }, createTables = DDLGen.DROP_CREATE)
     private EntityManagerFactory emf;
+
+    public void setup() {
+        //Populate the tables
+        EntityManager em = emf.createEntityManager();
+        try {
+            em.getTransaction().begin();
+            QueryOrder queryOrder1 = new QueryOrder();
+            queryOrder1.setOrderKey(1);
+            em.persist(queryOrder1);
+            QueryOrder queryOrder2 = new QueryOrder();
+            queryOrder2.setOrderKey(2);
+            em.persist(queryOrder2);
+            QueryOrderLine queryOrderLine1 = new QueryOrderLine();
+            queryOrderLine1.setOrderLineKey(101);
+            queryOrderLine1.setOrder(queryOrder1);
+            em.persist(queryOrderLine1);
+            QueryOrderLine queryOrderLine2 = new QueryOrderLine();
+            queryOrderLine2.setOrderLineKey(102);
+            queryOrderLine2.setOrder(queryOrder1);
+            em.persist(queryOrderLine2);
+            em.getTransaction().commit();
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if(em.isOpen()) {
+                em.close();
+            }
+        }
+    }
 
     /**
      * Test that setting the Query Hint: QueryHints.JDBC_TIMEOUT to the default value
@@ -83,7 +117,7 @@ public class TestQueryHints implements PUPropertiesProvider {
                 queryTimeoutSeconds += 1;
             }
 
-            Assert.assertEquals((int)queryTimeoutSeconds, TestQueryHints.statementTimeout);
+            assertEquals((int)queryTimeoutSeconds, TestQueryHints.statementTimeout);
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -107,7 +141,7 @@ public class TestQueryHints implements PUPropertiesProvider {
                 queryTimeoutSeconds += 1;
             }
 
-            Assert.assertEquals((int)queryTimeoutSeconds, TestQueryHints.statementTimeout);
+            assertEquals((int)queryTimeoutSeconds, TestQueryHints.statementTimeout);
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -134,7 +168,7 @@ public class TestQueryHints implements PUPropertiesProvider {
             //Convert the timeout set (SECONDS) to what is expected by the JDBC layer (SECONDS)
             int queryTimeoutSecondsDouble = TestQueryHints.propertyTimeout;
 
-            Assert.assertEquals(queryTimeoutSecondsDouble, TestQueryHints.statementTimeout);
+            assertEquals(queryTimeoutSecondsDouble, TestQueryHints.statementTimeout);
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -154,7 +188,7 @@ public class TestQueryHints implements PUPropertiesProvider {
             //Convert the timeout set (SECONDS) to what is expected by the JDBC layer (SECONDS)
             int queryTimeoutSecondsDouble = TestQueryHints.propertyTimeout;
 
-            Assert.assertEquals(queryTimeoutSecondsDouble, TestQueryHints.statementTimeout);
+            assertEquals(queryTimeoutSecondsDouble, TestQueryHints.statementTimeout);
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -181,7 +215,7 @@ public class TestQueryHints implements PUPropertiesProvider {
             //Convert the timeout set (MINUTES) to what is expected by the JDBC layer (SECONDS)
             int queryTimeoutSeconds = TestQueryHints.propertyTimeout * 60;
 
-            Assert.assertEquals(queryTimeoutSeconds, TestQueryHints.statementTimeout);
+            assertEquals(queryTimeoutSeconds, TestQueryHints.statementTimeout);
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -201,7 +235,7 @@ public class TestQueryHints implements PUPropertiesProvider {
             //Convert the timeout set (MINUTES) to what is expected by the JDBC layer (SECONDS)
             int queryTimeoutSeconds = TestQueryHints.propertyTimeout * 60;
 
-            Assert.assertEquals(queryTimeoutSeconds, TestQueryHints.statementTimeout);
+            assertEquals(queryTimeoutSeconds, TestQueryHints.statementTimeout);
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -244,6 +278,68 @@ public class TestQueryHints implements PUPropertiesProvider {
              */
             Query query3 = em.createNamedQuery("QueryEmployee.findAll");
             query3.getResultList();
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if(em.isOpen()) {
+                em.close();
+            }
+        }
+    }
+
+    /**
+     * Test that setting the Query Hint: QueryHints.PRINT_INNER_JOIN_IN_WHERE_CLAUSE are correctly applied.
+     */
+    @Test
+    public void testPrintInnerJoinInWhereClauseHint() {
+        setup();
+        EntityManager em = emf.createEntityManager();
+        try {
+            em.getTransaction().begin();
+
+            /*
+             * First create a NamedQuery and return the result list without hint (defaut value)
+             */
+            Query query1 = em.createNamedQuery("QueryOrder.findAllOrdersWithEmptyOrderLines", QueryOrder.class);
+            List<QueryOrder> result1 = query1.getResultList();
+            assertEquals(1, result1.size());
+            assertEquals(2L, result1.get(0).getOrderKey());
+
+            /*
+             * Second create a NamedQuery and return the result list with hint (true value)
+             */
+            Query query2 = em.createNamedQuery("QueryOrder.findAllOrdersWithEmptyOrderLinesHintTrue", QueryOrder.class);
+            List<QueryOrder> result2 = query2.getResultList();
+            assertEquals(1, result2.size());
+            assertEquals(2L, result2.get(0).getOrderKey());
+
+            /*
+             * Third create a NamedQuery and return the result list with hint (false value)
+             * This test is based on bug in EL normalization part as some queries are not correctly translated
+             * in case of PrintInnerJoinInWhereClause == false
+             * Generated SQL query incorrectly doesn't return any value.
+             * Some fix in this part should lead into crash there.
+             */
+            Query query3 = em.createNamedQuery("QueryOrder.findAllOrdersWithEmptyOrderLinesHintFalse", QueryOrder.class);
+            List<QueryOrder> result3 = query3.getResultList();
+            assertEquals(0, result3.size());
+
+            /*
+             * Fourth create a Query based on JPQL and return the result list with hint (false value)
+             * This test is based on bug in EL normalization part as some queries are not correctly translated
+             * in case of PrintInnerJoinInWhereClause == false
+             * Generated SQL query incorrectly doesn't return any value.
+             * Some fix in this part should lead into crash there.
+             */
+            //JPQL Query test
+            String jpql = "SELECT o FROM QueryOrder o WHERE o.queryOrderLines IS EMPTY";
+            Query query4 = em.createQuery(jpql, QueryOrder.class);
+            query4.setHint(QueryHints.PRINT_INNER_JOIN_IN_WHERE_CLAUSE, "false");
+            List<QueryOrder> result4 = query4.getResultList();
+            assertEquals(0, result4.size());
+
+
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/model/QueryOrder.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/model/QueryOrder.java
@@ -37,7 +37,7 @@ import java.util.List;
                 query="SELECT o FROM QueryOrder o WHERE o.queryOrderLines IS EMPTY"
                 ,
                 hints={
-                       @QueryHint(name=QueryHints.PRINT_INNER_JOIN_IN_WHERE_CLAUSE, value="true")
+                       @QueryHint(name=QueryHints.INNER_JOIN_IN_WHERE_CLAUSE, value="true")
                 }
         ),
         //PRINT_INNER_JOIN_IN_WHERE true
@@ -46,7 +46,7 @@ import java.util.List;
                 query="SELECT o FROM QueryOrder o WHERE o.queryOrderLines IS EMPTY"
                 ,
                 hints={
-                        @QueryHint(name=QueryHints.PRINT_INNER_JOIN_IN_WHERE_CLAUSE, value="false")
+                        @QueryHint(name=QueryHints.INNER_JOIN_IN_WHERE_CLAUSE, value="false")
                 }
         )
 })

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/model/QueryOrder.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/model/QueryOrder.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.query.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.QueryHint;
+import jakarta.persistence.Table;
+import org.eclipse.persistence.config.QueryHints;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "QUERY_ORDER")
+@NamedQueries({
+        @NamedQuery(
+                name="QueryOrder.findAllOrdersWithEmptyOrderLines",
+                query="SELECT o FROM QueryOrder o WHERE o.queryOrderLines IS EMPTY"
+        ),
+        //PRINT_INNER_JOIN_IN_WHERE true
+        @NamedQuery(
+                name="QueryOrder.findAllOrdersWithEmptyOrderLinesHintTrue",
+                query="SELECT o FROM QueryOrder o WHERE o.queryOrderLines IS EMPTY"
+                ,
+                hints={
+                       @QueryHint(name=QueryHints.PRINT_INNER_JOIN_IN_WHERE_CLAUSE, value="true")
+                }
+        ),
+        //PRINT_INNER_JOIN_IN_WHERE true
+        @NamedQuery(
+                name="QueryOrder.findAllOrdersWithEmptyOrderLinesHintFalse",
+                query="SELECT o FROM QueryOrder o WHERE o.queryOrderLines IS EMPTY"
+                ,
+                hints={
+                        @QueryHint(name=QueryHints.PRINT_INNER_JOIN_IN_WHERE_CLAUSE, value="false")
+                }
+        )
+})
+public class QueryOrder {
+
+    @Id
+    private long orderKey;
+
+    @OneToMany(mappedBy = "queryOrder")
+    List<QueryOrderLine> queryOrderLines = new ArrayList<>();
+
+    public long getOrderKey() {
+        return orderKey;
+    }
+
+    public void setOrderKey(long orderKey) {
+        this.orderKey = orderKey;
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/model/QueryOrderLine.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/model/QueryOrderLine.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.query.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "QUERY_ORDER_LINE")
+public class QueryOrderLine {
+
+    @Id
+    private long orderLineKey;
+
+    @ManyToOne
+    private QueryOrder queryOrder;
+
+    public long getOrderLineKey() {
+        return orderLineKey;
+    }
+
+    public void setOrderLineKey(long orderLineKey) {
+        this.orderLineKey = orderLineKey;
+    }
+
+    public QueryOrder getOrder() {
+        return queryOrder;
+    }
+
+    public void setOrder(QueryOrder queryOrder) {
+        this.queryOrder = queryOrder;
+    }
+}

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/QueryHintsHandler.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/QueryHintsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2021 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -318,6 +318,7 @@ public class QueryHintsHandler {
             addHint(new ResultSetAccess());
             addHint(new SerializedObject());
             addHint(new ReturnNameValuePairsHint());
+            addHint(new PrintInnerJoinInWhereClauseHint());
         }
 
         Hint(String name, String defaultValue) {
@@ -2204,4 +2205,25 @@ public class QueryHintsHandler {
             return query;
         }
     }
+
+    protected static class PrintInnerJoinInWhereClauseHint extends Hint {
+        PrintInnerJoinInWhereClauseHint() {
+            super(QueryHints.PRINT_INNER_JOIN_IN_WHERE_CLAUSE, HintValues.TRUE);
+            valueArray = new Object[][] {
+                    {HintValues.TRUE, Boolean.TRUE},
+                    {HintValues.FALSE, Boolean.FALSE}
+            };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isObjectLevelReadQuery()) {
+                ((ObjectLevelReadQuery)query).setPrintInnerJoinInWhereClause((Boolean)valueToApply);
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
 }

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/QueryHintsHandler.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/QueryHintsHandler.java
@@ -2208,7 +2208,7 @@ public class QueryHintsHandler {
 
     protected static class PrintInnerJoinInWhereClauseHint extends Hint {
         PrintInnerJoinInWhereClauseHint() {
-            super(QueryHints.PRINT_INNER_JOIN_IN_WHERE_CLAUSE, HintValues.TRUE);
+            super(QueryHints.INNER_JOIN_IN_WHERE_CLAUSE, HintValues.TRUE);
             valueArray = new Object[][] {
                     {HintValues.TRUE, Boolean.TRUE},
                     {HintValues.FALSE, Boolean.FALSE}


### PR DESCRIPTION
This change extend usage of `PrintInnerJoinInWhereClause` from current persistence unit property into query hint like

```
@NamedQuery(
    name="QueryOrder.findAllOrdersWithEmptyOrderLinesHintFalse",
    query="SELECT o FROM QueryOrder o WHERE o.queryOrderLines IS EMPTY",
    hints={@QueryHint(name=QueryHints.PRINT_INNER_JOIN_IN_WHERE_CLAUSE, value="false")})
```

or
```
String jpql = "SELECT o FROM QueryOrder o WHERE o.queryOrderLines IS EMPTY";
Query query = em.createQuery(jpql, QueryOrder.class);
query.setHint(QueryHints.PRINT_INNER_JOIN_IN_WHERE_CLAUSE, "false");
```

It allows developers more preciously target (optimize) this property to the selected queries.