### PR TITLE
[3.0] PrintInnerJoinInWhereClause as query hint - backport from master

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/QueryHints.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/QueryHints.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 1998, 2019 IBM Corporation. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -919,4 +919,13 @@ public class QueryHints {
      * @see org.eclipse.persistence.queries.ResultSetMappingQuery#shouldReturnNameValuePairs()
      */
     public static final String RETURN_NAME_VALUE_PAIRS = "eclipselink.query-return-name-value-pairs";
+
+    /**
+     * "eclipselink.inner-join-in-where-clause"
+     * <p>Changes the way that inner joins are printed in generated SQL for the database.
+     * With a value of true, inner joins are printed in the WHERE clause, if false, inner joins are printed in the FROM clause.
+     * This query hint should override global/session switch {@link org.eclipse.persistence.internal.databaseaccess.DatabasePlatform#setPrintInnerJoinInWhereClause(boolean)}
+     * @see org.eclipse.persistence.internal.databaseaccess.DatabasePlatform#setPrintInnerJoinInWhereClause(boolean)
+     */
+    public static final String INNER_JOIN_IN_WHERE_CLAUSE = "eclipselink.inner-join-in-where-clause";
 }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/expressions/ExpressionBuilder.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/expressions/ExpressionBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -52,7 +52,7 @@ import org.eclipse.persistence.queries.ReadQuery;
  */
 public class ExpressionBuilder extends ObjectExpression {
     protected transient AbstractSession session;
-    protected Class queryClass;
+    protected Class<?> queryClass;
     protected SQLSelectStatement statement;
     protected DatabaseTable viewTable;
     protected DatabaseTable aliasedViewTable;
@@ -75,7 +75,7 @@ public class ExpressionBuilder extends ObjectExpression {
      * This can be used for the purpose of parallel expressions.
      * This is a type of query that searches on the relationship between to un-related objects.
      */
-    public ExpressionBuilder(Class queryClass) {
+    public ExpressionBuilder(Class<?> queryClass) {
         super();
         this.queryClass = queryClass;
         this.wasQueryClassSetInternally = false;
@@ -219,7 +219,7 @@ public class ExpressionBuilder extends ObjectExpression {
     /**
      * INTERNAL:
      */
-    public Class getQueryClass() {
+    public Class<?> getQueryClass() {
         return queryClass;
     }
 
@@ -278,7 +278,7 @@ public class ExpressionBuilder extends ObjectExpression {
         // Normalize the ON clause if present.  Need to use rebuild, not twist as parameters are real parameters.
         if (this.onClause != null) {
             this.onClause = this.onClause.normalize(normalizer);
-            if (shouldUseOuterJoin() || (!getSession().getPlatform().shouldPrintInnerJoinInWhereClause())) {
+            if (shouldUseOuterJoin() || (!getSession().getPlatform().shouldPrintInnerJoinInWhereClause((normalizer.getStatement().getParentStatement() != null ? normalizer.getStatement().getParentStatement().getQuery() : normalizer.getStatement().getQuery())))) {
                 normalizer.getStatement().addOuterJoinExpressionsHolders(this, null, null, null);
                 if ((getDescriptor() != null) && (getDescriptor().getHistoryPolicy() != null)) {
                     Expression historyCriteria = getDescriptor().getHistoryPolicy().additionalHistoryExpression(this, this);
@@ -416,7 +416,7 @@ public class ExpressionBuilder extends ObjectExpression {
      * INTERNAL:
      * Set the class which this node represents.
      */
-    public void setQueryClass(Class queryClass) {
+    public void setQueryClass(Class<?> queryClass) {
         this.queryClass = queryClass;
         this.descriptor = null;
     }
@@ -425,7 +425,7 @@ public class ExpressionBuilder extends ObjectExpression {
      * INTERNAL:
      * Set the class and descriptor which this node represents.
      */
-    public void setQueryClassAndDescriptor(Class queryClass, ClassDescriptor descriptor) {
+    public void setQueryClassAndDescriptor(Class<?> queryClass, ClassDescriptor descriptor) {
         this.queryClass = queryClass;
         this.descriptor = convertToCastDescriptor(descriptor, session);
     }
@@ -523,7 +523,7 @@ public class ExpressionBuilder extends ObjectExpression {
         // The base case
         // The following special case is where there is a parallel builder
         // which has a different reference class as the primary builder.
-        Class queryClass = getQueryClass();
+        Class<?> queryClass = getQueryClass();
         if ((queryClass != null) && ((query == null) || (queryClass != query.getReferenceClass()))) {
            return convertToCastDescriptor( session.getDescriptor(queryClass), session);
         }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
@@ -97,6 +97,8 @@ import org.eclipse.persistence.platform.database.partitioning.DataPartitioningCa
 import org.eclipse.persistence.queries.Call;
 import org.eclipse.persistence.queries.DataReadQuery;
 import org.eclipse.persistence.queries.DatabaseQuery;
+import org.eclipse.persistence.queries.ObjectBuildingQuery;
+import org.eclipse.persistence.queries.ReadQuery;
 import org.eclipse.persistence.queries.ReportQuery;
 import org.eclipse.persistence.queries.SQLCall;
 import org.eclipse.persistence.queries.StoredProcedureCall;
@@ -2326,11 +2328,16 @@ public class DatabasePlatform extends DatasourcePlatform {
      * By default most platforms put inner joins in the WHERE clause.
      * If set to false, inner joins will be printed in the FROM clause.
      */
-    public boolean shouldPrintInnerJoinInWhereClause() {
-        if (this.printInnerJoinInWhereClause == null) {
-            return true;
+    public boolean shouldPrintInnerJoinInWhereClause(ReadQuery query) {
+        Boolean printInnerJoinInWhereClauseQueryHint = ((query != null) && (query instanceof ObjectBuildingQuery)) ? ((ObjectBuildingQuery)query).printInnerJoinInWhereClause() : null;
+        if (printInnerJoinInWhereClauseQueryHint != null) {
+            return printInnerJoinInWhereClauseQueryHint;
+        } else {
+            if (this.printInnerJoinInWhereClause == null) {
+                return true;
+            }
+            return this.printInnerJoinInWhereClause;
         }
-        return this.printInnerJoinInWhereClause;
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/QueryKeyExpression.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/QueryKeyExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -191,7 +191,7 @@ public class QueryKeyExpression extends ObjectExpression {
         Vector tables = getDescriptor().getTables();
         // skip the main table - start with i=1
         int tablesSize = tables.size();
-        if (shouldUseOuterJoin() || (!getSession().getPlatform().shouldPrintInnerJoinInWhereClause())) {
+        if (shouldUseOuterJoin() || (!getSession().getPlatform().shouldPrintInnerJoinInWhereClause(getDescriptor().getQueryManager().getReadAllQuery()))) {
             for (int i=1; i < tablesSize; i++) {
                 DatabaseTable table = (DatabaseTable)tables.elementAt(i);
                 Expression joinExpression = getDescriptor().getQueryManager().getTablesJoinExpressions().get(table);
@@ -839,7 +839,7 @@ public class QueryKeyExpression extends ObjectExpression {
                 normalizer.addAdditionalExpression(mappingExpression.and(additionalExpressionCriteria()));
                 return this;
             } else if ((shouldUseOuterJoin() && (!getSession().getPlatform().shouldPrintOuterJoinInWhereClause()))
-                    || (!getSession().getPlatform().shouldPrintInnerJoinInWhereClause())) {
+                    || (!getSession().getPlatform().shouldPrintInnerJoinInWhereClause((normalizer.getStatement().getParentStatement() != null ? normalizer.getStatement().getParentStatement().getQuery() : normalizer.getStatement().getQuery())))) {
                 setOuterJoinExpIndex(statement.addOuterJoinExpressionsHolders(this, mappingExpression, additionalExpressionCriteriaMap(), null));
                 if ((getDescriptor() != null) && (getDescriptor().getHistoryPolicy() != null)) {
                     Expression historyOnClause = getDescriptor().getHistoryPolicy().additionalHistoryExpression(this, this, 0);

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/RelationExpression.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/RelationExpression.java
@@ -796,7 +796,7 @@ public class RelationExpression extends CompoundExpression {
             //.equal(anyOf() or get())
             (first.isExpressionBuilder() && second.isQueryKeyExpression()
                     &&  (!((QueryKeyExpression)second).hasDerivedExpressions()) // The right side is not used for anything else.
-                    && normalizer.getSession().getPlatform().shouldPrintInnerJoinInWhereClause()) {
+                    && normalizer.getSession().getPlatform().shouldPrintInnerJoinInWhereClause((normalizer.getStatement().getParentStatement() != null ? normalizer.getStatement().getParentStatement().getQuery() : normalizer.getStatement().getQuery()))) {
             first = (ExpressionBuilder)first.normalize(normalizer);
 
             // If FK joins go in the WHERE clause, want to get hold of it and

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/SQLSelectStatement.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/SQLSelectStatement.java
@@ -571,7 +571,7 @@ public class SQLSelectStatement extends SQLStatement {
         if (hasOuterJoinExpressions()) {
             if (session.getPlatform().isInformixOuterJoin()) {
                 appendFromClauseForInformixOuterJoin(printer, outerJoinedAliases);
-            } else if (!session.getPlatform().shouldPrintOuterJoinInWhereClause() || !session.getPlatform().shouldPrintInnerJoinInWhereClause()) {
+            } else if (!session.getPlatform().shouldPrintOuterJoinInWhereClause() || !session.getPlatform().shouldPrintInnerJoinInWhereClause(query)) {
                 appendFromClauseForOuterJoin(printer, outerJoinedAliases, aliasesOfTablesToBeLocked, shouldPrintUpdateClauseForAllTables);
             }
             firstTable = false;

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/TreatAsExpression.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/TreatAsExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -621,7 +621,7 @@ public class TreatAsExpression extends QueryKeyExpression {
                 normalizer.addAdditionalLocalExpression(typeExpression.and(additionalTreatExpressionCriteria()).and(this.onClause));
                 return this;
             } else if (((!getSession().getPlatform().shouldPrintOuterJoinInWhereClause()))
-                    || (!getSession().getPlatform().shouldPrintInnerJoinInWhereClause())) {
+                    || (!getSession().getPlatform().shouldPrintInnerJoinInWhereClause((normalizer.getStatement().getParentStatement() != null ? normalizer.getStatement().getParentStatement().getQuery() : normalizer.getStatement().getQuery())))) {
 
                 //Adds the left joins from treat to the base QKE joins.
                 Map<DatabaseTable, Expression> map = statement.getOuterJoinExpressionsHolders().get(postition).outerJoinedAdditionalJoinCriteria;
@@ -633,7 +633,7 @@ public class TreatAsExpression extends QueryKeyExpression {
                 return this;
             }
         } else if (!getSession().getPlatform().shouldPrintOuterJoinInWhereClause()
-                || (!getSession().getPlatform().shouldPrintInnerJoinInWhereClause())) {
+                || (!getSession().getPlatform().shouldPrintInnerJoinInWhereClause((normalizer.getStatement().getParentStatement() != null ? normalizer.getStatement().getParentStatement().getQuery() : normalizer.getStatement().getQuery())))) {
             //the base is not using an outer join, so we add a new one for this class' tables.
             Map additionalExpMap = additionalTreatExpressionCriteriaMap();
             if (additionalExpMap!=null && !additionalExpMap.isEmpty()) {

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/ObjectBuildingQuery.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/ObjectBuildingQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -102,6 +102,13 @@ public abstract class ObjectBuildingQuery extends ReadQuery {
     protected boolean isCacheCheckComplete;
 
     protected Map<Object, CacheKey> prefetchedCacheKeys;
+
+    /** Indicates whether the query printer/normalizer changes the way that inner joins are printed
+     * in generated SQL for the database. With a value of true, inner joins are printed in the WHERE clause,
+     * if false, inner joins are printed in the FROM clause.
+     * If value is set it overrides printInnerJoinInWhereClause persistence unit property.
+     * Default value null - value from printInnerJoinInWhereClause persistence unit property is used*/
+    protected Boolean printInnerJoinInWhereClause;
 
     /**
      * INTERNAL:
@@ -800,5 +807,26 @@ public abstract class ObjectBuildingQuery extends ReadQuery {
      */
     public boolean shouldUseSerializedObjectPolicy() {
         return false;
+    }
+
+    /**
+     * INTERNAL:
+     * Indicates whether the query will change the way that inner joins are printed in generated SQL for the database.
+     * With a value of true, inner joins are printed in the WHERE clause, if false, inner joins are printed in the FROM clause.
+     */
+    public Boolean printInnerJoinInWhereClause() {
+        return this.printInnerJoinInWhereClause;
+    }
+
+    /**
+     * INTERNAL:
+     * Set a flag that indicates whether the query will change the way that inner joins are printed in generated SQL for the database.
+     * With a value of true, inner joins are printed in the WHERE clause, if false, inner joins are printed in the FROM clause.
+     */
+    public void setPrintInnerJoinInWhereClause(boolean printInnerJoinInWhereClause) {
+        if (this.printInnerJoinInWhereClause == null || this.printInnerJoinInWhereClause != printInnerJoinInWhereClause) {
+            this.printInnerJoinInWhereClause = printInnerJoinInWhereClause;
+            setIsPrepared(false);
+        }
     }
 }

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/model/QueryOrder.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/model/QueryOrder.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.query.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.QueryHint;
+import jakarta.persistence.Table;
+import org.eclipse.persistence.config.QueryHints;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "QUERY_ORDER")
+@NamedQueries({
+        @NamedQuery(
+                name="QueryOrder.findAllOrdersWithEmptyOrderLines",
+                query="SELECT o FROM QueryOrder o WHERE o.queryOrderLines IS EMPTY"
+        ),
+        //PRINT_INNER_JOIN_IN_WHERE true
+        @NamedQuery(
+                name="QueryOrder.findAllOrdersWithEmptyOrderLinesHintTrue",
+                query="SELECT o FROM QueryOrder o WHERE o.queryOrderLines IS EMPTY"
+                ,
+                hints={
+                       @QueryHint(name=QueryHints.INNER_JOIN_IN_WHERE_CLAUSE, value="true")
+                }
+        ),
+        //PRINT_INNER_JOIN_IN_WHERE true
+        @NamedQuery(
+                name="QueryOrder.findAllOrdersWithEmptyOrderLinesHintFalse",
+                query="SELECT o FROM QueryOrder o WHERE o.queryOrderLines IS EMPTY"
+                ,
+                hints={
+                        @QueryHint(name=QueryHints.INNER_JOIN_IN_WHERE_CLAUSE, value="false")
+                }
+        )
+})
+public class QueryOrder {
+
+    @Id
+    private long orderKey;
+
+    @OneToMany(mappedBy = "queryOrder")
+    List<QueryOrderLine> queryOrderLines = new ArrayList<>();
+
+    public long getOrderKey() {
+        return orderKey;
+    }
+
+    public void setOrderKey(long orderKey) {
+        this.orderKey = orderKey;
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/model/QueryOrderLine.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/model/QueryOrderLine.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.query.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "QUERY_ORDER_LINE")
+public class QueryOrderLine {
+
+    @Id
+    private long orderLineKey;
+
+    @ManyToOne
+    private QueryOrder queryOrder;
+
+    public long getOrderLineKey() {
+        return orderLineKey;
+    }
+
+    public void setOrderLineKey(long orderLineKey) {
+        this.orderLineKey = orderLineKey;
+    }
+
+    public QueryOrder getOrder() {
+        return queryOrder;
+    }
+
+    public void setOrder(QueryOrder queryOrder) {
+        this.queryOrder = queryOrder;
+    }
+}

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/QueryHintsHandler.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/QueryHintsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2021 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -318,6 +318,7 @@ public class QueryHintsHandler {
             addHint(new ResultSetAccess());
             addHint(new SerializedObject());
             addHint(new ReturnNameValuePairsHint());
+            addHint(new PrintInnerJoinInWhereClauseHint());
         }
 
         Hint(String name, String defaultValue) {
@@ -2204,4 +2205,25 @@ public class QueryHintsHandler {
             return query;
         }
     }
+
+    protected static class PrintInnerJoinInWhereClauseHint extends Hint {
+        PrintInnerJoinInWhereClauseHint() {
+            super(QueryHints.INNER_JOIN_IN_WHERE_CLAUSE, HintValues.TRUE);
+            valueArray = new Object[][] {
+                    {HintValues.TRUE, Boolean.TRUE},
+                    {HintValues.FALSE, Boolean.FALSE}
+            };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isObjectLevelReadQuery()) {
+                ((ObjectLevelReadQuery)query).setPrintInnerJoinInWhereClause((Boolean)valueToApply);
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
 }


### PR DESCRIPTION
This change extend usage of `PrintInnerJoinInWhereClause` from current persistence unit property into query hint like

```
@NamedQuery(
    name="QueryOrder.findAllOrdersWithEmptyOrderLinesHintFalse",
    query="SELECT o FROM QueryOrder o WHERE o.queryOrderLines IS EMPTY",
    hints={@QueryHint(name=QueryHints.PRINT_INNER_JOIN_IN_WHERE_CLAUSE, value="false")})
```

or
```
String jpql = "SELECT o FROM QueryOrder o WHERE o.queryOrderLines IS EMPTY";
Query query = em.createQuery(jpql, QueryOrder.class);
query.setHint(QueryHints.PRINT_INNER_JOIN_IN_WHERE_CLAUSE, "false");
```

It allows developers more preciously target (optimize) this property to the selected queries.
Fixes #1522.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>