### PR TITLE
[2.7] PrintInnerJoinInWhereClause as query hint - backport from master

### DIFF
--- a/etc/jenkins/pr_verify.groovy
+++ b/etc/jenkins/pr_verify.groovy
@@ -157,7 +157,7 @@ spec:
                         container('el-build') {
                             sh """
                                 echo '-[ EclipseLink Core LRG ]-----------------------------------------------------------'
-                                $ANT_HOME/bin/ant -f antbuild.xml -Dtest.fail.fast=true -Dfail.on.error=true test-core
+                                $ANT_HOME/bin/ant -f antbuild.xml -Dfail.on.error=true test-core
                             """
                         }
                     }
@@ -166,7 +166,7 @@ spec:
                     steps {
                         container('el-build') {
                             sh """
-                                $ANT_HOME/bin/ant -f antbuild.xml -Dtest.fail.fast=true -Dfail.on.error=true test-moxy
+                                $ANT_HOME/bin/ant -f antbuild.xml -Dfail.on.error=true test-moxy
                             """
                         }
                     }
@@ -178,7 +178,7 @@ spec:
             steps {
                 container('el-build') {
                     sh """
-                        $ANT_HOME/bin/ant -f antbuild.xml -Dtest.fail.fast=true -Dfail.on.error=true test-jpa22
+                        $ANT_HOME/bin/ant -f antbuild.xml -Dfail.on.error=true test-jpa22
                     """
                 }
             }
@@ -187,7 +187,7 @@ spec:
             steps {
                 container('el-build') {
                     sh """
-                        $ANT_HOME/bin/ant -f antbuild.xml -Dtest.fail.fast=true -Dfail.on.error=true test-sdo
+                        $ANT_HOME/bin/ant -f antbuild.xml -Dfail.on.error=true test-sdo
                     """
                 }
             }
@@ -196,7 +196,7 @@ spec:
             steps {
                 container('el-build') {
                     sh """
-                        $ANT_HOME/bin/ant -f antbuild.xml -Dtest.fail.fast=true -Dfail.on.error=true test-jpa-jse test-ext test-jpql test-wdf test-jpars test-dbws test-dbws-builder test-osgi
+                        $ANT_HOME/bin/ant -f antbuild.xml -Dfail.on.error=true test-jpa-jse test-ext test-jpql test-wdf test-jpars test-dbws test-dbws-builder test-osgi
                     """
                 }
             }
@@ -205,7 +205,7 @@ spec:
             steps {
                 container('el-build') {
                     sh """
-                        $ANT_HOME/bin/ant -f antbuild.xml -Dtest.fail.fast=true -Dfail.on.error=true build-distribution
+                        $ANT_HOME/bin/ant -f antbuild.xml -Dfail.on.error=true build-distribution
                     """
                 }
             }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/QueryHints.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/QueryHints.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -917,4 +917,13 @@ public class QueryHints {
      * @see org.eclipse.persistence.queries.ResultSetMappingQuery#shouldReturnNameValuePairs()
      */
     public static final String RETURN_NAME_VALUE_PAIRS = "eclipselink.query-return-name-value-pairs";
+
+    /**
+     * "eclipselink.inner-join-in-where-clause"
+     * <p>Changes the way that inner joins are printed in generated SQL for the database.
+     * With a value of true, inner joins are printed in the WHERE clause, if false, inner joins are printed in the FROM clause.
+     * This query hint should override global/session switch {@link org.eclipse.persistence.internal.databaseaccess.DatabasePlatform#setPrintInnerJoinInWhereClause(boolean)}
+     * @see org.eclipse.persistence.internal.databaseaccess.DatabasePlatform#setPrintInnerJoinInWhereClause(boolean)
+     */
+    public static final String INNER_JOIN_IN_WHERE_CLAUSE = "eclipselink.inner-join-in-where-clause";
 }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/expressions/ExpressionBuilder.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/expressions/ExpressionBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -270,7 +270,7 @@ public class ExpressionBuilder extends ObjectExpression {
         // Normalize the ON clause if present.  Need to use rebuild, not twist as parameters are real parameters.
         if (this.onClause != null) {
             this.onClause = this.onClause.normalize(normalizer);
-            if (shouldUseOuterJoin() || (!getSession().getPlatform().shouldPrintInnerJoinInWhereClause())) {
+            if (shouldUseOuterJoin() || (!getSession().getPlatform().shouldPrintInnerJoinInWhereClause((normalizer.getStatement().getParentStatement() != null ? normalizer.getStatement().getParentStatement().getQuery() : normalizer.getStatement().getQuery())))) {
                 normalizer.getStatement().addOuterJoinExpressionsHolders(this, null, null, null);
                 if ((getDescriptor() != null) && (getDescriptor().getHistoryPolicy() != null)) {
                     Expression historyCriteria = getDescriptor().getHistoryPolicy().additionalHistoryExpression(this, this);

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
@@ -97,6 +97,8 @@ import org.eclipse.persistence.platform.database.partitioning.DataPartitioningCa
 import org.eclipse.persistence.queries.Call;
 import org.eclipse.persistence.queries.DataReadQuery;
 import org.eclipse.persistence.queries.DatabaseQuery;
+import org.eclipse.persistence.queries.ObjectBuildingQuery;
+import org.eclipse.persistence.queries.ReadQuery;
 import org.eclipse.persistence.queries.ReportQuery;
 import org.eclipse.persistence.queries.SQLCall;
 import org.eclipse.persistence.queries.StoredProcedureCall;
@@ -2351,11 +2353,16 @@ public class DatabasePlatform extends DatasourcePlatform {
      * By default most platforms put inner joins in the WHERE clause.
      * If set to false, inner joins will be printed in the FROM clause.
      */
-    public boolean shouldPrintInnerJoinInWhereClause() {
-        if (this.printInnerJoinInWhereClause == null) {
-            return true;
+    public boolean shouldPrintInnerJoinInWhereClause(ReadQuery query) {
+        Boolean printInnerJoinInWhereClauseQueryHint = ((query != null) && (query instanceof ObjectBuildingQuery)) ? ((ObjectBuildingQuery)query).printInnerJoinInWhereClause() : null;
+        if (printInnerJoinInWhereClauseQueryHint != null) {
+            return printInnerJoinInWhereClauseQueryHint;
+        } else {
+            if (this.printInnerJoinInWhereClause == null) {
+                return true;
+            }
+            return this.printInnerJoinInWhereClause;
         }
-        return this.printInnerJoinInWhereClause;
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/expressions/QueryKeyExpression.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/expressions/QueryKeyExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -193,7 +193,7 @@ public class QueryKeyExpression extends ObjectExpression {
         Vector tables = getDescriptor().getTables();
         // skip the main table - start with i=1
         int tablesSize = tables.size();
-        if (shouldUseOuterJoin() || (!getSession().getPlatform().shouldPrintInnerJoinInWhereClause())) {
+        if (shouldUseOuterJoin() || (!getSession().getPlatform().shouldPrintInnerJoinInWhereClause(getDescriptor().getQueryManager().getReadAllQuery()))) {
             for (int i=1; i < tablesSize; i++) {
                 DatabaseTable table = (DatabaseTable)tables.elementAt(i);
                 Expression joinExpression = getDescriptor().getQueryManager().getTablesJoinExpressions().get(table);
@@ -841,7 +841,7 @@ public class QueryKeyExpression extends ObjectExpression {
                 normalizer.addAdditionalExpression(mappingExpression.and(additionalExpressionCriteria()));
                 return this;
             } else if ((shouldUseOuterJoin() && (!getSession().getPlatform().shouldPrintOuterJoinInWhereClause()))
-                    || (!getSession().getPlatform().shouldPrintInnerJoinInWhereClause())) {
+                    || (!getSession().getPlatform().shouldPrintInnerJoinInWhereClause((normalizer.getStatement().getParentStatement() != null ? normalizer.getStatement().getParentStatement().getQuery() : normalizer.getStatement().getQuery())))) {
                 setOuterJoinExpIndex(statement.addOuterJoinExpressionsHolders(this, mappingExpression, additionalExpressionCriteriaMap(), null));
                 if ((getDescriptor() != null) && (getDescriptor().getHistoryPolicy() != null)) {
                     Expression historyOnClause = getDescriptor().getHistoryPolicy().additionalHistoryExpression(this, this, 0);

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/expressions/RelationExpression.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/expressions/RelationExpression.java
@@ -783,7 +783,7 @@ public class RelationExpression extends CompoundExpression {
             //.equal(anyOf() or get())
             (first.isExpressionBuilder() && second.isQueryKeyExpression()
                     &&  (!((QueryKeyExpression)second).hasDerivedExpressions()) // The right side is not used for anything else.
-                    && normalizer.getSession().getPlatform().shouldPrintInnerJoinInWhereClause()) {
+                    && normalizer.getSession().getPlatform().shouldPrintInnerJoinInWhereClause((normalizer.getStatement().getParentStatement() != null ? normalizer.getStatement().getParentStatement().getQuery() : normalizer.getStatement().getQuery()))) {
             first = (ExpressionBuilder)first.normalize(normalizer);
 
             // If FK joins go in the WHERE clause, want to get hold of it and

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/expressions/SQLSelectStatement.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/expressions/SQLSelectStatement.java
@@ -571,7 +571,7 @@ public class SQLSelectStatement extends SQLStatement {
         if (hasOuterJoinExpressions()) {
             if (session.getPlatform().isInformixOuterJoin()) {
                 appendFromClauseForInformixOuterJoin(printer, outerJoinedAliases);
-            } else if (!session.getPlatform().shouldPrintOuterJoinInWhereClause() || !session.getPlatform().shouldPrintInnerJoinInWhereClause()) {
+            } else if (!session.getPlatform().shouldPrintOuterJoinInWhereClause() || !session.getPlatform().shouldPrintInnerJoinInWhereClause(query)) {
                 appendFromClauseForOuterJoin(printer, outerJoinedAliases, aliasesOfTablesToBeLocked, shouldPrintUpdateClauseForAllTables);
             }
             firstTable = false;

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/expressions/TreatAsExpression.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/expressions/TreatAsExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -590,7 +590,7 @@ public class TreatAsExpression extends QueryKeyExpression {
                 normalizer.addAdditionalLocalExpression(typeExpression.and(additionalTreatExpressionCriteria()).and(this.onClause));
                 return this;
             } else if (((!getSession().getPlatform().shouldPrintOuterJoinInWhereClause()))
-                    || (!getSession().getPlatform().shouldPrintInnerJoinInWhereClause())) {
+                    || (!getSession().getPlatform().shouldPrintInnerJoinInWhereClause((normalizer.getStatement().getParentStatement() != null ? normalizer.getStatement().getParentStatement().getQuery() : normalizer.getStatement().getQuery())))) {
 
                 //Adds the left joins from treat to the base QKE joins.
                 Map<DatabaseTable, Expression> map = statement.getOuterJoinExpressionsHolders().get(postition).outerJoinedAdditionalJoinCriteria;
@@ -602,7 +602,7 @@ public class TreatAsExpression extends QueryKeyExpression {
                 return this;
             }
         } else if (!getSession().getPlatform().shouldPrintOuterJoinInWhereClause()
-                || (!getSession().getPlatform().shouldPrintInnerJoinInWhereClause())) {
+                || (!getSession().getPlatform().shouldPrintInnerJoinInWhereClause((normalizer.getStatement().getParentStatement() != null ? normalizer.getStatement().getParentStatement().getQuery() : normalizer.getStatement().getQuery())))) {
             //the base is not using an outer join, so we add a new one for this class' tables.
             Map additionalExpMap = additionalTreatExpressionCriteriaMap();
             if (additionalExpMap!=null && !additionalExpMap.isEmpty()) {

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/ObjectBuildingQuery.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/queries/ObjectBuildingQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -103,6 +103,13 @@ public abstract class ObjectBuildingQuery extends ReadQuery {
     protected boolean isCacheCheckComplete;
 
     protected Map<Object, CacheKey> prefetchedCacheKeys;
+
+    /** Indicates whether the query printer/normalizer changes the way that inner joins are printed
+     * in generated SQL for the database. With a value of true, inner joins are printed in the WHERE clause,
+     * if false, inner joins are printed in the FROM clause.
+     * If value is set it overrides printInnerJoinInWhereClause persistence unit property.
+     * Default value null - value from printInnerJoinInWhereClause persistence unit property is used*/
+    protected Boolean printInnerJoinInWhereClause;
 
     /**
      * INTERNAL:
@@ -801,5 +808,26 @@ public abstract class ObjectBuildingQuery extends ReadQuery {
      */
     public boolean shouldUseSerializedObjectPolicy() {
         return false;
+    }
+
+    /**
+     * INTERNAL:
+     * Indicates whether the query will change the way that inner joins are printed in generated SQL for the database.
+     * With a value of true, inner joins are printed in the WHERE clause, if false, inner joins are printed in the FROM clause.
+     */
+    public Boolean printInnerJoinInWhereClause() {
+        return this.printInnerJoinInWhereClause;
+    }
+
+    /**
+     * INTERNAL:
+     * Set a flag that indicates whether the query will change the way that inner joins are printed in generated SQL for the database.
+     * With a value of true, inner joins are printed in the WHERE clause, if false, inner joins are printed in the FROM clause.
+     */
+    public void setPrintInnerJoinInWhereClause(boolean printInnerJoinInWhereClause) {
+        if (this.printInnerJoinInWhereClause == null || this.printInnerJoinInWhereClause != printInnerJoinInWhereClause) {
+            this.printInnerJoinInWhereClause = printInnerJoinInWhereClause;
+            setIsPrepared(false);
+        }
     }
 }

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQueryHints2.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQueryHints2.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     09/08/2022 - Oracle
+package org.eclipse.persistence.jpa.test.query;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Query;
+
+import org.eclipse.persistence.config.HintValues;
+import org.eclipse.persistence.config.PersistenceUnitProperties;
+import org.eclipse.persistence.config.QueryHints;
+import org.eclipse.persistence.jpa.test.framework.DDLGen;
+import org.eclipse.persistence.jpa.test.framework.Emf;
+import org.eclipse.persistence.jpa.test.framework.EmfRunner;
+import org.eclipse.persistence.jpa.test.framework.Property;
+import org.eclipse.persistence.jpa.test.framework.PUPropertiesProvider;
+import org.eclipse.persistence.jpa.test.query.model.QueryOrder;
+import org.eclipse.persistence.jpa.test.query.model.QueryOrderLine;
+import org.eclipse.persistence.queries.ScrollableCursor;
+import org.eclipse.persistence.sessions.Connector;
+import org.eclipse.persistence.sessions.DatabaseLogin;
+import org.eclipse.persistence.sessions.Session;
+import org.eclipse.persistence.sessions.SessionEvent;
+import org.eclipse.persistence.sessions.SessionEventAdapter;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(EmfRunner.class)
+public class TestQueryHints2 {
+
+    private static boolean POPULATED = false;
+
+    @Emf(createTables = DDLGen.DROP_CREATE, classes = { QueryOrder.class, QueryOrderLine.class },
+            properties = { @Property(name="eclipselink.logging.level", value="FINEST")})
+    private EntityManagerFactory emf;
+
+    /**
+     * Test that setting the Query Hint: QueryHints.INNER_JOIN_IN_WHERE_CLAUSE are correctly applied.
+     */
+    @Test
+    public void testPrintInnerJoinInWhereClauseHint() {
+        if (emf == null)
+            return;
+
+        if(!POPULATED)
+            populate();
+
+        EntityManager em = emf.createEntityManager();
+
+        try {
+            em.getTransaction().begin();
+
+            /*
+             * First create a NamedQuery and return the result list without hint (defaut value)
+             */
+            Query query1 = em.createNamedQuery("QueryOrder.findAllOrdersWithEmptyOrderLines", QueryOrder.class);
+            List<QueryOrder> result1 = query1.getResultList();
+            Assert.assertEquals(1, result1.size());
+            Assert.assertEquals(2L, result1.get(0).getOrderKey());
+
+            /*
+             * Second create a NamedQuery and return the result list with hint (true value)
+             */
+            Query query2 = em.createNamedQuery("QueryOrder.findAllOrdersWithEmptyOrderLinesHintTrue", QueryOrder.class);
+            List<QueryOrder> result2 = query2.getResultList();
+            Assert.assertEquals(1, result2.size());
+            Assert.assertEquals(2L, result2.get(0).getOrderKey());
+
+            /*
+             * Third create a NamedQuery and return the result list with hint (false value)
+             * This test is based on bug in EL normalization part as some queries are not correctly translated
+             * in case of PrintInnerJoinInWhereClause == false
+             * Generated SQL query incorrectly doesn't return any value.
+             * Some fix in this part should lead into crash there.
+             */
+            Query query3 = em.createNamedQuery("QueryOrder.findAllOrdersWithEmptyOrderLinesHintFalse", QueryOrder.class);
+            List<QueryOrder> result3 = query3.getResultList();
+            Assert.assertEquals(0, result3.size());
+
+            /*
+             * Fourth create a Query based on JPQL and return the result list with hint (false value)
+             * This test is based on bug in EL normalization part as some queries are not correctly translated
+             * in case of PrintInnerJoinInWhereClause == false
+             * Generated SQL query incorrectly doesn't return any value.
+             * Some fix in this part should lead into crash there.
+             */
+            //JPQL Query test
+            String jpql = "SELECT o FROM QueryOrder o WHERE o.queryOrderLines IS EMPTY";
+            Query query4 = em.createQuery(jpql, QueryOrder.class);
+            query4.setHint(QueryHints.INNER_JOIN_IN_WHERE_CLAUSE, "false");
+            List<QueryOrder> result4 = query4.getResultList();
+            Assert.assertEquals(0, result4.size());
+
+
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if(em.isOpen()) {
+                em.close();
+            }
+        }
+    }
+
+    public void populate() {
+        //Populate the tables
+        EntityManager em = emf.createEntityManager();
+        try {
+            em.getTransaction().begin();
+
+            QueryOrder queryOrder1 = new QueryOrder();
+            queryOrder1.setOrderKey(1);
+            em.persist(queryOrder1);
+            QueryOrder queryOrder2 = new QueryOrder();
+            queryOrder2.setOrderKey(2);
+            em.persist(queryOrder2);
+            QueryOrderLine queryOrderLine1 = new QueryOrderLine();
+            queryOrderLine1.setOrderLineKey(101);
+            queryOrderLine1.setOrder(queryOrder1);
+            em.persist(queryOrderLine1);
+            QueryOrderLine queryOrderLine2 = new QueryOrderLine();
+            queryOrderLine2.setOrderLineKey(102);
+            queryOrderLine2.setOrder(queryOrder1);
+            em.persist(queryOrderLine2);
+
+            em.getTransaction().commit();
+
+            POPULATED = true;
+        } finally {
+            if(em.isOpen()) {
+                em.close();
+            }
+        }
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/model/QueryOrder.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/model/QueryOrder.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.query.model;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
+import javax.persistence.OneToMany;
+import javax.persistence.QueryHint;
+import javax.persistence.Table;
+import org.eclipse.persistence.config.QueryHints;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "QUERY_ORDER")
+@NamedQueries({
+        @NamedQuery(
+                name="QueryOrder.findAllOrdersWithEmptyOrderLines",
+                query="SELECT o FROM QueryOrder o WHERE o.queryOrderLines IS EMPTY"
+        ),
+        //PRINT_INNER_JOIN_IN_WHERE true
+        @NamedQuery(
+                name="QueryOrder.findAllOrdersWithEmptyOrderLinesHintTrue",
+                query="SELECT o FROM QueryOrder o WHERE o.queryOrderLines IS EMPTY"
+                ,
+                hints={
+                        @QueryHint(name=QueryHints.INNER_JOIN_IN_WHERE_CLAUSE, value="true")
+                }
+        ),
+        //PRINT_INNER_JOIN_IN_WHERE false
+        @NamedQuery(
+                name="QueryOrder.findAllOrdersWithEmptyOrderLinesHintFalse",
+                query="SELECT o FROM QueryOrder o WHERE o.queryOrderLines IS EMPTY"
+                ,
+                hints={
+                        @QueryHint(name=QueryHints.INNER_JOIN_IN_WHERE_CLAUSE, value="false")
+                }
+        )
+})
+public class QueryOrder {
+
+    @Id
+    private long orderKey;
+
+    @OneToMany(mappedBy = "queryOrder")
+    List<QueryOrderLine> queryOrderLines = new ArrayList<>();
+
+    public long getOrderKey() {
+        return orderKey;
+    }
+
+    public void setOrderKey(long orderKey) {
+        this.orderKey = orderKey;
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/model/QueryOrderLine.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/model/QueryOrderLine.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.query.model;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "QUERY_ORDER_LINE")
+public class QueryOrderLine {
+
+    @Id
+    private long orderLineKey;
+
+    @ManyToOne
+    private QueryOrder queryOrder;
+
+    public long getOrderLineKey() {
+        return orderLineKey;
+    }
+
+    public void setOrderLineKey(long orderLineKey) {
+        this.orderLineKey = orderLineKey;
+    }
+
+    public QueryOrder getOrder() {
+        return queryOrder;
+    }
+
+    public void setOrder(QueryOrder queryOrder) {
+        this.queryOrder = queryOrder;
+    }
+}

--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/QueryHintsHandler.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/QueryHintsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -315,6 +315,7 @@ public class QueryHintsHandler {
             addHint(new ResultSetAccess());
             addHint(new SerializedObject());
             addHint(new ReturnNameValuePairsHint());
+            addHint(new PrintInnerJoinInWhereClauseHint());
         }
 
         Hint(String name, String defaultValue) {
@@ -2124,6 +2125,26 @@ public class QueryHintsHandler {
         DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
             if (query.isObjectLevelReadQuery()) {
                 ((ObjectLevelReadQuery)query).setShouldUseSerializedObjectPolicy((Boolean)valueToApply);
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    protected static class PrintInnerJoinInWhereClauseHint extends Hint {
+        PrintInnerJoinInWhereClauseHint() {
+            super(QueryHints.INNER_JOIN_IN_WHERE_CLAUSE, HintValues.TRUE);
+            valueArray = new Object[][] {
+                    {HintValues.TRUE, Boolean.TRUE},
+                    {HintValues.FALSE, Boolean.FALSE}
+            };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isObjectLevelReadQuery()) {
+                ((ObjectLevelReadQuery)query).setPrintInnerJoinInWhereClause((Boolean)valueToApply);
             } else {
                 throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
             }


### PR DESCRIPTION
This change extend usage of `PrintInnerJoinInWhereClause` from current persistence unit property into query hint like

```
@NamedQuery(
    name="QueryOrder.findAllOrdersWithEmptyOrderLinesHintFalse",
    query="SELECT o FROM QueryOrder o WHERE o.queryOrderLines IS EMPTY",
    hints={@QueryHint(name=QueryHints.PRINT_INNER_JOIN_IN_WHERE_CLAUSE, value="false")})
```

or
```
String jpql = "SELECT o FROM QueryOrder o WHERE o.queryOrderLines IS EMPTY";
Query query = em.createQuery(jpql, QueryOrder.class);
query.setHint(QueryHints.PRINT_INNER_JOIN_IN_WHERE_CLAUSE, "false");
```

It allows developers more preciously target (optimize) this property to the selected queries.
Fixes #1522.


Signed-off-by: Radek Felcman <radek.felcman@oracle.com>