### PR TITLE
Oracle21Platform unused field removal to fix JPA remote test

### DIFF
--- a/foundation/org.eclipse.persistence.oracle/src/main/java/org/eclipse/persistence/platform/database/oracle/Oracle21Platform.java
+++ b/foundation/org.eclipse.persistence.oracle/src/main/java/org/eclipse/persistence/platform/database/oracle/Oracle21Platform.java
@@ -21,7 +21,6 @@ import java.util.Hashtable;
 import java.util.Map;
 
 import oracle.jdbc.OracleType;
-import oracle.sql.json.OracleJsonFactory;
 import oracle.sql.json.OracleJsonValue;
 import org.eclipse.persistence.internal.databaseaccess.FieldTypeDefinition;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
@@ -34,15 +33,11 @@ import org.eclipse.persistence.internal.sessions.AbstractSession;
  */
 public class Oracle21Platform extends Oracle19Platform {
 
-    // Oracle JSON factory.
-    private final OracleJsonFactory factory;
-
     /**
      * Creates an instance of Oracle 21c database platform.
      */
     public Oracle21Platform() {
         super();
-        this.factory = new OracleJsonFactory();
     }
 
     /**


### PR DESCRIPTION
This PR fixes issue which happens if EntityManager API using a remote EntityManager and `org.eclipse.persistence.platform.database.oracle.Oracle21Platform` is specified.
`org.eclipse.persistence.platform.database.oracle.Oracle21Platform` had `private final OracleJsonFactory factory;` field which wasn't used but is serialized via RMI if remote EntityManager is used.
With this field following exception was thrown:
```
...
Internal Exception: java.rmi.UnmarshalException: error unmarshalling return; nested exception is: 
	java.io.WriteAbortedException: writing aborted; java.io.NotSerializableException: oracle.sql.json.OracleJsonFactory
[INFO] 
[ERROR] Tests run: 106, Failures: 1, Errors: 99, Skipped: 0
```
in
`mvn verify -pl :org.eclipse.persistence.jpa.testapps.remote -amd -Pstaging,oracle`

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>