### PR TITLE
[master] Hamcrest dependency removal

### DIFF
--- a/etc/el-test.oracle.properties
+++ b/etc/el-test.oracle.properties
@@ -14,13 +14,13 @@
 db.driver=oracle.jdbc.OracleDriver
 db.xa.driver=oracle.jdbc.OracleDriver
 #db.xa.driver=oracle.jdbc.xa.client.OracleXADataSource
-db.url=jdbc:oracle:thin:@localhost:1521:ORCL
-#db.url=jdbc:oracle:thin:@localhost:1521/XEPDB1
+#db.url=jdbc:oracle:thin:@localhost:1521:ORCL
+db.url=jdbc:oracle:thin:@localhost:1521/XEPDB1
 #db.url=jdbc:oracle:oci:@localhost:1521:ORCL
 db.user=scott
 db.pwd=tiger
 #db.platform=org.eclipse.persistence.platform.database.OraclePlatform
-db.platform=org.eclipse.persistence.platform.database.oracle.Oracle12Platform
+db.platform=org.eclipse.persistence.platform.database.oracle.Oracle21Platform
 #Property names in the next line (URL, User, Password) are case sensitive (Oracle driver only).
 db.properties=URL=jdbc:oracle:thin:@localhost:1521:ORCL;User=scott;Password=tiger
 #db.properties=URL=jdbc:oracle:thin:@localhost:1521/XEPDB1;User=scott;Password=tiger

--- a/etc/el-test.oracle.properties
+++ b/etc/el-test.oracle.properties
@@ -14,13 +14,13 @@
 db.driver=oracle.jdbc.OracleDriver
 db.xa.driver=oracle.jdbc.OracleDriver
 #db.xa.driver=oracle.jdbc.xa.client.OracleXADataSource
-#db.url=jdbc:oracle:thin:@localhost:1521:ORCL
-db.url=jdbc:oracle:thin:@localhost:1521/XEPDB1
+db.url=jdbc:oracle:thin:@localhost:1521:ORCL
+#db.url=jdbc:oracle:thin:@localhost:1521/XEPDB1
 #db.url=jdbc:oracle:oci:@localhost:1521:ORCL
 db.user=scott
 db.pwd=tiger
 #db.platform=org.eclipse.persistence.platform.database.OraclePlatform
-db.platform=org.eclipse.persistence.platform.database.oracle.Oracle21Platform
+db.platform=org.eclipse.persistence.platform.database.oracle.Oracle12Platform
 #Property names in the next line (URL, User, Password) are case sensitive (Oracle driver only).
 db.properties=URL=jdbc:oracle:thin:@localhost:1521:ORCL;User=scott;Password=tiger
 #db.properties=URL=jdbc:oracle:thin:@localhost:1521/XEPDB1;User=scott;Password=tiger

--- a/jpa/eclipselink.jpa.nosql.test/pom.xml
+++ b/jpa/eclipselink.jpa.nosql.test/pom.xml
@@ -77,11 +77,6 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-        <!--Required for JPA server test server-test-jpa21-sessionbean.-->
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-        </dependency>
         <!--Other modules-->
         <dependency>
             <groupId>org.eclipse.persistence</groupId>

--- a/jpa/eclipselink.jpa.test.jse/pom.xml
+++ b/jpa/eclipselink.jpa.test.jse/pom.xml
@@ -42,12 +42,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <version>1.3</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>test</scope>

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/canonical/TestCanonicalMetaModel.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/canonical/TestCanonicalMetaModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,9 +15,6 @@
 //       - #539822: JPA Canonical metamodel not processing metamodelMappedSuperclasses
 package org.eclipse.persistence.jpa.test.canonical;
 
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import java.util.Arrays;
 import java.util.Properties;
 
@@ -30,6 +27,7 @@ import org.eclipse.persistence.internal.sessions.AbstractSession;
 import org.eclipse.persistence.jpa.PersistenceProvider;
 import org.eclipse.persistence.sessions.Session;
 import org.junit.Test;
+import static org.junit.Assert.assertNotNull;
 
 public class TestCanonicalMetaModel {
 
@@ -61,7 +59,7 @@ public class TestCanonicalMetaModel {
 
         try (AutoCloseableEntityManagerFactory acemf = new AutoCloseableEntityManagerFactory(persistenceProvider,
                 persistenceUnitInfo, properties)) {
-            assertThat("The \"name\" field is properly initialized", DomainInterface_.name, notNullValue());
+            assertNotNull("The \"name\" field is properly initialized", DomainInterface_.name);
         }
 
     }

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/criteria/TestDateTimeFunctions.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/criteria/TestDateTimeFunctions.java
@@ -24,14 +24,11 @@ import java.time.Period;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
-import java.util.Locale;
 import java.util.TimeZone;
 
-import jakarta.enterprise.inject.Typed;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.Query;
-import jakarta.persistence.TypedQuery;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.CriteriaUpdate;
@@ -45,12 +42,12 @@ import org.eclipse.persistence.jpa.test.framework.Property;
 import org.eclipse.persistence.logging.AbstractSessionLog;
 import org.eclipse.persistence.logging.SessionLog;
 import org.eclipse.persistence.sessions.Session;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test {@code LocalTime}/{@code LocalDate}/{@code LocalDateTime} functions in CriteriaBuilder.
@@ -191,10 +188,10 @@ public class TestDateTimeFunctions {
             long diffMilis = Duration.between(data.getTimeValue(), LocalTime.now().plusSeconds(dbOffset + 1)).toMillis();
             // Positive value means that test did not pass midnight.
             if (diffMilis > 0) {
-                MatcherAssert.assertThat(diffMilis, Matchers.lessThan(30000L));
+                assertTrue(diffMilis < 30000L);
             // Midnight pass correction.
             } else {
-                MatcherAssert.assertThat(86400000L + diffMilis, Matchers.lessThan(30000L));
+                assertTrue(86400000L + diffMilis < 30000L);
             }
         } finally {
             if (em.getTransaction().isActive()) {
@@ -226,9 +223,9 @@ public class TestDateTimeFunctions {
             // Verify updated entity
             DateTimeEntity data = em.find(DateTimeEntity.class, 2);
             Period diff = Period.between(data.getDateValue(), LocalDate.now());
-            MatcherAssert.assertThat(diff.getYears(), Matchers.equalTo(0));
-            MatcherAssert.assertThat(diff.getMonths(), Matchers.equalTo(0));
-            MatcherAssert.assertThat(diff.getDays(), Matchers.lessThan(2));
+            assertEquals(0, diff.getYears());
+            assertEquals(0, diff.getMonths());
+            assertTrue(diff.getDays() < 2);
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -258,7 +255,7 @@ public class TestDateTimeFunctions {
             // Verify updated entity
             DateTimeEntity data = em.find(DateTimeEntity.class, 3);
             long diffMilis = Duration.between(data.getDatetimeValue(), LocalDateTime.now().plusSeconds(dbOffset + 1)).toMillis();
-            MatcherAssert.assertThat(diffMilis, Matchers.lessThan(30000L));
+            assertTrue(diffMilis < 30000L);
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -306,7 +303,7 @@ public class TestDateTimeFunctions {
             cq.where(cb.and(cb.greaterThan(entity.get("timeValue"), cb.localTime()), cb.equal(entity.get("id"), 4)));
             List<DateTimeEntity> data = em.createQuery(cq).getResultList();
             em.getTransaction().commit();
-            MatcherAssert.assertThat(data.size(), Matchers.equalTo(0));
+            assertEquals(0, data.size());
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -354,7 +351,7 @@ public class TestDateTimeFunctions {
             cq.where(cb.and(cb.greaterThan(entity.get("dateValue"), cb.localDate()), cb.equal(entity.get("id"), 4)));
             List<DateTimeEntity> data = em.createQuery(cq).getResultList();
             em.getTransaction().commit();
-            MatcherAssert.assertThat(data.size(), Matchers.equalTo(0));
+            assertEquals(0, data.size());
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -402,7 +399,7 @@ public class TestDateTimeFunctions {
             cq.where(cb.and(cb.greaterThan(entity.get("datetimeValue"), cb.localDateTime()), cb.equal(entity.get("id"), 4)));
             List<DateTimeEntity> data = em.createQuery(cq).getResultList();
             em.getTransaction().commit();
-            MatcherAssert.assertThat(data.size(), Matchers.equalTo(0));
+            assertEquals(0, data.size());
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -427,10 +424,10 @@ public class TestDateTimeFunctions {
             long diffMilis = Duration.between(time, LocalTime.now().plusSeconds(1 + dbOffset)).toMillis();
             // Positive value means that test did not pass midnight.
             if (diffMilis > 0) {
-                MatcherAssert.assertThat(diffMilis, Matchers.lessThan(30000L));
+                assertTrue(diffMilis < 30000L);
             // Midnight pass correction.
             } else {
-                MatcherAssert.assertThat(86400000L + diffMilis, Matchers.lessThan(30000L));
+                assertTrue(86400000L + diffMilis < 30000L);
             }
         } finally {
             if (em.getTransaction().isActive()) {
@@ -454,9 +451,9 @@ public class TestDateTimeFunctions {
             LocalDate date = em.createQuery(cq).getSingleResult();
             em.getTransaction().commit();
             Period diff = Period.between(date, LocalDate.now());
-            MatcherAssert.assertThat(diff.getYears(), Matchers.equalTo(0));
-            MatcherAssert.assertThat(diff.getMonths(), Matchers.equalTo(0));
-            MatcherAssert.assertThat(diff.getDays(), Matchers.lessThan(2));
+            assertEquals(0, diff.getYears());
+            assertEquals(0, diff.getMonths());
+            assertTrue(diff.getDays() < 2);
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -479,7 +476,7 @@ public class TestDateTimeFunctions {
             LocalDateTime datetime = em.createQuery(cq).getSingleResult();
             em.getTransaction().commit();
             long diffMilis = Duration.between(datetime, LocalDateTime.now().plusSeconds(dbOffset + 1)).toMillis();
-            MatcherAssert.assertThat(diffMilis, Matchers.lessThan(30000L));
+            assertTrue(diffMilis < 30000L);
         } catch (Throwable t) {
             t.printStackTrace();
             throw t;
@@ -490,5 +487,4 @@ public class TestDateTimeFunctions {
             em.close();
         }
     }
-
 }

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/criteria/TestMathFunctions.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/criteria/TestMathFunctions.java
@@ -32,14 +32,14 @@ import org.eclipse.persistence.jpa.test.framework.Emf;
 import org.eclipse.persistence.jpa.test.framework.EmfRunner;
 import org.eclipse.persistence.jpa.test.framework.Property;
 import org.eclipse.persistence.sessions.Session;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test math functions in CriteriaBuilder.
@@ -469,12 +469,10 @@ public class TestMathFunctions {
         try (final EntityManager em = emf.createEntityManager()) {
             Double result = callPower(em, 2, 3, "doubleValue");
             if (emf.unwrap(Session.class).getPlatform().isDerby()) {
-                MatcherAssert.assertThat(
-                        Math.abs(Math.pow(NUMBER[3].getDoubleValue(), 2) - result), Matchers.lessThan(0.0000001D));
+                assertTrue(Math.abs(Math.pow(NUMBER[3].getDoubleValue(), 2) - result) < 0.0000001D);
             // Oracle DB result is less accurate
             } else if (emf.unwrap(Session.class).getPlatform().isOracle()) {
-                MatcherAssert.assertThat(
-                        Math.abs(Math.pow(NUMBER[3].getDoubleValue(), 2) - result), Matchers.lessThan(0.0001D));
+                assertTrue(Math.abs(Math.pow(NUMBER[3].getDoubleValue(), 2) - result) < 0.0001D);
             } else {
                 Assert.assertEquals(
                         Double.valueOf(Math.pow(NUMBER[3].getDoubleValue(), 2)), result);
@@ -503,11 +501,9 @@ public class TestMathFunctions {
             Double result = callPower(em, 2, 4, "doubleValue");
             // Oracle DB result is less accurate
             if (emf.unwrap(Session.class).getPlatform().isOracle()) {
-                MatcherAssert.assertThat(
-                        Math.abs(Math.pow(NUMBER[4].getDoubleValue(), 2) - result), Matchers.lessThan(0.0001D));
+                assertTrue(Math.abs(Math.pow(NUMBER[4].getDoubleValue(), 2) - result) < 0.0001D);
             } else {
-                Assert.assertEquals(
-                        Double.valueOf(Math.pow(NUMBER[4].getDoubleValue(), 2)), result);
+                assertEquals(Double.valueOf(Math.pow(NUMBER[4].getDoubleValue(), 2)), result);
             }
         }
     }
@@ -519,8 +515,7 @@ public class TestMathFunctions {
         Assume.assumeFalse(emf.unwrap(Session.class).getPlatform().isDerby());
         try (final EntityManager em = emf.createEntityManager()) {
             Double result = callPower(em, 3, 4, "longValue");
-            Assert.assertEquals(
-                    Double.valueOf(Math.pow(NUMBER[4].getLongValue(), 3)), result);
+            assertEquals(Double.valueOf(Math.pow(NUMBER[4].getLongValue(), 3)), result);
         }
     }
 
@@ -533,11 +528,9 @@ public class TestMathFunctions {
             Double result = callPower(em, 3, 4, "doubleValue");
             // Oracle DB result is less accurate
             if (emf.unwrap(Session.class).getPlatform().isOracle()) {
-                MatcherAssert.assertThat(
-                        Math.abs(Math.pow(NUMBER[4].getDoubleValue(), 3) - result), Matchers.lessThan(0.0000001D));
+                assertTrue(Math.abs(Math.pow(NUMBER[4].getDoubleValue(), 3) - result) < 0.0000001D);
             } else {
-                Assert.assertEquals(
-                        Double.valueOf(Math.pow(NUMBER[4].getDoubleValue(), 3)), result);
+                assertEquals(Double.valueOf(Math.pow(NUMBER[4].getDoubleValue(), 3)), result);
             }
         }
     }
@@ -560,12 +553,9 @@ public class TestMathFunctions {
         try (final EntityManager em = emf.createEntityManager()) {
             Double result = callExprPower(em, 7);
             if (emf.unwrap(Session.class).getPlatform().isDerby() || emf.unwrap(Session.class).getPlatform().isOracle()) {
-                MatcherAssert.assertThat(
-                        Math.abs(Math.pow(NUMBER[7].getDoubleValue(), NUMBER[7].getLongValue()) - result),
-                        Matchers.lessThan(0.0000001d));
+                assertTrue(Math.abs(Math.pow(NUMBER[7].getDoubleValue(), NUMBER[7].getLongValue()) - result) < 0.0000001d);
             } else {
-                Assert.assertEquals(
-                        Double.valueOf(Math.pow(NUMBER[7].getDoubleValue(), NUMBER[7].getLongValue())), result);
+                assertEquals(Double.valueOf(Math.pow(NUMBER[7].getDoubleValue(), NUMBER[7].getLongValue())), result);
             }
         }
     }
@@ -611,10 +601,9 @@ public class TestMathFunctions {
             Double result = callDoubleRound(em, 6,8);
             // Oracle DB result is less accurate
             if (emf.unwrap(Session.class).getPlatform().isOracle()) {
-                MatcherAssert.assertThat(
-                        Math.abs(Double.valueOf(44.754238D) - result), Matchers.lessThan(0.0001D));
+                assertTrue(Math.abs(Double.valueOf(44.754238D) - result) < 0.0001D);
             } else {
-                Assert.assertEquals(Double.valueOf(44.754238D), result);
+                assertEquals(Double.valueOf(44.754238D), result);
             }
         }
     }
@@ -626,10 +615,9 @@ public class TestMathFunctions {
             Float result = callFloatRound(em, 6,8);
             // Oracle DB result is less accurate
             if (emf.unwrap(Session.class).getPlatform().isOracle()) {
-                MatcherAssert.assertThat(
-                        Math.abs(Float.valueOf(44.754238F) - result), Matchers.lessThan(0.0001F));
+                assertTrue(Math.abs(Float.valueOf(44.754238F) - result) < 0.0001F);
             } else {
-                Assert.assertEquals(Float.valueOf(44.754238F), result);
+                assertEquals(Float.valueOf(44.754238F), result);
             }
         }
     }
@@ -641,10 +629,9 @@ public class TestMathFunctions {
             Double result = callDoubleRound(em, 6, 9);
             // Oracle DB result is less accurate
             if (emf.unwrap(Session.class).getPlatform().isOracle()) {
-                MatcherAssert.assertThat(
-                        Math.abs(Double.valueOf(-214.245732D) - result), Matchers.lessThan(0.0001D));
+                assertTrue(Math.abs(Double.valueOf(-214.245732D) - result) < 0.0001D);
             } else {
-                Assert.assertEquals(Double.valueOf(-214.245732D), result);
+                assertEquals(Double.valueOf(-214.245732D), result);
             }
         }
     }
@@ -656,10 +643,9 @@ public class TestMathFunctions {
             Float result = callFloatRound(em, 6, 9);
             // Oracle DB result is less accurate
             if (emf.unwrap(Session.class).getPlatform().isOracle()) {
-                MatcherAssert.assertThat(
-                        Math.abs(Float.valueOf(-214.245732F) - result), Matchers.lessThan(0.0001F));
+                assertTrue(Math.abs(Float.valueOf(-214.245732F) - result) < 0.0001F);
             } else {
-                Assert.assertEquals(Float.valueOf(-214.245732F), result);
+                assertEquals(Float.valueOf(-214.245732F), result);
             }
         }
     }
@@ -674,8 +660,8 @@ public class TestMathFunctions {
             cq.select(cb.ceiling(number.get("bdValue")));
             cq.where(cb.equal(number.get("id"), 8));
             Number result = em.createQuery(cq).getSingleResult();
-            MatcherAssert.assertThat(result, Matchers.is(Matchers.instanceOf(BigDecimal.class)));
-            MatcherAssert.assertThat(result.doubleValue(), Matchers.equalTo(Math.ceil(NUMBER[8].getBdValue().doubleValue())));
+            assertTrue(result instanceof BigDecimal);
+            assertEquals(Math.ceil(NUMBER[8].getBdValue().doubleValue()), result.doubleValue(), 0);
         }
     }
 
@@ -689,8 +675,8 @@ public class TestMathFunctions {
             cq.select(cb.floor(number.get("bdValue")));
             cq.where(cb.equal(number.get("id"), 8));
             Number result = em.createQuery(cq).getSingleResult();
-            MatcherAssert.assertThat(result, Matchers.is(Matchers.instanceOf(BigDecimal.class)));
-            MatcherAssert.assertThat(result.doubleValue(), Matchers.equalTo(Math.floor(NUMBER[8].getBdValue().doubleValue())));
+            assertTrue(result instanceof BigDecimal);
+            assertEquals(result.doubleValue(), Math.floor(NUMBER[8].getBdValue().doubleValue()), 0);
         }
     }
 
@@ -704,9 +690,8 @@ public class TestMathFunctions {
             cq.select(cb.round(number.get("bdValue"), 1));
             cq.where(cb.equal(number.get("id"), 8));
             Number result = em.createQuery(cq).getSingleResult();
-            MatcherAssert.assertThat(result, Matchers.is(Matchers.instanceOf(BigDecimal.class)));
-            MatcherAssert.assertThat(result.doubleValue(), Matchers.equalTo(Double.valueOf(Math.round(NUMBER[8].getBdValue().doubleValue()*10))/10));
+            assertTrue(result instanceof BigDecimal);
+            assertEquals(result.doubleValue(), Double.valueOf(Math.round(NUMBER[8].getBdValue().doubleValue()*10))/10, 0);
         }
     }
-
 }

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/criteria/TestSimpleCase.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/criteria/TestSimpleCase.java
@@ -30,12 +30,11 @@ import org.eclipse.persistence.jpa.test.framework.DDLGen;
 import org.eclipse.persistence.jpa.test.framework.Emf;
 import org.eclipse.persistence.jpa.test.framework.EmfRunner;
 import org.eclipse.persistence.jpa.test.framework.Property;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Test new API 3.1.0 when methods of SimpleCase subclass of CriteriaBuilder.
@@ -114,7 +113,7 @@ public class TestSimpleCase {
                     .otherwise(0);
             cq.where(cb.equal(entity.get("doubleValue"), selectCase));
             List<NumberEntity> result = em.createQuery(cq).getResultList();
-            MatcherAssert.assertThat(result.size(), Matchers.equalTo(3));
+            assertEquals(3, result.size());
         } catch (Throwable t) {
             t.printStackTrace();
             throw t;
@@ -136,11 +135,10 @@ public class TestSimpleCase {
                     .otherwise(0);
             cq.where(cb.equal(entity.get("doubleValue"), selectCase));
             List<NumberEntity> result = em.createQuery(cq).getResultList();
-            MatcherAssert.assertThat(result.size(), Matchers.equalTo(3));
+            assertEquals(3, result.size());
         } catch (Throwable t) {
             t.printStackTrace();
             throw t;
         }
     }
-
 }

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/jpql/TestDateTimeFunctions.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/jpql/TestDateTimeFunctions.java
@@ -34,12 +34,11 @@ import org.eclipse.persistence.jpa.test.framework.EmfRunner;
 import org.eclipse.persistence.jpa.test.framework.Property;
 import org.eclipse.persistence.logging.AbstractSessionLog;
 import org.eclipse.persistence.logging.SessionLog;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import static org.junit.Assert.assertEquals;
 
 @RunWith(EmfRunner.class)
 public class TestDateTimeFunctions {
@@ -199,7 +198,7 @@ public class TestDateTimeFunctions {
             em.getTransaction().begin();
             List<DateTimeEntity> result = query.getResultList();
             em.getTransaction().commit();
-            MatcherAssert.assertThat(result.size(), Matchers.equalTo(4));
+            assertEquals(4, result.size());
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -219,7 +218,7 @@ public class TestDateTimeFunctions {
             em.getTransaction().begin();
             List<DateTimeEntity> result = query.getResultList();
             em.getTransaction().commit();
-            MatcherAssert.assertThat(result.size(), Matchers.equalTo(4));
+            assertEquals(4, result.size());
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();
@@ -227,5 +226,4 @@ public class TestDateTimeFunctions {
             em.close();
         }
     }
-
 }

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/TestDateTimeFunctions.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/TestDateTimeFunctions.java
@@ -28,14 +28,13 @@ import org.eclipse.persistence.jpa.test.framework.EmfRunner;
 import org.eclipse.persistence.jpa.test.framework.Property;
 import org.eclipse.persistence.jpa.test.query.model.DateTimeQueryEntity;
 import org.eclipse.persistence.sessions.Session;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test {@code LocalTime}/{@code LocalDate}/{@code LocalDateTime} functions in queries.
@@ -113,7 +112,7 @@ public class TestDateTimeFunctions {
             q.setParameter("id", 1);
             long y = q.getSingleResult().longValue();
             em.getTransaction().commit();
-            MatcherAssert.assertThat(y, Matchers.equalTo(2022L));
+            assertEquals(y, 2022L);
         } catch (Throwable t) {
             t.printStackTrace();
             throw t;
@@ -135,7 +134,7 @@ public class TestDateTimeFunctions {
             q.setParameter("id", 1);
             long y = q.getSingleResult().longValue();
             em.getTransaction().commit();
-            MatcherAssert.assertThat(y, Matchers.equalTo(1L));
+            assertEquals(y, 1L);
         } catch (Throwable t) {
             t.printStackTrace();
             throw t;
@@ -157,7 +156,7 @@ public class TestDateTimeFunctions {
             q.setParameter("id", 1);
             long y = q.getSingleResult().longValue();
             em.getTransaction().commit();
-            MatcherAssert.assertThat(y, Matchers.equalTo(3L));
+            assertEquals(y, 3L);
         } catch (Throwable t) {
             t.printStackTrace();
             throw t;
@@ -179,7 +178,7 @@ public class TestDateTimeFunctions {
             q.setParameter("id", 1);
             long y = q.getSingleResult().longValue();
             em.getTransaction().commit();
-            MatcherAssert.assertThat(y, Matchers.equalTo(9L));
+            assertEquals(y, 9L);
         } catch (Throwable t) {
             t.printStackTrace();
             throw t;
@@ -201,7 +200,7 @@ public class TestDateTimeFunctions {
             q.setParameter("id", 1);
             long y = q.getSingleResult().longValue();
             em.getTransaction().commit();
-            MatcherAssert.assertThat(y, Matchers.equalTo(14L));
+            assertEquals(y, 14L);
         } catch (Throwable t) {
             t.printStackTrace();
             throw t;
@@ -223,7 +222,7 @@ public class TestDateTimeFunctions {
             q.setParameter("id", 1);
             long y = q.getSingleResult().longValue();
             em.getTransaction().commit();
-            MatcherAssert.assertThat(y, Matchers.equalTo(30L));
+            assertEquals(y, 30L);
         } catch (Throwable t) {
             t.printStackTrace();
             throw t;
@@ -245,7 +244,7 @@ public class TestDateTimeFunctions {
             q.setParameter("id", 1);
             long y = q.getSingleResult().longValue();
             em.getTransaction().commit();
-            MatcherAssert.assertThat(y, Matchers.equalTo(25L));
+            assertEquals(y, 25L);
         } catch (Throwable t) {
             t.printStackTrace();
             throw t;
@@ -267,7 +266,7 @@ public class TestDateTimeFunctions {
             q.setParameter("id", 1);
             long y = q.getSingleResult().longValue();
             em.getTransaction().commit();
-            MatcherAssert.assertThat(y, Matchers.equalTo(2022L));
+            assertEquals(y, 2022L);
         } catch (Throwable t) {
             t.printStackTrace();
             throw t;
@@ -289,7 +288,7 @@ public class TestDateTimeFunctions {
             q.setParameter("id", 1);
             long y = q.getSingleResult().longValue();
             em.getTransaction().commit();
-            MatcherAssert.assertThat(y, Matchers.equalTo(1L));
+            assertEquals(y, 1L);
         } catch (Throwable t) {
             t.printStackTrace();
             throw t;
@@ -311,7 +310,7 @@ public class TestDateTimeFunctions {
             q.setParameter("id", 1);
             long y = q.getSingleResult().longValue();
             em.getTransaction().commit();
-            MatcherAssert.assertThat(y, Matchers.equalTo(3L));
+            assertEquals(y, 3L);
         } catch (Throwable t) {
             t.printStackTrace();
             throw t;
@@ -333,7 +332,7 @@ public class TestDateTimeFunctions {
             q.setParameter("id", 1);
             long y = q.getSingleResult().longValue();
             em.getTransaction().commit();
-            MatcherAssert.assertThat(y, Matchers.equalTo(9L));
+            assertEquals(y, 9L);
         } catch (Throwable t) {
             t.printStackTrace();
             throw t;
@@ -355,7 +354,7 @@ public class TestDateTimeFunctions {
             q.setParameter("id", 1);
             long y = q.getSingleResult().longValue();
             em.getTransaction().commit();
-            MatcherAssert.assertThat(y, Matchers.equalTo(14L));
+            assertEquals(y, 14L);
         } catch (Throwable t) {
             t.printStackTrace();
             throw t;
@@ -377,7 +376,7 @@ public class TestDateTimeFunctions {
             q.setParameter("id", 1);
             long y = q.getSingleResult().longValue();
             em.getTransaction().commit();
-            MatcherAssert.assertThat(y, Matchers.equalTo(30L));
+            assertEquals(y, 30L);
         } catch (Throwable t) {
             t.printStackTrace();
             throw t;
@@ -399,7 +398,7 @@ public class TestDateTimeFunctions {
             q.setParameter("id", 1);
             long y = q.getSingleResult().longValue();
             em.getTransaction().commit();
-            MatcherAssert.assertThat(y, Matchers.equalTo(25L));
+            assertEquals(y, 25L);
         } catch (Throwable t) {
             t.printStackTrace();
             throw t;
@@ -422,7 +421,7 @@ public class TestDateTimeFunctions {
             query.setParameter("datetimeValue", TS[1]);
             List<DateTimeQueryEntity> result = query.getResultList();
             em.getTransaction().commit();
-            MatcherAssert.assertThat(result.size(), Matchers.equalTo(1));
+            assertEquals(result.size(), 1);
         } catch (Throwable t) {
             t.printStackTrace();
             throw t;
@@ -445,7 +444,7 @@ public class TestDateTimeFunctions {
             Number year = query.getSingleResult();
             em.getTransaction().commit();
             // Check returned year value
-            MatcherAssert.assertThat(year.intValue(), Matchers.equalTo(2022));
+            assertEquals(year.intValue(),2022);
         } catch (Throwable t) {
             t.printStackTrace();
             throw t;
@@ -474,7 +473,7 @@ public class TestDateTimeFunctions {
                     found = true;
                 }
             }
-            Assert.assertTrue("Record with ID = 1 containing year 2022 was not found", found);
+            assertTrue("Record with ID = 1 containing year 2022 was not found", found);
         } catch (Throwable t) {
             t.printStackTrace();
             throw t;
@@ -498,7 +497,7 @@ public class TestDateTimeFunctions {
             q.setParameter("id", 3);
             long y = q.getSingleResult().longValue();
             em.getTransaction().commit();
-            MatcherAssert.assertThat(y, Matchers.equalTo(23L));
+            assertEquals(y, 23L);
         } catch (Throwable t) {
             t.printStackTrace();
             throw t;
@@ -522,7 +521,7 @@ public class TestDateTimeFunctions {
             for (String operand : extractOps) {
                 TypedQuery<Number> query = em.createQuery("SELECT EXTRACT(" + operand + " FROM qdte.dateValue) FROM DateTimeQueryEntity qdte WHERE qdte.id = 1", Number.class);
                 Number value = query.getSingleResult();
-                MatcherAssert.assertThat(value, Matchers.anyOf(Matchers.instanceOf(Integer.class), Matchers.instanceOf(Long.class)));
+                assertTrue(value instanceof Integer || value instanceof Long);
             }
             em.getTransaction().commit();
         } catch (Throwable t) {
@@ -546,7 +545,7 @@ public class TestDateTimeFunctions {
             for (String operand : extractOps) {
                 TypedQuery<Number> query = em.createQuery("SELECT EXTRACT(" + operand + " FROM qdte.timeValue) FROM DateTimeQueryEntity qdte WHERE qdte.id = 1", Number.class);
                 Number value = query.getSingleResult();
-                MatcherAssert.assertThat(value, Matchers.instanceOf(Integer.class));
+                assertTrue(value instanceof Integer);
             }
             em.getTransaction().commit();
         } catch (Throwable t) {
@@ -568,7 +567,7 @@ public class TestDateTimeFunctions {
             em.getTransaction().begin();
             TypedQuery<Number> query = em.createQuery("SELECT EXTRACT(SECOND FROM qdte.timeValue) FROM DateTimeQueryEntity qdte WHERE qdte.id = 1", Number.class);
             Number value = query.getSingleResult();
-            MatcherAssert.assertThat(value, Matchers.instanceOf(Double.class));
+            assertTrue(value instanceof Double);
             em.getTransaction().commit();
         } catch (Throwable t) {
             t.printStackTrace();
@@ -591,10 +590,10 @@ public class TestDateTimeFunctions {
             em.getTransaction().begin();
             TypedQuery<Number> query = em.createQuery("SELECT EXTRACT(SECOND FROM qdte.timeValue) FROM DateTimeQueryEntity qdte WHERE qdte.id = 4", Number.class);
             Number value = query.getSingleResult();
-            MatcherAssert.assertThat(value, Matchers.instanceOf(Double.class));
+            assertTrue(value instanceof Double);
             double secWithNs = (double)TS[3].getNano() / 1000000000 + TS[3].getSecond();
             double diff = Math.abs(secWithNs - value.doubleValue());
-            MatcherAssert.assertThat(diff, Matchers.lessThan(0.000001));
+            assertTrue(diff < 0.000001);
             em.getTransaction().commit();
         } catch (Throwable t) {
             t.printStackTrace();
@@ -606,5 +605,4 @@ public class TestDateTimeFunctions {
             em.close();
         }
     }
-
 }

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/TestMathFunctions.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/TestMathFunctions.java
@@ -30,14 +30,14 @@ import org.eclipse.persistence.jpa.test.framework.Emf;
 import org.eclipse.persistence.jpa.test.framework.EmfRunner;
 import org.eclipse.persistence.jpa.test.framework.Property;
 import org.eclipse.persistence.sessions.Session;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test math functions in CriteriaBuilder.
@@ -444,15 +444,11 @@ public class TestMathFunctions {
         try (final EntityManager em = emf.createEntityManager()) {
             Double result = callPower(em, 2, 3, "doubleValue");
             if (emf.unwrap(Session.class).getPlatform().isDerby()) {
-                MatcherAssert.assertThat(
-                        Math.abs(Math.pow(NUMBER[3].getDoubleValue(), 2) - result), Matchers.lessThan(0.0000001d));
+                assertTrue(Math.abs(Math.pow(NUMBER[3].getDoubleValue(), 2) - result) < 0.0000001d);
             } else if (emf.unwrap(Session.class).getPlatform().isOracle()) {
-                MatcherAssert.assertThat(
-                        Math.pow(NUMBER[3].getDoubleValue(), 2) - result,
-                        Matchers.lessThan(0.0001D));
+                assertTrue(Math.pow(NUMBER[3].getDoubleValue(), 2) - result < 0.0001D);
             } else {
-                Assert.assertEquals(
-                        Double.valueOf(Math.pow(NUMBER[3].getDoubleValue(), 2)), result);
+                assertEquals(Double.valueOf(Math.pow(NUMBER[3].getDoubleValue(), 2)), result);
             }
         }
     }
@@ -464,8 +460,7 @@ public class TestMathFunctions {
         Assume.assumeFalse(emf.unwrap(Session.class).getPlatform().isDerby());
         try (final EntityManager em = emf.createEntityManager()) {
             Double result = callPower(em, 2, 4, "longValue");
-            Assert.assertEquals(
-                    Double.valueOf(Math.pow(NUMBER[4].getLongValue(), 2)), result);
+            assertEquals(Double.valueOf(Math.pow(NUMBER[4].getLongValue(), 2)), result);
         }
     }
 
@@ -478,12 +473,9 @@ public class TestMathFunctions {
             Double result = callPower(em, 2, 4, "doubleValue");
             // Oracle DB result is less accurate
             if (emf.unwrap(Session.class).getPlatform().isOracle()) {
-                MatcherAssert.assertThat(
-                        (float) (Math.pow(NUMBER[4].getDoubleValue(), 2) - result),
-                        Matchers.lessThan(0.0001F));
+                assertTrue((float) (Math.pow(NUMBER[4].getDoubleValue(), 2) - result) < 0.0001F);
             } else {
-                Assert.assertEquals(
-                        Double.valueOf(Math.pow(NUMBER[4].getDoubleValue(), 2)), result);
+                assertEquals(Double.valueOf(Math.pow(NUMBER[4].getDoubleValue(), 2)), result);
             }
         }
     }
@@ -495,8 +487,7 @@ public class TestMathFunctions {
         Assume.assumeFalse(emf.unwrap(Session.class).getPlatform().isDerby());
         try (final EntityManager em = emf.createEntityManager()) {
             Double result = callPower(em, 3, 4, "longValue");
-            Assert.assertEquals(
-                    Double.valueOf(Math.pow(NUMBER[4].getLongValue(), 3)), result);
+            assertEquals(Double.valueOf(Math.pow(NUMBER[4].getLongValue(), 3)), result);
         }
     }
 
@@ -509,9 +500,7 @@ public class TestMathFunctions {
             Double result = callPower(em, 3, 4, "doubleValue");
             // Oracle DB result is less accurate
             if (emf.unwrap(Session.class).getPlatform().isOracle()) {
-                MatcherAssert.assertThat(
-                        Math.pow(NUMBER[4].getDoubleValue(), 3) - result,
-                        Matchers.lessThan(0.0000001d));
+                assertTrue(Math.pow(NUMBER[4].getDoubleValue(), 3) - result < 0.0000001d);
             } else {
                 Assert.assertEquals(
                         Double.valueOf(Math.pow(NUMBER[4].getDoubleValue(), 3)), result);
@@ -534,12 +523,9 @@ public class TestMathFunctions {
         try (final EntityManager em = emf.createEntityManager()) {
             Double result = callExprPower(em, 7);
             if (emf.unwrap(Session.class).getPlatform().isDerby() || emf.unwrap(Session.class).getPlatform().isOracle()) {
-                MatcherAssert.assertThat(
-                        Math.abs(Math.pow(NUMBER[7].getDoubleValue(), NUMBER[7].getLongValue()) - result),
-                        Matchers.lessThan(0.0000001d));
+                assertTrue(Math.abs(Math.pow(NUMBER[7].getDoubleValue(), NUMBER[7].getLongValue()) - result) < 0.0000001d);
             } else {
-                Assert.assertEquals(
-                        Double.valueOf(Math.pow(NUMBER[7].getDoubleValue(), NUMBER[7].getLongValue())), result);
+                assertEquals(Double.valueOf(Math.pow(NUMBER[7].getDoubleValue(), NUMBER[7].getLongValue())), result);
             }
         }
     }
@@ -581,8 +567,7 @@ public class TestMathFunctions {
             Double result = callRoundDouble(em, 6, 8);
             // Oracle DB result is less accurate
             if (emf.unwrap(Session.class).getPlatform().isOracle()) {
-                MatcherAssert.assertThat(
-                        Double.valueOf(44.754238D) - result, Matchers.lessThan(0.0001D));
+                assertTrue(Double.valueOf(44.754238D) - result < 0.0001D);
             } else {
                 Assert.assertEquals(Double.valueOf(44.754238D), result);
             }
@@ -596,11 +581,9 @@ public class TestMathFunctions {
             Float result = callRoundFloat(em, 6,8);
             // Oracle DB result is less accurate
             if (emf.unwrap(Session.class).getPlatform().isOracle()) {
-                MatcherAssert.assertThat(
-                        Float.valueOf(44.754238F) - result,
-                        Matchers.lessThan(0.0001F));
+                assertTrue(Float.valueOf(44.754238F) - result < 0.0001F);
             } else {
-                Assert.assertEquals(Float.valueOf(44.754238F), result);
+                assertEquals(Float.valueOf(44.754238F), result);
             }
         }
     }
@@ -612,11 +595,9 @@ public class TestMathFunctions {
             Double result = callRoundDouble(em, 6, 9);
             // Oracle DB result is less accurate
             if (emf.unwrap(Session.class).getPlatform().isOracle()) {
-                MatcherAssert.assertThat(
-                        Double.valueOf(-214.245732D) - result,
-                        Matchers.lessThan(0.0001D));
+                assertTrue(Double.valueOf(-214.245732D) - result < 0.0001D);
             } else {
-                Assert.assertEquals(Double.valueOf(-214.245732D), result);
+                assertEquals(Double.valueOf(-214.245732D), result);
             }
         }
     }
@@ -628,11 +609,9 @@ public class TestMathFunctions {
             Float result = callRoundFloat(em, 6, 9);
             // Oracle DB result is less accurate
             if (emf.unwrap(Session.class).getPlatform().isOracle()) {
-                MatcherAssert.assertThat(
-                        Float.valueOf(-214.245732F) - result,
-                        Matchers.lessThan(0.0001F));
+                assertTrue(Float.valueOf(-214.245732F) - result < 0.0001F);
             } else {
-                Assert.assertEquals(Float.valueOf(-214.245732F), result);
+                assertEquals(Float.valueOf(-214.245732F), result);
             }
         }
     }
@@ -676,9 +655,7 @@ public class TestMathFunctions {
             Double result = callRoundDoubleDigitsAsParam(em, 6,8);
             // Oracle DB result is less accurate
             if (emf.unwrap(Session.class).getPlatform().isOracle()) {
-                MatcherAssert.assertThat(
-                        Double.valueOf(44.754238D) - result,
-                        Matchers.lessThan(0.0001D));
+                assertTrue(Double.valueOf(44.754238D) - result < 0.0001D);
             } else {
                 Assert.assertEquals(Double.valueOf(44.754238D), result);
             }
@@ -694,11 +671,9 @@ public class TestMathFunctions {
             Float result = callRoundFloatDigitsAsParam(em, 6,8);
             // Oracle DB result is less accurate
             if (emf.unwrap(Session.class).getPlatform().isOracle()) {
-                MatcherAssert.assertThat(
-                        Float.valueOf(44.754238F) - result,
-                        Matchers.lessThan(0.0001F));
+                assertTrue(Float.valueOf(44.754238F) - result < 0.0001F);
             } else {
-                Assert.assertEquals(Float.valueOf(44.754238F), result);
+                assertEquals(Float.valueOf(44.754238F), result);
             }
         }
     }
@@ -712,11 +687,9 @@ public class TestMathFunctions {
             Double result = callRoundDoubleDigitsAsParam(em, 6, 9);
             // Oracle DB result is less accurate
             if (emf.unwrap(Session.class).getPlatform().isOracle()) {
-                MatcherAssert.assertThat(
-                        Double.valueOf(-214.245732D) - result,
-                        Matchers.lessThan(0.0001D));
+                assertTrue(Double.valueOf(-214.245732D) - result < 0.0001D);
             } else {
-                Assert.assertEquals(Double.valueOf(-214.245732D), result);
+                assertEquals(Double.valueOf(-214.245732D), result);
             }
         }
     }
@@ -730,14 +703,10 @@ public class TestMathFunctions {
             Float result = callRoundFloatDigitsAsParam(em, 6, 9);
             // Oracle DB result is less accurate
             if (emf.unwrap(Session.class).getPlatform().isOracle()) {
-                MatcherAssert.assertThat(
-                        Float.valueOf(-214.245732F) - result,
-                        Matchers.lessThan(0.0001F));
+                assertTrue(Float.valueOf(-214.245732F) - result < 0.0001F);
             } else {
-                Assert.assertEquals(Float.valueOf(-214.245732F), result);
+                assertEquals(Float.valueOf(-214.245732F), result);
             }
         }
     }
-
-
 }

--- a/jpa/eclipselink.jpa.test/pom.xml
+++ b/jpa/eclipselink.jpa.test/pom.xml
@@ -80,11 +80,6 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-        <!--Required for JPA server test server-test-jpa21-sessionbean.-->
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-        </dependency>
         <!--Other modules-->
         <dependency>
             <groupId>jakarta.persistence</groupId>

--- a/jpa/eclipselink.jpa.testapps/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/pom.xml
@@ -227,11 +227,6 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-            <scope>test</scope>
-        </dependency>
         <!--EclipseLink JPA test framework-->
         <dependency>
             <groupId>org.eclipse.persistence</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -865,12 +865,6 @@
                 <artifactId>junit</artifactId>
                 <version>${junit.version}</version>
             </dependency>
-            <!--Required for JPA server test server-test-jpa21-sessionbean.-->
-            <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-core</artifactId>
-                <version>${hamcrest.version}</version>
-            </dependency>
             <!--APIs and other libs used in test classes-->
             <dependency>
                 <groupId>jakarta.el</groupId>


### PR DESCRIPTION
This is minor test code refactoring to remove code dependency to hamcrest api. These tests with Hamcrest API should work in Maven environments as Hamcrest dependency is transitively loaded by JUnit but there should be problem in Ant and other non-Maven build systems.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>