### PR TITLE
[2.7] JPA JSE test fixes - master backports

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatasourcePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatasourcePlatform.java
@@ -1128,7 +1128,7 @@ public class DatasourcePlatform implements Platform {
      * Override this method if the platform needs to use a custom function based on the DatabaseField
      * @return An expression for the given field set equal to a parameter matching the field
      */
-    public Expression createExpressionFor(DatabaseField field, Expression builder) {
+    public Expression createExpressionFor(DatabaseField field, Expression builder, String fieldClassificationClassName) {
         Expression subExp1 = builder.getField(field);
         Expression subExp2 = builder.getParameter(field);
         return subExp1.equal(subExp2);

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/descriptors/ObjectBuilder.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/descriptors/ObjectBuilder.java
@@ -2989,7 +2989,11 @@ public class ObjectBuilder extends CoreObjectBuilder<AbstractRecord, AbstractSes
         if(null != primaryKeyFields) {
             for (int index = 0; index < primaryKeyFields.size(); index++) {
                 DatabaseField primaryKeyField = (DatabaseField)primaryKeyFields.get(index);
-                subExpression = ((DatasourcePlatform)session.getDatasourcePlatform()).createExpressionFor(primaryKeyField, builder);
+                String fieldClassificationClassName = null;
+                if (this.getBaseMappingForField(primaryKeyField) instanceof AbstractDirectMapping) {
+                    fieldClassificationClassName = ((AbstractDirectMapping)this.getBaseMappingForField(primaryKeyField)).getFieldClassificationClassName();
+                }
+                subExpression = ((DatasourcePlatform)session.getDatasourcePlatform()).createExpressionFor(primaryKeyField, builder, fieldClassificationClassName);
 
                 if (expression == null) {
                     expression = subExpression;

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/helper/ConversionManager.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/helper/ConversionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2020 IBM Corporation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -858,9 +858,8 @@ public class ConversionManager extends CoreConversionManager implements Serializ
         } else if (sourceObject instanceof java.sql.Timestamp) {
             localDate = ((java.sql.Timestamp) sourceObject).toLocalDateTime().toLocalDate();
         } else if (sourceObject instanceof java.util.Date) {
-            // handles sql.Time
-            java.util.Date date = (java.util.Date) sourceObject;
-            localDate = java.time.LocalDate.ofEpochDay(date.toInstant().getEpochSecond() / (60 * 60 * 24)); // Conv sec to day
+            // handles sql.Time too
+            localDate = ((java.util.Date) sourceObject).toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
         } else if (sourceObject instanceof Calendar) {
             Calendar cal = (Calendar) sourceObject;
             localDate = java.time.LocalDate.of(cal.get(Calendar.YEAR), cal.get(Calendar.MONTH) + 1, cal.get(Calendar.DAY_OF_MONTH));

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/mappings/foundation/AbstractDirectMapping.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/mappings/foundation/AbstractDirectMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2020 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -1324,5 +1324,13 @@ public abstract class AbstractDirectMapping extends AbstractColumnMapping implem
         if (isUpdatable() && ! isReadOnly()) {
             databaseRow.add(getField(), null);
         }
+    }
+
+    /**
+     * INTERNAL:
+     * Get fieldClassificationClassName. Value usually exist for fields with some kind of embedded converter like <code>@Lob</code> or <code>@Temporal</code>.
+     */
+    public String getFieldClassificationClassName() {
+        return this.fieldClassificationClassName;
     }
 }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/OraclePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/OraclePlatform.java
@@ -1209,15 +1209,17 @@ public class OraclePlatform extends org.eclipse.persistence.platform.database.Da
     }
 
     @Override
-    public Expression createExpressionFor(DatabaseField field, Expression builder) {
-        if (field.getType() == java.sql.Clob.class || 
-                field.getType() == java.sql.Blob.class) {
+    public Expression createExpressionFor(DatabaseField field, Expression builder, String fieldClassificationClassName) {
+        if (field.getType() == java.sql.Clob.class ||
+                field.getType() == java.sql.Blob.class ||
+                "java.sql.Clob".equals(fieldClassificationClassName) ||
+                "java.sql.Blob".equals(fieldClassificationClassName)) {
             Expression subExp1 = builder.getField(field);
             Expression subExp2 = builder.getParameter(field);
             subExp1 = subExp1.getFunction("dbms_lob.compare", subExp2);
             return subExp1.equal(0);
         }
-        return super.createExpressionFor(field, builder);
+        return super.createExpressionFor(field, builder, fieldClassificationClassName);
     }
 
     // Value of shouldCheckResultTableExistsQuery must be true.

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/embeddable/model/ElementCollectionEmbeddableTemporal.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/embeddable/model/ElementCollectionEmbeddableTemporal.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 IBM Corporation. All rights reserved.
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,6 +14,7 @@ package org.eclipse.persistence.jpa.embeddable.model;
 
 import java.util.Date;
 
+import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
@@ -21,6 +23,7 @@ import javax.persistence.TemporalType;
 public class ElementCollectionEmbeddableTemporal {
 
     @Temporal(value = TemporalType.DATE)
+    @Column(name = "TEMPORALVALUE", columnDefinition = "DATE")
     private Date temporalValue;
 
     public ElementCollectionEmbeddableTemporal() { }

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/conversion/TestJavaTimeTypeConverter.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/conversion/TestJavaTimeTypeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -26,7 +26,10 @@ import java.time.LocalTime;
 import java.time.Month;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.TemporalField;
 import java.util.Calendar;
 import java.util.Date;
 
@@ -77,8 +80,12 @@ public class TestJavaTimeTypeConverter {
         Assert.assertEquals(2, date.getDate());
 
         LocalDate ld = (LocalDate) cm.convertObject(date, ClassConstants.TIME_LDATE);
+        ZonedDateTime check = ZonedDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault());
 
         Assert.assertNotNull(ld);
+        Assert.assertEquals(check.getYear(), ld.getYear());
+        Assert.assertEquals(check.getMonth(), ld.getMonth());
+        Assert.assertEquals(check.getDayOfMonth(), ld.getDayOfMonth());
         Assert.assertEquals(2020, ld.getYear());
         Assert.assertEquals(Month.JANUARY, ld.getMonth());
         Assert.assertEquals(2, ld.getDayOfMonth());

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/mapping/TestMultitenantOneToMany.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/mapping/TestMultitenantOneToMany.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -64,6 +64,8 @@ public class TestMultitenantOneToMany {
             supportedPlatform = true;
             try {
                 em.getTransaction().begin();
+                em.createNativeQuery("DROP SCHEMA IF EXISTS tenant_1").executeUpdate();
+                em.createNativeQuery("DROP SCHEMA IF EXISTS tenant_2").executeUpdate();
                 em.createNativeQuery("CREATE SCHEMA tenant_1").executeUpdate();
                 em.createNativeQuery("CREATE SCHEMA tenant_2").executeUpdate();
                 em.createNativeQuery("CREATE TABLE tenant_1.parent(id bigint primary key)").executeUpdate();


### PR DESCRIPTION
This PR contains fixes for following test errors in JPA JSE module:

- org.eclipse.persistence.jpa.test.conversion.TestJavaTimeTypeConverter#timeConvertUtilDateToLocalDate
  There is backport from master https://github.com/eclipse-ee4j/eclipselink/commit/cff665dccda56ce0c125e9509b24b274f88c0b29#diff-94d9bb887b47c8e9471a37fc153dbad9d33c5c233db3af7cb3100e5b4c613b58

- org.eclipse.persistence.jpa.test.mapping.TestMultitenantOneToMany
  Test didn't clean environment. Calls `DROP SCHEMA IF EXISTS tenant_*` added.
   Backport from #1370

- org.eclipse.persistence.jpa.test.lob.TestLobMerge
   Based on product code changes. Backport from #1370

- org.eclipse.persistence.jpa.embeddable.TestCollectionTableEmbeddable
   Based on product code changes. Backport from #1370
