### PR TITLE
[master] Nightly build fix - Jenkins pipeline

### DIFF
--- a/etc/jenkins/build.groovy
+++ b/etc/jenkins/build.groovy
@@ -173,6 +173,16 @@ spec:
                 }
             }
         }
+        // Prepare artifacts to nightly
+        stage('Prepare to nightly') {
+            steps {
+                container('el-build') {
+                    sh """
+                            etc/jenkins/prepare_nightly.sh
+                        """
+                }
+            }
+        }
         // Publish to nightly
         stage('Publish to nightly') {
             steps {

--- a/etc/jenkins/prepare_nightly.sh
+++ b/etc/jenkins/prepare_nightly.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+#
+# Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Distribution License v. 1.0, which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+#
+# Arguments:
+#  N/A
+
+echo '-[ EclipseLink Nightly Build Preparation ]-----------------------------------------------------------'
+
+if [ ${CONTINUOUS_BUILD} = "true" ]; then
+    echo '-[ EclipseLink Continuous Build -> No preparing any artifacts]-------------------------------'
+else
+    echo '-[ EclipseLink Prepare Artifacts to Nightly ]-----------------------------------------------------------'
+    mvn -V -B clean package -f bundles/nightly/pom.xml
+fi
+
+
+

--- a/etc/jenkins/publish_nightly.sh
+++ b/etc/jenkins/publish_nightly.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -16,6 +16,5 @@ if [ ${CONTINUOUS_BUILD} = "true" ]; then
     echo '-[ EclipseLink Continuous Build -> No publishing any artifacts]-------------------------------'
 else
     echo '-[ EclipseLink Publish to Nightly ]-----------------------------------------------------------'
-    mvn -V -B clean package -f bundles/nightly/pom.xml
     scp -r $WORKSPACE/bundles/nightly/target/nightlybuild/* genie.eclipselink@projects-storage.eclipse.org:$BUILD_RESULTS_TARGET_DIR
 fi


### PR DESCRIPTION
This fix related with #1703 and `etc/jenkins/build.groovy` pipeline. Due security reason "Publish to nightly" stage is executed under different container, than EclipseLink build and tests. There should be Maven, but in different version, than `el-build`container used for a build and tests.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>