### PR TITLE
[master] Fix ConcurrentModificationException in BatchFetchPolicy - backport from 2.7

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/BatchFetchPolicy.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/BatchFetchPolicy.java
@@ -77,6 +77,9 @@ public class BatchFetchPolicy implements Serializable, Cloneable {
             dataResults.put(clone, list);
         }
         clone.setDataResults(dataResults);
+        if(this.attributeExpressions != null) {
+            clone.attributeExpressions = new ArrayList<>(this.attributeExpressions);
+        }
         return clone;
     }
 


### PR DESCRIPTION
Fixes #1506 . This change will fix the ConcurrentModificationException of the attributeExpression list, when running the same (batch)query with different entity managers.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>