### PR TITLE
[3.0] Fix ConcurrentModificationException in BatchFetchPolicy - backport from 2.7

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/BatchFetchPolicy.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/BatchFetchPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2022 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/BatchFetchPolicy.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/BatchFetchPolicy.java
@@ -77,6 +77,9 @@ public class BatchFetchPolicy implements Serializable, Cloneable {
             dataResults.put(clone, list);
         }
         clone.setDataResults(dataResults);
+        if(this.attributeExpressions != null) {
+            clone.attributeExpressions = new ArrayList<>(this.attributeExpressions);
+        }
         return clone;
     }
 


### PR DESCRIPTION
Fixes #1506 . This change will fix the ConcurrentModificationException of the attributeExpression list, when running the same (batch)query with different entity managers.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>