### PR TITLE
[2.7] Bugfix for: Specifying QName in XmlVariableNode results namespace written twice - backport from master

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/oxm/mappings/XMLVariableXPathObjectMapping.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/oxm/mappings/XMLVariableXPathObjectMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -198,6 +198,11 @@ public class XMLVariableXPathObjectMapping extends XMLCompositeObjectMapping  im
                 if(prefix != null && prefix.length() >0){
                     frag.setPrefix(prefix);
                     returnString = prefix + namespaceSep + returnString;
+                }
+                //In case of JSON marshalling namespace separator there should different like '.', than  default in XPathFragment ':'.
+                //Namespace separator from there should be promoted to XPathFragment to correctly set localName.
+                if(namespaceSep != 0){
+                    frag.setNamespaceSeparator(namespaceSep);
                 }
             }
             frag.setXPath(returnString);

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/xmlvariablenode/rootqname2NS.json
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/xmlvariablenode/rootqname2NS.json
@@ -1,0 +1,5 @@
+{
+  "xxx.data": {
+    "xxx.childdata": {}
+  }
+}

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/xmlvariablenode/rootqname2NS.xml
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/xmlvariablenode/rootqname2NS.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0,
+    or the Eclipse Distribution License v. 1.0 which is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+    SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+-->
+
+<xxx:data xmlns:xxx="uri1:">
+    <xxx:childdata/>
+</xxx:data>

--- a/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/xmlvariablenode/rootqname2NSWrite.xml
+++ b/moxy/eclipselink.moxy.test/resource/org/eclipse/persistence/testing/jaxb/xmlvariablenode/rootqname2NSWrite.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0,
+    or the Eclipse Distribution License v. 1.0 which is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+    SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+-->
+
+<xxx:data xmlns:xxx="uri1:">
+    <xxx:childdata/>
+</xxx:data>

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlvariablenode/AllVariableElementTestCases.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlvariablenode/AllVariableElementTestCases.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -32,6 +32,7 @@ public class AllVariableElementTestCases extends TestSuite {
         suite.addTestSuite(XmlVariableNodeTestCases.class);
         suite.addTestSuite(XmlVariableNodeQNameTestCases.class);
         suite.addTestSuite(XmlVariableNodeQNameNSTestCases.class);
+        suite.addTestSuite(XmlVariableNodeQNameNS2TestCases.class);
         suite.addTestSuite(XmlVariableNodeTestCases.class);
         suite.addTestSuite(XmlVariableNodeArrayTestCases.class);
         suite.addTestSuite(XmlVariableNodeMapTestCases.class);

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlvariablenode/Data.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlvariablenode/Data.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - Sep 2022 - - initial implementation
+package org.eclipse.persistence.testing.jaxb.xmlvariablenode;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import org.eclipse.persistence.oxm.annotations.XmlVariableNode;
+
+@XmlRootElement(name = "data", namespace = "uri1:")
+public class Data {
+
+    public Data() {
+    }
+
+    private DataChild child;
+
+    @XmlVariableNode("name")
+    public DataChild getChild() {
+        return child;
+    }
+
+    public void setChild(DataChild child) {
+        this.child = child;
+    }
+
+    @Override
+    public String toString() {
+        return "Data{" +
+                "child=" + child +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Data data = (Data) o;
+        return child.equals(data.child);
+    }
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlvariablenode/DataChild.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlvariablenode/DataChild.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - Sep 2022 - - initial implementation
+package org.eclipse.persistence.testing.jaxb.xmlvariablenode;
+
+import javax.xml.bind.annotation.XmlTransient;
+
+import javax.xml.namespace.QName;
+
+public class DataChild {
+
+    public DataChild() {
+    }
+
+    public DataChild(QName name) {
+        this.name = name;
+    }
+
+    private QName name;
+
+    @XmlTransient
+    public QName getName() {
+        return name;
+    }
+
+    public void setName(QName name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "DataChild{" +
+                "name=" + name +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DataChild dataChild = (DataChild) o;
+        return name.equals(dataChild.name);
+    }
+}

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlvariablenode/XmlVariableNodeQNameNS2TestCases.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/xmlvariablenode/XmlVariableNodeQNameNS2TestCases.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - Sep 2022 - - initial implementation
+package org.eclipse.persistence.testing.jaxb.xmlvariablenode;
+
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.Unmarshaller;
+import org.eclipse.persistence.jaxb.JAXBContextProperties;
+import org.eclipse.persistence.jaxb.MarshallerProperties;
+import org.eclipse.persistence.jaxb.UnmarshallerProperties;
+import org.eclipse.persistence.oxm.MediaType;
+import org.eclipse.persistence.testing.jaxb.JAXBWithJSONTestCases;
+import org.w3c.dom.Document;
+
+import javax.xml.namespace.QName;
+import javax.xml.transform.dom.DOMSource;
+import java.io.ByteArrayInputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test for: Specifying QName in XmlVariableNode results namespace written twice
+ *
+ * https://github.com/eclipse-ee4j/eclipselink/issues/1709
+ */
+public class XmlVariableNodeQNameNS2TestCases extends JAXBWithJSONTestCases {
+    protected final static String XML_RESOURCE = "org/eclipse/persistence/testing/jaxb/xmlvariablenode/rootqname2NS.xml";
+    protected final static String XML_WRITE_RESOURCE = "org/eclipse/persistence/testing/jaxb/xmlvariablenode/rootqname2NSWrite.xml";
+    protected final static String JSON_RESOURCE = "org/eclipse/persistence/testing/jaxb/xmlvariablenode/rootqname2NS.json";
+
+    private Marshaller marshaller = null;
+    private Unmarshaller unmarshaller = null;
+
+
+    public XmlVariableNodeQNameNS2TestCases(String name) throws Exception {
+        super(name);
+        setControlDocument(XML_RESOURCE);
+        setControlJSON(JSON_RESOURCE);
+        setWriteControlDocument(XML_WRITE_RESOURCE);
+        setClasses(new Class<?>[]{Data.class, DataChild.class});
+
+    }
+
+    @Override
+    protected Marshaller getJSONMarshaller() throws Exception{
+        if (marshaller == null) {
+            Map<String, String> namespaces = new HashMap<>();
+            namespaces.put("uri1:", "xxx");
+            marshaller = jaxbContext.createMarshaller();
+            marshaller.setProperty(MarshallerProperties.MEDIA_TYPE, MediaType.APPLICATION_JSON);
+            marshaller.setProperty(MarshallerProperties.NAMESPACE_PREFIX_MAPPER, namespaces);
+        }
+        return marshaller;
+    }
+
+    @Override
+    protected Unmarshaller getJSONUnmarshaller() throws Exception{
+        if (unmarshaller == null) {
+            Map<String, String> namespaces = new HashMap<>();
+            namespaces.put("uri1:", "xxx");
+            unmarshaller = jaxbContext.createUnmarshaller();
+            unmarshaller.setProperty(UnmarshallerProperties.MEDIA_TYPE, MediaType.APPLICATION_JSON);
+            unmarshaller.setProperty(UnmarshallerProperties.JSON_NAMESPACE_PREFIX_MAPPER, namespaces);
+        }
+        return unmarshaller;
+    }
+
+    @Override
+    protected Map getProperties() {
+        Map overrides = new HashMap();
+        String overridesString =
+                "<?xml version='1.0' encoding='UTF-8'?>" +
+                        "<xml-bindings xmlns='http://www.eclipse.org/eclipselink/xsds/persistence/oxm'>" +
+                        "<xml-schema>" +
+                        "<xml-ns namespace-uri='uri1:' prefix='xxx'/>" +
+                        "</xml-schema>" +
+                        "<java-types/>" +
+                        "</xml-bindings>";
+
+        DOMSource src = null;
+        try {
+            Document doc = parser.parse(new ByteArrayInputStream(overridesString.getBytes()));
+            src = new DOMSource(doc.getDocumentElement());
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("An error occurred during setup");
+        }
+
+        overrides.put("org.eclipse.persistence.testing.jaxb.xmlvariablenode", src);
+
+        Map props = new HashMap();
+        props.put(JAXBContextProperties.OXM_METADATA_SOURCE, overrides);
+        return props;
+    }
+
+    @Override
+    protected Object getControlObject() {
+        Data data = new Data();
+        DataChild dataChild = new DataChild(new QName("uri1:", "childdata"));
+        data.setChild(dataChild);
+
+        return data;
+    }
+}


### PR DESCRIPTION
Fixes #1709

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>