### PR TITLE
Issue #1727 - Fixed missing default FQN entity alias name.

### DIFF
--- a/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpql/advanced/JUnitJPQLSimpleTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpql/advanced/JUnitJPQLSimpleTest.java
@@ -215,7 +215,10 @@ public class JUnitJPQLSimpleTest extends JUnitTestCase {
         suite.addTest(new JUnitJPQLSimpleTest("testOrderByWithParenthesesCalculatedAndNormalDefault"));
         suite.addTest(new JUnitJPQLSimpleTest("testOrderByWithParenthesesAllAttributes"));
         suite.addTest(new JUnitJPQLSimpleTest("testOrderByWithParenthesesAllAttributesHybrid"));
-        
+        // Issue #1727 - Error execution delete operation without identification_variable on FQN entity
+        suite.addTest(new JUnitJPQLSimpleTest("testDeleteFQNEntityNoAlias"));
+        suite.addTest(new JUnitJPQLSimpleTest("testDeleteFQNEntityAlias"));
+
         return suite;
     }
 
@@ -2632,5 +2635,43 @@ public class JUnitJPQLSimpleTest extends JUnitTestCase {
             closeEntityManager(em);
         }
     }
-    
+
+    /**
+     * Test simple DELETE query with fully qualified entity class name and no alias.
+     */
+    public void testDeleteFQEntityNoAlias() {
+        EntityManager em = createEntityManager();
+        beginTransaction(em);
+        try {
+            Query query = em.createQuery(
+                    "DELETE FROM org.eclipse.persistence.testing.models.jpa.advanced.Employee " +
+                            "WHERE firstName = :fName AND lastName = :lName");
+            query.setParameter("fName", "Peter");
+            query.setParameter("lName", "Parker");
+            query.executeUpdate();
+        } finally {
+            rollbackTransaction(em);
+            closeEntityManager(em);
+        }
+    }
+
+    /**
+     * Test simple DELETE query with fully qualified entity class name and an alias.
+     */
+    public void testDeleteFQEntityAlias() {
+        EntityManager em = createEntityManager();
+        beginTransaction(em);
+        try {
+            Query query = em.createQuery(
+                    "DELETE FROM org.eclipse.persistence.testing.models.jpa.advanced.Employee e " +
+                            "WHERE e.firstName = :fName AND e.lastName = :lName");
+            query.setParameter("fName", "Peter");
+            query.setParameter("lName", "Parker");
+            query.executeUpdate();
+        } finally {
+            rollbackTransaction(em);
+            closeEntityManager(em);
+        }
+    }
+
 }

--- a/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpql/advanced/JUnitJPQLSimpleTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpql/advanced/JUnitJPQLSimpleTest.java
@@ -2639,7 +2639,7 @@ public class JUnitJPQLSimpleTest extends JUnitTestCase {
     /**
      * Test simple DELETE query with fully qualified entity class name and no alias.
      */
-    public void testDeleteFQEntityNoAlias() {
+    public void testDeleteFQNEntityNoAlias() {
         EntityManager em = createEntityManager();
         beginTransaction(em);
         try {
@@ -2658,7 +2658,7 @@ public class JUnitJPQLSimpleTest extends JUnitTestCase {
     /**
      * Test simple DELETE query with fully qualified entity class name and an alias.
      */
-    public void testDeleteFQEntityAlias() {
+    public void testDeleteFQNEntityAlias() {
         EntityManager em = createEntityManager();
         beginTransaction(em);
         try {

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/FullyQualifyPathExpressionVisitor.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/FullyQualifyPathExpressionVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -68,6 +68,7 @@ public final class FullyQualifyPathExpressionVisitor extends AbstractTraverseChi
     @Override
     public void visit(CollectionValuedPathExpression expression) {
         visitAbstractPathExpression(expression);
+        variableName = expression.toActualText().toLowerCase(Locale.ROOT);
     }
 
     @Override


### PR DESCRIPTION
NPE was caused my missing alias name. 
As you can see in `public void visit(AbstractSchemaName expression)`, which is being called for entity without FQN, default alias name is initialized there.
In `public void visit(CollectionValuedPathExpression expression)`, which is used for FQN entity name there was no default alias name initialization.