### PR TITLE
Correctly handle times after noon

### DIFF
--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/identitymaps/cacheinvalidation/CacheInvalidationPolicyCloneTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/identitymaps/cacheinvalidation/CacheInvalidationPolicyCloneTest.java
@@ -54,7 +54,7 @@ public class CacheInvalidationPolicyCloneTest extends TestCase {
             assertFalse("Clone should not be the same instance", policy == policyClone);
             assertEquals("Clone should be of the same type", policy.getClass(), policyClone.getClass());
             assertEquals("Clone's expiry time should be the same", policy.getExpiryTime().getTimeInMillis(), policyClone.getExpiryTime().getTimeInMillis());
-            assertEquals("Clone's expiry time should be 01:02:03.004 - hour", 1, policyClone.getExpiryTime().get(Calendar.HOUR));
+            assertEquals("Clone's expiry time should be 01:02:03.004 - hour", 1, policyClone.getExpiryTime().get(Calendar.HOUR_OF_DAY));
             assertEquals("Clone's expiry time should be 01:02:03.004 - minute", 2, policyClone.getExpiryTime().get(Calendar.MINUTE));
             assertEquals("Clone's expiry time should be 01:02:03.004 - second", 3, policyClone.getExpiryTime().get(Calendar.SECOND));
             assertEquals("Clone's expiry time should be 01:02:03.004 - millisecond", 4, policyClone.getExpiryTime().get(Calendar.MILLISECOND));

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/performance/java/DatePrintingTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/performance/java/DatePrintingTest.java
@@ -59,7 +59,7 @@ public class DatePrintingTest extends PerformanceComparisonTestCase {
                 writer.write(String.valueOf(calendar.get(Calendar.YEAR)));
                 writer.write(String.valueOf(calendar.get(Calendar.DATE)));
                 writer.write(String.valueOf(calendar.get(Calendar.MONTH)));
-                writer.write(String.valueOf(calendar.get(Calendar.HOUR)));
+                writer.write(String.valueOf(calendar.get(Calendar.HOUR_OF_DAY)));
                 writer.write(String.valueOf(calendar.get(Calendar.MINUTE)));
                 writer.write(String.valueOf(calendar.get(Calendar.SECOND)));
                 writer.toString();

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/types/TimeDateTester.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/types/TimeDateTester.java
@@ -50,7 +50,7 @@ public class TimeDateTester extends TypeTester {
     }
 
     public TimeDateTester(String nameOfTest, Calendar dateTime) {
-        this(nameOfTest, dateTime.get(Calendar.YEAR), dateTime.get(Calendar.MONTH), dateTime.get(Calendar.DATE), dateTime.get(Calendar.HOUR), dateTime.get(Calendar.MINUTE), dateTime.get(Calendar.SECOND), 0);
+        this(nameOfTest, dateTime.get(Calendar.YEAR), dateTime.get(Calendar.MONTH), dateTime.get(Calendar.DATE), dateTime.get(Calendar.HOUR_OF_DAY), dateTime.get(Calendar.MINUTE), dateTime.get(Calendar.SECOND), 0);
     }
 
     public static RelationalDescriptor descriptor() {

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ConversionManager.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ConversionManager.java
@@ -906,12 +906,12 @@ public class ConversionManager extends CoreConversionManager implements Serializ
             Calendar cal = Helper.allocateCalendar();
             cal.setTime((java.util.Date) sourceObject);
             localTime = java.time.LocalTime.of(
-                    cal.get(Calendar.HOUR), cal.get(Calendar.MINUTE), cal.get(Calendar.SECOND), cal.get(Calendar.MILLISECOND));
+                    cal.get(Calendar.HOUR_OF_DAY), cal.get(Calendar.MINUTE), cal.get(Calendar.SECOND), cal.get(Calendar.MILLISECOND));
             Helper.releaseCalendar(cal);
         } else if (sourceObject instanceof Calendar) {
             Calendar cal = (Calendar) sourceObject;
             localTime = java.time.LocalTime.of(
-                    cal.get(Calendar.HOUR), cal.get(Calendar.MINUTE), cal.get(Calendar.SECOND), cal.get(Calendar.MILLISECOND));
+                    cal.get(Calendar.HOUR_OF_DAY), cal.get(Calendar.MINUTE), cal.get(Calendar.SECOND), cal.get(Calendar.MILLISECOND));
         } else if (sourceObject instanceof Long) {
             localTime = java.time.LocalTime.ofSecondOfDay((Long) sourceObject);
         } else {
@@ -946,13 +946,13 @@ public class ConversionManager extends CoreConversionManager implements Serializ
             cal.setTime((java.util.Date) sourceObject);
             localDateTime = java.time.LocalDateTime.of(
                     cal.get(Calendar.YEAR), cal.get(Calendar.MONTH) + 1, cal.get(Calendar.DAY_OF_MONTH),
-                    cal.get(Calendar.HOUR), cal.get(Calendar.MINUTE), cal.get(Calendar.SECOND), cal.get(Calendar.MILLISECOND));
+                    cal.get(Calendar.HOUR_OF_DAY), cal.get(Calendar.MINUTE), cal.get(Calendar.SECOND), cal.get(Calendar.MILLISECOND));
             Helper.releaseCalendar(cal);
         } else if (sourceObject instanceof Calendar) {
             Calendar cal = (Calendar) sourceObject;
             localDateTime = java.time.LocalDateTime.of(
                     cal.get(Calendar.YEAR), cal.get(Calendar.MONTH) + 1, cal.get(Calendar.DAY_OF_MONTH),
-                    cal.get(Calendar.HOUR), cal.get(Calendar.MINUTE), cal.get(Calendar.SECOND), cal.get(Calendar.MILLISECOND));
+                    cal.get(Calendar.HOUR_OF_DAY), cal.get(Calendar.MINUTE), cal.get(Calendar.SECOND), cal.get(Calendar.MILLISECOND));
         } else if (sourceObject instanceof Long) {
             localDateTime = java.time.LocalDateTime.ofInstant(
                     java.time.Instant.ofEpochSecond((Long) sourceObject), getDefaultZoneOffset());
@@ -987,14 +987,14 @@ public class ConversionManager extends CoreConversionManager implements Serializ
             cal.setTime((java.util.Date) sourceObject);
             offsetDateTime = java.time.OffsetDateTime.of(
                     cal.get(Calendar.YEAR), cal.get(Calendar.MONTH) + 1, cal.get(Calendar.DAY_OF_MONTH),
-                    cal.get(Calendar.HOUR), cal.get(Calendar.MINUTE), cal.get(Calendar.SECOND), cal.get(Calendar.MILLISECOND) * 1000000,
+                    cal.get(Calendar.HOUR_OF_DAY), cal.get(Calendar.MINUTE), cal.get(Calendar.SECOND), cal.get(Calendar.MILLISECOND) * 1000000,
                     java.time.ZoneOffset.ofTotalSeconds((cal.get(Calendar.ZONE_OFFSET) + cal.get(Calendar.DST_OFFSET)) / 1000));
             Helper.releaseCalendar(cal);
         } else if (sourceObject instanceof Calendar) {
             Calendar cal = (Calendar) sourceObject;
             offsetDateTime = java.time.OffsetDateTime.of(
                     cal.get(Calendar.YEAR), cal.get(Calendar.MONTH) + 1, cal.get(Calendar.DAY_OF_MONTH),
-                    cal.get(Calendar.HOUR), cal.get(Calendar.MINUTE), cal.get(Calendar.SECOND), cal.get(Calendar.MILLISECOND)  * 1000000,
+                    cal.get(Calendar.HOUR_OF_DAY), cal.get(Calendar.MINUTE), cal.get(Calendar.SECOND), cal.get(Calendar.MILLISECOND)  * 1000000,
                     java.time.ZoneOffset.ofTotalSeconds((cal.get(Calendar.ZONE_OFFSET) + cal.get(Calendar.DST_OFFSET)) / 1000));
         } else if (sourceObject instanceof Long) {
             offsetDateTime = java.time.OffsetDateTime.ofInstant(
@@ -1033,13 +1033,13 @@ public class ConversionManager extends CoreConversionManager implements Serializ
             Calendar cal = Helper.allocateCalendar();
             cal.setTime((java.util.Date) sourceObject);
             offsetTime = java.time.OffsetTime.of(
-                    cal.get(Calendar.HOUR), cal.get(Calendar.MINUTE), cal.get(Calendar.SECOND), cal.get(Calendar.MILLISECOND),
+                    cal.get(Calendar.HOUR_OF_DAY), cal.get(Calendar.MINUTE), cal.get(Calendar.SECOND), cal.get(Calendar.MILLISECOND),
                     java.time.ZoneOffset.ofTotalSeconds((cal.get(Calendar.ZONE_OFFSET) + cal.get(Calendar.DST_OFFSET)) / 1000));
             Helper.releaseCalendar(cal);
         } else if (sourceObject instanceof Calendar) {
             Calendar cal = (Calendar) sourceObject;
             offsetTime = java.time.OffsetTime.of(
-                    cal.get(Calendar.HOUR), cal.get(Calendar.MINUTE), cal.get(Calendar.SECOND), cal.get(Calendar.MILLISECOND),
+                    cal.get(Calendar.HOUR_OF_DAY), cal.get(Calendar.MINUTE), cal.get(Calendar.SECOND), cal.get(Calendar.MILLISECOND),
                     java.time.ZoneOffset.ofTotalSeconds((cal.get(Calendar.ZONE_OFFSET) + cal.get(Calendar.DST_OFFSET)) / 1000));
         } else if (sourceObject instanceof Long) {
             offsetTime = java.time.OffsetTime.ofInstant(

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/oxm/XMLConversionManager.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/oxm/XMLConversionManager.java
@@ -1175,7 +1175,7 @@ public class XMLConversionManager extends ConversionManager implements org.eclip
     }
 
     private String stringFromCalendar(Calendar sourceCalendar) {
-        if (!(sourceCalendar.isSet(Calendar.HOUR) || sourceCalendar.isSet(Calendar.MINUTE) || sourceCalendar.isSet(Calendar.SECOND) || sourceCalendar.isSet(Calendar.MILLISECOND))) {
+        if (!(sourceCalendar.isSet(Calendar.HOUR_OF_DAY) || sourceCalendar.isSet(Calendar.MINUTE) || sourceCalendar.isSet(Calendar.SECOND) || sourceCalendar.isSet(Calendar.MILLISECOND))) {
             return stringFromCalendar(sourceCalendar, Constants.DATE_QNAME);
         } else if (!(sourceCalendar.isSet(Calendar.YEAR) || sourceCalendar.isSet(Calendar.MONTH) || sourceCalendar.isSet(Calendar.DATE))) {
             return stringFromCalendar(sourceCalendar, Constants.TIME_QNAME);

--- a/foundation/org.eclipse.persistence.core/src/test/java/org/eclipse/persistence/testing/oxm/mappings/typeddirect/TypedDirectMappingTestCases.java
+++ b/foundation/org.eclipse.persistence.core/src/test/java/org/eclipse/persistence/testing/oxm/mappings/typeddirect/TypedDirectMappingTestCases.java
@@ -115,13 +115,13 @@ public class TypedDirectMappingTestCases extends XMLMappingTestCases {
 
             parsedDate = new SimpleDateFormat(DATE_FORMAT).parse("2013-02-17");
             date = Calendar.getInstance();
-            date.setTime(parsedDate); date.clear(Calendar.HOUR); date.clear(Calendar.MINUTE); date.clear(Calendar.SECOND); date.clear(Calendar.MILLISECOND); date.clear(Calendar.ZONE_OFFSET);
+            date.setTime(parsedDate); date.clear(Calendar.HOUR_OF_DAY); date.clear(Calendar.MINUTE); date.clear(Calendar.SECOND); date.clear(Calendar.MILLISECOND); date.clear(Calendar.ZONE_OFFSET);
             parsedDate = new SimpleDateFormat(DATE_FORMAT).parse("2013-04-09");
             date2 = Calendar.getInstance();
-            date2.setTime(parsedDate); date2.clear(Calendar.HOUR); date2.clear(Calendar.MINUTE); date2.clear(Calendar.SECOND); date2.clear(Calendar.MILLISECOND); date2.clear(Calendar.ZONE_OFFSET);
+            date2.setTime(parsedDate); date2.clear(Calendar.HOUR_OF_DAY); date2.clear(Calendar.MINUTE); date2.clear(Calendar.SECOND); date2.clear(Calendar.MILLISECOND); date2.clear(Calendar.ZONE_OFFSET);
             parsedDate = new SimpleDateFormat(DATE_FORMAT).parse("2013-04-18");
             date3 = Calendar.getInstance();
-            date3.setTime(parsedDate); date3.clear(Calendar.HOUR); date3.clear(Calendar.MINUTE); date3.clear(Calendar.SECOND); date3.clear(Calendar.MILLISECOND); date3.clear(Calendar.ZONE_OFFSET);
+            date3.setTime(parsedDate); date3.clear(Calendar.HOUR_OF_DAY); date3.clear(Calendar.MINUTE); date3.clear(Calendar.SECOND); date3.clear(Calendar.MILLISECOND); date3.clear(Calendar.ZONE_OFFSET);
 
             parsedDate = new SimpleDateFormat(DATE_TIME_FORMAT).parse("2013-02-17T23:21:00");
             dateTime = Calendar.getInstance(); dateTime.clear();

--- a/foundation/org.eclipse.persistence.core/src/test/java/org/eclipse/persistence/testing/oxm/xmlconversionmanager/DateAndTimeTestCases.java
+++ b/foundation/org.eclipse.persistence.core/src/test/java/org/eclipse/persistence/testing/oxm/xmlconversionmanager/DateAndTimeTestCases.java
@@ -2867,7 +2867,7 @@ public class DateAndTimeTestCases extends OXTestCase {
     public void testCalendarToString_default_time_0ms() {
         Calendar calendar = Calendar.getInstance();
         calendar.clear();
-        calendar.set(Calendar.HOUR, 7);
+        calendar.set(Calendar.HOUR_OF_DAY, 7);
         calendar.set(Calendar.MINUTE, 47);
         calendar.set(Calendar.SECOND, 15);
         calendar.set(Calendar.MILLISECOND, 0);
@@ -2879,7 +2879,7 @@ public class DateAndTimeTestCases extends OXTestCase {
     public void testCalendarToString_default_time_1ms() {
         Calendar calendar = Calendar.getInstance();
         calendar.clear();
-        calendar.set(Calendar.HOUR, 7);
+        calendar.set(Calendar.HOUR_OF_DAY, 7);
         calendar.set(Calendar.MINUTE, 47);
         calendar.set(Calendar.SECOND, 15);
         calendar.set(Calendar.MILLISECOND, 1);
@@ -2891,7 +2891,7 @@ public class DateAndTimeTestCases extends OXTestCase {
     public void testCalendarToString_default_time_10ms() {
         Calendar calendar = Calendar.getInstance();
         calendar.clear();
-        calendar.set(Calendar.HOUR, 7);
+        calendar.set(Calendar.HOUR_OF_DAY, 7);
         calendar.set(Calendar.MINUTE, 47);
         calendar.set(Calendar.SECOND, 15);
         calendar.set(Calendar.MILLISECOND, 10);
@@ -2903,7 +2903,7 @@ public class DateAndTimeTestCases extends OXTestCase {
     public void testCalendarToString_default_time_100ms() {
         Calendar calendar = Calendar.getInstance();
         calendar.clear();
-        calendar.set(Calendar.HOUR, 7);
+        calendar.set(Calendar.HOUR_OF_DAY, 7);
         calendar.set(Calendar.MINUTE, 47);
         calendar.set(Calendar.SECOND, 15);
         calendar.set(Calendar.MILLISECOND, 100);
@@ -3786,7 +3786,7 @@ public class DateAndTimeTestCases extends OXTestCase {
         cal.set(Calendar.YEAR, 0001);
         cal.set(Calendar.MONTH, Calendar.JANUARY);
         cal.set(Calendar.DAY_OF_MONTH, 1);
-        cal.set(Calendar.HOUR, 1);
+        cal.set(Calendar.HOUR_OF_DAY, 1);
         cal.set(Calendar.MINUTE, 1);
         cal.set(Calendar.SECOND, 1);
         cal.set(Calendar.MILLISECOND, 1);
@@ -3818,7 +3818,7 @@ public class DateAndTimeTestCases extends OXTestCase {
         cal.set(Calendar.YEAR, 0001);
         cal.set(Calendar.MONTH, Calendar.JANUARY);
         cal.set(Calendar.DAY_OF_MONTH, 1);
-        cal.set(Calendar.HOUR, 1);
+        cal.set(Calendar.HOUR_OF_DAY, 1);
         cal.set(Calendar.MINUTE, 1);
         cal.set(Calendar.SECOND, 1);
         cal.set(Calendar.MILLISECOND, 1);
@@ -3857,7 +3857,7 @@ public class DateAndTimeTestCases extends OXTestCase {
         cal.set(Calendar.YEAR, 0001);
         cal.set(Calendar.MONTH, Calendar.JANUARY);
         cal.set(Calendar.DAY_OF_MONTH, 1);
-        cal.set(Calendar.HOUR, 1);
+        cal.set(Calendar.HOUR_OF_DAY, 1);
         cal.set(Calendar.MINUTE, 1);
         cal.set(Calendar.SECOND, 1);
         cal.set(Calendar.MILLISECOND, 1);
@@ -3876,7 +3876,7 @@ public class DateAndTimeTestCases extends OXTestCase {
         cal.set(Calendar.YEAR, 0001);
         cal.set(Calendar.MONTH, Calendar.JANUARY);
         cal.set(Calendar.DAY_OF_MONTH, 1);
-        cal.set(Calendar.HOUR, 1);
+        cal.set(Calendar.HOUR_OF_DAY, 1);
         cal.set(Calendar.MINUTE, 1);
         cal.set(Calendar.SECOND, 1);
         cal.set(Calendar.MILLISECOND, 1);
@@ -3912,7 +3912,7 @@ public class DateAndTimeTestCases extends OXTestCase {
         cal.set(Calendar.YEAR, 0001);
         cal.set(Calendar.MONTH, Calendar.JANUARY);
         cal.set(Calendar.DAY_OF_MONTH, 1);
-        cal.set(Calendar.HOUR, 1);
+        cal.set(Calendar.HOUR_OF_DAY, 1);
         cal.set(Calendar.MINUTE, 1);
         cal.set(Calendar.SECOND, 1);
         cal.set(Calendar.MILLISECOND, 1);
@@ -3944,7 +3944,7 @@ public class DateAndTimeTestCases extends OXTestCase {
         cal.set(Calendar.YEAR, 0001);
         cal.set(Calendar.MONTH, Calendar.JANUARY);
         cal.set(Calendar.DAY_OF_MONTH, 1);
-        cal.set(Calendar.HOUR, 1);
+        cal.set(Calendar.HOUR_OF_DAY, 1);
         cal.set(Calendar.MINUTE, 1);
         cal.set(Calendar.SECOND, 1);
         cal.set(Calendar.MILLISECOND, 1);
@@ -3963,7 +3963,7 @@ public class DateAndTimeTestCases extends OXTestCase {
         cal.set(Calendar.YEAR, 0001);
         cal.set(Calendar.MONTH, Calendar.JANUARY);
         cal.set(Calendar.DAY_OF_MONTH, 1);
-        cal.set(Calendar.HOUR, 1);
+        cal.set(Calendar.HOUR_OF_DAY, 1);
         cal.set(Calendar.MINUTE, 1);
         cal.set(Calendar.SECOND, 1);
         cal.set(Calendar.MILLISECOND, 1);
@@ -3981,7 +3981,7 @@ public class DateAndTimeTestCases extends OXTestCase {
         cal.set(Calendar.YEAR, 0001);
         cal.set(Calendar.MONTH, Calendar.JANUARY);
         cal.set(Calendar.DAY_OF_MONTH, 1);
-        cal.set(Calendar.HOUR, 1);
+        cal.set(Calendar.HOUR_OF_DAY, 1);
         cal.set(Calendar.MINUTE, 1);
         cal.set(Calendar.SECOND, 1);
         cal.set(Calendar.MILLISECOND, 1);
@@ -4010,7 +4010,7 @@ public class DateAndTimeTestCases extends OXTestCase {
         
         Calendar cal = Calendar.getInstance();
         cal.clear();
-        cal.set(Calendar.HOUR, 1);
+        cal.set(Calendar.HOUR_OF_DAY, 1);
         cal.set(Calendar.MINUTE, 1);
         cal.set(Calendar.SECOND, 1);
         cal.set(Calendar.MILLISECOND, 1);

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/conversion/TestJavaTimeTypeConverter.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/conversion/TestJavaTimeTypeConverter.java
@@ -29,7 +29,6 @@ import java.time.OffsetTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.time.temporal.TemporalField;
 import java.util.Calendar;
 import java.util.Date;
 
@@ -150,7 +149,7 @@ public class TestJavaTimeTypeConverter {
     // LocalDateTime
     @Test
     public void timeConvertLocalDateTimeToLocalDateTime() {
-        LocalDateTime src = LocalDateTime.of(2020, 1, 1, 1, 0, 0);
+        LocalDateTime src = LocalDateTime.of(2020, 1, 1, 16, 0, 0);
         LocalDateTime ld = cm.convertObject(src, ClassConstants.TIME_LDATETIME);
         
         Assert.assertNotNull(ld);
@@ -158,21 +157,21 @@ public class TestJavaTimeTypeConverter {
         Assert.assertEquals(Month.JANUARY, ld.getMonth());
         Assert.assertEquals(1, ld.getDayOfMonth());
         Assert.assertEquals(2020,  ld.getYear());
-        Assert.assertEquals(1, ld.getHour());
+        Assert.assertEquals(16, ld.getHour());
         Assert.assertEquals(0, ld.getMinute());
         Assert.assertEquals(0, ld.getSecond());
     }
     
     @Test
     public void timeConvertStringToLocalDateTime() {
-        String date = "2020-01-01T1:15:30";
+        String date = "2020-01-01T16:15:30";
         LocalDateTime ld = cm.convertObject(date, ClassConstants.TIME_LDATETIME);
         
         Assert.assertNotNull(ld);
         Assert.assertEquals(Month.JANUARY, ld.getMonth());
         Assert.assertEquals(1, ld.getDayOfMonth());
         Assert.assertEquals(2020,  ld.getYear());
-        Assert.assertEquals(1, ld.getHour());
+        Assert.assertEquals(16, ld.getHour());
         Assert.assertEquals(15, ld.getMinute());
         Assert.assertEquals(30, ld.getSecond());
     }
@@ -183,7 +182,7 @@ public class TestJavaTimeTypeConverter {
         java.util.Date date = null;
         LocalDateTime ldt = null;
         
-        cal.set(2020, 0, 1, 2, 15, 30);
+        cal.set(2020, 0, 1, 16, 15, 30);
         date = cal.getTime();
                
         ldt = cm.convertObject(date, ClassConstants.TIME_LDATETIME);
@@ -192,7 +191,7 @@ public class TestJavaTimeTypeConverter {
         Assert.assertEquals(Month.JANUARY, ldt.getMonth());
         Assert.assertEquals(1, ldt.getDayOfMonth());
         Assert.assertEquals(2020,  ldt.getYear());
-        Assert.assertEquals(2, ldt.getHour());
+        Assert.assertEquals(16, ldt.getHour());
         Assert.assertEquals(15, ldt.getMinute());
         Assert.assertEquals(30, ldt.getSecond());
     }
@@ -200,7 +199,7 @@ public class TestJavaTimeTypeConverter {
     @Test
     public void timeConvertCalendarToLocalDateTime() {
         Calendar cal = Calendar.getInstance();
-        cal.set(2020, 0, 1, 2, 15, 30);
+        cal.set(2020, 0, 1, 16, 15, 30);
         
         LocalDateTime ldt = cm.convertObject(cal, ClassConstants.TIME_LDATETIME);
         
@@ -208,7 +207,7 @@ public class TestJavaTimeTypeConverter {
         Assert.assertEquals(Month.JANUARY, ldt.getMonth());
         Assert.assertEquals(1, ldt.getDayOfMonth());
         Assert.assertEquals(2020,  ldt.getYear());
-        Assert.assertEquals(2, ldt.getHour());
+        Assert.assertEquals(16, ldt.getHour());
         Assert.assertEquals(15, ldt.getMinute());
         Assert.assertEquals(30, ldt.getSecond());
     }
@@ -239,47 +238,47 @@ public class TestJavaTimeTypeConverter {
     // LocalTime
     @Test
     public void timeConvertLocalTimeToLocalTime() {
-        LocalTime src = LocalTime.of(1, 15, 30);
+        LocalTime src = LocalTime.of(16, 15, 30);
         LocalTime ld = cm.convertObject(src, ClassConstants.TIME_LTIME);
         
         Assert.assertNotNull(ld);
         Assert.assertEquals(src, ld);
-        Assert.assertEquals(1, ld.getHour());
+        Assert.assertEquals(16, ld.getHour());
         Assert.assertEquals(15, ld.getMinute());
         Assert.assertEquals(30, ld.getSecond());
     }
     
     @Test
     public void timeConvertStringToLocalTime() {
-        String date = "T1:15:30";
+        String date = "T16:15:30";
         LocalTime ld = cm.convertObject(date, ClassConstants.TIME_LTIME);
         
         Assert.assertNotNull(ld);
-        Assert.assertEquals(1, ld.getHour());
+        Assert.assertEquals(16, ld.getHour());
         Assert.assertEquals(15, ld.getMinute());
         Assert.assertEquals(30, ld.getSecond());
     }
     
     @Test
     public void timeConvertTimestampToLocalTime() {
-        java.sql.Timestamp ts = java.sql.Timestamp.valueOf("2020-01-01 01:15:30");
+        java.sql.Timestamp ts = java.sql.Timestamp.valueOf("2020-01-01 16:15:30");
         
         LocalTime ld = cm.convertObject(ts, ClassConstants.TIME_LTIME);
         
         Assert.assertNotNull(ld);
-        Assert.assertEquals(1, ld.getHour());
+        Assert.assertEquals(16, ld.getHour());
         Assert.assertEquals(15, ld.getMinute());
         Assert.assertEquals(30, ld.getSecond());
     }
     
     @Test
     public void timeConvertTimeToLocalTime() {
-        java.sql.Time ts = java.sql.Time.valueOf("01:15:30");
+        java.sql.Time ts = java.sql.Time.valueOf("16:15:30");
         
         LocalTime ld = cm.convertObject(ts, ClassConstants.TIME_LTIME);
         
         Assert.assertNotNull(ld);
-        Assert.assertEquals(1, ld.getHour());
+        Assert.assertEquals(16, ld.getHour());
         Assert.assertEquals(15, ld.getMinute());
         Assert.assertEquals(30, ld.getSecond());
     }
@@ -290,24 +289,24 @@ public class TestJavaTimeTypeConverter {
         java.util.Date date = null;
         LocalTime ld = null;
         
-        cal.set(2020, 0, 1, 2, 15, 30);
+        cal.set(2020, 0, 1, 16, 15, 30);
         date = cal.getTime();
                
         ld = cm.convertObject(date, ClassConstants.TIME_LTIME);
         
         Assert.assertNotNull(ld);
-        Assert.assertEquals(2, ld.getHour());
+        Assert.assertEquals(16, ld.getHour());
         Assert.assertEquals(15, ld.getMinute());
         Assert.assertEquals(30, ld.getSecond());
     }
     
     @Test
     public void convertLongToLocalTime() {
-        long sod = 60*60 + 60*15 + 30;
+        long sod = 16*60*60 + 60*15 + 30;
         LocalTime ld = cm.convertObject(sod, ClassConstants.TIME_LTIME);
         
         Assert.assertNotNull(ld);
-        Assert.assertEquals(1, ld.getHour());
+        Assert.assertEquals(16, ld.getHour());
         Assert.assertEquals(15, ld.getMinute());
         Assert.assertEquals(30, ld.getSecond());
     }
@@ -329,7 +328,7 @@ public class TestJavaTimeTypeConverter {
     @Test
     public void timeConvertCalendarToOffsetDateTime() {
         Calendar cal = Calendar.getInstance();
-        cal.set(2020, 0, 1, 0, 0, 0);
+        cal.set(2020, 0, 1, 16, 15, 30);
         
         OffsetDateTime odt = cm.convertObject(cal, ClassConstants.TIME_ODATETIME);
         
@@ -337,6 +336,9 @@ public class TestJavaTimeTypeConverter {
         Assert.assertEquals(Month.JANUARY, odt.getMonth());
         Assert.assertEquals(1, odt.getDayOfMonth());
         Assert.assertEquals(2020,  odt.getYear());
+        Assert.assertEquals(16, odt.getHour());
+        Assert.assertEquals(15, odt.getMinute());
+        Assert.assertEquals(30, odt.getSecond());
     }
     
     @Test
@@ -345,7 +347,7 @@ public class TestJavaTimeTypeConverter {
         java.util.Date date = null;
         OffsetDateTime odt = null;
         
-        cal.set(2020, 0, 1, 0, 0, 0);
+        cal.set(2020, 0, 1, 16, 15, 30);
         date = cal.getTime();
                
         odt = cm.convertObject(date, ClassConstants.TIME_ODATETIME);
@@ -354,11 +356,14 @@ public class TestJavaTimeTypeConverter {
         Assert.assertEquals(Month.JANUARY, odt.getMonth());
         Assert.assertEquals(1, odt.getDayOfMonth());
         Assert.assertEquals(2020,  odt.getYear());
+        Assert.assertEquals(16, odt.getHour());
+        Assert.assertEquals(15, odt.getMinute());
+        Assert.assertEquals(30, odt.getSecond());
     }
     
     @Test
     public void timeConvertStringToOffsetDateTime() {
-        String date = "2020-01-01T1:15:30";
+        String date = "2020-01-01T16:15:30";
         OffsetDateTime odt = null;
                
         odt = cm.convertObject(date, ClassConstants.TIME_ODATETIME);
@@ -367,14 +372,14 @@ public class TestJavaTimeTypeConverter {
         Assert.assertEquals(Month.JANUARY, odt.getMonth());
         Assert.assertEquals(1, odt.getDayOfMonth());
         Assert.assertEquals(2020,  odt.getYear());
-        Assert.assertEquals(1, odt.getHour());
+        Assert.assertEquals(16, odt.getHour());
         Assert.assertEquals(15,  odt.getMinute());
         Assert.assertEquals(30, odt.getSecond());
     }
     
     @Test
     public void timeConvertOffsetDateTimeToOffsetDateTime() {
-        OffsetDateTime original = OffsetDateTime.of(2020, 1, 1, 1, 15, 30, 0, ZoneOffset.UTC);
+        OffsetDateTime original = OffsetDateTime.of(2020, 1, 1, 16, 15, 30, 0, ZoneOffset.UTC);
         OffsetDateTime odt = null;
                
         odt = cm.convertObject(original, ClassConstants.TIME_ODATETIME);
@@ -384,7 +389,7 @@ public class TestJavaTimeTypeConverter {
         Assert.assertEquals(Month.JANUARY, odt.getMonth());
         Assert.assertEquals(1, odt.getDayOfMonth());
         Assert.assertEquals(2020,  odt.getYear());
-        Assert.assertEquals(1, odt.getHour());
+        Assert.assertEquals(16, odt.getHour());
         Assert.assertEquals(15,  odt.getMinute());
         Assert.assertEquals(30, odt.getSecond());
     }
@@ -405,27 +410,27 @@ public class TestJavaTimeTypeConverter {
     
     @Test
     public void timeConvertOffsetTimeToOffsetTime() {
-        OffsetTime original = OffsetTime.of(1, 15, 30, 0, ZoneOffset.UTC);
+        OffsetTime original = OffsetTime.of(16, 15, 30, 0, ZoneOffset.UTC);
         OffsetTime odt = null;
                
         odt = cm.convertObject(original, ClassConstants.TIME_OTIME);
         
         Assert.assertNotNull(odt);
         Assert.assertSame(original,  odt);
-        Assert.assertEquals(1, odt.getHour());
+        Assert.assertEquals(16, odt.getHour());
         Assert.assertEquals(15,  odt.getMinute());
         Assert.assertEquals(30, odt.getSecond());
     }
     
     @Test
     public void timeConvertStringToOffsetTime() {
-        String date = "T1:15:30";
+        String date = "T16:15:30";
         OffsetTime odt = null;
                
         odt = cm.convertObject(date, ClassConstants.TIME_OTIME);
         
         Assert.assertNotNull(odt);
-        Assert.assertEquals(1, odt.getHour());
+        Assert.assertEquals(16, odt.getHour());
         Assert.assertEquals(15,  odt.getMinute());
         Assert.assertEquals(30, odt.getSecond());
     }
@@ -436,13 +441,13 @@ public class TestJavaTimeTypeConverter {
         java.util.Date date = null;
         OffsetTime odt = null;
         
-        cal.set(2020, 0, 1, 1, 15, 30);
+        cal.set(2020, 0, 1, 16, 15, 30);
         date = cal.getTime();
                
         odt = cm.convertObject(date, ClassConstants.TIME_OTIME);
         
         Assert.assertNotNull(odt);
-        Assert.assertEquals(1, odt.getHour());
+        Assert.assertEquals(16, odt.getHour());
         Assert.assertEquals(15,  odt.getMinute());
         Assert.assertEquals(30, odt.getSecond());
     }
@@ -450,23 +455,23 @@ public class TestJavaTimeTypeConverter {
     @Test
     public void timeConvertCalendarToOffsetTime() {
         Calendar cal = Calendar.getInstance();
-        cal.set(2020, 0, 1, 1, 15, 30);
+        cal.set(2020, 0, 1, 16, 15, 30);
         
         OffsetTime odt = cm.convertObject(cal, ClassConstants.TIME_OTIME);
         
         Assert.assertNotNull(odt);
-        Assert.assertEquals(1, odt.getHour());
+        Assert.assertEquals(16, odt.getHour());
         Assert.assertEquals(15,  odt.getMinute());
         Assert.assertEquals(30, odt.getSecond());
     }
     
     @Test
     public void testConvertLongToOffsetTime() {
-        long l = 18262 * (60 * 60 * 24) + (60*60 + 60*15 + 30); // 2020-01-01  T01:15:30     
+        long l = 18262 * (60 * 60 * 24) + (16*60*60 + 60*15 + 30); // 2020-01-01  T16:15:30     
         OffsetTime ldt = cm.convertObject(l, ClassConstants.TIME_OTIME);
         
         Assert.assertNotNull(ldt);
-        Assert.assertEquals(1, ldt.getHour());
+        Assert.assertEquals(16, ldt.getHour());
         Assert.assertEquals(15,  ldt.getMinute());
         Assert.assertEquals(30, ldt.getSecond());
     }

--- a/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.timestamptz/src/test/java/org/eclipse/persistence/testing/tests/jpa/timestamptz/TimeStampTZTest.java
+++ b/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.timestamptz/src/test/java/org/eclipse/persistence/testing/tests/jpa/timestamptz/TimeStampTZTest.java
@@ -85,7 +85,7 @@ public class TimeStampTZTest extends JUnitTestCase {
         assertEquals("The year is not match", year, dbCal.get(Calendar.YEAR));
         assertEquals("The month is not match", month, dbCal.get(Calendar.MONTH));
         assertEquals("The date is not match", date, dbCal.get(Calendar.DATE));
-        assertEquals("The hour is not match", hour, dbCal.get(Calendar.HOUR));
+        assertEquals("The hour is not match", hour, dbCal.get(Calendar.HOUR_OF_DAY));
         assertEquals("The minute is not match", minute, dbCal.get(Calendar.MINUTE));
         assertEquals("The second is not match", second, dbCal.get(Calendar.SECOND));
     }
@@ -120,7 +120,7 @@ public class TimeStampTZTest extends JUnitTestCase {
             assertEquals("The year is not match", year, dbCal.get(Calendar.YEAR));
             assertEquals("The month is not match", month, dbCal.get(Calendar.MONTH));
             assertEquals("The date is not match", date, dbCal.get(Calendar.DATE));
-            assertEquals("The hour is not match", hour, dbCal.get(Calendar.HOUR));
+            assertEquals("The hour is not match", hour, dbCal.get(Calendar.HOUR_OF_DAY));
             assertEquals("The minute is not match", minute, dbCal.get(Calendar.MINUTE));
             assertEquals("The second is not match", second, dbCal.get(Calendar.SECOND));
         } finally {

--- a/sdo/org.eclipse.persistence.sdo/src/main/java/org/eclipse/persistence/sdo/helper/SDODataHelper.java
+++ b/sdo/org.eclipse.persistence.sdo/src/main/java/org/eclipse/persistence/sdo/helper/SDODataHelper.java
@@ -269,7 +269,7 @@ public class SDODataHelper implements DataHelper {
         dur.append("M");
         dur.append(calendar.get(Calendar.DATE));
         dur.append("DT");
-        dur.append(calendar.get(Calendar.HOUR));
+        dur.append(calendar.get(Calendar.HOUR_OF_DAY));
         dur.append("H");
         dur.append(calendar.get(Calendar.MINUTE));
         dur.append("M");
@@ -573,7 +573,7 @@ public class SDODataHelper implements DataHelper {
             c.set(Calendar.DATE, data);
             break;
         case 3:
-            c.set(Calendar.HOUR, data);
+            c.set(Calendar.HOUR_OF_DAY, data);
             break;
         case 4:
             c.set(Calendar.MINUTE, data);

--- a/sdo/org.eclipse.persistence.sdo/src/test/java/org/eclipse/persistence/testing/sdo/helper/datahelper/DataHelperToCalendarTest.java
+++ b/sdo/org.eclipse.persistence.sdo/src/test/java/org/eclipse/persistence/testing/sdo/helper/datahelper/DataHelperToCalendarTest.java
@@ -86,13 +86,13 @@ public class DataHelperToCalendarTest extends DataHelperTestCases {
     public void testToCalendarWithTime() {
         Calendar controlCalendar = Calendar.getInstance();
         controlCalendar.clear();
-        controlCalendar.set(Calendar.HOUR, 1);
+        controlCalendar.set(Calendar.HOUR_OF_DAY, 1);
         controlCalendar.set(Calendar.MINUTE, 21);
         controlCalendar.set(Calendar.SECOND, 12);
         controlCalendar.set(Calendar.MILLISECOND, 0);
         controlCalendar.setTimeZone(TimeZone.getTimeZone("GMT"));
         Calendar aCalendar = dataHelper.toCalendar("01:21:12");
-        assertTrue("Expected HOUR: " + controlCalendar.get(Calendar.HOUR) + ", but was: " + aCalendar.get(Calendar.HOUR), controlCalendar.get(Calendar.HOUR) == aCalendar.get(Calendar.HOUR));
+        assertTrue("Expected HOUR: " + controlCalendar.get(Calendar.HOUR_OF_DAY) + ", but was: " + aCalendar.get(Calendar.HOUR_OF_DAY), controlCalendar.get(Calendar.HOUR_OF_DAY) == aCalendar.get(Calendar.HOUR_OF_DAY));
         assertTrue("Expected MINUTE: " + controlCalendar.get(Calendar.MINUTE) + ", but was: " + aCalendar.get(Calendar.MINUTE), controlCalendar.get(Calendar.MINUTE) == aCalendar.get(Calendar.MINUTE));
         assertTrue("Expected SECOND: " + controlCalendar.get(Calendar.SECOND) + ", but was: " + aCalendar.get(Calendar.SECOND), controlCalendar.get(Calendar.SECOND) == aCalendar.get(Calendar.SECOND));
         assertTrue("Expected MILLISECOND: " + controlCalendar.get(Calendar.MILLISECOND) + ", but was: " + aCalendar.get(Calendar.MILLISECOND), controlCalendar.get(Calendar.MILLISECOND) == aCalendar.get(Calendar.MILLISECOND));
@@ -121,7 +121,7 @@ public class DataHelperToCalendarTest extends DataHelperTestCases {
         controlCalendar.set(Calendar.YEAR, 2001);
         controlCalendar.set(Calendar.MONTH, 0);
         controlCalendar.set(Calendar.DATE, 1);
-        controlCalendar.set(Calendar.HOUR, 0);
+        controlCalendar.set(Calendar.HOUR_OF_DAY, 0);
         controlCalendar.set(Calendar.MINUTE, 0);
         controlCalendar.set(Calendar.SECOND, 1);
         controlCalendar.set(Calendar.MILLISECOND, 0);
@@ -130,7 +130,7 @@ public class DataHelperToCalendarTest extends DataHelperTestCases {
         assertTrue("Expected YEAR: " + controlCalendar.get(Calendar.YEAR) + ", but was: " + aCalendar.get(Calendar.YEAR), controlCalendar.get(Calendar.YEAR) == aCalendar.get(Calendar.YEAR));
         assertTrue("Expected MONTH: " + controlCalendar.get(Calendar.MONTH) + ", but was: " + aCalendar.get(Calendar.MONTH), controlCalendar.get(Calendar.MONTH) == aCalendar.get(Calendar.MONTH));
         assertTrue("Expected DATE: " + controlCalendar.get(Calendar.DATE) + ", but was: " + aCalendar.get(Calendar.DATE), controlCalendar.get(Calendar.DATE) == aCalendar.get(Calendar.DATE));
-        assertTrue("Expected HOUR: " + controlCalendar.get(Calendar.HOUR) + ", but was: " + aCalendar.get(Calendar.HOUR), controlCalendar.get(Calendar.HOUR) == aCalendar.get(Calendar.HOUR));
+        assertTrue("Expected HOUR: " + controlCalendar.get(Calendar.HOUR_OF_DAY) + ", but was: " + aCalendar.get(Calendar.HOUR_OF_DAY), controlCalendar.get(Calendar.HOUR_OF_DAY) == aCalendar.get(Calendar.HOUR_OF_DAY));
         assertTrue("Expected MINUTE: " + controlCalendar.get(Calendar.MINUTE) + ", but was: " + aCalendar.get(Calendar.MINUTE), controlCalendar.get(Calendar.MINUTE) == aCalendar.get(Calendar.MINUTE));
         assertTrue("Expected SECOND: " + controlCalendar.get(Calendar.SECOND) + ", but was: " + aCalendar.get(Calendar.SECOND), controlCalendar.get(Calendar.SECOND) == aCalendar.get(Calendar.SECOND));
         assertTrue("Expected MILLISECOND: " + controlCalendar.get(Calendar.MILLISECOND) + ", but was: " + aCalendar.get(Calendar.MILLISECOND), controlCalendar.get(Calendar.MILLISECOND) == aCalendar.get(Calendar.MILLISECOND));
@@ -144,7 +144,7 @@ public class DataHelperToCalendarTest extends DataHelperTestCases {
         controlCalendar.set(Calendar.YEAR, 12);
         controlCalendar.set(Calendar.MONTH, 9);
         controlCalendar.set(Calendar.DATE, 2);
-        controlCalendar.set(Calendar.HOUR, 0);
+        controlCalendar.set(Calendar.HOUR_OF_DAY, 0);
         controlCalendar.set(Calendar.MINUTE, 40);
         controlCalendar.set(Calendar.SECOND, 27);
         controlCalendar.set(Calendar.MILLISECOND, 870);
@@ -155,7 +155,7 @@ public class DataHelperToCalendarTest extends DataHelperTestCases {
         assertTrue("Expected YEAR: " + controlCalendar.get(Calendar.YEAR) + ", but was: " + aCalendar.get(Calendar.YEAR), controlCalendar.get(Calendar.YEAR) == aCalendar.get(Calendar.YEAR));
         assertTrue("Expected MONTH: " + controlCalendar.get(Calendar.MONTH) + ", but was: " + aCalendar.get(Calendar.MONTH), controlCalendar.get(Calendar.MONTH) == aCalendar.get(Calendar.MONTH));
         assertTrue("Expected DATE: " + controlCalendar.get(Calendar.DATE) + ", but was: " + aCalendar.get(Calendar.DATE), controlCalendar.get(Calendar.DATE) == aCalendar.get(Calendar.DATE));
-        assertTrue("Expected HOUR: " + controlCalendar.get(Calendar.HOUR) + ", but was: " + aCalendar.get(Calendar.HOUR), controlCalendar.get(Calendar.HOUR) == aCalendar.get(Calendar.HOUR));
+        assertTrue("Expected HOUR: " + controlCalendar.get(Calendar.HOUR_OF_DAY) + ", but was: " + aCalendar.get(Calendar.HOUR_OF_DAY), controlCalendar.get(Calendar.HOUR_OF_DAY) == aCalendar.get(Calendar.HOUR_OF_DAY));
         assertTrue("Expected MINUTE: " + controlCalendar.get(Calendar.MINUTE) + ", but was: " + aCalendar.get(Calendar.MINUTE), controlCalendar.get(Calendar.MINUTE) == aCalendar.get(Calendar.MINUTE));
         assertTrue("Expected SECOND: " + controlCalendar.get(Calendar.SECOND) + ", but was: " + aCalendar.get(Calendar.SECOND), controlCalendar.get(Calendar.SECOND) == aCalendar.get(Calendar.SECOND));
         assertTrue("Expected MILLISECOND: " + controlCalendar.get(Calendar.MILLISECOND) + ", but was: " + aCalendar.get(Calendar.MILLISECOND), controlCalendar.get(Calendar.MILLISECOND) == aCalendar.get(Calendar.MILLISECOND));

--- a/sdo/org.eclipse.persistence.sdo/src/test/java/org/eclipse/persistence/testing/sdo/helper/datahelper/DataHelperToCalendarWithLocale.java
+++ b/sdo/org.eclipse.persistence.sdo/src/test/java/org/eclipse/persistence/testing/sdo/helper/datahelper/DataHelperToCalendarWithLocale.java
@@ -93,13 +93,13 @@ public class DataHelperToCalendarWithLocale extends DataHelperTestCases {
         Locale lc = Locale.US;
         Calendar controlCalendar = Calendar.getInstance(lc);
         controlCalendar.clear();
-        controlCalendar.set(Calendar.HOUR, 1);
+        controlCalendar.set(Calendar.HOUR_OF_DAY, 1);
         controlCalendar.set(Calendar.MINUTE, 21);
         controlCalendar.set(Calendar.SECOND, 12);
         controlCalendar.set(Calendar.MILLISECOND, 0);
         controlCalendar.setTimeZone(TimeZone.getTimeZone("GMT"));
         Calendar aCalendar = dataHelper.toCalendar("01:21:12", lc);
-        assertTrue("Expected HOUR: " + controlCalendar.get(Calendar.HOUR) + ", but was: " + aCalendar.get(Calendar.HOUR), controlCalendar.get(Calendar.HOUR) == aCalendar.get(Calendar.HOUR));
+        assertTrue("Expected HOUR: " + controlCalendar.get(Calendar.HOUR_OF_DAY) + ", but was: " + aCalendar.get(Calendar.HOUR_OF_DAY), controlCalendar.get(Calendar.HOUR_OF_DAY) == aCalendar.get(Calendar.HOUR_OF_DAY));
         assertTrue("Expected MINUTE: " + controlCalendar.get(Calendar.MINUTE) + ", but was: " + aCalendar.get(Calendar.MINUTE), controlCalendar.get(Calendar.MINUTE) == aCalendar.get(Calendar.MINUTE));
         assertTrue("Expected SECOND: " + controlCalendar.get(Calendar.SECOND) + ", but was: " + aCalendar.get(Calendar.SECOND), controlCalendar.get(Calendar.SECOND) == aCalendar.get(Calendar.SECOND));
         assertTrue("Expected MILLISECOND: " + controlCalendar.get(Calendar.MILLISECOND) + ", but was: " + aCalendar.get(Calendar.MILLISECOND), controlCalendar.get(Calendar.MILLISECOND) == aCalendar.get(Calendar.MILLISECOND));
@@ -130,7 +130,7 @@ public class DataHelperToCalendarWithLocale extends DataHelperTestCases {
         controlCalendar.set(Calendar.YEAR, 2001);
         controlCalendar.set(Calendar.MONTH, 0);
         controlCalendar.set(Calendar.DATE, 1);
-        controlCalendar.set(Calendar.HOUR, 0);
+        controlCalendar.set(Calendar.HOUR_OF_DAY, 0);
         controlCalendar.set(Calendar.MINUTE, 0);
         controlCalendar.set(Calendar.SECOND, 1);
         controlCalendar.set(Calendar.MILLISECOND, 0);
@@ -139,7 +139,7 @@ public class DataHelperToCalendarWithLocale extends DataHelperTestCases {
         assertTrue("Expected YEAR: " + controlCalendar.get(Calendar.YEAR) + ", but was: " + aCalendar.get(Calendar.YEAR), controlCalendar.get(Calendar.YEAR) == aCalendar.get(Calendar.YEAR));
         assertTrue("Expected MONTH: " + controlCalendar.get(Calendar.MONTH) + ", but was: " + aCalendar.get(Calendar.MONTH), controlCalendar.get(Calendar.MONTH) == aCalendar.get(Calendar.MONTH));
         assertTrue("Expected DATE: " + controlCalendar.get(Calendar.DATE) + ", but was: " + aCalendar.get(Calendar.DATE), controlCalendar.get(Calendar.DATE) == aCalendar.get(Calendar.DATE));
-        assertTrue("Expected HOUR: " + controlCalendar.get(Calendar.HOUR) + ", but was: " + aCalendar.get(Calendar.HOUR), controlCalendar.get(Calendar.HOUR) == aCalendar.get(Calendar.HOUR));
+        assertTrue("Expected HOUR: " + controlCalendar.get(Calendar.HOUR_OF_DAY) + ", but was: " + aCalendar.get(Calendar.HOUR_OF_DAY), controlCalendar.get(Calendar.HOUR_OF_DAY) == aCalendar.get(Calendar.HOUR_OF_DAY));
         assertTrue("Expected MINUTE: " + controlCalendar.get(Calendar.MINUTE) + ", but was: " + aCalendar.get(Calendar.MINUTE), controlCalendar.get(Calendar.MINUTE) == aCalendar.get(Calendar.MINUTE));
         assertTrue("Expected SECOND: " + controlCalendar.get(Calendar.SECOND) + ", but was: " + aCalendar.get(Calendar.SECOND), controlCalendar.get(Calendar.SECOND) == aCalendar.get(Calendar.SECOND));
         assertTrue("Expected MILLISECOND: " + controlCalendar.get(Calendar.MILLISECOND) + ", but was: " + aCalendar.get(Calendar.MILLISECOND), controlCalendar.get(Calendar.MILLISECOND) == aCalendar.get(Calendar.MILLISECOND));
@@ -154,7 +154,7 @@ public class DataHelperToCalendarWithLocale extends DataHelperTestCases {
         controlCalendar.set(Calendar.YEAR, 12);
         controlCalendar.set(Calendar.MONTH, Calendar.OCTOBER);
         controlCalendar.set(Calendar.DATE, 2);
-        controlCalendar.set(Calendar.HOUR, 0);
+        controlCalendar.set(Calendar.HOUR_OF_DAY, 0);
         controlCalendar.set(Calendar.MINUTE, 40);
         controlCalendar.set(Calendar.SECOND, 27);
         controlCalendar.set(Calendar.MILLISECOND, 870);
@@ -163,7 +163,7 @@ public class DataHelperToCalendarWithLocale extends DataHelperTestCases {
         assertTrue("Expected YEAR: " + controlCalendar.get(Calendar.YEAR) + ", but was: " + aCalendar.get(Calendar.YEAR), controlCalendar.get(Calendar.YEAR) == aCalendar.get(Calendar.YEAR));
         assertTrue("Expected MONTH: " + controlCalendar.get(Calendar.MONTH) + ", but was: " + aCalendar.get(Calendar.MONTH), controlCalendar.get(Calendar.MONTH) == aCalendar.get(Calendar.MONTH));
         assertTrue("Expected DATE: " + controlCalendar.get(Calendar.DATE) + ", but was: " + aCalendar.get(Calendar.DATE), controlCalendar.get(Calendar.DATE) == aCalendar.get(Calendar.DATE));
-        assertTrue("Expected HOUR: " + controlCalendar.get(Calendar.HOUR) + ", but was: " + aCalendar.get(Calendar.HOUR), controlCalendar.get(Calendar.HOUR) == aCalendar.get(Calendar.HOUR));
+        assertTrue("Expected HOUR: " + controlCalendar.get(Calendar.HOUR_OF_DAY) + ", but was: " + aCalendar.get(Calendar.HOUR_OF_DAY), controlCalendar.get(Calendar.HOUR_OF_DAY) == aCalendar.get(Calendar.HOUR_OF_DAY));
         assertTrue("Expected MINUTE: " + controlCalendar.get(Calendar.MINUTE) + ", but was: " + aCalendar.get(Calendar.MINUTE), controlCalendar.get(Calendar.MINUTE) == aCalendar.get(Calendar.MINUTE));
         assertTrue("Expected SECOND: " + controlCalendar.get(Calendar.SECOND) + ", but was: " + aCalendar.get(Calendar.SECOND), controlCalendar.get(Calendar.SECOND) == aCalendar.get(Calendar.SECOND));
         assertTrue("Expected MILLISECOND: " + controlCalendar.get(Calendar.MILLISECOND) + ", but was: " + aCalendar.get(Calendar.MILLISECOND), controlCalendar.get(Calendar.MILLISECOND) == aCalendar.get(Calendar.MILLISECOND));

--- a/sdo/org.eclipse.persistence.sdo/src/test/java/org/eclipse/persistence/testing/sdo/helper/datahelper/DataHelperToDateTest.java
+++ b/sdo/org.eclipse.persistence.sdo/src/test/java/org/eclipse/persistence/testing/sdo/helper/datahelper/DataHelperToDateTest.java
@@ -93,7 +93,7 @@ public class DataHelperToDateTest extends DataHelperTestCases {
     public void testToDateWithTime() {
         Calendar controlCalendar = Calendar.getInstance();
         controlCalendar.clear();
-        controlCalendar.set(Calendar.HOUR, 1);
+        controlCalendar.set(Calendar.HOUR_OF_DAY, 1);
         controlCalendar.set(Calendar.MINUTE, 21);
         controlCalendar.set(Calendar.SECOND, 12);
         controlCalendar.set(Calendar.MILLISECOND, 37);
@@ -121,7 +121,7 @@ public class DataHelperToDateTest extends DataHelperTestCases {
         controlCalendar.set(Calendar.YEAR, 2001);
         controlCalendar.set(Calendar.MONTH, 9);
         controlCalendar.set(Calendar.DATE, 1);
-        controlCalendar.set(Calendar.HOUR, 0);
+        controlCalendar.set(Calendar.HOUR_OF_DAY, 0);
         controlCalendar.set(Calendar.MINUTE, 0);
         controlCalendar.set(Calendar.SECOND, 1);
         controlCalendar.set(Calendar.MILLISECOND, 1);
@@ -137,7 +137,7 @@ public class DataHelperToDateTest extends DataHelperTestCases {
         controlCalendar.set(Calendar.YEAR, 12);
         controlCalendar.set(Calendar.MONTH, 9);
         controlCalendar.set(Calendar.DATE, 2);
-        controlCalendar.set(Calendar.HOUR, 0);
+        controlCalendar.set(Calendar.HOUR_OF_DAY, 0);
         controlCalendar.set(Calendar.MINUTE, 40);
         controlCalendar.set(Calendar.SECOND, 27);
         controlCalendar.set(Calendar.MILLISECOND, 87);

--- a/sdo/org.eclipse.persistence.sdo/src/test/java/org/eclipse/persistence/testing/sdo/helper/datahelper/DataHelperToDateTimeTest.java
+++ b/sdo/org.eclipse.persistence.sdo/src/test/java/org/eclipse/persistence/testing/sdo/helper/datahelper/DataHelperToDateTimeTest.java
@@ -31,7 +31,7 @@ public class DataHelperToDateTimeTest extends DataHelperTestCases {
         controlCalendar.set(Calendar.YEAR, 2001);
         controlCalendar.set(Calendar.MONTH, 4);
         controlCalendar.set(Calendar.DATE, 1);
-        controlCalendar.set(Calendar.HOUR, 12);
+        controlCalendar.set(Calendar.HOUR_OF_DAY, 12);
         controlCalendar.set(Calendar.MINUTE, 23);
         controlCalendar.set(Calendar.SECOND, 11);
         controlCalendar.set(Calendar.MILLISECOND, 1);

--- a/sdo/org.eclipse.persistence.sdo/src/test/java/org/eclipse/persistence/testing/sdo/helper/datahelper/DataHelperToDurationTest.java
+++ b/sdo/org.eclipse.persistence.sdo/src/test/java/org/eclipse/persistence/testing/sdo/helper/datahelper/DataHelperToDurationTest.java
@@ -31,7 +31,7 @@ public class DataHelperToDurationTest extends DataHelperTestCases {
         controlCalendar.set(Calendar.YEAR, 12);
         controlCalendar.set(Calendar.MONTH, 8);
         controlCalendar.set(Calendar.DATE, 2);
-        controlCalendar.set(Calendar.HOUR, 0);
+        controlCalendar.set(Calendar.HOUR_OF_DAY, 0);
         controlCalendar.set(Calendar.MINUTE, 40);
         controlCalendar.set(Calendar.SECOND, 27);
         controlCalendar.set(Calendar.MILLISECOND, 870);

--- a/sdo/org.eclipse.persistence.sdo/src/test/java/org/eclipse/persistence/testing/sdo/helper/datahelper/DataHelperToDurationWithCalnTest.java
+++ b/sdo/org.eclipse.persistence.sdo/src/test/java/org/eclipse/persistence/testing/sdo/helper/datahelper/DataHelperToDurationWithCalnTest.java
@@ -30,7 +30,7 @@ public class DataHelperToDurationWithCalnTest extends DataHelperTestCases {
         controlCalendar.set(Calendar.YEAR, 12);
         controlCalendar.set(Calendar.MONTH, 10);
         controlCalendar.set(Calendar.DATE, 2);
-        controlCalendar.set(Calendar.HOUR, 0);
+        controlCalendar.set(Calendar.HOUR_OF_DAY, 0);
         controlCalendar.set(Calendar.MINUTE, 40);
         controlCalendar.set(Calendar.SECOND, 27);
         controlCalendar.set(Calendar.MILLISECOND, 870);

--- a/sdo/org.eclipse.persistence.sdo/src/test/java/org/eclipse/persistence/testing/sdo/helper/datahelper/DataHelperToTimeTest.java
+++ b/sdo/org.eclipse.persistence.sdo/src/test/java/org/eclipse/persistence/testing/sdo/helper/datahelper/DataHelperToTimeTest.java
@@ -28,7 +28,7 @@ public class DataHelperToTimeTest extends DataHelperTestCases {
     public void testToTimeWithFullSetting() {
         Calendar controlCalendar = Calendar.getInstance();
         controlCalendar.clear();
-        controlCalendar.set(Calendar.HOUR, 12);
+        controlCalendar.set(Calendar.HOUR_OF_DAY, 12);
         controlCalendar.set(Calendar.MINUTE, 23);
         controlCalendar.set(Calendar.SECOND, 11);
         controlCalendar.set(Calendar.MILLISECOND, 1);


### PR DESCRIPTION
Some conversions in EclipseLink use `Calendar.HOUR` instead of `Calendar.HOUR_OF_DAY`, causing times after noon to be processed incorrectly. (`Calendar.HOUR` should only be used in conjunction with `Calendar.AM_PM`, in all other cases `Calendar.HOUR_OF_DAY` must be used)

In particular all sorts of conversions to `OffsetTime` and `OffsetDateTime` in `org.eclipse.persistence.internal.helper.ConversionManager` were producing wrong results.

This PR just fixes the bug, but the conversion code in `ConversionManager` could be streamlined greatly by using Java Time directly rather than converting  with a `Calendar`.

Code like this:
```
        } else if (sourceObject instanceof java.util.Date) {
            // handles sql.Time, sql.Date, sql.Timestamp
            Calendar cal = Helper.allocateCalendar();
            cal.setTime((java.util.Date) sourceObject);
            offsetDateTime = java.time.OffsetDateTime.of(
                    cal.get(Calendar.YEAR), cal.get(Calendar.MONTH) + 1, cal.get(Calendar.DAY_OF_MONTH),
                    cal.get(Calendar.HOUR_OF_DAY), cal.get(Calendar.MINUTE), cal.get(Calendar.SECOND), cal.get(Calendar.MILLISECOND) * 1000000,
                    java.time.ZoneOffset.ofTotalSeconds((cal.get(Calendar.ZONE_OFFSET) + cal.get(Calendar.DST_OFFSET)) / 1000));
            Helper.releaseCalendar(cal);
        }
```
could become something like:
```
        } else if (sourceObject instanceof java.util.Date) {
            offsetDateTime = ((java.util.Date) sourceObject).toInstant()
                    .atZone(getDefaultZoneOffset())
                    .toOffsetDateTime();
        }
```
This may change the offset, but it looks like that's the point of `getDefaultZoneOffset()`; if the offset should stay the same `ZoneId.systemDefault()` should be used instead of `getDefaultZoneOffset()`. (I'm not sure why `getDefaultZoneOffset()` is there in the first place, if conversions fail with the system default zone instead of `ZoneOffset.UTC`, the code is broken and should be fixed, rather than changing the zone that's used to work around the bug)