### PR TITLE
[3.0] remove the noisy entries from the logs - backport from the master

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
+          distribution: 'adopt'
           java-version: ${{ matrix.java_version }}
       - name: Verify
         run: mvn -B -V -U -C -Pstaging,oss-release,test-lrg,mysql clean verify -Dgpg.skip=true -Dwarn.limit=15 -Dcomp.xlint=-Xlint:none

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/accessors/objects/MetadataAsmFactory.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/accessors/objects/MetadataAsmFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2018 Hans Harz, Andrew Rustleund, IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -112,19 +112,14 @@ public class MetadataAsmFactory extends MetadataFactory {
             // supported and tested JDK
             // in such case log a warning and try to re-read the class
             // without class version check
-            SessionLog log = getLogger().getSession() != null
-                    ? getLogger().getSession().getSessionLog() : AbstractSessionLog.getLog();
-            if (log.shouldLog(SessionLog.WARNING, SessionLog.METADATA)) {
-                SessionLogEntry entry = new SessionLogEntry(getLogger().getSession(), SessionLog.WARNING, SessionLog.METADATA, iae);
-                entry.setMessage(ExceptionLocalization.buildMessage("unsupported_classfile_version", new Object[] { className }));
-                log.log(entry);
-            }
             if (stream != null) {
                 try {
                     ClassReader reader = new EclipseLinkClassReader(stream);
                     Attribute[] attributes = new Attribute[0];
                     reader.accept(visitor, attributes, ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
                 } catch (Exception e) {
+                    SessionLog log = getLogger().getSession() != null
+                            ? getLogger().getSession().getSessionLog() : AbstractSessionLog.getLog();
                     // our fall-back failed, this is severe
                     if (log.shouldLog(SessionLog.SEVERE, SessionLog.METADATA)) {
                         SessionLogEntry entry = new SessionLogEntry(getLogger().getSession(), SessionLog.SEVERE, SessionLog.METADATA, e);
@@ -137,11 +132,6 @@ public class MetadataAsmFactory extends MetadataFactory {
                 addMetadataClass(getVirtualMetadataClass(className));
             }
         } catch (Exception exception) {
-            SessionLog log = getLogger().getSession() != null
-                    ? getLogger().getSession().getSessionLog() : AbstractSessionLog.getLog();
-            if (log.shouldLog(SessionLog.FINEST, SessionLog.METADATA)) {
-                log.logThrowable(SessionLog.FINEST, SessionLog.METADATA, exception);
-            }
             addMetadataClass(getVirtualMetadataClass(className));
         } finally {
             try {
@@ -559,11 +549,7 @@ public class MetadataAsmFactory extends MetadataFactory {
                     metadataClass.addInterface(reflectInterface.getName());
                 }
             } catch (Exception failed) {
-                SessionLog log = getLogger().getSession() != null
-                        ? getLogger().getSession().getSessionLog() : AbstractSessionLog.getLog();
-                if (log.shouldLog(SessionLog.FINE, SessionLog.METADATA)) {
-                    log.logThrowable(SessionLog.FINE, SessionLog.METADATA, failed);
-                }
+                //ignore
                 metadataClass.setIsAccessible(false);
             }
         } else {


### PR DESCRIPTION
should log only exceptional cases and definitely not info about "internal" virtual metadataclasses

fixes #1606

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>

Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>
(cherry picked from commit e2da068a260cb9bf9afeaf5df23fb7ace188cdcb)