### PR TITLE
[master] Oracle NoSQL cloud connection fix to set compartment

### DIFF
--- a/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLConnectionFactory.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLConnectionFactory.java
@@ -59,6 +59,7 @@ public class OracleNoSQLConnectionFactory implements ConnectionFactory {
             //TODO handle all available properties in NoSQLHandleConfig
             NoSQLHandleConfig config = new NoSQLHandleConfig(connectionSpec.getEndPoint());
             config.setAuthorizationProvider(getAuthorizationProvider(config, connectionSpec));
+            config.setDefaultCompartment(connectionSpec.getCompartment());
 
             noSQLHandle = NoSQLHandleFactory.createNoSQLHandle(config);
         } catch (Exception exception) {


### PR DESCRIPTION
Without this NoSQL instance (driver) from cloud environment should throw
`Caused by: oracle.nosql.driver.TableNotFoundException: .....` although table exist in the DB.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>