### PR TITLE
fix: issue with multiple aliases against same table

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/TableExpression.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/TableExpression.java
@@ -45,7 +45,7 @@ public class TableExpression extends DataExpression {
     protected void assignAlias(DatabaseTable alias, DatabaseTable table) {
         if (this.baseExpression.isQueryKeyExpression()){
             QueryKeyExpression qkExpression = ((QueryKeyExpression)this.baseExpression);
-            if (qkExpression.getTableAliases() != null && qkExpression.getTableAliases().keyAtValue(table) != null ) {
+            if (!qkExpression.hasQueryKey && qkExpression.getTableAliases() != null && qkExpression.getTableAliases().keyAtValue(table) != null ) {
                 return;
             }
         }

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced/src/main/java/org/eclipse/persistence/testing/models/jpa/advanced/Customizer.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced/src/main/java/org/eclipse/persistence/testing/models/jpa/advanced/Customizer.java
@@ -19,6 +19,7 @@ import org.eclipse.persistence.config.SessionCustomizer;
 import org.eclipse.persistence.descriptors.ClassDescriptor;
 import org.eclipse.persistence.descriptors.SerializedObjectPolicy;
 import org.eclipse.persistence.descriptors.VersionLockingPolicy;
+import org.eclipse.persistence.expressions.Expression;
 import org.eclipse.persistence.expressions.ExpressionBuilder;
 import org.eclipse.persistence.internal.databaseaccess.DatasourceAccessor;
 import org.eclipse.persistence.internal.helper.DatabaseField;
@@ -218,6 +219,19 @@ public class Customizer implements SessionCustomizer, DescriptorCustomizer {
                     builder.getTable("CMP3_EMP_PROJ").getField("EMPLOYEES_EMP_ID").equal(
                     builder.getField("CMP3_EMPLOYEE.EMP_ID")))));
             descriptor.addQueryKey(employesQueryKey);
+
+            // Project leader's manager
+            ManyToManyQueryKey projectLeaderManager = new ManyToManyQueryKey();
+            projectLeaderManager.setName("projectLeaderManager");
+            projectLeaderManager.setReferenceClass(Employee.class);
+            builder = new ExpressionBuilder();
+
+            projectLeaderManager.setJoinCriteria(
+                    (builder.getParameter("CMP3_PROJECT.LEADER_ID").equal(
+                            builder.getTable("CMP3_EMPLOYEE").getField("EMP_ID")).and(
+                            builder.getTable("CMP3_EMPLOYEE").getField("MANAGER_EMP_ID").equal(
+                                    builder.getField("CMP3_EMPLOYEE.EMP_ID")))));
+            descriptor.addQueryKey(projectLeaderManager);
         }
     }
     //**temp

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced/src/test/java/org/eclipse/persistence/testing/tests/jpa/advanced/JoinedAttributeAdvancedJunitTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced/src/test/java/org/eclipse/persistence/testing/tests/jpa/advanced/JoinedAttributeAdvancedJunitTest.java
@@ -169,6 +169,7 @@ public class JoinedAttributeAdvancedJunitTest extends JUnitTestCase {
         suite.addTest(new JoinedAttributeAdvancedJunitTest("testManagedProjects"));
         suite.addTest(new JoinedAttributeAdvancedJunitTest("testManagedLargeProjects"));
         suite.addTest(new JoinedAttributeAdvancedJunitTest("testProjectsQK"));
+        suite.addTest(new JoinedAttributeAdvancedJunitTest("testProjectLeaderManagerQK"));
         suite.addTest(new JoinedAttributeAdvancedJunitTest("testLargeProjects"));
 //        suite.addTest(new JoinedAttributeAdvancedJunitTest("testResponsibilitiesQK"));
         suite.addTest(new JoinedAttributeAdvancedJunitTest("testOwner"));
@@ -1048,6 +1049,24 @@ public class JoinedAttributeAdvancedJunitTest extends JUnitTestCase {
         // choose example that actually selects something
         if(emps.isEmpty()) {
             fail();
+        }
+    }
+
+    public void testProjectLeaderManagerQK() {
+        final String projectLeaderManagerFirstName = "Jim-bob";
+        ReadAllQuery query = new ReadAllQuery(Project.class);
+        ExpressionBuilder eb = query.getExpressionBuilder();
+        query.setSelectionCriteria(eb.anyOf("projectLeaderManager").get("firstName").equal(projectLeaderManagerFirstName));
+        @SuppressWarnings({"unchecked"})
+        List<Project> projects = (List<Project>)getDbSession().executeQuery(query);
+
+        // choose example that actually selects something
+        if(projects.isEmpty()) {
+            fail();
+        }
+
+        for(final Project project : projects) {
+            assertEquals(projectLeaderManagerFirstName, project.getTeamLeader().getManager().getFirstName());
         }
     }
 


### PR DESCRIPTION
With the current implementation of `TableExpression#assignAlias` you cannot have multiple aliases against the same table. The code block below prevents the second reference from being added to the table alias list.

```
        if (this.baseExpression.isQueryKeyExpression()){
            QueryKeyExpression qkExpression = ((QueryKeyExpression)this.baseExpression);
            if (qkExpression.getTableAliases() != null && qkExpression.getTableAliases().keyAtValue(table) != null ) {
                return;
            }
        }
```

Removing the override of `assignAlias` in `TableExpression` and deferring to `DataExpression`'s implementation results in the expected behavior.
