### PR TITLE
[master] New WildFly EE platform

### DIFF
--- a/etc/el-testjee.wildfly.properties
+++ b/etc/el-testjee.wildfly.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2022 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2023 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at

--- a/etc/el-testjee.wildfly.properties
+++ b/etc/el-testjee.wildfly.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2022 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,7 +16,7 @@
 server.name=jboss
 
 #Server type/major version (value is specified by cargo-maven2-plugin).
-server.containerId=wildfly17x
+server.containerId=wildfly27x
 
 #Hostname to which server binds. Used by testing client (EJB client) too.
 server.host=localhost
@@ -40,14 +40,14 @@ server.pwd=adminadmin
 server.initialCtxFactory=org.wildfly.naming.client.WildFlyInitialContextFactory
 
 #EclipseLink specific property/hint to identify server family.
-server.platform=JBoss
-server.platform.class=jboss-platform
+server.platform=WildFly
+server.platform.class=wildfly-platform
 
 #JEE server client library. There are Maven artifact properties. Use Maven Central to find right values.
 jee.client.groupId=org.wildfly
 jee.client.artifactId=wildfly-ejb-client-bom
 #In case of WildFly this property is used as a substitution property in eclipselink-wildfly-module.xsl file.
-jee.client.version=18.0.0.Final
+jee.client.version=27.0.0.Final
 
 #Server binaries location.
 #Just binaries are needed. cargo-maven2-plugin during maven build/tests configures server/server domain automatically in .../target/cargo directory.
@@ -56,7 +56,7 @@ jee.client.version=18.0.0.Final
 #cargo.container.installation.home=/usr/local/javaApplications/wildfly-15.0.1.Final
 #false - Maven will download and unpack JEE server to the "${user.home}/.eclipselinktests" directory automatically.
 skip.jee.server.installation=false
-cargo.container.installation.home=${user.home}/.eclipselinktests/wildfly-18.0.0.Final
+cargo.container.installation.home=${user.home}/.eclipselinktests/27.0.0.Final
 
 #Part of JNDI name (suffix) used by generic JPA test client. This JNDI points to the testing EJBs deployed to the server.
 #Most test using only first value, but in some cases other JNDIs EJBs are used too.

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/sessionsxml/SessionsXMLSchemaWildFlyPlatformTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/sessionsxml/SessionsXMLSchemaWildFlyPlatformTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.testing.tests.sessionsxml;
+
+import org.eclipse.persistence.platform.server.wildfly.WildFlyPlatform;
+import org.eclipse.persistence.sessions.DatabaseSession;
+import org.eclipse.persistence.sessions.factories.SessionManager;
+import org.eclipse.persistence.sessions.factories.XMLSessionConfigLoader;
+import org.eclipse.persistence.testing.framework.AutoVerifyTestCase;
+import org.eclipse.persistence.testing.framework.TestErrorException;
+
+
+/**
+ * Tests server platform tag for WildFly.
+ *
+ * @version 1.0
+ */
+public class SessionsXMLSchemaWildFlyPlatformTest extends AutoVerifyTestCase {
+    Exception m_exceptionCaught;
+    DatabaseSession m_employeeSession;
+
+    public SessionsXMLSchemaWildFlyPlatformTest() {
+        setDescription("Tests loading a WildFly platform from the schema.");
+    }
+
+    @Override
+    public void reset() {
+        if ((m_employeeSession != null) && m_employeeSession.isConnected()) {
+            m_employeeSession.logout();
+            SessionManager.getManager().getSessions().remove(m_employeeSession);
+            m_employeeSession = null;
+        }
+    }
+
+    @Override
+    protected void setup() {
+        m_exceptionCaught = null;
+    }
+
+    @Override
+    public void test() {
+        try {
+            XMLSessionConfigLoader loader = new XMLSessionConfigLoader("org/eclipse/persistence/testing/models/sessionsxml/XMLSchemaSessionWildFlyPlatform.xml");
+
+            m_employeeSession = (DatabaseSession)SessionManager.getManager().getSession(loader, "EmployeeSessionWildFly", getClass().getClassLoader(), false, true);
+        } catch (Exception e) {
+            m_exceptionCaught = e;
+        }
+    }
+
+    @Override
+    protected void verify() {
+        if (m_exceptionCaught != null) {
+            throw new TestErrorException("Loading of the session failed: " + m_exceptionCaught);
+        }
+
+        if (m_employeeSession == null) {
+            throw new TestErrorException("Loaded session was null");
+        }
+
+        if (!(m_employeeSession.getServerPlatform() instanceof WildFlyPlatform)) {
+            throw new TestErrorException("The loaded server platform was not the correct type.");
+        }
+    }
+}

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/sessionsxml/SessionsXMLSchemaWildFlyPlatformTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/sessionsxml/SessionsXMLSchemaWildFlyPlatformTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/sessionsxml/SessionsXMLTestModel.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/sessionsxml/SessionsXMLTestModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/sessionsxml/SessionsXMLTestModel.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/sessionsxml/SessionsXMLTestModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -76,6 +76,7 @@ public class SessionsXMLTestModel extends TestModel {
         suite.addTest(new SessionsXMLSchemaWeblogicPlatformTest());
         suite.addTest(new SessionsXMLSchemaLoggingOptionsTest());
         suite.addTest(new SessionsXMLSchemaJBossPlatformTest());
+        suite.addTest(new SessionsXMLSchemaWildFlyPlatformTest());
         suite.addTest(new SessionManagerGetMultipleSessionsTest());
         suite.addTest(new FailoverLoginSettingsTest());
 

--- a/foundation/eclipselink.core.test/src/it/resources/org/eclipse/persistence/testing/models/sessionsxml/XMLSchemaSessionWildFlyPlatform.xml
+++ b/foundation/eclipselink.core.test/src/it/resources/org/eclipse/persistence/testing/models/sessionsxml/XMLSchemaSessionWildFlyPlatform.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<!--
+
+    Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0,
+    or the Eclipse Distribution License v. 1.0 which is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+
+    SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+-->
+
+<sessions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="file://xsd/eclipselink_sessions_1.0.xsd" version="0">
+    <session xsi:type="database-session">
+        <name>EmployeeSessionWildFly</name>
+        <server-platform xsi:type="wildfly-platform"/>
+        <primary-project xsi:type="class">org.eclipse.persistence.testing.models.employee.relational.EmployeeProject</primary-project>
+        <login xsi:type="database-login">
+            <user-name>@dbUser@</user-name>
+            <password>@dbPassword@</password>
+            <driver-class>@driverClass@</driver-class>
+            <connection-url>@dbURL@</connection-url>
+        </login>
+    </session>
+</sessions>

--- a/foundation/eclipselink.core.test/src/it/resources/org/eclipse/persistence/testing/models/sessionsxml/XMLSchemaSessionWildFlyPlatform.xml
+++ b/foundation/eclipselink.core.test/src/it/resources/org/eclipse/persistence/testing/models/sessionsxml/XMLSchemaSessionWildFlyPlatform.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="US-ASCII"?>
 <!--
 
-    Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/TargetServer.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/TargetServer.java
@@ -43,6 +43,7 @@ public class TargetServer {
     public static final String  WebLogic_12 = "WebLogic_12";
     public static final String  JBoss = "JBoss";
     public static final String  SAPNetWeaver_7_1 = "NetWeaver_7_1";
+    public static final String  WildFly = "WildFly";
 
     public static final String DEFAULT = None;
 }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/TargetServer.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/TargetServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2022 IBM Corporation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/PropertiesHandler.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/PropertiesHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2018 IBM Corporation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/PropertiesHandler.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/PropertiesHandler.java
@@ -613,7 +613,8 @@ public class PropertiesHandler {
                 {TargetServer.WebLogic_10, pcg + "wls.WebLogic_10_Platform"},
                 {TargetServer.WebLogic_12, pcg + "wls.WebLogic_12_Platform"},
                 {TargetServer.JBoss, pcg + "jboss.JBossPlatform"},
-                {TargetServer.SAPNetWeaver_7_1, pcg + "sap.SAPNetWeaver_7_1_Platform"}
+                {TargetServer.SAPNetWeaver_7_1, pcg + "sap.SAPNetWeaver_7_1_Platform"},
+                {TargetServer.WildFly, pcg + "wildfly.WildFlyPlatform"}
                 };
         }
     }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/factories/XMLSessionConfigProject.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/factories/XMLSessionConfigProject.java
@@ -52,6 +52,7 @@ import org.eclipse.persistence.internal.sessions.factories.model.platform.WebSph
 import org.eclipse.persistence.internal.sessions.factories.model.platform.WebSphere_5_0_PlatformConfig;
 import org.eclipse.persistence.internal.sessions.factories.model.platform.WebSphere_5_1_PlatformConfig;
 import org.eclipse.persistence.internal.sessions.factories.model.platform.WebSphere_6_0_PlatformConfig;
+import org.eclipse.persistence.internal.sessions.factories.model.platform.WildFlyPlatformConfig;
 import org.eclipse.persistence.internal.sessions.factories.model.pool.ConnectionPolicyConfig;
 import org.eclipse.persistence.internal.sessions.factories.model.pool.ConnectionPoolConfig;
 import org.eclipse.persistence.internal.sessions.factories.model.pool.PoolsConfig;
@@ -226,6 +227,7 @@ public class XMLSessionConfigProject extends org.eclipse.persistence.sessions.Pr
         addDescriptor(buildServerPlatformConfigDescriptorFor(WebSphere_6_0_PlatformConfig.class));
         addDescriptor(buildServerPlatformConfigDescriptorFor(JBossPlatformConfig.class));
         addDescriptor(buildServerPlatformConfigDescriptorFor(NetWeaver_7_1_PlatformConfig.class));
+        addDescriptor(buildServerPlatformConfigDescriptorFor(WildFlyPlatformConfig.class));
 
         // Set the namespaces on all descriptors.
         NamespaceResolver namespaceResolver = new NamespaceResolver();
@@ -1200,6 +1202,7 @@ public class XMLSessionConfigProject extends org.eclipse.persistence.sessions.Pr
         descriptor.getInheritancePolicy().addClassIndicator(WebSphere_5_1_PlatformConfig.class, "websphere-51-platform");
         descriptor.getInheritancePolicy().addClassIndicator(WebSphere_6_0_PlatformConfig.class, "websphere-60-platform");
         descriptor.getInheritancePolicy().addClassIndicator(JBossPlatformConfig.class, "jboss-platform");
+        descriptor.getInheritancePolicy().addClassIndicator(WildFlyPlatformConfig.class, "wildfly-platform");
         descriptor.getInheritancePolicy().addClassIndicator(NetWeaver_7_1_PlatformConfig.class, "netweaver-71-platform");
 
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/factories/XMLSessionConfigProject.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/factories/XMLSessionConfigProject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/factories/model/platform/WildFlyPlatformConfig.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/factories/model/platform/WildFlyPlatformConfig.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.internal.sessions.factories.model.platform;
+
+/**
+ * INTERNAL:
+ */
+public class WildFlyPlatformConfig extends ServerPlatformConfig {
+    public WildFlyPlatformConfig() {
+        super("org.eclipse.persistence.platform.server.wildfly.WildFlyPlatform");
+    }
+}

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/factories/model/platform/WildFlyPlatformConfig.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/factories/model/platform/WildFlyPlatformConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/server/wildfly/WildFlyPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/server/wildfly/WildFlyPlatform.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.platform.server.wildfly;
+
+import jakarta.persistence.spi.PersistenceUnitInfo;
+import org.eclipse.persistence.internal.helper.JPAClassLoaderHolder;
+import org.eclipse.persistence.logging.AbstractSessionLog;
+import org.eclipse.persistence.platform.server.JMXEnabledPlatform;
+import org.eclipse.persistence.platform.server.JMXServerPlatformBase;
+import org.eclipse.persistence.services.wildfly.MBeanWildFlyRuntimeServices;
+import org.eclipse.persistence.sessions.DatabaseSession;
+import org.eclipse.persistence.sessions.ExternalTransactionController;
+import org.eclipse.persistence.transaction.wildfly.WildFlyTransactionController;
+import org.eclipse.persistence.transaction.wildfly.WildFlyTransactionController11;
+
+/**
+ * PUBLIC:
+ *
+ * This is the concrete subclass responsible for representing WildFly-specific server behavior.
+ *
+ * This platform overrides:
+ *
+ * getExternalTransactionControllerClass(): to use an WildFly-specific controller class
+ *
+ */
+public class WildFlyPlatform extends JMXServerPlatformBase implements JMXEnabledPlatform {
+
+    /**
+     * The following constants and attributes are used to determine the module and application name
+     * to satisfy the requirements for 248746 where we provide an identifier pair for JMX sessions.
+     * Each application can have several modules.
+     * 1) Application name - the persistence unit associated with the session (a 1-1 relationship)
+     * 2) Module name - the ejb or war jar name (there is a 1-many relationship for module:session(s))
+     */
+    static {
+        /** Override by subclass: Search String in application server ClassLoader for the application:persistence_unit name */
+        APP_SERVER_CLASSLOADER_APPLICATION_PU_SEARCH_STRING_PREFIX = "/deploy/";
+        /** Override by subclass: Search String in application server session for ejb modules */
+        APP_SERVER_CLASSLOADER_MODULE_EJB_SEARCH_STRING_PREFIX = ".jar/";
+        /** Override by subclass: Search String in application server session for war modules */
+        APP_SERVER_CLASSLOADER_MODULE_WAR_SEARCH_STRING_PREFIX = ".war/";
+        APP_SERVER_CLASSLOADER_APPLICATION_PU_SEARCH_STRING_POSTFIX = "/}";
+        APP_SERVER_CLASSLOADER_MODULE_EJB_WAR_SEARCH_STRING_POSTFIX = "postfix,match~not;required^";
+    }
+
+    /**
+     * INTERNAL:
+     * Default Constructor: All behavior for the default constructor is inherited
+     */
+    public WildFlyPlatform(DatabaseSession newDatabaseSession) {
+        super(newDatabaseSession);
+        this.enableRuntimeServices();
+        // Create the JMX MBean specific to this platform for later registration
+        this.prepareServerSpecificServicesMBean();
+    }
+
+    @Override
+    public boolean isRuntimeServicesEnabledDefault() {
+        return true;
+    }
+
+    /**
+     * INTERNAL: getExternalTransactionControllerClass(): Answer the class of external transaction controller to use
+     * for WildFly. This is read-only.
+     *
+     * @return Class externalTransactionControllerClass
+     *
+     * @see org.eclipse.persistence.transaction.JTATransactionController
+     * @see org.eclipse.persistence.platform.server.ServerPlatformBase#isJTAEnabled()
+     * @see org.eclipse.persistence.platform.server.ServerPlatformBase#disableJTA()
+     * @see org.eclipse.persistence.platform.server.ServerPlatformBase#initializeExternalTransactionController()
+     */
+    @Override
+    public Class<? extends ExternalTransactionController> getExternalTransactionControllerClass() {
+        if (externalTransactionControllerClass == null){
+            externalTransactionControllerClass = isJTA11()
+                    ? WildFlyTransactionController11.class : WildFlyTransactionController.class;
+        }
+        return externalTransactionControllerClass;
+    }
+
+    /**
+     * INTERNAL:
+     * JIRA EJBTHREE-572 requires that we use the real classLoader in place of the getNewTempClassLoader().
+     * The override code should stay in place until the UCL3 loader does not throw a NPE on loadClass()
+     *
+     * @param puInfo - the persistence unit info
+     * @return ClassLoaderHolder - a composite object containing the classLoader and the flag
+     *     that is true if the classLoader returned is temporary
+     *
+     *  @see JPAClassLoaderHolder
+     */
+    @Override
+    public JPAClassLoaderHolder getNewTempClassLoader(PersistenceUnitInfo puInfo) {
+        // Bug 6460732: Use real classLoader instead of getNewTempClassLoader for now to avoid a WildFly NPE on loadClass()
+        ClassLoader realClassLoader = puInfo.getClassLoader();
+        AbstractSessionLog.getLog().log(AbstractSessionLog.WARNING, "persistence_unit_processor_wildfly_temp_classloader_bypassed",//
+                puInfo.getPersistenceUnitName(), realClassLoader);
+        return new JPAClassLoaderHolder(realClassLoader, false);
+    }
+
+    /**
+     * INTERNAL:
+     * prepareServerSpecificServicesMBean(): Server specific implementation of the
+     * creation and deployment of the JMX MBean to provide runtime services for the
+     * databaseSession.
+     *
+     * Default is to do nothing.
+     * Implementing platform classes must override this function and supply
+     * the server specific MBean instance for later registration by calling it in the constructor.
+     *
+     * @see #isRuntimeServicesEnabled()
+     * @see #disableRuntimeServices()
+     * @see #registerMBean()
+     */
+    @Override
+    public void prepareServerSpecificServicesMBean() {
+        // No check for an existing cached MBean - we will replace it if it exists
+        if(getDatabaseSession() != null && shouldRegisterRuntimeBean) {
+            this.setRuntimeServicesMBean(new MBeanWildFlyRuntimeServices(getDatabaseSession()));
+        }
+    }
+
+    /**
+     * INTERNAL:
+     * serverSpecificRegisterMBean(): Server specific implementation of the
+     * creation and deployment of the JMX MBean to provide runtime services for my
+     * databaseSession.
+     *
+     * @see #isRuntimeServicesEnabled()
+     * @see #disableRuntimeServices()
+     * @see #registerMBean()
+     */
+    @Override
+    public void serverSpecificRegisterMBean() {
+       super.serverSpecificRegisterMBean();
+        // get and cache module and application name during registration
+        initializeApplicationNameAndModuleName();
+    }
+
+}

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/server/wildfly/WildFlyPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/server/wildfly/WildFlyPlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/services/wildfly/ClassSummaryDetail.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/services/wildfly/ClassSummaryDetail.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.services.wildfly;
+
+import org.eclipse.persistence.services.ClassSummaryDetailBase;
+
+/**
+ * The class is used internally by the Portable JMX Framework to convert
+ * model specific classes into Open Types so that the attributes of model class can
+ * be exposed by MBeans.
+ *
+ * @since EclipseLink 4.0.1
+ */
+public class ClassSummaryDetail extends ClassSummaryDetailBase {
+
+    static {
+        COMPOSITE_TYPE_TYPENAME = "org.eclipse.persistence.services.wildfly";
+        COMPOSITE_TYPE_DESCRIPTION = "org.eclipse.persistence.services.wildfly.ClassSummaryDetail";
+    }
+
+    /**
+     * Construct a ClassSummaryDetail instance. The PropertyNames annotation is used
+     * to be able to construct a ClassSummaryDetail instance out of a CompositeData
+     * instance. See MXBeans documentation for more details.
+     */
+    public ClassSummaryDetail(String className, String cacheType, String configuredSize, String currentSize , String parentClassName) {
+        super(className, cacheType, configuredSize, currentSize , parentClassName);
+    }
+}

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/services/wildfly/ClassSummaryDetail.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/services/wildfly/ClassSummaryDetail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/services/wildfly/MBeanWildFlyRuntimeServices.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/services/wildfly/MBeanWildFlyRuntimeServices.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.services.wildfly;
+
+import org.eclipse.persistence.internal.sessions.AbstractSession;
+import org.eclipse.persistence.sessions.Session;
+
+/**
+ * <p>
+ * <b>Purpose</b>: Provide a dynamic interface into the EclipseLink Session.
+ * <p>
+ * <b>Description</b>: This class is meant to provide a framework for gaining access to configuration
+ * of the EclipseLink Session during runtime.  It will provide the basis for development
+ * of a JMX service and possibly other frameworks.
+ *
+ * @since EclipseLink 4.0.1
+ */
+public class MBeanWildFlyRuntimeServices extends WildFlyRuntimeServices implements MBeanWildFlyRuntimeServicesMBean {
+    public MBeanWildFlyRuntimeServices(Session session) {
+        super((AbstractSession)session);
+    }
+}

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/services/wildfly/MBeanWildFlyRuntimeServices.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/services/wildfly/MBeanWildFlyRuntimeServices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/services/wildfly/MBeanWildFlyRuntimeServicesMBean.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/services/wildfly/MBeanWildFlyRuntimeServicesMBean.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.services.wildfly;
+
+import org.eclipse.persistence.services.mbean.MBeanRuntimeServicesMBean;
+
+/**
+ * <p>
+ * <b>Purpose</b>: Provide a dynamic interface into the EclipseLink Session.
+ * <p>
+ * <b>Description</b>: This class is meant to provide facilities for managing an EclipseLink session external
+ * to EclipseLink over JMX.
+ *
+ * @since EclipseLink 4.0.1
+ */
+public interface MBeanWildFlyRuntimeServicesMBean extends MBeanRuntimeServicesMBean {
+
+}

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/services/wildfly/MBeanWildFlyRuntimeServicesMBean.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/services/wildfly/MBeanWildFlyRuntimeServicesMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/services/wildfly/WildFlyRuntimeServices.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/services/wildfly/WildFlyRuntimeServices.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.services.wildfly;
+
+import org.eclipse.persistence.internal.sessions.AbstractSession;
+import org.eclipse.persistence.services.RuntimeServices;
+
+import java.util.Locale;
+
+/**
+ * <p>
+ * <b>Purpose</b>: Provide a dynamic interface into the EclipseLink Session.
+ * <p>
+ * <b>Description</b>: This class is meant to provide facilities for managing an EclipseLink session external
+ * to EclipseLink over JMX.
+ *
+ * @since EclipseLink 4.0.1
+ */
+public class WildFlyRuntimeServices extends RuntimeServices {
+
+    static {
+        PLATFORM_NAME = "WildFly";
+    }
+
+    /**
+     * PUBLIC:
+     *  Default Constructor
+     */
+    public WildFlyRuntimeServices() {
+        super();
+    }
+
+    /**
+     *  PUBLIC:
+     *  Create an instance of WildFlyRuntimeServices to be associated with the provided session
+     *
+     *  @param session The session to be used with these RuntimeServices
+     */
+    public WildFlyRuntimeServices(AbstractSession session) {
+        super();
+        this.session = session;
+        this.updateDeploymentTimeData();
+    }
+
+    /**
+     *  Create an instance of WildFlyRuntimeServices to be associated with the provided locale
+     *
+     *  The user must call setSession(Session) afterwards to define the session.
+     */
+    public WildFlyRuntimeServices(Locale locale) {
+    }
+
+}

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/services/wildfly/WildFlyRuntimeServices.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/services/wildfly/WildFlyRuntimeServices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/factories/XMLSessionConfigLoader.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/factories/XMLSessionConfigLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/factories/XMLSessionConfigLoader.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/factories/XMLSessionConfigLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -82,7 +82,7 @@ public class XMLSessionConfigLoader {
     /** Used to store the entity resolver to validate the XML schema when parsing. */
     protected PersistenceEntityResolver entityResolver;
 
-    public static final String ECLIPSELINK_SESSIONS_SCHEMA = "org/eclipse/persistence/eclipselink_sessions_2.1.xsd";
+    public static final String ECLIPSELINK_SESSIONS_SCHEMA = "org/eclipse/persistence/eclipselink_sessions_2.2.xsd";
     protected static final String DEFAULT_RESOURCE_NAME = "sessions.xml";
     protected static final String DEFAULT_RESOURCE_NAME_IN_META_INF = "META-INF/sessions.xml";
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/transaction/wildfly/WildFlyTransactionController.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/transaction/wildfly/WildFlyTransactionController.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.transaction.wildfly;
+
+import jakarta.transaction.TransactionManager;
+import org.eclipse.persistence.exceptions.TransactionException;
+import org.eclipse.persistence.transaction.JTATransactionController;
+
+/**
+ * <p>
+ * <b>Purpose</b>: TransactionController implementation for WildFly JTA
+ * <p>
+ * <b>Description</b>: Implements the required behavior for controlling JTA 1.0
+ * transactions in WildFly. The JTA TransactionManager must be set on the instance.
+ *
+ * @see JTATransactionController
+ */
+public class WildFlyTransactionController extends JTATransactionController {
+
+    public static final String JNDI_TRANSACTION_MANAGER_NAME_AS4 = "java:/TransactionManager";
+    public static final String JNDI_TRANSACTION_MANAGER_NAME_AS7 = "java:wildfly/TransactionManager";
+
+    /**
+     * Default constructor
+     */
+    public WildFlyTransactionController() {
+        super();
+    }
+
+    /**
+     * INTERNAL:
+     * Obtain and return the JTA TransactionManager on this platform
+     */
+    @Override
+    protected TransactionManager acquireTransactionManager() throws Exception {
+        try {
+            return (TransactionManager)jndiLookup(JNDI_TRANSACTION_MANAGER_NAME_AS7);
+        } catch(TransactionException transactionException) {
+            if (transactionException.getErrorCode() == TransactionException.ERROR_DOING_JNDI_LOOKUP) {
+                return (TransactionManager)jndiLookup(JNDI_TRANSACTION_MANAGER_NAME_AS4);
+            } else {
+                throw transactionException;
+            }
+        }
+    }
+}

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/transaction/wildfly/WildFlyTransactionController.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/transaction/wildfly/WildFlyTransactionController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/transaction/wildfly/WildFlyTransactionController11.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/transaction/wildfly/WildFlyTransactionController11.java
@@ -31,7 +31,7 @@ import org.eclipse.persistence.transaction.JTA11TransactionController;
 public class WildFlyTransactionController11 extends JTA11TransactionController {
 
     /** WildFly specific JNDI name of {@code TransactionSynchronizationRegistry} instance. */
-    public static final String JNDI_TRANSACTION_SYNCHRONIZATION_REGISTRY = "java:wildfly/TransactionSynchronizationRegistry";
+    public static final String JNDI_TRANSACTION_SYNCHRONIZATION_REGISTRY = "java:jboss/TransactionSynchronizationRegistry";
 
     /**
      * Default constructor

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/transaction/wildfly/WildFlyTransactionController11.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/transaction/wildfly/WildFlyTransactionController11.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.transaction.wildfly;
+
+import jakarta.transaction.TransactionManager;
+import jakarta.transaction.TransactionSynchronizationRegistry;
+import org.eclipse.persistence.exceptions.TransactionException;
+import org.eclipse.persistence.transaction.JTA11TransactionController;
+
+/**
+ * <p>
+ * <b>Purpose</b>: TransactionController implementation for WildFly JTA
+ * <p>
+ * <b>Description</b>: Implements the required behavior for controlling JTA 1.0
+ * transactions in WildFly. The JTA TransactionManager must be set on the instance.
+ *
+ * @see org.eclipse.persistence.transaction.JTATransactionController
+ */
+public class WildFlyTransactionController11 extends JTA11TransactionController {
+
+    /** WildFly specific JNDI name of {@code TransactionSynchronizationRegistry} instance. */
+    public static final String JNDI_TRANSACTION_SYNCHRONIZATION_REGISTRY = "java:wildfly/TransactionSynchronizationRegistry";
+
+    /**
+     * Default constructor
+     */
+    public WildFlyTransactionController11() {
+        super();
+    }
+
+    /**
+     * INTERNAL:
+     * Obtain and return the JTA TransactionManager on this platform
+     */
+    @Override
+    protected TransactionManager acquireTransactionManager() throws Exception {
+        try {
+            return (TransactionManager)jndiLookup(WildFlyTransactionController.JNDI_TRANSACTION_MANAGER_NAME_AS7);
+        } catch(TransactionException transactionException) {
+            if (transactionException.getErrorCode() == TransactionException.ERROR_DOING_JNDI_LOOKUP) {
+                return (TransactionManager)jndiLookup(WildFlyTransactionController.JNDI_TRANSACTION_MANAGER_NAME_AS4);
+            } else {
+                throw transactionException;
+            }
+        }
+    }
+
+    /**
+     * INTERNAL:
+     * Obtain and return the JTA 1.1 {@link TransactionSynchronizationRegistry} on this platform.
+     *
+     * @return the {@code TransactionSynchronizationRegistry} for the transaction system
+     * @since 2.7.1
+     */
+    @Override
+    protected TransactionSynchronizationRegistry acquireTransactionSynchronizationRegistry() throws TransactionException {
+        return (TransactionSynchronizationRegistry)jndiLookup(JNDI_TRANSACTION_SYNCHRONIZATION_REGISTRY);
+    }
+
+}

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/transaction/wildfly/WildFlyTransactionController11.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/transaction/wildfly/WildFlyTransactionController11.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/foundation/org.eclipse.persistence.core/src/main/resources/org/eclipse/persistence/eclipselink_sessions_2.1.xsd
+++ b/foundation/org.eclipse.persistence.core/src/main/resources/org/eclipse/persistence/eclipselink_sessions_2.1.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -328,6 +328,11 @@ of this file are typically located as: 'META-INF/sessions.xml'
         </xsd:complexContent>
     </xsd:complexType>
     <xsd:complexType name="glassfish-platform">
+        <xsd:complexContent>
+            <xsd:extension base="server-platform" />
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="wildfly-platform">
         <xsd:complexContent>
             <xsd:extension base="server-platform" />
         </xsd:complexContent>

--- a/foundation/org.eclipse.persistence.core/src/main/resources/org/eclipse/persistence/eclipselink_sessions_2.1.xsd
+++ b/foundation/org.eclipse.persistence.core/src/main/resources/org/eclipse/persistence/eclipselink_sessions_2.1.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at

--- a/foundation/org.eclipse.persistence.core/src/main/resources/org/eclipse/persistence/eclipselink_sessions_2.2.xsd
+++ b/foundation/org.eclipse.persistence.core/src/main/resources/org/eclipse/persistence/eclipselink_sessions_2.2.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,10 +15,7 @@
 
 <!--
 Contributors:
-    Oracle - initial API and implementation from Oracle TopLink
-    tware - update version number to 2.0
-    pkrogh- update version number to 2.1
-    agoerler - add Net weaver support
+    Oracle - initial API and implementation, add WildFly weaver support and new version 2.2
 -->
 <!--
 
@@ -28,7 +25,7 @@ of this file are typically located as: 'META-INF/sessions.xml'
  -->
 
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-    elementFormDefault="qualified" version="2.1">
+    elementFormDefault="qualified" version="2.2">
     <xsd:element name="sessions">
         <xsd:annotation>
             <xsd:documentation>
@@ -328,6 +325,11 @@ of this file are typically located as: 'META-INF/sessions.xml'
         </xsd:complexContent>
     </xsd:complexType>
     <xsd:complexType name="glassfish-platform">
+        <xsd:complexContent>
+            <xsd:extension base="server-platform" />
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="wildfly-platform">
         <xsd:complexContent>
             <xsd:extension base="server-platform" />
         </xsd:complexContent>

--- a/foundation/org.eclipse.persistence.core/src/main/resources/org/eclipse/persistence/eclipselink_sessions_2.2.xsd
+++ b/foundation/org.eclipse.persistence.core/src/main/resources/org/eclipse/persistence/eclipselink_sessions_2.2.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at

--- a/jpa/eclipselink.jpa.testapps/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/pom.xml
@@ -625,7 +625,7 @@
                     <dependency>
                         <groupId>org.wildfly</groupId>
                         <artifactId>wildfly-client-all</artifactId>
-                        <version>27.0.0.Alpha4</version>
+                        <version>${wildfly.version}</version>
                     </dependency>
                 </dependencies>
             </dependencyManagement>
@@ -641,7 +641,6 @@
                     <plugin>
                         <groupId>org.wildfly.plugins</groupId>
                         <artifactId>wildfly-maven-plugin</artifactId>
-                        <version>2.1.0.Beta1</version>
                         <configuration>
                             <skip>${wildfly.deploy.skip}</skip>
                             <username>${wildfly.username}</username>

--- a/jpa/eclipselink.jpa.testapps/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at

--- a/pom.xml
+++ b/pom.xml
@@ -134,8 +134,8 @@
 
         <!--Default location for JEE servers binaries-->
         <test.directory>${user.home}/.eclipselinktests</test.directory>
-        <installation.url>https://download.jboss.org/wildfly/18.0.0.Final/wildfly-18.0.0.Final.zip</installation.url>
-        <installation.checksum.md5>8e4d435bb5d6fe466b478dc49d34bf27</installation.checksum.md5>
+        <installation.url>https://github.com/wildfly/wildfly/releases/download/27.0.0.Final/wildfly-27.0.0.Final.zip</installation.url>
+        <installation.checksum.md5>56e2dd6f54e65603ada5659a06ad782b</installation.checksum.md5>
 
         <!--Test DB property file names-->
         <test.mysql.properties.file>el-test.mysql.properties</test.mysql.properties.file>
@@ -256,7 +256,7 @@
         <!-- CQ #23233 -->
         <weld-se.version>5.0.1.Final</weld-se.version>
         <weblogic.version>12.2.1-3</weblogic.version>
-        <wildfly.version>18.0.0.Final</wildfly.version>
+        <wildfly.version>27.0.0.Final</wildfly.version>
         <wsdl4j.version>1.6.3</wsdl4j.version>
 
         <!--Documentation Dependencies version-->
@@ -1319,6 +1319,11 @@
                         </dependency>
                     </dependencies>
                 </plugin>
+                <plugin>
+                    <groupId>org.wildfly.plugins</groupId>
+                    <artifactId>wildfly-maven-plugin</artifactId>
+                    <version>4.0.0.Final</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -1842,8 +1847,8 @@
                 <jee.client.version>${wildfly.version}</jee.client.version>
                 <jee.client.type>pom</jee.client.type>
                 <!--Download properties-->
-                <installation.url>https://download.jboss.org/wildfly/18.0.0.Final/wildfly-18.0.0.Final.zip</installation.url>
-                <installation.checksum.md5>8e4d435bb5d6fe466b478dc49d34bf27</installation.checksum.md5>
+                <installation.url>https://github.com/wildfly/wildfly/releases/download/27.0.0.Final/wildfly-27.0.0.Final.zip</installation.url>
+                <installation.checksum.md5>56e2dd6f54e65603ada5659a06ad782b</installation.checksum.md5>
             </properties>
         </profile>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at

--- a/sdo/eclipselink.sdo.test.server/pom.xml
+++ b/sdo/eclipselink.sdo.test.server/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at

--- a/sdo/eclipselink.sdo.test.server/pom.xml
+++ b/sdo/eclipselink.sdo.test.server/pom.xml
@@ -106,6 +106,14 @@
         </testResources>
 
         <plugins>
+<!-- Temporary disabled to unblock build due following
+###WildFly###
+[WARNING] Supported source version 'RELEASE_8' from annotation processor 'org.kohsuke.metainf_services.AnnotationProcessorImpl' less than -source '11'
+[WARNING] No processor claimed any of these annotations: /jakarta.ejb.Remote,/jakarta.ejb.Startup,/jakarta.ejb.Stateless,/jakarta.annotation.PostConstruct,/jakarta.ejb.Singleton
+###GlassFish###
+[WARNING] Supported source version 'RELEASE_8' from annotation processor 'org.glassfish.corba.annotation.processing.ExceptionWrapperProcessor' less than -source '11'
+[WARNING] No processor claimed any of these annotations: /jakarta.ejb.Remote,/jakarta.ejb.Startup,/jakarta.ejb.Stateless,/jakarta.annotation.PostConstruct,/jakarta.ejb.Singleton
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -115,6 +123,7 @@
                     </compilerArgs>
                 </configuration>
             </plugin>
+-->
             <!--Required for XLST to configure Wildfly modules (see sdo/eclipselink.sdo.test.server.maven/src/test/resources/wildfly/elResources.xml)-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This change add WildFly server into JEE platforms supported by EclipseLink.
It should better reflect changes in WildFly as latest WildFly (27.0.0.Final) support Jakarta EE10 and JBoss (EAP 7.4) Jakarta EE 8.
There are test dependencies update to the latest WildFly 27.0.0.Final.