### PR TITLE
[New Feature] Added support for optional connection parameter authSource in NOSQL MONGODB

### DIFF
--- a/foundation/org.eclipse.persistence.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/mongo/MongoDatabaseConnectionFactory.java
+++ b/foundation/org.eclipse.persistence.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/mongo/MongoDatabaseConnectionFactory.java
@@ -95,7 +95,15 @@ public class MongoDatabaseConnectionFactory implements ConnectionFactory {
                 isExternal = false;
                 List<MongoCredential> credentialsList =  new ArrayList<>();
                 if ((connectionSpec.getUser() != null) && (connectionSpec.getUser().length() > 0)) {
-                    MongoCredential credential = MongoCredential.createCredential(connectionSpec.getUser(), connectionSpec.getDB(), connectionSpec.getPassword());
+                    MongoCredential credential = null;
+
+                    if ( connectionSpec.getAuthSource() != null ) {
+                        credential = MongoCredential.createCredential(connectionSpec.getUser(), connectionSpec.getAuthSource(), connectionSpec.getPassword());
+                    }
+                    else {
+                        credential = MongoCredential.createCredential(connectionSpec.getUser(), connectionSpec.getDB(), connectionSpec.getPassword());
+                    }
+
                     credentialsList.add(credential);
                 }
                 Builder optionsBuilder = new MongoClientOptions.Builder();

--- a/foundation/org.eclipse.persistence.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/mongo/MongoJCAConnectionSpec.java
+++ b/foundation/org.eclipse.persistence.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/mongo/MongoJCAConnectionSpec.java
@@ -33,6 +33,9 @@ public class MongoJCAConnectionSpec implements ConnectionSpec {
     /** Mongo database name. */
     protected String db = "mydb";
 
+    /** Optional authSource https://www.mongodb.com/docs/manual/reference/connection-string/#mongodb-urioption-urioption.authSource */
+    protected String authSource;
+
     /** Optional user name. */
     protected String user;
     /** Optional password. */
@@ -157,5 +160,13 @@ public class MongoJCAConnectionSpec implements ConnectionSpec {
 
     public void setServerSelectionTimeout(int serverSelectionTimeout) {
         this.serverSelectionTimeout = serverSelectionTimeout;
+    }
+
+    public String getAuthSource() {
+        return authSource;
+    }
+
+    public void setAuthSource(String authSource) {
+        this.authSource = authSource;
     }
 }

--- a/foundation/org.eclipse.persistence.nosql/src/main/java/org/eclipse/persistence/nosql/adapters/mongo/MongoConnectionSpec.java
+++ b/foundation/org.eclipse.persistence.nosql/src/main/java/org/eclipse/persistence/nosql/adapters/mongo/MongoConnectionSpec.java
@@ -47,6 +47,7 @@ public class MongoConnectionSpec extends EISConnectionSpec {
     public static final String READ_PREFERENCE = "mongo.read-preference";
     public static final String WRITE_CONCERN = "mongo.write-concern";
     public static final String SERVER_SELECTION_TIMEOUT = "mongo.server-selection-timeout";
+    public static final String AUTH_SOURCE = "mongo.auth-source";
 
     /**
      * PUBLIC:
@@ -72,6 +73,8 @@ public class MongoConnectionSpec extends EISConnectionSpec {
             String host = (String)properties.get(HOST);
             String port = (String)properties.get(PORT);
             String db = (String)properties.get(DB);
+            String authSource = (String)properties.get(AUTH_SOURCE); //https://www.mongodb.com/docs/manual/reference/connection-string/#mongodb-urioption-urioption.authSource
+
             if (host != null) {
                 if (host.indexOf(',') == -1) {
                     spec.getHosts().add(host);
@@ -102,6 +105,10 @@ public class MongoConnectionSpec extends EISConnectionSpec {
             }
             if (db != null) {
                 spec.setDB(db);
+            }
+
+            if ( authSource != null ) {
+                spec.setAuthSource(authSource);
             }
 
             String user = (String)properties.get("user");


### PR DESCRIPTION
[New Feature] Added support for optional connection parameter authSource in NOSQL MongoDB server.

The class MongoConnectionSpec and MongoJCAConnectionSpec not read this important parameter from persistent.xml file. And the class MongoDatabaseConnectionFactory take care of presence of value in the authSource parameter. To send the appropriates values to MongoDB connection.

When the Mongo db server had configured user and password. The MongoDB server assume in wrong way the user and password is stored in the same target database. But is not true for 100% of cases. Sometimes is need specific the admin database name is most cases called "admin".

More info about the authSource Paramerter

[https://www.mongodb.com/docs/manual/reference/connection-string/#mongodb-urioption-urioption.authSource](https://www.mongodb.com/docs/manual/reference/connection-string/#mongodb-urioption-urioption.authSource)