### PR TITLE
[master] Oracle NoSQL Database - Json type fix

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/eis/EISDescriptor.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/eis/EISDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -370,11 +370,13 @@ public class EISDescriptor extends ClassDescriptor {
         if (isXMLFormat()) {
             if(!(field instanceof XMLField)) {
                 String xPath = field.getName();
+                String columnDefinition = field.getColumnDefinition();
                 // Moxy requires /text on elements.
                 if ((xPath.indexOf('@') == -1) && (xPath.indexOf("/text()") == -1)) {
                     xPath = xPath + "/text()";
                 }
                 field = new XMLField(xPath);
+                field.setColumnDefinition(columnDefinition);
             }
             ((XMLField)field).setNamespaceResolver(getNamespaceResolver());
             ((XMLField)field).initialize();

--- a/foundation/org.eclipse.persistence.oracle.nosql/pom.xml
+++ b/foundation/org.eclipse.persistence.oracle.nosql/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -285,6 +285,11 @@
                     <groupId>javax.jms</groupId>
                     <artifactId>javax.jms-api</artifactId>
                     <version>2.0.1</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.eclipse.parsson</groupId>
+                    <artifactId>parsson</artifactId>
                     <scope>test</scope>
                 </dependency>
                 <!--JDBC driver dependencies-->

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/models/jpa/nosql/DataTypesEntity.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/models/jpa/nosql/DataTypesEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,6 +14,7 @@
 //     Oracle - initial API and implementation
 package org.eclipse.persistence.testing.models.jpa.nosql;
 
+import jakarta.persistence.Cacheable;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -35,6 +36,7 @@ import java.util.Arrays;
         @NamedQuery(name = "DataTypesEntity.findByIdAndName", query = "SELECT t FROM DataTypesEntity t WHERE t.id = :id AND t.fieldString = :name")
 })
 @NoSql
+@Cacheable(false)
 public class DataTypesEntity {
     @Id
     private long id;
@@ -43,8 +45,10 @@ public class DataTypesEntity {
     private byte[] fieldBinary;
     @Column(name = "col_boolean")
     private boolean fieldBoolean;
-    @Column(name = "col_json", columnDefinition = "JSON")
-    private String fieldJson;
+    @Column(name = "col_json_string", columnDefinition = "JSON")
+    private String fieldJsonString;
+    @Column(name = "col_json_object", columnDefinition = "JSON")
+    private String fieldJsonObject;
     @Column(name = "col_null")
     private String fieldNull;
     @Column(name = "col_string")
@@ -83,12 +87,20 @@ public class DataTypesEntity {
         this.fieldBoolean = fieldBoolean;
     }
 
-    public String getFieldJson() {
-        return fieldJson;
+    public String getFieldJsonString() {
+        return fieldJsonString;
     }
 
-    public void setFieldJson(String fieldJson) {
-        this.fieldJson = fieldJson;
+    public void setFieldJsonString(String fieldJsonString) {
+        this.fieldJsonString = fieldJsonString;
+    }
+
+    public String getFieldJsonObject() {
+        return fieldJsonObject;
+    }
+
+    public void setFieldJsonObject(String fieldJsonObject) {
+        this.fieldJsonObject = fieldJsonObject;
     }
 
     public String getFieldNull() {
@@ -121,7 +133,8 @@ public class DataTypesEntity {
                 "id=" + id +
                 ", fieldBinary=" + Arrays.toString(fieldBinary) +
                 ", fieldBoolean=" + fieldBoolean +
-                ", fieldJson='" + fieldJson + '\'' +
+                ", fieldJsonString='" + fieldJsonString + '\'' +
+                ", fieldJsonObject='" + fieldJsonObject + '\'' +
                 ", fieldNull='" + fieldNull + '\'' +
                 ", fieldString='" + fieldString + '\'' +
                 ", fieldTimestamp=" + fieldTimestamp +


### PR DESCRIPTION
This if fix + unit test for following case. Oracle NoSQL database allows store into JSON column type two kinds of values:

- String form which was currently supported
- Object tree based on `oracle.nosql.driver.values.MapValue`

Object tree wasn't supported before and there were incorrect results during various reading operations (find(...), query..)
At the Entity side is JSON stored as a `java.lang.String`.
This PR fixes conversion between JSON data stored as `oracle.nosql.driver.values.MapValue` and `java.lang.String` JPA field.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>