### PR TITLE
[2.7] Jenkins environment - switch to JDK 11

### DIFF
--- a/etc/jenkins/build.groovy
+++ b/etc/jenkins/build.groovy
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2019, 2023 Oracle and/or its affiliates. All rights reserved.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -104,7 +104,7 @@ spec:
         }
     }
     tools {
-        jdk 'adoptopenjdk-hotspot-jdk8-latest'
+        jdk 'adoptopenjdk-hotspot-jdk11-latest'
     }
     stages {
         // Initialize build environment

--- a/etc/jenkins/promote.groovy
+++ b/etc/jenkins/promote.groovy
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2019, 2023 Oracle and/or its affiliates. All rights reserved.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -98,6 +98,9 @@ spec:
     - cat
 """
         }
+    }
+    tools {
+        jdk 'adoptopenjdk-hotspot-jdk11-latest'
     }
     stages {
         // Prepare and promote EclipseLink artifacts to oss.sonatype.org (staging) and to the Eclipse.org Milestone Builds area


### PR DESCRIPTION
This is technical switch into JDK 11. Output will be still compatible with JDK 8.0 due Tycho setting in `.settings/org.eclipse.jdt.core.prefs`.
Signed-off-by: Radek Felcman <radek.felcman@oracle.com>