### PR TITLE
[2.6_WAS] Issue 1779: Add DB2zOS support for UNICODE Timestamps

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/DB2ZPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/DB2ZPlatform.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2022 Oracle, IBM Corporation, and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle, IBM Corporation, and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the 
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0 
  * which accompanies this distribution. 
@@ -47,6 +47,7 @@ import org.eclipse.persistence.logging.SessionLog;
 import org.eclipse.persistence.mappings.structures.ObjectRelationalDatabaseField;
 import org.eclipse.persistence.platform.database.converters.StructConverter;
 import org.eclipse.persistence.queries.StoredProcedureCall;
+import org.eclipse.persistence.queries.ValueReadQuery;
 
 /**
  * <b>Purpose</b>: Provides DB2 z/OS specific behavior.
@@ -103,6 +104,25 @@ public class DB2ZPlatform extends DB2Platform {
     @Override
     public String getProcedureOptionList() {
         return " DISABLE DEBUG MODE ";
+    }
+
+    /**
+     * INTERNAL:
+     * This method returns the query to select the timestamp from the server for
+     * DB2.
+     */
+    @Override
+    public ValueReadQuery getTimestampQuery() {
+        if (timestampQuery == null) {
+            if (getUseNationalCharacterVaryingTypeForString()) {
+                timestampQuery = new ValueReadQuery();
+                timestampQuery.setSQLString("SELECT CAST (CURRENT TIMESTAMP AS TIMESTAMP CCSID UNICODE) FROM SYSIBM.SYSDUMMY1");
+                timestampQuery.setAllowNativeSQLQuery(true);
+            } else {
+                timestampQuery = super.getTimestampQuery();
+            }
+        }
+        return timestampQuery;
     }
 
     /**
@@ -198,7 +218,7 @@ public class DB2ZPlatform extends DB2Platform {
      * With binding enabled, DB2 z/OS will throw an error:
      * <pre>The statement string specified as the object of a PREPARE contains a 
      * predicate or expression where parameter markers have been used as operands of 
-     * the same operator—for example: ? > ?. DB2 SQL Error: SQLCODE=-417, SQLSTATE=42609</pre>
+     * the same operator for example: ? > ?. DB2 SQL Error: SQLCODE=-417, SQLSTATE=42609</pre>
      */
     protected ExpressionOperator equalOperator() {
         ExpressionOperator operator = disableAtLeast1BindingExpression();
@@ -212,7 +232,7 @@ public class DB2ZPlatform extends DB2Platform {
      * With binding enabled, DB2 z/OS will throw an error:
      * <pre>The statement string specified as the object of a PREPARE contains a 
      * predicate or expression where parameter markers have been used as operands of 
-     * the same operator—for example: ? > ?. DB2 SQL Error: SQLCODE=-417, SQLSTATE=42609</pre>
+     * the same operator for example: ? > ?. DB2 SQL Error: SQLCODE=-417, SQLSTATE=42609</pre>
      */
     protected ExpressionOperator notEqualOperator() {
         ExpressionOperator operator = disableAtLeast1BindingExpression();
@@ -226,7 +246,7 @@ public class DB2ZPlatform extends DB2Platform {
      * With binding enabled, DB2 z/OS will throw an error:
      * <pre>The statement string specified as the object of a PREPARE contains a 
      * predicate or expression where parameter markers have been used as operands of 
-     * the same operator—for example: ? > ?. DB2 SQL Error: SQLCODE=-417, SQLSTATE=42609</pre>
+     * the same operator for example: ? > ?. DB2 SQL Error: SQLCODE=-417, SQLSTATE=42609</pre>
      */
     protected ExpressionOperator greaterThanOperator() {
         ExpressionOperator operator = disableAtLeast1BindingExpression();
@@ -240,7 +260,7 @@ public class DB2ZPlatform extends DB2Platform {
      * With binding enabled, DB2 z/OS will throw an error:
      * <pre>The statement string specified as the object of a PREPARE contains a 
      * predicate or expression where parameter markers have been used as operands of 
-     * the same operator—for example: ? > ?. DB2 SQL Error: SQLCODE=-417, SQLSTATE=42609</pre>
+     * the same operator for example: ? > ?. DB2 SQL Error: SQLCODE=-417, SQLSTATE=42609</pre>
      */
     protected ExpressionOperator greaterThanEqualOperator() {
         ExpressionOperator operator = disableAtLeast1BindingExpression();
@@ -254,7 +274,7 @@ public class DB2ZPlatform extends DB2Platform {
      * For ALL, DB2 z/OS will throw an error:
      * <pre>The statement string specified as the object of a PREPARE contains a 
      * predicate or expression where parameter markers have been used as operands of 
-     * the same operator—for example: ? > ?. DB2 SQL Error: SQLCODE=-417, SQLSTATE=42609</pre>
+     * the same operator for example: ? > ?. DB2 SQL Error: SQLCODE=-417, SQLSTATE=42609</pre>
      */
     protected ExpressionOperator lessThanOperator() {
         ExpressionOperator operator = disableAtLeast1BindingExpression();
@@ -268,7 +288,7 @@ public class DB2ZPlatform extends DB2Platform {
      * With binding enabled, DB2 z/OS will throw an error:
      * <pre>The statement string specified as the object of a PREPARE contains a 
      * predicate or expression where parameter markers have been used as operands of 
-     * the same operator—for example: ? > ?. DB2 SQL Error: SQLCODE=-417, SQLSTATE=42609</pre>
+     * the same operator for example: ? > ?. DB2 SQL Error: SQLCODE=-417, SQLSTATE=42609</pre>
      */
     protected ExpressionOperator lessThanEqualOperator() {
         ExpressionOperator operator = disableAtLeast1BindingExpression();
@@ -282,7 +302,7 @@ public class DB2ZPlatform extends DB2Platform {
      * With binding enabled, DB2 z/OS will throw an error:
      * <pre>The statement string specified as the object of a PREPARE contains a 
      * predicate or expression where parameter markers have been used as operands of 
-     * the same operator—for example: ? > ?. DB2 SQL Error: SQLCODE=-417, SQLSTATE=42609</pre>
+     * the same operator for example: ? > ?. DB2 SQL Error: SQLCODE=-417, SQLSTATE=42609</pre>
      */
     protected ExpressionOperator isNullOperator() {
         ExpressionOperator operator = disableAllBindingExpression();
@@ -296,7 +316,7 @@ public class DB2ZPlatform extends DB2Platform {
      * With binding enabled, DB2 z/OS will throw an error:
      * <pre>The statement string specified as the object of a PREPARE contains a 
      * predicate or expression where parameter markers have been used as operands of 
-     * the same operator—for example: ? > ?. DB2 SQL Error: SQLCODE=-417, SQLSTATE=42609</pre>
+     * the same operator for example: ? > ?. DB2 SQL Error: SQLCODE=-417, SQLSTATE=42609</pre>
      */
     protected ExpressionOperator isNotNullOperator() {
         ExpressionOperator operator = disableAllBindingExpression();
@@ -310,7 +330,7 @@ public class DB2ZPlatform extends DB2Platform {
      * With binding enabled, DB2 z/OS will throw an error:
      * <pre>The statement string specified as the object of a PREPARE contains a 
      * predicate or expression where parameter markers have been used as operands of 
-     * the same operator—for example: ? > ?. DB2 SQL Error: SQLCODE=-417, SQLSTATE=42609</pre>
+     * the same operator for example: ? > ?. DB2 SQL Error: SQLCODE=-417, SQLSTATE=42609</pre>
      */
     protected ExpressionOperator betweenOperator() {
         ExpressionOperator operator = disableAtLeast1BindingExpression();
@@ -324,7 +344,7 @@ public class DB2ZPlatform extends DB2Platform {
      * With binding enabled, DB2 z/OS will throw an error:
      * <pre>The statement string specified as the object of a PREPARE contains a 
      * predicate or expression where parameter markers have been used as operands of 
-     * the same operator—for example: ? > ?. DB2 SQL Error: SQLCODE=-417, SQLSTATE=42609</pre>
+     * the same operator for example: ? > ?. DB2 SQL Error: SQLCODE=-417, SQLSTATE=42609</pre>
      */
     protected ExpressionOperator notBetweenOperator() {
         ExpressionOperator operator = disableAtLeast1BindingExpression();

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQuerySyntaxFunctionTests.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQuerySyntaxFunctionTests.java
@@ -3189,7 +3189,7 @@ public class TestQuerySyntaxFunctionTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = LOCATE('HI', 'ABCDEFGHIJKLMNOP'))", _sql.remove(0));
+                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = LOCATE('HI', 'ABCDEFGHIJKLMNOP'))", _sql2.remove(0));
             } else if(platform.isDB2() || platform.isDerby()) {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = LOCATE('HI', 'ABCDEFGHIJKLMNOP'))", _sql2.remove(0));
             } else if(platform.isOracle()) {

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/sequence/TestIdentityGeneration.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/sequence/TestIdentityGeneration.java
@@ -27,6 +27,7 @@ import org.eclipse.persistence.jpa.test.framework.Emf;
 import org.eclipse.persistence.jpa.test.framework.EmfRunner;
 import org.eclipse.persistence.jpa.test.framework.Property;
 import org.eclipse.persistence.jpa.test.sequence.model.Coffee;
+import org.eclipse.persistence.jpa.test.sequence.model.StepExecutionEntity;
 import org.eclipse.persistence.jpa.test.sequence.model.Tea;
 import org.eclipse.persistence.jpa.test.sequence.model.TeaShop;
 import org.eclipse.persistence.platform.database.DatabasePlatform;

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/storedproc/TestStoredProceduresCursors.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/storedproc/TestStoredProceduresCursors.java
@@ -153,7 +153,7 @@ public class TestStoredProceduresCursors {
             if(platform.isOracle()) {
                 proc.addOutputArgument("out_cursor_one", "SYS_REFCURSOR");
                 proc.addStatement("OPEN out_cursor_one FOR SELECT ITEM_STRING1 FROM STORED_PROCEDURE_ENTITY WHERE ITEM_INTEGER1 = in_param_one");
-            } else if (platform.isDB2()) {
+            } else if (platform.isDB2() && !platform.isDB2Z()) {
                 proc.addOutputArgument("out_cursor_one", "CURSOR");
                 proc.addStatement("SET out_cursor_one = CURSOR FOR SELECT ITEM_STRING1 FROM STORED_PROCEDURE_ENTITY WHERE ITEM_INTEGER1 = in_param_one; OPEN out_cursor_one");
             } else {

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/version/TestVersioning.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/version/TestVersioning.java
@@ -35,7 +35,9 @@ public class TestVersioning {
 	@Emf(createTables = DDLGen.DROP_CREATE, classes = { TemporalVersionedEntity.class, TemporalVersionedEntity2.class,
 			IntegerVersionedEntity.class},
 			properties = { @Property(name="eclipselink.logging.level", value="FINE"),
-					       @Property(name="eclipselink.logging.parameters", value="true")})
+					       @Property(name="eclipselink.logging.parameters", value="true"),
+                           @Property(name = "eclipselink.target-database-properties",
+                                     value = "UseNationalCharacterVaryingTypeForString=true")})
     private EntityManagerFactory emf;
 	
 	private final static String qStr1 = "UPDATE TemporalVersionedEntity " + 


### PR DESCRIPTION
for #1779

For non-IBM JDKs, against DB2 zOS, the existing test `org.eclipse.persistence.jpa.test.version.TestVersioning.testTemporalVersionField1()` fails:
```sql
<error message="java.nio.charset.UnsupportedCharsetException: Cp1027" type="javax.persistence.RollbackException">javax.persistence.RollbackException: java.nio.charset.UnsupportedCharsetException: Cp1027
	at org.eclipse.persistence.internal.jpa.transaction.EntityTransactionImpl.commit(EntityTransactionImpl.java:159)
	at org.eclipse.persistence.jpa.test.version.TestVersioning.testTemporalVersionField1(TestVersioning.java:62)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at org.eclipse.persistence.jpa.test.framework.EmfRunner.run(EmfRunner.java:40)
Caused by: java.nio.charset.UnsupportedCharsetException: Cp1027
	at java.base/java.nio.charset.Charset.forName(Charset.java:529)
	at com.ibm.db2.jcc.am.x.&lt;init&gt;(x.java:20)
	at com.ibm.db2.jcc.am.w.a(w.java:12)
	at com.ibm.db2.jcc.am.Agent.getByteToCharConverter(Agent.java:497)
	at com.ibm.db2.jcc.t4.a8.a(a8.java:2438)
	at com.ibm.db2.jcc.t4.ab.a(ab.java:4350)
	at com.ibm.db2.jcc.t4.ab.a(ab.java:2777)
	at com.ibm.db2.jcc.t4.ab.a(ab.java:2698)
	at com.ibm.db2.jcc.t4.ab.q(ab.java:1546)
	at com.ibm.db2.jcc.t4.ab.l(ab.java:735)
	at com.ibm.db2.jcc.t4.ab.d(ab.java:111)
	at com.ibm.db2.jcc.t4.p.c(p.java:44)
	at com.ibm.db2.jcc.t4.av.j(av.java:162)
	at com.ibm.db2.jcc.am.k3.an(k3.java:2249)
	at com.ibm.db2.jcc.am.k4.a(k4.java:4638)
	at com.ibm.db2.jcc.am.k4.b(k4.java:4154)
	at com.ibm.db2.jcc.am.k4.bd(k4.java:774)
	at com.ibm.db2.jcc.am.k4.executeQuery(k4.java:739)
	at org.eclipse.persistence.internal.databaseaccess.DatabaseAccessor.executeSelect(DatabaseAccessor.java:1018)
```

Signed-off-by: William Dazey <wadazey@us.ibm.com>