### PR TITLE
[2.7] Issue 1779: Add DB2zOS support for UNICODE Timestamps

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/DB2ZPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/DB2ZPlatform.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2015, 2022 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2022 IBM Corporation. All rights reserved.
+ * Copyright (c) 2015, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -57,6 +57,7 @@ import org.eclipse.persistence.logging.SessionLog;
 import org.eclipse.persistence.mappings.structures.ObjectRelationalDatabaseField;
 import org.eclipse.persistence.platform.database.converters.StructConverter;
 import org.eclipse.persistence.queries.StoredProcedureCall;
+import org.eclipse.persistence.queries.ValueReadQuery;
 
 /**
  * <b>Purpose</b>: Provides DB2 z/OS specific behavior.
@@ -111,6 +112,25 @@ public class DB2ZPlatform extends DB2Platform {
     @Override
     public String getProcedureOptionList() {
         return " DISABLE DEBUG MODE ";
+    }
+
+    /**
+     * INTERNAL:
+     * This method returns the query to select the timestamp from the server for
+     * DB2.
+     */
+    @Override
+    public ValueReadQuery getTimestampQuery() {
+        if (timestampQuery == null) {
+            if (getUseNationalCharacterVaryingTypeForString()) {
+                timestampQuery = new ValueReadQuery();
+                timestampQuery.setSQLString("SELECT CAST (CURRENT TIMESTAMP AS TIMESTAMP CCSID UNICODE) FROM SYSIBM.SYSDUMMY1");
+                timestampQuery.setAllowNativeSQLQuery(true);
+            } else {
+                timestampQuery = super.getTimestampQuery();
+            }
+        }
+        return timestampQuery;
     }
 
     @Override

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQuerySyntaxFunctionTests.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/query/TestQuerySyntaxFunctionTests.java
@@ -3191,7 +3191,7 @@ public class TestQuerySyntaxFunctionTests {
             query.getResultList();
             Assert.assertEquals(1, _sql2.size());
             if(platform.isDB2Z()) {
-                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = LOCATE('HI', 'ABCDEFGHIJKLMNOP'))", _sql.remove(0));
+                Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = LOCATE('HI', 'ABCDEFGHIJKLMNOP'))", _sql2.remove(0));
             } else if(platform.isDB2() || platform.isDerby()) {
                 Assert.assertEquals("SELECT INTVAL1 FROM QUERYSYNTAXENTITY WHERE (INTVAL1 = LOCATE('HI', 'ABCDEFGHIJKLMNOP'))", _sql2.remove(0));
             } else if(platform.isOracle()) {

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/storedproc/TestStoredProceduresCursors.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/storedproc/TestStoredProceduresCursors.java
@@ -156,7 +156,7 @@ public class TestStoredProceduresCursors {
             if(platform.isOracle()) {
                 proc.addOutputArgument("out_cursor_one", "SYS_REFCURSOR");
                 proc.addStatement("OPEN out_cursor_one FOR SELECT ITEM_STRING1 FROM STORED_PROCEDURE_ENTITY WHERE ITEM_INTEGER1 = in_param_one");
-            } else if (platform.isDB2()) {
+            } else if (platform.isDB2() && !platform.isDB2Z()) {
                 proc.addOutputArgument("out_cursor_one", "CURSOR");
                 proc.addStatement("SET out_cursor_one = CURSOR FOR SELECT ITEM_STRING1 FROM STORED_PROCEDURE_ENTITY WHERE ITEM_INTEGER1 = in_param_one; OPEN out_cursor_one");
             } else {

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/version/TestVersioning.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/version/TestVersioning.java
@@ -38,7 +38,9 @@ public class TestVersioning {
 	@Emf(createTables = DDLGen.DROP_CREATE, classes = { TemporalVersionedEntity.class, TemporalVersionedEntity2.class,
 			IntegerVersionedEntity.class},
 			properties = { @Property(name="eclipselink.logging.level", value="FINE"),
-					       @Property(name="eclipselink.logging.parameters", value="true")})
+					       @Property(name="eclipselink.logging.parameters", value="true"),
+                           @Property(name = "eclipselink.target-database-properties",
+                           value = "UseNationalCharacterVaryingTypeForString=true")})
     private EntityManagerFactory emf;
 	
 	private final static String qStr1 = "UPDATE TemporalVersionedEntity " + 


### PR DESCRIPTION
for #1779

For non-IBM JDKs, against DB2 zOS, the existing test `org.eclipse.persistence.jpa.test.version.TestVersioning.testTemporalVersionField1()` fails:
```sql
<error message="java.nio.charset.UnsupportedCharsetException: Cp1027" type="javax.persistence.RollbackException">javax.persistence.RollbackException: java.nio.charset.UnsupportedCharsetException: Cp1027
	at org.eclipse.persistence.internal.jpa.transaction.EntityTransactionImpl.commit(EntityTransactionImpl.java:159)
	at org.eclipse.persistence.jpa.test.version.TestVersioning.testTemporalVersionField1(TestVersioning.java:62)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at org.eclipse.persistence.jpa.test.framework.EmfRunner.run(EmfRunner.java:40)
Caused by: java.nio.charset.UnsupportedCharsetException: Cp1027
	at java.base/java.nio.charset.Charset.forName(Charset.java:529)
	at com.ibm.db2.jcc.am.x.&lt;init&gt;(x.java:20)
	at com.ibm.db2.jcc.am.w.a(w.java:12)
	at com.ibm.db2.jcc.am.Agent.getByteToCharConverter(Agent.java:497)
	at com.ibm.db2.jcc.t4.a8.a(a8.java:2438)
	at com.ibm.db2.jcc.t4.ab.a(ab.java:4350)
	at com.ibm.db2.jcc.t4.ab.a(ab.java:2777)
	at com.ibm.db2.jcc.t4.ab.a(ab.java:2698)
	at com.ibm.db2.jcc.t4.ab.q(ab.java:1546)
	at com.ibm.db2.jcc.t4.ab.l(ab.java:735)
	at com.ibm.db2.jcc.t4.ab.d(ab.java:111)
	at com.ibm.db2.jcc.t4.p.c(p.java:44)
	at com.ibm.db2.jcc.t4.av.j(av.java:162)
	at com.ibm.db2.jcc.am.k3.an(k3.java:2249)
	at com.ibm.db2.jcc.am.k4.a(k4.java:4638)
	at com.ibm.db2.jcc.am.k4.b(k4.java:4154)
	at com.ibm.db2.jcc.am.k4.bd(k4.java:774)
	at com.ibm.db2.jcc.am.k4.executeQuery(k4.java:739)
	at org.eclipse.persistence.internal.databaseaccess.DatabaseAccessor.executeSelect(DatabaseAccessor.java:1018)
```

Signed-off-by: William Dazey <wadazey@us.ibm.com>