### PR TITLE
[2.7] Jenkins build pipeline - javadoc build fix

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022 Contributors to the Eclipse Foundation
+# Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at
@@ -20,7 +20,7 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 env:
-  maven_version: 3.8.6
+  maven_version: 3.8.7
 jobs:
   build:
     name: Test on JDK ${{ matrix.java_version }}
@@ -43,16 +43,16 @@ jobs:
           mysql -e 'CREATE DATABASE ecltests;' -uroot -proot
           mysql -e 'SHOW DATABASES;' -uroot -proot
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Checkout for build
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.java_version }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+# Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at
@@ -26,7 +26,7 @@ on:
   schedule:
     - cron: '0 19 * * 1'
 env:
-  maven_version: 3.8.6
+  maven_version: 3.8.7
 
 jobs:
   analyze:
@@ -44,11 +44,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml

--- a/antbuild.xml
+++ b/antbuild.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -202,11 +202,18 @@
         <pathelement path="${eclipselink.plugins}/${ejb-api.jar}"/>
         <pathelement path="${eclipselink.plugins}/${jms-api.jar}"/>
         <pathelement path="${eclipselink.plugins}/${transaction-api.jar}"/>
+        <pathelement path="${eclipselink.plugins}/${servlet-api.jar}"/>
+        <pathelement path="${eclipselink.plugins}/${soap-api.jar}"/>
+        <pathelement path="${eclipselink.plugins}/${cdi-api.jar}"/>
         <pathelement path="${eclipselink.plugins}/${mail.jar}"/>
+        <pathelement path="${eclipselink.plugins}/${ws-api.jar}"/>
+        <pathelement path="${eclipselink.plugins}/${wsdl.jar}"/>
         <pathelement path="${eclipselink.plugins}/${wsrs-api.jar}"/>
         <pathelement path="${eclipselink.plugins}/${slf4j-api.jar}"/>
         <pathelement path="${eclipselink.plugins}/org.eclipse.persistence.nosql_${version.string}.jar"/>
         <pathelement path="${eclipselink.plugins}/org.eclipse.persistence.extension_${version.string}.jar"/>
+        <pathelement path="${eclipselink.util.plugins}/org.eclipse.persistence.oracleddlparser_1.0.0.v201807030954.jar"/>
+        <pathelement path="${eclipselink.util.plugins}/javax.wsdl_1.6.2.v201012040545.jar"/>
         <pathelement path="${extensions.depend.dir}/${jgroups.jar}"/>
         <pathelement path="${java.class.path}"/>
     </path>

--- a/autobuild.xml
+++ b/autobuild.xml
@@ -833,7 +833,7 @@
         <echo message="        build.date      ='${build.date}'"/>
         <echo message="        build.type      ='${build.type}'"/>
         <echo message="        bundle.dir      ='${tmp.maven.dir}'"/>
-        <ant antfile="uploadToNexus.xml" dir="${tmp.maven.dir}" target="upload-maven-all">
+        <ant antfile="uploadToNexus.xml" dir="${basedir}" target="upload-maven-all">
             <property name="build.deps.dir"   value="${build.deps.dir}"/>
             <property name="custom.tasks.lib" value="${releng.repo.dir}/ant_customizations.jar"/>
             <property name="release.version"  value="${release.version}"/>

--- a/autobuild.xml
+++ b/autobuild.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -841,6 +841,7 @@
             <property name="build.date"       value="${build.date}"/>
             <property name="build.type"       value="${build.type}"/>
             <property name="bundle.dir"       value="${tmp.maven.dir}"/>
+            <property name="antbuild.dir"    value="${basedir}"/>
         </ant>
     </target>
 

--- a/etc/jenkins/init.sh
+++ b/etc/jenkins/init.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2023 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -24,6 +24,7 @@ wget -nc https://repo1.maven.org/maven2/org/jboss/logging/jboss-logging/3.4.1.Fi
 wget -nc https://repo1.maven.org/maven2/org/glassfish/javax.el/3.0.1-b08/javax.el-3.0.1-b08.jar -O $HOME/extension.lib.external/javax.el-3.0.1-b08.jar
 wget -nc https://repo1.maven.org/maven2/com/fasterxml/classmate/1.5.1/classmate-1.5.1.jar -O $HOME/extension.lib.external/classmate-1.5.1.jar
 wget -nc https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.28/mysql-connector-java-8.0.28.jar -O $HOME/extension.lib.external/mysql-connector-java-8.0.28.jar
+wget -nc https://repo1.maven.org/maven2/org/jgroups/jgroups/4.1.8.Final/jgroups-4.1.8.Final.jar -O $HOME/extension.lib.external/jgroups.jar
 wget -nc https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.7-bin.tar.gz -O $HOME/extension.lib.external/apache-ant-1.10.7-bin.tar.gz
 wget -nc https://archive.apache.org/dist/maven/ant-tasks/2.1.3/binaries/maven-ant-tasks-2.1.3.jar -O $HOME/extension.lib.external/mavenant/maven-ant-tasks-2.1.3.jar
 wget -nc https://download.jboss.org/wildfly/15.0.1.Final/wildfly-15.0.1.Final.tar.gz -O $HOME/extension.lib.external/wildfly-15.0.1.Final.tar.gz

--- a/uploadToNexus.xml
+++ b/uploadToNexus.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -27,6 +27,7 @@
 *         build.date      - in format YYYYMMDD
 *         build.type      - should be set to "SNAPSHOT, "M##", or "RELEASE"
 *         git.hash        - for stamping pom, to link build with source repo
+*         antbuild.dir    - Ant build directory
 *    Optional variables:
 *         bundle.dir      - if location of bundles to publish isn't a git "view"
 *
@@ -62,6 +63,7 @@
 *   - Ant properties are lower case.
 -->
 <project name="Upload2Maven"  basedir="." xmlns:artifact="urn:maven-artifact-ant" default="upload-maven-all">
+    <include file="${antbuild.dir}/antbuild.xml"/>
     <property file="${user.home}/build.properties"/>
     <property file="build.properties"/>
     <!-- The following properties defined so they can be overridden for testing -->
@@ -82,6 +84,20 @@
     <property name="stagingURL"  value="https://jakarta.oss.sonatype.org/service/local/staging/deploy/maven2"/>
     <property name="snapshotId"  value="ossrh"/>
     <property name="snapshotURL" value="https://jakarta.oss.sonatype.org/content/repositories/snapshots/"/>
+
+    <target name="javadoc-path-init">
+        <path id="unified.javadoc.path">
+            <path refid="javadoc.path"/>
+            <path refid="nosql.javadoc.path"/>
+            <path refid="jpars.javadoc.path"/>
+            <pathelement path="${oracle.extensions.depend.dir}/${ojdbc.jar}"/>
+            <pathelement path="${oracle.extensions.depend.dir}/${sdoapi.jar}"/>
+            <pathelement path="${oracle.extensions.depend.dir}/${xdb.jar}"/>
+            <pathelement path="${oracle.extensions.depend.dir}/${xmlparser.jar}"/>
+            <pathelement path="${oracle.extensions.depend.dir}/${ucp.jar}"/>
+            <pathelement path="${oracle.extensions.depend.dir}/${dms.jar}"/>
+        </path>
+    </target>
 
     <target name="upload-maven-all" depends="upload-eclipselink"/>
 
@@ -573,14 +589,16 @@
     </target>
 
     <!-- Generates missing Javadoc. jakarta.oss.sonatype.org requires it (repository closing rules)-->
-    <target name="prepare-javadoc">
+    <target name="prepare-javadoc" depends="javadoc-path-init">
         <property name="src.tmp" value="prepare-javadoc.src.tmp"/>
         <property name="doc.tmp" value="prepare-javadoc.doc.tmp"/>
-
         <delete dir="${src.tmp}" failonerror="false"/>
         <delete dir="${doc.tmp}" failonerror="false"/>
         <unjar src="${artifactSrc}" dest="${src.tmp}"/>
         <javadoc sourcepath="${src.tmp}" destdir="${doc.tmp}" version="true" additionalparam="-Xdoclint:none" packagenames="org.eclipse.persistence.*" noindex="true">
+            <classpath>
+                <path refid="unified.javadoc.path"/>
+            </classpath>
         </javadoc>
         <zip destfile="${artifactJavadoc}">
             <!-- miscellaneous files -->


### PR DESCRIPTION
This is fix for JavaDoc generation for generated Maven artifacts. javadoc utility in the JDK 11 is more strict for missing imported classes in the classpath than previous JDK 8.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>