### PR TITLE
[3.0] Diagnostic new feature - corrupted cache (backport from master)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
+          distribution: 'adopt'
           java-version: ${{ matrix.java_version }}
       - name: Verify
         run: mvn -B -V -U -C -Pstaging,oss-release,test-lrg,mysql clean verify -Dgpg.skip=true -Dwarn.limit=15 -Dcomp.xlint=-Xlint:none

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -41,18 +41,18 @@ jobs:
           mysql -e 'CREATE DATABASE ecltests;' -uroot -proot
           mysql -e 'SHOW DATABASES;' -uroot -proot
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Checkout for build
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ matrix.java_version }}
       - name: Verify
         run: mvn -B -V -U -C -Pstaging,oss-release,test-lrg,mysql clean verify -Dgpg.skip=true -Dwarn.limit=15 -Dcomp.xlint=-Xlint:none

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/PersistenceUnitProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/PersistenceUnitProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2022 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -4145,6 +4145,21 @@ public class PersistenceUnitProperties {
      * </p>
      */
     public static final String CONCURRENCY_SEMAPHORE_LOG_TIMEOUT = "eclipselink.concurrency.semaphore.log.timeout";
+
+    /**
+     * <p>
+     * This property control (enable/disable) query result cache validation in {@link org.eclipse.persistence.internal.sessions.UnitOfWorkImpl#internalExecuteQuery}
+     * </p>
+     * This can be used to help debugging an object identity problem. An object identity problem is when an managed/active entity in the cache references an entity not in managed state.
+     * This method will validate that objects in query results (object tree) are in a correct state. As a result there are new log messages in the log.
+     * It's related with "read" queries like <code>em.find(...);</code> or JPQL queries like <code>SELECT e FROM Entity e</code>.
+     * It should be controlled at query level too by query hint {@link org.eclipse.persistence.config.QueryHints#QUERY_RESULTS_CACHE_VALIDATION}
+     * <ul>
+     * <li>"<code>true</code>" - validate query result object tree and if content is not valid print diagnostic messages. In this case there should be negative impact to the performance.
+     * <li>"<code>false</code>" (DEFAULT) - don't validate and print any diagnostic messages
+     * </ul>
+     */
+    public static final String QUERY_RESULTS_CACHE_VALIDATION = "eclipselink.query-results-cache.validation";
 
     /**
      * INTERNAL: The following properties will not be displayed through logging

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/QueryHints.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/QueryHints.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2022 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -183,6 +183,21 @@ public class QueryHints {
      * @see org.eclipse.persistence.queries.QueryResultsCachePolicy#setCacheInvalidationPolicy(org.eclipse.persistence.descriptors.invalidation.CacheInvalidationPolicy)
      */
     public static final String QUERY_RESULTS_CACHE_EXPIRY_TIME_OF_DAY = "eclipselink.query-results-cache.expiry-time-of-day";
+
+    /**
+     * <p>
+     * This property control (enable/disable) query result cache validation in {@link org.eclipse.persistence.internal.sessions.UnitOfWorkImpl#internalExecuteQuery}
+     * </p>
+     * This can be used to help debugging an object identity problem. An object identity problem is when an managed/active entity in the cache references an entity not in managed state.
+     * This method will validate that objects in query results are in a correct state. As a result there are new log messages in the log.
+     * It's related with "read" queries like <code>em.find(...);</code> or JPQL queries like <code>SELECT e FROM Entity e</code>.
+     * It should be controlled at persistence unit level too by persistence unit property {@link org.eclipse.persistence.config.PersistenceUnitProperties#QUERY_RESULTS_CACHE_VALIDATION}
+     * <ul>
+     * <li>"<code>true</code>" - validate query result object tree and if content is not valid print diagnostic messages. In this case there should be negative impact to the performance.
+     * <li>"<code>false</code>" (DEFAULT) - don't validate and print any diagnostic messages
+     * </ul>
+     */
+    public static final String QUERY_RESULTS_CACHE_VALIDATION = "eclipselink.query-results-cache.validation";
 
     /**
      * "eclipselink.query.redirector"

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/LoggingLocalizationResource.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/LoggingLocalizationResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2022 IBM Corporation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -491,7 +491,11 @@ public class LoggingLocalizationResource extends ListResourceBundle {
         { "dbws_xml_schema_read_error", "The [{0}] XML schema could not be read."},
         { "dbws_orm_metadata_read_error", "The [{0}] ORM metadata could not be read."},
         { "dbws_oxm_metadata_read_error", "The [{0}] OXM metadata could not be read."},
-        { "dbws_no_wsdl_inline_schema", "The [{0}] WSDL inline schema could not be read."}
+        { "dbws_no_wsdl_inline_schema", "The [{0}] WSDL inline schema could not be read."},
+        { "validate_object_space", "validate object space." },
+        { "stack_of_visited_objects_that_refer_to_the_corrupt_object", "stack of visited objects that refer to the corrupt object: {0}" },
+        { "corrupt_object_referenced_through_mapping", "corrupt object referenced through mapping: {0}" },
+        { "corrupt_object", "corrupt object: {0}" }
     };
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -3007,7 +3007,27 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
         }
         Object result = query.executeInUnitOfWork(this, databaseRow);
         executeDeferredEvents();
+        if (query instanceof ReadQuery && (project.isAllowQueryResultsCacheValidation() || ((ReadQuery)query).shouldAllowQueryResultsCacheValidation())) {
+            validateObjectTree(result);
+        }
         return result;
+    }
+
+    private void validateObjectTree(Object startNode) {
+        log(SessionLog.INFO, SessionLog.TRANSACTION, "validate_object_space");
+        // This defines an inner class for process the iteration operation, don't be scared, it's just an inner class.
+        DescriptorIterator iterator = new DescriptorIterator() {
+            @Override
+            public void iterate(Object object) {
+                if (object != null && !isObjectRegistered(object) && getVisitedStack() != null && getVisitedStack().size() > 0) {
+                    log(SessionLog.WARNING, SessionLog.CACHE, "stack_of_visited_objects_that_refer_to_the_corrupt_object", getVisitedStack());
+                    log(SessionLog.WARNING, SessionLog.CACHE, "corrupt_object_referenced_through_mapping", getCurrentMapping());
+                    log(SessionLog.WARNING, SessionLog.CACHE, "corrupt_object", object);
+                }
+            }
+        };
+        iterator.setSession(this);
+        iterator.startIterationOn(startNode);
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/ReadQuery.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/ReadQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -63,6 +63,9 @@ public abstract class ReadQuery extends DatabaseQuery {
 
     /** Stores the JPA maxResult settings for a NamedQuery */
     protected int maxResults = -1;
+
+    /** Flag that allows query result cache validation or not.*/
+    protected boolean allowQueryResultsCacheValidation = false;
 
     /**
      * PUBLIC:
@@ -479,5 +482,13 @@ public abstract class ReadQuery extends DatabaseQuery {
      */
     public void setTemporaryCachedQueryResults(Object queryResults){
         temporaryCachedQueryResults = queryResults;
+    }
+
+    public boolean shouldAllowQueryResultsCacheValidation() {
+        return allowQueryResultsCacheValidation;
+    }
+
+    public void setAllowQueryResultsCacheValidation(boolean allowQueryResultsCacheValidation) {
+        this.allowQueryResultsCacheValidation = allowQueryResultsCacheValidation;
     }
 }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/Project.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/Project.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -166,6 +166,9 @@ public class Project extends CoreProject<ClassDescriptor, Login, DatabaseSession
 
     /** Flag that allows add to extended thread logging output thread stack trace or not.*/
     protected boolean allowExtendedThreadLoggingThreadDump = false;
+
+    /** Flag that allows query result cache validation or not.*/
+    protected boolean allowQueryResultsCacheValidation = false;
 
     /**
      * Mapped Superclasses (JPA 2) collection of parent non-relational descriptors keyed on MetadataClass
@@ -1352,6 +1355,14 @@ public class Project extends CoreProject<ClassDescriptor, Login, DatabaseSession
     }
 
     /**
+     * INTERNAL:
+     * Flag that allows query result cache validation or not. If true result is presented via log messages.
+     */
+    public boolean isAllowQueryResultsCacheValidation() {
+        return allowQueryResultsCacheValidation;
+    }
+
+    /**
      * PUBLIC:
      * Return the descriptor for  the alias
      */
@@ -1428,6 +1439,14 @@ public class Project extends CoreProject<ClassDescriptor, Login, DatabaseSession
      */
     public void setAllowExtendedThreadLoggingThreadDump(boolean allowExtendedThreadLoggingThreadDump) {
         this.allowExtendedThreadLoggingThreadDump = allowExtendedThreadLoggingThreadDump;
+    }
+
+    /**
+     * INTERNAL:
+     * Set to true to enable query result cache validation or not. Result is presented via log messages.
+     */
+    public void setAllowQueryResultsCacheValidation(boolean allowQueryResultsCacheValidation) {
+        this.allowQueryResultsCacheValidation = allowQueryResultsCacheValidation;
     }
 
     /**

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/diagnostic/LogWrapper.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/diagnostic/LogWrapper.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation from Oracle TopLink
+package org.eclipse.persistence.jpa.test.diagnostic;
+
+import org.eclipse.persistence.logging.DefaultSessionLog;
+import org.eclipse.persistence.logging.SessionLogEntry;
+
+//Simple log handler which counts selected messages.
+public class LogWrapper extends DefaultSessionLog {
+
+    private final String CHECKED_MESSAGE;
+    private int messageCounter = 0;
+
+    public LogWrapper(String checkedMessage) {
+        CHECKED_MESSAGE = checkedMessage;
+    }
+
+
+    @Override
+    public synchronized void log(SessionLogEntry entry) {
+        if (CHECKED_MESSAGE.equals(entry.getMessage())) {
+            messageCounter++;
+        }
+        super.log(entry);
+    }
+
+    @Override
+    public boolean shouldLog(int level, String category) {
+        return true;
+    }
+
+    public String getCheckedMessage() {
+        return CHECKED_MESSAGE;
+    }
+
+    public int getMessageCount() {
+        return messageCounter;
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/diagnostic/TestDiagnostic.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/diagnostic/TestDiagnostic.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.jpa.test.diagnostic;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Persistence;
+import jakarta.persistence.Query;
+
+import org.eclipse.persistence.internal.jpa.EntityManagerImpl;
+import org.eclipse.persistence.jpa.JpaEntityManager;
+import org.eclipse.persistence.jpa.test.diagnostic.model.BranchADiagnostic;
+import org.eclipse.persistence.jpa.test.diagnostic.model.BranchBDiagnostic;
+import org.eclipse.persistence.sessions.DatabaseSession;
+import org.eclipse.persistence.sessions.Session;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+//This test is about additional diagnostic log messages. This is why org.eclipse.persistence.testing.tests.jpa.diagnostic.LogWrapper is used there.
+//It's used as a log handler registered to the session. There is selected log messages counter.
+public class TestDiagnostic {
+
+    @BeforeClass
+    public static void setup() {
+        EntityManagerFactory emf = Persistence.createEntityManagerFactory("cachedeadlockdetection-pu");
+        EntityManager em = emf.createEntityManager();
+        try {
+            DatabaseSession session = ((EntityManagerImpl) em).getDatabaseSession();
+            try {
+                session.executeNonSelectingSQL("DROP TABLE BRANCHB_DIAGNOSTIC");
+            } catch (Exception ignore) {
+            }
+            try {
+                session.executeNonSelectingSQL("DROP TABLE BRANCHA_DIAGNOSTIC");
+            } catch (Exception ignore) {
+            }
+            try {
+                session.executeNonSelectingSQL("CREATE TABLE BRANCHA_DIAGNOSTIC (id integer NOT NULL, PRIMARY KEY(id))");
+                session.executeNonSelectingSQL("CREATE TABLE BRANCHB_DIAGNOSTIC (id integer NOT NULL, brancha_fk integer, PRIMARY KEY(id))");
+                session.executeNonSelectingSQL("ALTER TABLE BRANCHB_DIAGNOSTIC ADD CONSTRAINT fk_brancha FOREIGN KEY ( brancha_fk ) REFERENCES brancha_diagnostic (id)");
+            } catch (Exception ignore) {
+            }
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if (em.isOpen()) {
+                em.close();
+            }
+            if (emf.isOpen()) {
+                emf.close();
+            }
+        }
+    }
+
+    @Test
+    public void testCorruptedCachePersistenceUnitProperty() {
+        final int BRANCHA_ID = 1;
+        final int BRANCHB_ID = 11;
+
+        EntityManagerFactory emf = Persistence.createEntityManagerFactory("diagnostic-with-property-test-pu");
+        EntityManager em = emf.createEntityManager();
+        Session serverSession  = ((JpaEntityManager) em).getServerSession();
+        LogWrapper logWrapper = new LogWrapper("corrupt_object_referenced_through_mapping");
+        serverSession.setSessionLog(logWrapper);
+
+        em.getTransaction().begin();
+
+        //Initialize data
+        BranchADiagnostic branchADiagnostic = new BranchADiagnostic();
+        BranchBDiagnostic branchBDiagnostic = new BranchBDiagnostic();
+        branchADiagnostic.setId(BRANCHA_ID);
+        branchADiagnostic.getBranchBs().add(branchBDiagnostic);
+        branchBDiagnostic.setId(BRANCHB_ID);
+        branchBDiagnostic.setBranchA(branchADiagnostic);
+        em.persist(branchADiagnostic);
+        em.persist(branchBDiagnostic);
+        em.flush();
+        em.getTransaction().commit();
+
+        //Simulate business transaction where we do work with Entity removed
+        em.getTransaction().begin();
+        if (branchADiagnostic.getBranchBs().contains(branchBDiagnostic)) {
+            branchADiagnostic.getBranchBs().remove(branchBDiagnostic);
+        }
+        branchBDiagnostic.setBranchA(null);
+        em.remove(branchBDiagnostic);
+        em.getTransaction().commit();
+        //After commit is entity branchBDiagnostic removed from database but still exists as object in memory (detached state)
+
+        //Assign detached entity (branchBDiagnostic) to attached (branchADiagnostic)
+        //Simulation of code logical error to mix into same object tree attached and detached entities
+        //Add already removed (detached) entity back to the object tree
+        //Required prerequisite are: caching enabled
+        em.getTransaction().begin();
+        branchADiagnostic.getBranchBs().add(branchBDiagnostic);
+        branchBDiagnostic.setBranchA(branchADiagnostic);
+        //Detached entity (branchBDiagnostic) is not persisted again - logical error
+        em.getTransaction().commit();
+
+        //This em.find() will resolve objects from cache
+        BranchADiagnostic branchADiagnosticFindResult = em.find(BranchADiagnostic.class, BRANCHA_ID);
+        assertEquals(1, branchADiagnosticFindResult.getBranchBs().size());
+
+        //Verifies, that diagnostic message is produced
+        assertEquals(1, logWrapper.getMessageCount());
+
+        if (em.getTransaction().isActive()) {
+            em.getTransaction().rollback();
+        }
+        if (em.isOpen()) {
+            em.close();
+        }
+        if (emf.isOpen()) {
+            emf.close();
+        }
+    }
+
+    @Test
+    public void testCorruptedCacheQueryHint() {
+        final int BRANCHA_ID = 2;
+        final int BRANCHB_ID = 22;
+
+        EntityManagerFactory emf = Persistence.createEntityManagerFactory("diagnostic-test-pu");
+        EntityManager em = emf.createEntityManager();
+        Session serverSession  = ((JpaEntityManager) em).getServerSession();
+        LogWrapper logWrapper = new LogWrapper("corrupt_object_referenced_through_mapping");
+        serverSession.setSessionLog(logWrapper);
+
+        em.getTransaction().begin();
+
+        //Initialize data
+        BranchADiagnostic branchADiagnostic = new BranchADiagnostic();
+        BranchBDiagnostic branchBDiagnostic = new BranchBDiagnostic();
+        branchADiagnostic.setId(BRANCHA_ID);
+        branchADiagnostic.getBranchBs().add(branchBDiagnostic);
+        branchBDiagnostic.setId(BRANCHB_ID);
+        branchBDiagnostic.setBranchA(branchADiagnostic);
+        em.persist(branchADiagnostic);
+        em.persist(branchBDiagnostic);
+        em.flush();
+        em.getTransaction().commit();
+
+        //Simulate business transaction where we do work with Entity removed
+        em.getTransaction().begin();
+        if (branchADiagnostic.getBranchBs().contains(branchBDiagnostic)) {
+            branchADiagnostic.getBranchBs().remove(branchBDiagnostic);
+        }
+        branchBDiagnostic.setBranchA(null);
+        em.remove(branchBDiagnostic);
+        em.getTransaction().commit();
+        //After commit is entity branchBDiagnostic removed from database but still exists as object in memory (detached state)
+
+        //Assign detached entity (branchBDiagnostic) to attached (branchADiagnostic)
+        //Simulation of code logical error to mix into same object tree attached and detached entities
+        //Add already removed (detached) entity back to the object tree
+        //Required prerequisite are: caching enabled
+        em.getTransaction().begin();
+        branchADiagnostic.getBranchBs().add(branchBDiagnostic);
+        branchBDiagnostic.setBranchA(branchADiagnostic);
+        //Detached entity (branchBDiagnostic) is not persisted again - logical error
+        em.getTransaction().commit();
+
+        //This em.find() will resolve objects from cache
+        Map<String, Object> findProperties = new HashMap<>();
+        findProperties.put("eclipselink.query-results-cache.validation", true);
+        BranchADiagnostic branchADiagnosticFindResult = em.find(BranchADiagnostic.class, BRANCHA_ID, findProperties);
+        assertEquals(1, branchADiagnosticFindResult.getBranchBs().size());
+
+        Query query = em.createNamedQuery("findBranchADiagnosticById", BranchADiagnostic.class);
+        query.setHint("eclipselink.query-results-cache.validation", true);
+        query.setParameter("id", BRANCHA_ID);
+        BranchADiagnostic branchADiagnosticQueryResult = (BranchADiagnostic)query.getSingleResult();
+        assertEquals(1, branchADiagnosticQueryResult.getBranchBs().size());
+
+        assertEquals(2, logWrapper.getMessageCount());
+
+        if (em.getTransaction().isActive()) {
+            em.getTransaction().rollback();
+        }
+        if (em.isOpen()) {
+            em.close();
+        }
+        if (emf.isOpen()) {
+            emf.close();
+        }
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/diagnostic/model/BranchADiagnostic.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/diagnostic/model/BranchADiagnostic.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation from Oracle TopLink
+package org.eclipse.persistence.jpa.test.diagnostic.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@NamedQueries({
+        @NamedQuery(name = "findBranchADiagnosticById", query = "SELECT bd FROM BranchADiagnostic bd " + "WHERE bd.id = :id")}
+)
+@Entity
+@Table(name = "BRANCHA_DIAGNOSTIC")
+public class BranchADiagnostic {
+    protected int id;
+
+    protected List<BranchBDiagnostic> branchBs;
+
+    public BranchADiagnostic() {
+        this.branchBs = new ArrayList<>();
+    }
+    /**
+     * @return the id
+     */
+    @Id
+    public int getId() {
+        return id;
+    }
+
+    /**
+     * @param id
+     *            the id to set
+     */
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    /**
+     * @return the branchBs
+     */
+    @OneToMany(mappedBy = "branchA")
+    public List<BranchBDiagnostic> getBranchBs() {
+        return branchBs;
+    }
+
+    /**
+     * @param branchBs
+     *            the branchBs to set
+     */
+    public void setBranchBs(List<BranchBDiagnostic> branchBs) {
+        this.branchBs = branchBs;
+    }
+
+    @Override
+    public String toString() {
+        return "BranchADiagnostic{" +
+                "id=" + id + '}';
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/diagnostic/model/BranchBDiagnostic.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/diagnostic/model/BranchBDiagnostic.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation from Oracle TopLink
+package org.eclipse.persistence.jpa.test.diagnostic.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+/**
+ * Entity implementation class for Entity: BranchA
+ *
+ */
+@Entity
+@Table(name = "BRANCHB_DIAGNOSTIC")
+public class BranchBDiagnostic {
+
+    private static final long serialVersionUID = 1L;
+
+    protected int id;
+    protected BranchADiagnostic branchA;
+
+    /**
+     * @return the id
+     */
+    @Id
+    public int getId() {
+        return id;
+    }
+
+    /**
+     * @param id
+     *            the id to set
+     */
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    /**
+     * @return the branchA
+     */
+    @ManyToOne
+    @JoinColumn(name = "BRANCHA_FK", nullable = true)
+    public BranchADiagnostic getBranchA() {
+        return branchA;
+    }
+
+    /**
+     * @param branchA
+     *            the branchA to set
+     */
+    public void setBranchA(BranchADiagnostic branchA) {
+        this.branchA = branchA;
+    }
+
+    @Override
+    public String toString() {
+        return "BranchBDiagnostic{" +
+                "id=" + id + '}';
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/resources/META-INF/persistence.xml
+++ b/jpa/eclipselink.jpa.test.jse/src/it/resources/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -100,4 +100,17 @@
           </properties>
      </persistence-unit>
 
+     <persistence-unit name="diagnostic-test-pu">
+          <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+          <class>org.eclipse.persistence.jpa.test.diagnostic.model.BranchADiagnostic</class>
+          <class>org.eclipse.persistence.jpa.test.diagnostic.model.BranchBDiagnostic</class>
+     </persistence-unit>
+     <persistence-unit name="diagnostic-with-property-test-pu">
+          <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+          <class>org.eclipse.persistence.jpa.test.diagnostic.model.BranchADiagnostic</class>
+          <class>org.eclipse.persistence.jpa.test.diagnostic.model.BranchBDiagnostic</class>
+          <properties>
+               <property name="eclipselink.query-results-cache.validation" value="true"/>
+          </properties>
+     </persistence-unit>
 </persistence>

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2022 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -2894,6 +2894,7 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
             updateAllowExtendedThreadLogging(m);
             updateAllowExtendedThreadLoggingThreadDump(m);
             updateTemporalMutableSetting(m);
+            updateAllowQueryResultsCacheValidation(m);
             updateTableCreationSettings(m);
             updateIndexForeignKeys(m);
             if (!session.hasBroker()) {
@@ -3967,6 +3968,24 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
                 session.getProject().setAllowExtendedThreadLoggingThreadDump(false);
             } else {
                 session.handleException(ValidationException.invalidBooleanValueForProperty(allowExtendedThreadLoggingThreadDump, PersistenceUnitProperties.THREAD_EXTENDED_LOGGING_THREADDUMP));
+            }
+        }
+    }
+
+    /**
+     * Enable or disable query result cache validation.
+     * The method needs to be called in deploy stage.
+     */
+    protected void updateAllowQueryResultsCacheValidation(Map m){
+        String allowQueryResultsCacheValidation = EntityManagerFactoryProvider.getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.QUERY_RESULTS_CACHE_VALIDATION, m, session);
+
+        if (allowQueryResultsCacheValidation != null) {
+            if (allowQueryResultsCacheValidation.equalsIgnoreCase("true")) {
+                session.getProject().setAllowQueryResultsCacheValidation(true);
+            } else if (allowQueryResultsCacheValidation.equalsIgnoreCase("false")) {
+                session.getProject().setAllowQueryResultsCacheValidation(false);
+            } else {
+                session.handleException(ValidationException.invalidBooleanValueForProperty(allowQueryResultsCacheValidation, PersistenceUnitProperties.QUERY_RESULTS_CACHE_VALIDATION));
             }
         }
     }

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/QueryHintsHandler.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/QueryHintsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2021 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -319,6 +319,7 @@ public class QueryHintsHandler {
             addHint(new SerializedObject());
             addHint(new ReturnNameValuePairsHint());
             addHint(new PrintInnerJoinInWhereClauseHint());
+            addHint(new QueryResultsCacheValidation());
         }
 
         Hint(String name, String defaultValue) {
@@ -2226,4 +2227,23 @@ public class QueryHintsHandler {
         }
     }
 
+    protected static class QueryResultsCacheValidation extends Hint {
+        QueryResultsCacheValidation() {
+            super(QueryHints.QUERY_RESULTS_CACHE_VALIDATION, HintValues.FALSE);
+            valueArray = new Object[][] {
+                    {HintValues.TRUE, Boolean.TRUE},
+                    {HintValues.FALSE, Boolean.FALSE}
+            };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query instanceof ReadQuery) {
+                ((ReadQuery)query).setAllowQueryResultsCacheValidation((Boolean)valueToApply);
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
 }


### PR DESCRIPTION
This is new diagnostic feature which could help developers to analyze inconsistent query results. Inconsistent means, that there is mix of managed and detached entities in the query result by logical error in their code. It should happens if JPA L2 caching is enabled.
E.g. let's have following code:

```
em.remove(branchBDiagnostic);
commitTransaction(em);
//branchBDiagnostic is in Detached state
...
em.getTransaction().begin();
branchADiagnostic.getBranchBs().add(branchBDiagnostic);
branchBDiagnostic.setBranchA(branchADiagnostic);
//Detached entity (branchBDiagnostic) is not persisted again - logical error
commitTransaction(em);

//This em.find() will resolve objects from cache
BranchADiagnostic branchADiagnosticFindResult = em.find(BranchADiagnostic.class, BRANCHA_ID);
...
```
if cache validation is enabled by
persistence unit property
`<property name="eclipselink.query-results-cache.validation" value="true"/>`
or by query hint
`query.setHint("eclipselink.query-results-cache.validation", true);`
EclipseLink will print into log output messages like
```
[EL Warning]: cache: 2022-12-07 14:26:50.86--UnitOfWork(1211586911)--stack of visited objects that refer to the corrupt object: [BranchADiagnostic{id=1}]
[EL Warning]: cache: 2022-12-07 14:26:50.86--UnitOfWork(1211586911)--corrupt object referenced through mapping: org.eclipse.persistence.mappings.OneToManyMapping[branchBs]
[EL Warning]: cache: 2022-12-07 14:26:50.86--UnitOfWork(1211586911)--corrupt object: BranchBDiagnostic{id=11}
```
Note: `<Entity>.toString()` method is used.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>
