### PR TITLE
[master] Oracle NoSQL Database - NativeQueries and more complex JPA queries support

### DIFF
--- a/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/models/jpa/nosql/NativeQueryEntity.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/models/jpa/nosql/NativeQueryEntity.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.testing.models.jpa.nosql;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedNativeQuery;
+import jakarta.persistence.Table;
+
+import org.eclipse.persistence.nosql.annotations.DataFormatType;
+import org.eclipse.persistence.nosql.annotations.NoSql;
+
+@Entity
+@Table(name = "TEST_TAB")
+@NamedNativeQuery(
+        name="NativeQueryEntity.findByIdSQLNativeQueryEntity",
+        query="DECLARE $id INTEGER; SELECT $tab.id, $tab.col_json_object.map[$element.m1 = 5] as component FROM TEST_TAB $tab WHERE id = $id",
+        resultClass= org.eclipse.persistence.testing.models.jpa.nosql.NativeQueryEntity.class
+)
+//@NoSql -> it's not possible to use default (dataFormat= DataFormatType.XML) as QueryStringInteraction which is behind @NamedNativeQuery extends MappedInteraction not XMLInteraction
+@NoSql(dataFormat= DataFormatType.MAPPED)
+public class NativeQueryEntity {
+    @Id
+    private long id;
+    @Column(name = "component", columnDefinition = "JSON")
+    private String component;
+
+    public NativeQueryEntity() {
+    }
+
+    public NativeQueryEntity(long id) {
+        this.id = id;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getComponent() {
+        return component;
+    }
+
+    public void setComponent(String component) {
+        this.component = component;
+    }
+
+    @Override
+    public String toString() {
+        return "NativeQueryEntity{" +
+                "id=" + id +
+                ", component='" + component + '\'' +
+                '}';
+    }
+}

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/it/resources/META-INF/persistence.xml
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/it/resources/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -60,6 +60,7 @@
     <persistence-unit name="nosql-datatypes-sdk" transaction-type="RESOURCE_LOCAL">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
         <class>org.eclipse.persistence.testing.models.jpa.nosql.DataTypesEntity</class>
+        <class>org.eclipse.persistence.testing.models.jpa.nosql.NativeQueryEntity</class>
         <properties>
             <property name="eclipselink.nosql.property.nosql.service" value="@nosql.sdk.service@"/>
             <property name="eclipselink.nosql.property.nosql.endpoint" value="@nosql.sdk.endpoint@"/>

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLOperation.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/nosql/adapters/sdk/OracleNoSQLOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -21,5 +21,5 @@ package org.eclipse.persistence.internal.nosql.adapters.sdk;
  * @since EclipseLink 4.0
  */
 public enum OracleNoSQLOperation {
-    GET, PUT, PUT_IF_ABSENT, PUT_IF_PRESENT, PUT_IF_VERSION, DELETE, DELETE_IF_VERSION, ITERATOR, ITERATOR_QUERY
+    GET, PUT, PUT_IF_ABSENT, PUT_IF_PRESENT, PUT_IF_VERSION, DELETE, DELETE_IF_VERSION, ITERATOR, ITERATOR_QUERY, NATIVE_QUERY
 }

--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@
         <!-- CQ #21141 -->
         <oracle.nosql.version>18.3.10</oracle.nosql.version>
         <!-- CQ #24195 -->
-        <oracle.nosql.sdk.version>5.4.7</oracle.nosql.sdk.version>
+        <oracle.nosql.sdk.version>5.4.8</oracle.nosql.sdk.version>
         <!-- CQ #21142 -->
         <osgi.version>6.0.0</osgi.version>
         <!-- CQ #21143 -->


### PR DESCRIPTION
This change brings into EclipseLink and Oracle NoSQL Database platform support for:

- JPA `@NamedNativeQuery`
- support for more complex Jakarta Persistence queries like `SELECT t FROM DataTypesEntity t WHERE t.id = :id AND t.fieldString = :name`

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>