### PR TITLE
[3.0] GitHub Actions fix for Javadoc generation

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,7 +26,7 @@ jobs:
 
     strategy:
       matrix:
-        java_version: [ 11 ]
+        java_version: [ 11.0.18+10 ]
 
     steps:
       - name: Cancel previous runs of this workflow

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021 Contributors to the Eclipse Foundation
+# Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at


### PR DESCRIPTION
Select Adopt JDK 11.0.18+10 which seems doesn't have issue with JavaDoc above `package-info.java` with content like

```
@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://www.eclipse.org/eclipselink/xsds/persistence/oxm", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
package org.eclipse.persistence.jaxb.xmlmodel;

```
from _src/main/java/org/eclipse/persistence/jaxb/xmlmodel/package-info.java_

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>