### PR TITLE
[master] JGroups dependency upgrade plus additonal JUnit tests

### DIFF
--- a/foundation/org.eclipse.persistence.extension/src/test/java/org/eclipse/persistence/testing/tests/jgroups/JGroupsCommandProcessor.java
+++ b/foundation/org.eclipse.persistence.extension/src/test/java/org/eclipse/persistence/testing/tests/jgroups/JGroupsCommandProcessor.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - Initial implementation
+package org.eclipse.persistence.testing.tests.jgroups;
+
+import org.eclipse.persistence.internal.sessions.AbstractSession;
+import org.eclipse.persistence.sessions.DatabaseLogin;
+import org.eclipse.persistence.sessions.Login;
+import org.eclipse.persistence.sessions.coordination.CommandManager;
+import org.eclipse.persistence.sessions.coordination.CommandProcessor;
+
+public class JGroupsCommandProcessor extends AbstractSession implements CommandProcessor {
+
+    private String commandContent = null;
+
+    @Override
+    public void processCommand(Object command) {
+        commandContent = command.toString();
+    }
+
+    @Override
+    public CommandManager getCommandManager() {
+        return null;
+    }
+
+    @Override
+    public void setCommandManager(CommandManager commandManager) {
+
+    }
+
+    @Override
+    public boolean shouldLogMessages(int logLevel) {
+        return false;
+    }
+
+    @Override
+    public void logMessage(int logLevel, String message) {
+
+    }
+
+    @Override
+    public void incrementProfile(String counter) {
+
+    }
+
+    @Override
+    public void updateProfile(String info, Object value) {
+
+    }
+
+    @Override
+    public void startOperationProfile(String operationName) {
+
+    }
+
+    @Override
+    public void endOperationProfile(String operationName) {
+
+    }
+
+    @Override
+    public Object handleException(RuntimeException exception) {
+        return null;
+    }
+
+    @Override
+    public Login getDatasourceLogin() {
+        Login login = new DatabaseLogin();
+        return login;
+    }
+
+    public String getCommandContent() {
+        return commandContent;
+    }
+}

--- a/foundation/org.eclipse.persistence.extension/src/test/java/org/eclipse/persistence/testing/tests/jgroups/JGroupsRemoteConnectionTest.java
+++ b/foundation/org.eclipse.persistence.extension/src/test/java/org/eclipse/persistence/testing/tests/jgroups/JGroupsRemoteConnectionTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - Initial implementation
+package org.eclipse.persistence.testing.tests.jgroups;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.persistence.internal.sessions.coordination.jgroups.JGroupsRemoteConnection;
+import org.eclipse.persistence.sessions.coordination.Command;
+import org.eclipse.persistence.sessions.coordination.RemoteCommandManager;
+import org.eclipse.persistence.sessions.coordination.ServiceId;
+import org.eclipse.persistence.sessions.coordination.TransportManager;
+
+import org.jgroups.JChannel;
+import org.jgroups.protocols.pbcast.FLUSH;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+
+public class JGroupsRemoteConnectionTest {
+
+    private final String COMMAND_CONTENT = "testCommand";
+    private final String CLUSTER_NAME = "ChatCluster";
+
+    private JChannel jChannel = null;
+    private JGroupsRemoteConnection remoteConnection = null;
+    private JGroupsCommandProcessor commandProcessor = null;
+
+    @Before
+    public void init() throws Exception {
+        commandProcessor = new JGroupsCommandProcessor();
+        RemoteCommandManager remoteCommandManager = new RemoteCommandManager(commandProcessor);
+        TransportManager senderTransportManager = new JGroupsTestTransportManager();
+        remoteCommandManager.setTransportManager(senderTransportManager);
+        jChannel = new JChannel();
+        jChannel.getProtocolStack().addProtocol(new FLUSH());
+        remoteConnection = new JGroupsRemoteConnection(remoteCommandManager, jChannel, true);
+        jChannel.connect(CLUSTER_NAME);
+    }
+
+    @After
+    public void shutdown() throws Exception {
+        remoteConnection.close();
+        jChannel.close();
+    }
+
+    /**
+     * Test JGroupsRemoteConnection with Command passed as a Object.
+     */
+    @Test
+    public void testObjectCommand() throws Exception {
+        ServiceId serviceId = new ServiceId();
+        serviceId.setChannel(RemoteCommandManager.DEFAULT_CHANNEL);
+        Command testCommand = new JGroupsTestCommand(serviceId, COMMAND_CONTENT);
+        jChannel.connect(CLUSTER_NAME);
+        remoteConnection.executeCommand(testCommand);
+        jChannel.startFlush(true);
+        assertEquals(COMMAND_CONTENT, commandProcessor.getCommandContent());
+    }
+
+    /**
+     * Test JGroupsRemoteConnection with Command passed as an array of bytes.
+     */
+    @Test
+    public void testByteArrayCommand() throws Exception {
+        ServiceId serviceId = new ServiceId();
+        serviceId.setChannel(RemoteCommandManager.DEFAULT_CHANNEL);
+        Command testCommand = new JGroupsTestCommand(serviceId, COMMAND_CONTENT);
+        byte[] testCommandSerialized = serializeCommand(testCommand);
+        jChannel.connect(CLUSTER_NAME);
+        remoteConnection.executeCommand(testCommandSerialized);
+        jChannel.startFlush(true);
+        assertEquals(COMMAND_CONTENT, commandProcessor.getCommandContent());
+    }
+
+    private byte[] serializeCommand(Command command) {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ObjectOutputStream out = null;
+        byte[] result = null;
+        try {
+            out = new ObjectOutputStream(bos);
+            out.writeObject(command);
+            out.flush();
+            result = bos.toByteArray();
+            bos.close();
+        } catch (IOException ex) {
+            // ignore exception
+        }
+        return result;
+    }
+}

--- a/foundation/org.eclipse.persistence.extension/src/test/java/org/eclipse/persistence/testing/tests/jgroups/JGroupsTestCommand.java
+++ b/foundation/org.eclipse.persistence.extension/src/test/java/org/eclipse/persistence/testing/tests/jgroups/JGroupsTestCommand.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - Initial implementation
+package org.eclipse.persistence.testing.tests.jgroups;
+
+import org.eclipse.persistence.internal.sessions.AbstractSession;
+import org.eclipse.persistence.sessions.coordination.Command;
+import org.eclipse.persistence.sessions.coordination.ServiceId;
+
+public class JGroupsTestCommand extends Command {
+
+    private String commmand = null;
+
+    public JGroupsTestCommand(ServiceId serviceId, String commmand) {
+        this.setServiceId(serviceId);
+        this.commmand = commmand;
+    }
+
+    @Override
+    public void executeWithSession(AbstractSession session) {
+        session.logMessage("Command: " + commmand);
+    }
+
+    @Override
+    public String toString() {
+        return commmand;
+    }
+}

--- a/foundation/org.eclipse.persistence.extension/src/test/java/org/eclipse/persistence/testing/tests/jgroups/JGroupsTestTransportManager.java
+++ b/foundation/org.eclipse.persistence.extension/src/test/java/org/eclipse/persistence/testing/tests/jgroups/JGroupsTestTransportManager.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - Initial implementation
+package org.eclipse.persistence.testing.tests.jgroups;
+
+import org.eclipse.persistence.sessions.coordination.broadcast.BroadcastTransportManager;
+
+public class JGroupsTestTransportManager extends BroadcastTransportManager {
+
+    @Override
+    public void createLocalConnection() {
+    }
+
+    @Override
+    public void removeLocalConnection() {
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
         <hibernate.version>8.0.0.Final</hibernate.version>
         <checkstyle.version>10.7.0</checkstyle.version>
         <!-- CQ #23049 -->
-        <jgroups.version>4.2.11.Final</jgroups.version>
+        <jgroups.version>5.2.12.Final</jgroups.version>
         <jmh.version>1.36</jmh.version>
         <junit.version>4.13.2</junit.version>
         <!-- CQ #24079 -->


### PR DESCRIPTION
This JGroups upgrade reflects JGroups API changes between 4.x and 5.x versions like
https://github.com/belaban/JGroups/commit/e3ce11056735982faba109d9c8e9571c494b00f3

There are new JUnit tests to verify `org.eclipse.persistence.internal.sessions.coordination.jgroups.JGroupsRemoteConnection` class by test commands.