### PR TITLE
[master] Fix for java.lang.StackOverflowError after bumping from 4.0.0 to 4.0.1 after ASM refactor

### DIFF
--- a/jpa/eclipselink.jpa.testapps/jpa.test.metamodel.apectj/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.metamodel.apectj/pom.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0,
+    or the Eclipse Distribution License v. 1.0 which is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+
+    SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
+        <groupId>org.eclipse.persistence</groupId>
+        <version>4.0.2-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>org.eclipse.persistence.jpa.testapps.metamodel.aspectj</artifactId>
+
+    <name>Test - metamodel.aspectj</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.aspectj</groupId>
+            <artifactId>aspectjrt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.aspectj</groupId>
+            <artifactId>aspectjweaver</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>compile-with-processor</id>
+                        <phase>compile</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>aspectj-maven-plugin</artifactId>
+                <configuration>
+                    <complianceLevel>${maven.compiler.release}</complianceLevel>
+                    <source>${maven.compiler.release}</source>
+                    <target>${maven.compiler.release}</target>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.carlspring.maven</groupId>
+                <artifactId>derby-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>start-derby</id>
+                        <phase>process-test-classes</phase>
+                    </execution>
+                    <execution>
+                        <id>stop-derby</id>
+                        <phase>prepare-package</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>server-test</id>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/EntityManagerImplTest</exclude>
+                                <exclude>**/EntityManagerFactoryImplTest</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>package-model</id>
+                        <phase>package</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.metamodel.apectj/src/main/java/org/eclipse/persistence/testing/models/jpa/weaving/aspectj/EntityListenerAspect.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.metamodel.apectj/src/main/java/org/eclipse/persistence/testing/models/jpa/weaving/aspectj/EntityListenerAspect.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial implementation
+package org.eclipse.persistence.testing.models.jpa.weaving.aspectj;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+
+@Aspect
+public class EntityListenerAspect {
+
+    @Before(value = "execution (* org.eclipse.persistence.testing.models.jpa.weaving.aspectj.EntityListenerAspectJ.*(..))")
+    public void before(JoinPoint joinPoint) {
+        System.out.println("AspectJ method call from EntityListener");
+    }
+}

--- a/jpa/eclipselink.jpa.testapps/jpa.test.metamodel.apectj/src/main/java/org/eclipse/persistence/testing/models/jpa/weaving/aspectj/EntityListenerAspectJ.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.metamodel.apectj/src/main/java/org/eclipse/persistence/testing/models/jpa/weaving/aspectj/EntityListenerAspectJ.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial implementation
+package org.eclipse.persistence.testing.models.jpa.weaving.aspectj;
+
+import jakarta.persistence.PrePersist;
+
+public class EntityListenerAspectJ {
+
+    @PrePersist
+    public void logBeforeCreate(Object target) {
+        System.out.println("Before create:\t" + target);
+    }
+}

--- a/jpa/eclipselink.jpa.testapps/jpa.test.metamodel.apectj/src/main/java/org/eclipse/persistence/testing/models/jpa/weaving/aspectj/ItemAspectJ.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.metamodel.apectj/src/main/java/org/eclipse/persistence/testing/models/jpa/weaving/aspectj/ItemAspectJ.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial implementation
+package org.eclipse.persistence.testing.models.jpa.weaving.aspectj;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name="ASPECTJ_ITEM")
+@EntityListeners({EntityListenerAspectJ.class})
+public class ItemAspectJ {
+    @Id
+    private long id;
+    private String name;
+
+    public ItemAspectJ() {
+    }
+
+    public ItemAspectJ(long id, String aaaa) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "ItemAspectJ{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                '}';
+    }
+}

--- a/jpa/eclipselink.jpa.testapps/jpa.test.metamodel.apectj/src/main/resources/META-INF/persistence.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.metamodel.apectj/src/main/resources/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at

--- a/jpa/eclipselink.jpa.testapps/jpa.test.metamodel.apectj/src/main/resources/META-INF/persistence.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.metamodel.apectj/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,37 @@
+<!--
+
+    Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0,
+    or the Eclipse Distribution License v. 1.0 which is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+
+    SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+-->
+
+<persistence version="3.0" xmlns="https://jakarta.ee/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd">
+    <persistence-unit name="ignore" transaction-type="JTA">
+        <description>This PU is for validation purpose only - it should not
+            break the rest of the tests</description>
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+        <jta-data-source>java:comp/DefaultDataSource</jta-data-source>
+    </persistence-unit>
+
+    <persistence-unit name="metamodel1_aspectj">
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+        <class>org.eclipse.persistence.testing.models.jpa.weaving.aspectj.ItemAspectJ</class>
+        <class>org.eclipse.persistence.testing.models.jpa.weaving.aspectj.EntityListenerAspectJ</class>
+        <exclude-unlisted-classes>true</exclude-unlisted-classes>
+        <properties>
+            <property name="eclipselink.session-name" value="isolated-session1053"/>
+            <property name="eclipselink.cache.shared.default" value="false"/>
+            <property name="eclipselink.logging.level" value="${eclipselink.logging.level}"/>
+            <property name="eclipselink.logging.level.sql" value="${eclipselink.logging.sql.level}"/>
+            <property name="eclipselink.logging.parameters" value="${eclipselink.logging.parameters}"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.metamodel.apectj/src/test/java/org/eclipse/persistence/testing/tests/jpa/weaving/aspectj/MetamodelAspectJTableCreator.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.metamodel.apectj/src/test/java/org/eclipse/persistence/testing/tests/jpa/weaving/aspectj/MetamodelAspectJTableCreator.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.testing.tests.jpa.weaving.aspectj;
+
+import org.eclipse.persistence.tools.schemaframework.FieldDefinition;
+import org.eclipse.persistence.tools.schemaframework.TableCreator;
+import org.eclipse.persistence.tools.schemaframework.TableDefinition;
+
+public class MetamodelAspectJTableCreator extends TableCreator {
+
+    public MetamodelAspectJTableCreator() {
+        setName("JPAOrphanRemovalModelTableCreator");
+        addTableDefinition(buildVEHICLETable());
+    }
+
+        public static TableDefinition buildVEHICLETable() {
+        // CREATE TABLE ASPECTJ_ITEM (ID NUMBER(10) NOT NULL, NAME VARCHAR2(255) NULL, PRIMARY KEY (ID))
+        TableDefinition table = new TableDefinition();
+        table.setName("ASPECTJ_ITEM");
+
+        FieldDefinition fieldID = new FieldDefinition();
+        fieldID.setName("ID");
+        fieldID.setTypeName("NUMERIC");
+        fieldID.setSize(10);
+        fieldID.setSubSize(0);
+        fieldID.setIsPrimaryKey(true);
+        fieldID.setIsIdentity(true);
+        fieldID.setShouldAllowNull(false);
+        fieldID.setUnique(false);
+        table.addField(fieldID);
+
+        FieldDefinition fieldMODEL = new FieldDefinition();
+        fieldMODEL.setName("NAME");
+        fieldMODEL.setTypeName("VARCHAR");
+        fieldMODEL.setSize(60);
+        fieldMODEL.setSubSize(0);
+        fieldMODEL.setIsPrimaryKey(false);
+        fieldMODEL.setIsIdentity(false);
+        fieldMODEL.setShouldAllowNull(true);
+        fieldMODEL.setUnique(false);
+        table.addField(fieldMODEL);
+
+        return table;
+    }
+
+}

--- a/jpa/eclipselink.jpa.testapps/jpa.test.metamodel.apectj/src/test/java/org/eclipse/persistence/testing/tests/jpa/weaving/aspectj/MetamodelAspectJTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.metamodel.apectj/src/test/java/org/eclipse/persistence/testing/tests/jpa/weaving/aspectj/MetamodelAspectJTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.testing.tests.jpa.weaving.aspectj;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.metamodel.Metamodel;
+import junit.framework.Test;
+import junit.framework.TestSuite;
+
+import org.eclipse.persistence.testing.framework.jpa.junit.JUnitTestCase;
+import org.eclipse.persistence.testing.models.jpa.weaving.aspectj.ItemAspectJ;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+/**
+ * This test is to verify that managed classes like Entities, Entity Listeners weaved by AspectJ will be functional.
+ * There was issue to get some class metadata through ASM org.eclipse.persistence.internal.jpa.metadata.accessors.objects.MetadataAsmFactory.MetadataMethodVisitor*
+ * Except entityManagerFactory.getMetamodel() there are some JPA basic operations called (merge(), find(), remove()).
+ */
+public class MetamodelAspectJTest extends JUnitTestCase {
+
+    public static final String PERSISTENCE_UNIT_NAME = "metamodel1_aspectj";
+
+    private static final long ID = 1L;
+    private static final String NAME = "Master 1";
+
+    EntityManagerFactory entityManagerFactory = null;
+
+    public MetamodelAspectJTest() {
+        super();
+    }
+
+    public MetamodelAspectJTest(String name) {
+        super(name);
+    }
+
+    @Override
+    public String getPersistenceUnitName() {
+        return PERSISTENCE_UNIT_NAME;
+    }
+
+    public static Test suite() {
+        TestSuite suite = new TestSuite("MetamodelTest with ApectJ Weaved Managed Classes");
+        suite.addTest(new MetamodelAspectJTest("testSetup"));
+        suite.addTest(new MetamodelAspectJTest("testMetamodel"));
+        return suite;
+    }
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        entityManagerFactory = getEntityManagerFactory(PERSISTENCE_UNIT_NAME);
+    }
+
+        /**
+     * The setup is done as a test, both to record its failure, and to allow execution in the server.
+     */
+    public void testSetup() {
+        new MetamodelAspectJTableCreator().replaceTables(getPersistenceUnitServerSession());
+        clearCache();
+    }
+
+    public void testMetamodel() {
+        Metamodel metamodel = entityManagerFactory.getMetamodel();
+        assertNotNull(entityManagerFactory);
+        assertNotNull(metamodel);
+
+        EntityManager em = entityManagerFactory.createEntityManager();
+
+        try {
+            em.getTransaction().begin();
+            ItemAspectJ entity = new ItemAspectJ(ID, "aaaa");
+            em.persist(entity);
+            em.getTransaction().commit();
+            em.getTransaction().begin();
+            entity.setName(NAME);
+            em.merge(entity);
+            em.getTransaction().commit();
+            ItemAspectJ entity1 = em.find(ItemAspectJ.class, ID);
+            assertNotNull(entity1);
+            assertEquals(ID, entity1.getId());
+            assertEquals(NAME, entity1.getName());
+            em.getTransaction().begin();
+            em.remove(entity);
+            em.getTransaction().commit();
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException();
+        }
+        finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            em.close();
+        }
+    }
+}

--- a/jpa/eclipselink.jpa.testapps/jpa.test.metamodel.apectj/src/test/java/org/eclipse/persistence/testing/tests/jpa/weaving/aspectj/MetamodelAspectJTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.metamodel.apectj/src/test/java/org/eclipse/persistence/testing/tests/jpa/weaving/aspectj/MetamodelAspectJTest.java
@@ -25,6 +25,7 @@ import org.eclipse.persistence.testing.models.jpa.weaving.aspectj.ItemAspectJ;
 
 /**
  * This test is to verify that managed classes like Entities, Entity Listeners weaved by AspectJ will be functional.
+ * Test for bugfix: java.lang.StackOverflowError after bumping from 4.0.0 to 4.0.1 #1832 - https://github.com/eclipse-ee4j/eclipselink/issues/1832
  * There was issue to get some class metadata through ASM org.eclipse.persistence.internal.jpa.metadata.accessors.objects.MetadataAsmFactory.MetadataMethodVisitor*
  * Except entityManagerFactory.getMetamodel() there are some JPA basic operations called (merge(), find(), remove()).
  */

--- a/jpa/eclipselink.jpa.testapps/jpa.test.metamodel.apectj/src/test/java/org/eclipse/persistence/testing/tests/jpa/weaving/aspectj/MetamodelAspectJTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.metamodel.apectj/src/test/java/org/eclipse/persistence/testing/tests/jpa/weaving/aspectj/MetamodelAspectJTest.java
@@ -23,9 +23,6 @@ import junit.framework.TestSuite;
 import org.eclipse.persistence.testing.framework.jpa.junit.JUnitTestCase;
 import org.eclipse.persistence.testing.models.jpa.weaving.aspectj.ItemAspectJ;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-
 /**
  * This test is to verify that managed classes like Entities, Entity Listeners weaved by AspectJ will be functional.
  * There was issue to get some class metadata through ASM org.eclipse.persistence.internal.jpa.metadata.accessors.objects.MetadataAsmFactory.MetadataMethodVisitor*

--- a/jpa/eclipselink.jpa.testapps/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/pom.xml
@@ -319,6 +319,7 @@
         <module>jpa.test.lob</module>
         <module>jpa.test.memory</module>
         <module>jpa.test.metamodel</module>
+        <module>jpa.test.metamodel.apectj</module>
         <module>jpa.test.orphanremoval</module>
         <module>jpa.test.partitioned</module>
         <module>jpa.test.performance</module>

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/accessors/objects/MetadataAsmFactory.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/accessors/objects/MetadataAsmFactory.java
@@ -541,6 +541,11 @@ public class MetadataAsmFactory extends MetadataFactory {
             return null;
         }
 
+        @Override
+        public void visitAttribute(Attribute attr) {
+            super.visitAttributeSuper(attr);
+        }
+
         /**
          * At the end of visiting this method add it to the
          * {@link MetadataClass} and handle duplicate method names by chaining

--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,7 @@
         <apache.felix.framework.version>7.0.5</apache.felix.framework.version>
         <!-- CQ #21133 -->
         <ant.version>1.10.13</ant.version>
+        <aspectj.version>1.9.19</aspectj.version>
         <commonj.sdo.version>2.1.1</commonj.sdo.version>
         <derby.version>10.15.2.0</derby.version>
         <db2.version>11.5.8.0</db2.version>
@@ -901,6 +902,16 @@
             </dependency>
             <!--APIs and other libs used in test classes-->
             <dependency>
+                <groupId>org.aspectj</groupId>
+                <artifactId>aspectjrt</artifactId>
+                <version>${aspectj.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.aspectj</groupId>
+                <artifactId>aspectjweaver</artifactId>
+                <version>${aspectj.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>jakarta.el</groupId>
                 <artifactId>jakarta.el-api</artifactId>
                 <version>${el-api.version}</version>
@@ -1179,6 +1190,23 @@
                     <groupId>org.codehaus.gmaven</groupId>
                     <artifactId>groovy-maven-plugin</artifactId>
                     <version>2.1.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>aspectj-maven-plugin</artifactId>
+                    <version>1.14.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.aspectj</groupId>
+                            <artifactId>aspectjrt</artifactId>
+                            <version>${aspectj.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.aspectj</groupId>
+                            <artifactId>aspectjweaver</artifactId>
+                            <version>${aspectj.version}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Fixes #1832
This PR contains fix for reported error and new JPA test module as this issue happens when AspectJ Weaver is applied to JPA managed classes. It was related with `EntityManagerFactory.getMetamodel();`