### PR TITLE
[master] fix #1596 Major performance issue in case of many new entities

### DIFF
--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/ConformResultsWithPrimaryKeyExpressionTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/ConformResultsWithPrimaryKeyExpressionTest.java
@@ -158,7 +158,7 @@ public class ConformResultsWithPrimaryKeyExpressionTest extends ConformResultsIn
         case CASE_NEW: {
             selectionObject = newEmployee;
             if (shouldCheckCacheByExactPrimaryKey()) {
-                expectedGetIdCallCount = 1;
+                expectedGetIdCallCount = 0;
             } else {
                 expectedGetIdCallCount = n + 1;
             }
@@ -192,7 +192,7 @@ public class ConformResultsWithPrimaryKeyExpressionTest extends ConformResultsIn
                 // S.M. This went from 5 calls to 4, which is good.
                 // When checking the one new object + registration +
                 // building clone + building backup clone.
-                expectedGetIdCallCount = 3;
+                expectedGetIdCallCount = 2;
             } else {
                 expectedGetIdCallCount = n + 4;
             }

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/ConformResultsWithPrimaryKeyExpressionTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/ConformResultsWithPrimaryKeyExpressionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/DoubleNestedUnitOfWorkDeleteConformedNestedNewObjectTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/DoubleNestedUnitOfWorkDeleteConformedNestedNewObjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,6 +15,7 @@
 package org.eclipse.persistence.testing.tests.unitofwork;
 
 import java.math.BigDecimal;
+import java.util.Collection;
 
 import org.eclipse.persistence.internal.sessions.UnitOfWorkImpl;
 import org.eclipse.persistence.queries.ReadObjectQuery;
@@ -62,6 +63,10 @@ public class DoubleNestedUnitOfWorkDeleteConformedNestedNewObjectTest extends Au
         nestedNestedUOW.commit();
         nestedUow1.commit();
         if (!((UnitOfWorkImpl)uow).getNewObjectsCloneToOriginal().isEmpty()) {
+            throw new TestErrorException("Failed to unregister the Object in the nested unit of work");
+        }
+
+        if (!((UnitOfWorkImpl)uow).getPrimaryKeyToNewObjects().values().stream().allMatch(Collection::isEmpty)) {
             throw new TestErrorException("Failed to unregister the Object in the nested unit of work");
         }
 

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/DoubleNestedUnitOfWorkDeleteConformedNestedNewObjectTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/DoubleNestedUnitOfWorkDeleteConformedNestedNewObjectTest.java
@@ -66,7 +66,7 @@ public class DoubleNestedUnitOfWorkDeleteConformedNestedNewObjectTest extends Au
             throw new TestErrorException("Failed to unregister the Object in the nested unit of work");
         }
 
-        if (!((UnitOfWorkImpl)uow).getPrimaryKeyToNewObjects().values().stream().allMatch(Collection::isEmpty)) {
+        if (!((UnitOfWorkImpl)uow).getPrimaryKeyToNewObjects().isEmpty()) {
             throw new TestErrorException("Failed to unregister the Object in the nested unit of work");
         }
 

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/DoubleNestedUnitOfWorkRegisterNewObjectTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/DoubleNestedUnitOfWorkRegisterNewObjectTest.java
@@ -66,7 +66,7 @@ public class DoubleNestedUnitOfWorkRegisterNewObjectTest extends AutoVerifyTestC
             throw new TestErrorException("Failed to unregister the Object in the nested unit of work");
         }
 
-        if (!((UnitOfWorkImpl)uow).getPrimaryKeyToNewObjects().values().stream().allMatch(Collection::isEmpty)) {
+        if (!((UnitOfWorkImpl)uow).getPrimaryKeyToNewObjects().isEmpty()) {
             throw new TestErrorException("Failed to unregister the Object in the nested unit of work");
         }
 

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/DoubleNestedUnitOfWorkRegisterNewObjectTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/DoubleNestedUnitOfWorkRegisterNewObjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,6 +15,7 @@
 package org.eclipse.persistence.testing.tests.unitofwork;
 
 import java.math.BigDecimal;
+import java.util.Collection;
 
 import org.eclipse.persistence.internal.sessions.UnitOfWorkImpl;
 import org.eclipse.persistence.queries.ReadObjectQuery;
@@ -62,6 +63,10 @@ public class DoubleNestedUnitOfWorkRegisterNewObjectTest extends AutoVerifyTestC
         nestedNestedUOW.commit();
         nestedUow1.commit();
         if (!((UnitOfWorkImpl)uow).getNewObjectsCloneToOriginal().isEmpty()) {
+            throw new TestErrorException("Failed to unregister the Object in the nested unit of work");
+        }
+
+        if (!((UnitOfWorkImpl)uow).getPrimaryKeyToNewObjects().values().stream().allMatch(Collection::isEmpty)) {
             throw new TestErrorException("Failed to unregister the Object in the nested unit of work");
         }
 

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/NestedUnitOfWorkDeleteConformedNestedNewObjectTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/NestedUnitOfWorkDeleteConformedNestedNewObjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,6 +16,7 @@ package org.eclipse.persistence.testing.tests.unitofwork;
 
 import java.math.BigDecimal;
 
+import java.util.Collection;
 import java.util.Vector;
 
 import org.eclipse.persistence.internal.sessions.UnitOfWorkImpl;
@@ -64,6 +65,10 @@ public class NestedUnitOfWorkDeleteConformedNestedNewObjectTest extends AutoVeri
         nestedUow1.deleteObject(nestedEmployee);
         nestedUow1.commit();
         if (!((UnitOfWorkImpl)uow).getNewObjectsCloneToOriginal().isEmpty()) {
+            throw new TestErrorException("Failed to unregister the Object in the nested unit of work");
+        }
+
+        if (!((UnitOfWorkImpl)uow).getPrimaryKeyToNewObjects().values().stream().allMatch(Collection::isEmpty)) {
             throw new TestErrorException("Failed to unregister the Object in the nested unit of work");
         }
 

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/NestedUnitOfWorkDeleteConformedNestedNewObjectTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/NestedUnitOfWorkDeleteConformedNestedNewObjectTest.java
@@ -68,7 +68,7 @@ public class NestedUnitOfWorkDeleteConformedNestedNewObjectTest extends AutoVeri
             throw new TestErrorException("Failed to unregister the Object in the nested unit of work");
         }
 
-        if (!((UnitOfWorkImpl)uow).getPrimaryKeyToNewObjects().values().stream().allMatch(Collection::isEmpty)) {
+        if (!((UnitOfWorkImpl)uow).getPrimaryKeyToNewObjects().isEmpty()) {
             throw new TestErrorException("Failed to unregister the Object in the nested unit of work");
         }
 

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/NestedUnitOfWorkDeleteNestedNewObjectTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/NestedUnitOfWorkDeleteNestedNewObjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -46,6 +46,10 @@ public class NestedUnitOfWorkDeleteNestedNewObjectTest extends AutoVerifyTestCas
         nestedUow1.commit();
         uow.commit();
         if (((UnitOfWorkImpl)uow).getNewObjectsCloneToOriginal().containsKey(employee)) {
+            throw new TestErrorException("Failed to unregister the Object in the nested unit of work");
+        }
+
+        if (((UnitOfWorkImpl)uow).getPrimaryKeyToNewObjects().values().stream().anyMatch(c -> c.contains(employee))) {
             throw new TestErrorException("Failed to unregister the Object in the nested unit of work");
         }
 

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/NestedUnitOfWorkDeleteNewObjectTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/NestedUnitOfWorkDeleteNewObjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -41,6 +41,10 @@ public class NestedUnitOfWorkDeleteNewObjectTest extends AutoVerifyTestCase {
         nestedUOW2.commit();
         uow.commit();
         if (((UnitOfWorkImpl)uow).getNewObjectsCloneToOriginal().containsKey(original)) {
+            throw new TestErrorException("Failed to move the deleted new object into the parent UOW");
+        }
+
+        if (((UnitOfWorkImpl)uow).getPrimaryKeyToNewObjects().values().stream().anyMatch(c -> c.contains(original))) {
             throw new TestErrorException("Failed to move the deleted new object into the parent UOW");
         }
 

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/UnregisterUnitOfWorkTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/UnregisterUnitOfWorkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,6 +14,7 @@
 //     Oracle - initial API and implementation from Oracle TopLink
 package org.eclipse.persistence.testing.tests.unitofwork;
 
+import java.util.Collection;
 import java.util.Enumeration;
 import java.util.Vector;
 
@@ -55,6 +56,10 @@ public class UnregisterUnitOfWorkTest extends AutoVerifyTestCase {
             throw new TestErrorException("Deep unregister object did not work");
         }
 
+        if (!uow.getPrimaryKeyToNewObjects().values().stream().allMatch(Collection::isEmpty)) {
+            throw new TestErrorException("Deep unregister object did not work");
+        }
+
         uow.commit();
 
         uow = (UnitOfWorkImpl)getSession().acquireUnitOfWork();
@@ -73,6 +78,10 @@ public class UnregisterUnitOfWorkTest extends AutoVerifyTestCase {
         }
 
         if (!uow.getNewObjectsCloneToOriginal().isEmpty()) {
+            throw new TestErrorException("Deep unregister object did not work");
+        }
+
+        if (!uow.getPrimaryKeyToNewObjects().values().stream().allMatch(Collection::isEmpty)) {
             throw new TestErrorException("Deep unregister object did not work");
         }
 

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/UnregisterUnitOfWorkTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/UnregisterUnitOfWorkTest.java
@@ -56,7 +56,7 @@ public class UnregisterUnitOfWorkTest extends AutoVerifyTestCase {
             throw new TestErrorException("Deep unregister object did not work");
         }
 
-        if (!uow.getPrimaryKeyToNewObjects().values().stream().allMatch(Collection::isEmpty)) {
+        if (!uow.getPrimaryKeyToNewObjects().isEmpty()) {
             throw new TestErrorException("Deep unregister object did not work");
         }
 
@@ -81,7 +81,7 @@ public class UnregisterUnitOfWorkTest extends AutoVerifyTestCase {
             throw new TestErrorException("Deep unregister object did not work");
         }
 
-        if (!uow.getPrimaryKeyToNewObjects().values().stream().allMatch(Collection::isEmpty)) {
+        if (!uow.getPrimaryKeyToNewObjects().isEmpty()) {
             throw new TestErrorException("Deep unregister object did not work");
         }
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
@@ -5074,7 +5074,14 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
      * Removes an object from primaryKeyToNewObjects.
      */
     protected void removeObjectFromPrimaryKeyToNewObjects(Object object, Object primaryKey){
-        getPrimaryKeyToNewObjects().getOrDefault(primaryKey, new ArrayList<>(0)).remove(object);
+        Map<Object, List<Object>> pkToNewObjects = getPrimaryKeyToNewObjects();
+        if (pkToNewObjects.containsKey(primaryKey)) {
+            List<Object> newObjects = pkToNewObjects.get(primaryKey);
+            newObjects.remove(object);
+            if (newObjects.isEmpty()) {
+               pkToNewObjects.remove(primaryKey);
+            }
+        }
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/remote/RemoteUnitOfWork.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/remote/RemoteUnitOfWork.java
@@ -659,6 +659,7 @@ public class RemoteUnitOfWork extends RepeatableWriteUnitOfWork {
 
         this.newObjectsOriginalToClone = originalToClone;
         this.newObjectsCloneToOriginal = cloneToOriginal;
+        setupPrimaryKeyToNewObjects();
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/remote/RemoteUnitOfWork.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/remote/RemoteUnitOfWork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at


### PR DESCRIPTION
- Fixes #1596 

When a lookup is performed in a UnitOfWork, eclipselink used to perform a linear search through all new entities. If the UnitOfWork contains many new objects, this becomes a major performance issue, since in the worst case every persisted entity has to be checked and a primary key extraction performed.
By instead maintaining a HashMap of primary key to new objects in the UnitOfWork, the performance impact of a lookup becomes negligible even if there are many persisted entities.

To demonstrate this, I used the UnitTest attached to [this comment](https://github.com/eclipse-ee4j/eclipselink/issues/1596#issuecomment-1252273264) in the original issue with 10k new entities:

In the original implementation 75% of the execution time is spent in `org.eclipse.persistence.internal.sessions.UnitOfWorkImpl.getObjectFromNewObjects (Class, Object)` and there are ~50k calls to `org.eclipse.persistence.internal.descriptors.ObjectBuilder.extractPrimaryKeyFromObject (Object, org.eclipse.persistence.internal.sessions.AbstractSession, boolean)`:

![visualVM_linearSearch](https://user-images.githubusercontent.com/13404745/228239968-be2f2b6e-7c71-4ed8-a316-35b2c56a49ff.png)

With my new implementation using a HashMap, time spent in `getObjectFromNewObjects (Class, Object)` is reduced to 0.1% and no additional primary key extraction is needed:

![visualVM_HashMap](https://user-images.githubusercontent.com/13404745/228241241-4b28578a-87c5-476f-9b7d-de9d0552bd5b.png)
