### PR TITLE
[2.7] JPA test fixes

### DIFF
--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/advanced/EntityManagerJUnitTestSuite.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/advanced/EntityManagerJUnitTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2019 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -240,12 +240,11 @@ public class EntityManagerJUnitTestSuite extends JUnitTestCase {
 
     public static Test suite() {
         TestSuite suite = new TestSuite();
+        suite.addTest(suiteSpring());
         suite.addTest(new EntityManagerJUnitTestSuite("testCacheUsage"));
-
         if (!isJPA10()) {
             suite.addTest(new EntityManagerJUnitTestSuite("testIsLoaded"));
         }
-        suite.addTest(suiteSpring());
         return suite;
     }
 


### PR DESCRIPTION
There are some minor JPA test issues discovered with tests in WLS environment.
- `public static Test suite() {` ensure, that tables like `EMPLOYEE_SEQ` are created before test. As these tables are created by another tests too error

`Internal Exception: java.sql.SQLSyntaxErrorException: ORA-00942: table or view does not exist Error Code: 942 Call: UPDATE CMP3_EMPLOYEE_SEQ SET SEQ_COUNT = SEQ_COUNT + ? WHERE SEQ_NAME = ? bind => [2 parameters bound] Query: DataModifyQuery(name="EMPLOYEE_SEQ" sql="UPDATE CMP3_EMPLOYEE_SEQ SET SEQ_COUNT = SEQ_COUNT + ? WHERE SEQ_NAME = ?") `
should happen only if this test is executed first in the suite.

- `public void testApplicationManagedInServer() {` there should be two instances of `DatabaseSession` based on same persistence unit from the same JEE application.