### PR TITLE
[3.0] ASM version switch to 9.5 to be ready for JDK 21.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
         <docs.status>DRAFT</docs.status>
 
         <!--Eclipse Dependencies version-->
-        <eclipselink.asm.version>9.3.0</eclipselink.asm.version>
+        <eclipselink.asm.version>9.5.0</eclipselink.asm.version>
         <activation.version>2.0.1</activation.version>
         <annotation.version>2.0.0</annotation.version>
         <cdi.version>3.0.0</cdi.version>


### PR DESCRIPTION
As https://central.sonatype.com/artifact/org.eclipse.persistence/org.eclipse.persistence.asm/9.5.0 is released.