### PR TITLE
[2.7] ASM version switch to 9.5 to be ready for JDK 21.

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -20,7 +20,7 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 env:
-  maven_version: 3.8.7
+  maven_version: 3.8.8
 jobs:
   build:
     name: Test on JDK ${{ matrix.java_version }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,7 +26,7 @@ on:
   schedule:
     - cron: '0 19 * * 1'
 env:
-  maven_version: 3.8.7
+  maven_version: 3.8.8
 
 jobs:
   analyze:

--- a/buildsystem/compdeps/pom.xml
+++ b/buildsystem/compdeps/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -62,7 +62,7 @@
         <eclipse.drop>2018-12</eclipse.drop>
 
         <!-- DEPENDENCY Versions -->
-        <eclipselink.asm.version>9.4.0</eclipselink.asm.version>
+        <eclipselink.asm.version>9.5.0</eclipselink.asm.version>
         <!-- CQ #21139, 21140 -->
         <ch.qos.logback.version>1.2.3</ch.qos.logback.version>
         <com.sun.xml.bind.version>2.3.3</com.sun.xml.bind.version>

--- a/dbws/org.eclipse.persistence.dbws/META-INF/MANIFEST.MF
+++ b/dbws/org.eclipse.persistence.dbws/META-INF/MANIFEST.MF
@@ -26,7 +26,7 @@ Created-By: 1.6.0_21 (Sun Microsystems Inc.)
 Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version>=1.8))"
 HK2-Bundle-Name: org.eclipse.persistence:org.eclipse.persistence.dbws
 Require-Bundle: org.eclipse.persistence.core;bundle-version="2.7.13",
- org.eclipse.persistence.asm;bundle-version="9.4.0",
+ org.eclipse.persistence.asm;bundle-version="9.5.0",
  org.eclipse.persistence.jpa;bundle-version="2.7.13",
  org.eclipse.persistence.moxy;bundle-version="2.7.13"
 Bundle-Vendor: Eclipse.org - EclipseLink Project

--- a/foundation/org.eclipse.persistence.core/META-INF/MANIFEST.MF
+++ b/foundation/org.eclipse.persistence.core/META-INF/MANIFEST.MF
@@ -175,7 +175,7 @@ Bundle-ClassPath: .
 HK2-Bundle-Name: org.eclipse.persistence:org.eclipse.persistence.core
 Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version>=1.8))"
 Require-Bundle: org.eclipse.persistence.antlr;bundle-version="3.5.2";resolution:=optional,
- org.eclipse.persistence.asm;bundle-version="9.4.0";resolution:=optional
+ org.eclipse.persistence.asm;bundle-version="9.5.0";resolution:=optional
 Bundle-SymbolicName: org.eclipse.persistence.core
 Eclipse-ExtensibleAPI: true
 Bundle-Name: EclipseLink Core

--- a/jpa/org.eclipse.persistence.jpa/META-INF/MANIFEST.MF
+++ b/jpa/org.eclipse.persistence.jpa/META-INF/MANIFEST.MF
@@ -41,7 +41,7 @@ Created-By: 1.6.0_21 (Sun Microsystems Inc.)
 HK2-Bundle-Name: org.eclipse.persistence:org.eclipse.persistence.jpa
 Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version>=1.8))"
 Require-Bundle: org.eclipse.persistence.core;bundle-version="2.7.13";visibility:=reexport,
- org.eclipse.persistence.asm;bundle-version="9.4.0";resolution:=optional
+ org.eclipse.persistence.asm;bundle-version="9.5.0";resolution:=optional
 Bundle-Vendor: Eclipse.org - EclipseLink Project
 Bundle-Version: 2.7.13.qualifier
 Bundle-ManifestVersion: 2

--- a/moxy/org.eclipse.persistence.moxy/META-INF/MANIFEST.MF
+++ b/moxy/org.eclipse.persistence.moxy/META-INF/MANIFEST.MF
@@ -16,7 +16,7 @@ Bundle-Name: EclipseLink MOXy
 Created-By: 1.6.0_21 (Sun Microsystems Inc.)
 HK2-Bundle-Name: org.eclipse.persistence:org.eclipse.persistence.moxy
 Require-Bundle: org.eclipse.persistence.core;bundle-version="2.7.13";visibility:=reexport,
- org.eclipse.persistence.asm;bundle-version="9.4.0";resolution:=optional
+ org.eclipse.persistence.asm;bundle-version="9.5.0";resolution:=optional
 Bundle-Vendor: Eclipse.org - EclipseLink Project
 Bundle-Version: 2.7.13.qualifier
 Bundle-ManifestVersion: 2

--- a/sdo/org.eclipse.persistence.sdo/META-INF/MANIFEST.MF
+++ b/sdo/org.eclipse.persistence.sdo/META-INF/MANIFEST.MF
@@ -14,7 +14,7 @@ Created-By: 1.6.0_21 (Sun Microsystems Inc.)
 HK2-Bundle-Name: org.eclipse.persistence:org.eclipse.persistence.sdo
 Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version>=1.8))"
 Require-Bundle: org.eclipse.persistence.core;bundle-version="2.7.13";visibility:=reexport,
- org.eclipse.persistence.asm;bundle-version="9.4.0";resolution:=optional,
+ org.eclipse.persistence.asm;bundle-version="9.5.0";resolution:=optional,
  org.eclipse.persistence.moxy;bundle-version="2.7.13";resolution:=optional,
  commonj.sdo;bundle-version="2.1.1"
 Bundle-Vendor: Eclipse.org - EclipseLink Project


### PR DESCRIPTION
As https://central.sonatype.com/artifact/org.eclipse.persistence/org.eclipse.persistence.asm/9.5.0 is released.