### PR TITLE
[3.0] fix #1596 Major performance issue in case of many new entities (#1843) - backport from master

### DIFF
--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/ConformResultsWithPrimaryKeyExpressionTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/ConformResultsWithPrimaryKeyExpressionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -158,7 +158,7 @@ public class ConformResultsWithPrimaryKeyExpressionTest extends ConformResultsIn
         case CASE_NEW: {
             selectionObject = newEmployee;
             if (shouldCheckCacheByExactPrimaryKey()) {
-                expectedGetIdCallCount = 1;
+                expectedGetIdCallCount = 0;
             } else {
                 expectedGetIdCallCount = n + 1;
             }
@@ -192,7 +192,7 @@ public class ConformResultsWithPrimaryKeyExpressionTest extends ConformResultsIn
                 // S.M. This went from 5 calls to 4, which is good.
                 // When checking the one new object + registration +
                 // building clone + building backup clone.
-                expectedGetIdCallCount = 3;
+                expectedGetIdCallCount = 2;
             } else {
                 expectedGetIdCallCount = n + 4;
             }

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/DoubleNestedUnitOfWorkDeleteConformedNestedNewObjectTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/DoubleNestedUnitOfWorkDeleteConformedNestedNewObjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -62,6 +62,10 @@ public class DoubleNestedUnitOfWorkDeleteConformedNestedNewObjectTest extends Au
         nestedNestedUOW.commit();
         nestedUow1.commit();
         if (!((UnitOfWorkImpl)uow).getNewObjectsCloneToOriginal().isEmpty()) {
+            throw new TestErrorException("Failed to unregister the Object in the nested unit of work");
+        }
+
+        if (!((UnitOfWorkImpl)uow).getPrimaryKeyToNewObjects().isEmpty()) {
             throw new TestErrorException("Failed to unregister the Object in the nested unit of work");
         }
 

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/DoubleNestedUnitOfWorkRegisterNewObjectTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/DoubleNestedUnitOfWorkRegisterNewObjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -62,6 +62,10 @@ public class DoubleNestedUnitOfWorkRegisterNewObjectTest extends AutoVerifyTestC
         nestedNestedUOW.commit();
         nestedUow1.commit();
         if (!((UnitOfWorkImpl)uow).getNewObjectsCloneToOriginal().isEmpty()) {
+            throw new TestErrorException("Failed to unregister the Object in the nested unit of work");
+        }
+
+        if (!((UnitOfWorkImpl)uow).getPrimaryKeyToNewObjects().isEmpty()) {
             throw new TestErrorException("Failed to unregister the Object in the nested unit of work");
         }
 

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/NestedUnitOfWorkDeleteConformedNestedNewObjectTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/NestedUnitOfWorkDeleteConformedNestedNewObjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -64,6 +64,10 @@ public class NestedUnitOfWorkDeleteConformedNestedNewObjectTest extends AutoVeri
         nestedUow1.deleteObject(nestedEmployee);
         nestedUow1.commit();
         if (!((UnitOfWorkImpl)uow).getNewObjectsCloneToOriginal().isEmpty()) {
+            throw new TestErrorException("Failed to unregister the Object in the nested unit of work");
+        }
+
+        if (!((UnitOfWorkImpl)uow).getPrimaryKeyToNewObjects().isEmpty()) {
             throw new TestErrorException("Failed to unregister the Object in the nested unit of work");
         }
 

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/NestedUnitOfWorkDeleteNestedNewObjectTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/NestedUnitOfWorkDeleteNestedNewObjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -46,6 +46,10 @@ public class NestedUnitOfWorkDeleteNestedNewObjectTest extends AutoVerifyTestCas
         nestedUow1.commit();
         uow.commit();
         if (((UnitOfWorkImpl)uow).getNewObjectsCloneToOriginal().containsKey(employee)) {
+            throw new TestErrorException("Failed to unregister the Object in the nested unit of work");
+        }
+
+        if (((UnitOfWorkImpl)uow).getPrimaryKeyToNewObjects().values().stream().anyMatch(c -> c.contains(employee))) {
             throw new TestErrorException("Failed to unregister the Object in the nested unit of work");
         }
 

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/NestedUnitOfWorkDeleteNewObjectTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/NestedUnitOfWorkDeleteNewObjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -41,6 +41,10 @@ public class NestedUnitOfWorkDeleteNewObjectTest extends AutoVerifyTestCase {
         nestedUOW2.commit();
         uow.commit();
         if (((UnitOfWorkImpl)uow).getNewObjectsCloneToOriginal().containsKey(original)) {
+            throw new TestErrorException("Failed to move the deleted new object into the parent UOW");
+        }
+
+        if (((UnitOfWorkImpl)uow).getPrimaryKeyToNewObjects().values().stream().anyMatch(c -> c.contains(original))) {
             throw new TestErrorException("Failed to move the deleted new object into the parent UOW");
         }
 

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/UnregisterUnitOfWorkTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/UnregisterUnitOfWorkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -55,6 +55,10 @@ public class UnregisterUnitOfWorkTest extends AutoVerifyTestCase {
             throw new TestErrorException("Deep unregister object did not work");
         }
 
+        if (!uow.getPrimaryKeyToNewObjects().isEmpty()) {
+            throw new TestErrorException("Deep unregister object did not work");
+        }
+
         uow.commit();
 
         uow = (UnitOfWorkImpl)getSession().acquireUnitOfWork();
@@ -73,6 +77,10 @@ public class UnregisterUnitOfWorkTest extends AutoVerifyTestCase {
         }
 
         if (!uow.getNewObjectsCloneToOriginal().isEmpty()) {
+            throw new TestErrorException("Deep unregister object did not work");
+        }
+
+        if (!uow.getPrimaryKeyToNewObjects().isEmpty()) {
             throw new TestErrorException("Deep unregister object did not work");
         }
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
@@ -155,6 +155,11 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
     protected Map<Object, Object> cloneMapping;
     protected Map<Object, Object> newObjectsCloneToOriginal;
     protected Map<Object, Object> newObjectsOriginalToClone;
+
+    /**
+     * Map of primary key to list of new objects. Used to speedup in-memory querying.
+     */
+    protected Map<Object, List<Object>> primaryKeyToNewObjects;
     /**
      * Stores a map from the clone to the original merged object, as a different instance is used as the original for merges.
      */
@@ -544,6 +549,8 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
             ObjectBuilder builder = descriptor.getObjectBuilder();
             try {
                 value = builder.assignSequenceNumber(object, this);
+                getPrimaryKeyToNewObjects().putIfAbsent(value, new ArrayList<>());
+                getPrimaryKeyToNewObjects().get(value).add(object);
             } catch (RuntimeException exception) {
                 handleException(exception);
             } finally {
@@ -580,6 +587,7 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
         }
         if (hasNewObjects()) {
             assignSequenceNumbers(getNewObjectsCloneToOriginal());
+            setupPrimaryKeyToNewObjects();
         }
     }
 
@@ -2396,6 +2404,18 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
 
     /**
      * INTERNAL:
+     * The primaryKeyToNewObjects stores a list of objects for every primary key.
+     * It is used to speed up in-memory-querying.
+     */
+    public Map<Object, List<Object>> getPrimaryKeyToNewObjects() {
+        if (primaryKeyToNewObjects == null) {
+            primaryKeyToNewObjects = new HashMap<>();
+        }
+        return primaryKeyToNewObjects;
+    }
+
+    /**
+     * INTERNAL:
      * The stores a map from new object clones to the original object used from merge.
      */
     public Map getNewObjectsCloneToMergeOriginal() {
@@ -2544,15 +2564,12 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
         boolean readSubclassesOrNoInheritance = (!descriptor.hasInheritance() || descriptor.getInheritancePolicy().shouldReadSubclasses());
 
         ObjectBuilder objectBuilder = descriptor.getObjectBuilder();
-        for (Iterator newObjectsEnum = getNewObjectsCloneToOriginal().keySet().iterator();
-                 newObjectsEnum.hasNext();) {
+        for (Iterator newObjectsEnum = getPrimaryKeyToNewObjects().getOrDefault(selectionKey, new ArrayList<>(0)).iterator();
+             newObjectsEnum.hasNext(); ) {
             Object object = newObjectsEnum.next();
             // bug 327900
             if ((object.getClass() == theClass) || (readSubclassesOrNoInheritance && (theClass.isInstance(object)))) {
-                Object primaryKey = objectBuilder.extractPrimaryKeyFromObject(object, this, true);
-                if ((primaryKey != null) && primaryKey.equals(selectionKey)) {
                     return object;
-                }
             }
         }
         return null;
@@ -3861,6 +3878,7 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
                     Object referenceObjectToRemove = getNewObjectsCloneToOriginal().get(removedObject);
                     if (referenceObjectToRemove != null) {
                         getNewObjectsCloneToOriginal().remove(removedObject);
+                        removeObjectFromPrimaryKeyToNewObjects(removedObject);
                         getNewObjectsOriginalToClone().remove(referenceObjectToRemove);
                     }
                 }
@@ -4480,6 +4498,7 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
         registerNewObjectInIdentityMap(clone, original, descriptor);
 
         getNewObjectsCloneToOriginal().put(clone, original);
+        addNewObjectToPrimaryKeyToNewObjects(clone,descriptor);
         if (original != null) {
             getNewObjectsOriginalToClone().put(original, clone);
         }
@@ -5001,6 +5020,69 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
      */
     protected void setNewObjectsCloneToOriginal(Map newObjects) {
         this.newObjectsCloneToOriginal = newObjects;
+        setupPrimaryKeyToNewObjects();
+    }
+
+    /**
+     * INTERNAL:
+     * Create the map of primary key to new objects used to speed up in-memory querying.
+     */
+    protected void setupPrimaryKeyToNewObjects() {
+        primaryKeyToNewObjects = null;
+        if (hasNewObjects()) {
+            primaryKeyToNewObjects = new HashMap<>();
+            getNewObjectsCloneToOriginal().forEach((object, o2) -> {
+                addNewObjectToPrimaryKeyToNewObjects(object);
+            });
+        }
+    }
+
+    /**
+     * INTERNAL:
+     * Extracts the primary key from a new object and puts it in primaryKeyToNewObjects.
+     */
+    protected void addNewObjectToPrimaryKeyToNewObjects(Object newObject){
+        ClassDescriptor descriptor = getDescriptor(newObject.getClass());
+        addNewObjectToPrimaryKeyToNewObjects(newObject,descriptor);
+    }
+
+    /**
+     * INTERNAL:
+     * Extracts the primary key from a new object and puts it in primaryKeyToNewObjects.
+     * Allows passing of the ClassDescriptor.
+     */
+    protected void addNewObjectToPrimaryKeyToNewObjects(Object newObject, ClassDescriptor descriptor){
+        ObjectBuilder objectBuilder = descriptor.getObjectBuilder();
+        Object pk = objectBuilder.extractPrimaryKeyFromObject(newObject, this, true);
+        if(pk!=null) {
+            getPrimaryKeyToNewObjects().putIfAbsent(pk, new ArrayList<>());
+            getPrimaryKeyToNewObjects().get(pk).add(newObject);
+        }
+    }
+    /**
+     * INTERNAL:
+     * Extracts the primary key and removes an object from primaryKeyToNewObjects.
+     */
+    protected void removeObjectFromPrimaryKeyToNewObjects(Object object){
+        ClassDescriptor descriptor = getDescriptor(object.getClass());
+        ObjectBuilder objectBuilder = descriptor.getObjectBuilder();
+        Object pk = objectBuilder.extractPrimaryKeyFromObject(object, this, true);
+        removeObjectFromPrimaryKeyToNewObjects(object,pk);
+    }
+
+    /**
+     * INTERNAL:
+     * Removes an object from primaryKeyToNewObjects.
+     */
+    protected void removeObjectFromPrimaryKeyToNewObjects(Object object, Object primaryKey){
+        Map<Object, List<Object>> pkToNewObjects = getPrimaryKeyToNewObjects();
+        if (pkToNewObjects.containsKey(primaryKey)) {
+            List<Object> newObjects = pkToNewObjects.get(primaryKey);
+            newObjects.remove(object);
+            if (newObjects.isEmpty()) {
+               pkToNewObjects.remove(primaryKey);
+            }
+        }
     }
 
     /**
@@ -5460,6 +5542,7 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
             }
             this.newObjectsCloneToOriginal = null;
             this.newObjectsOriginalToClone = null;
+            this.primaryKeyToNewObjects = null;
         }
         this.unregisteredExistingObjects = null;
         this.unregisteredNewObjects = null;
@@ -5580,6 +5663,7 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
                 // PERF: Avoid initialization of new objects if none.
                 if (hasNewObjects()) {
                     Object original = getNewObjectsCloneToOriginal().remove(object);
+                    removeObjectFromPrimaryKeyToNewObjects(object, primaryKey);
                     if (original != null) {
                         getNewObjectsOriginalToClone().remove(original);
                     }
@@ -5943,6 +6027,7 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
         this.cloneMapping = null;
         this.newObjectsCloneToOriginal = null;
         this.newObjectsOriginalToClone = null;
+        this.primaryKeyToNewObjects = null;
         this.deletedObjects = null;
         this.allClones = null;
         this.objectsDeletedDuringCommit = null;

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/remote/RemoteUnitOfWork.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/remote/RemoteUnitOfWork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -659,6 +659,7 @@ public class RemoteUnitOfWork extends RepeatableWriteUnitOfWork {
 
         this.newObjectsOriginalToClone = originalToClone;
         this.newObjectsCloneToOriginal = cloneToOriginal;
+        setupPrimaryKeyToNewObjects();
     }
 
     /**


### PR DESCRIPTION
* Issue 1596: use a hash-based collection to lookup objects in the cache instead of a linear search
* Adjusted source according to review:
- extended tests
- updated copyright year
- call removeObjectFromPrimaryKeyToNewObjects in preMergeChanges
- remove list from primaryKeyToNewObjects if it is empty
- simplify tests



(cherry picked from commit 76d82744b14f9a3ad11c1a5215542955b43bea1a)