### PR TITLE
[2.7] SDO potential memory leak fix 2.0 - backport from the master

### DIFF
--- a/sdo/eclipselink.sdo.test/src/org/eclipse/persistence/testing/sdo/helper/SDOHelperContextTest.java
+++ b/sdo/eclipselink.sdo.test/src/org/eclipse/persistence/testing/sdo/helper/SDOHelperContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,6 +16,7 @@ package org.eclipse.persistence.testing.sdo.helper;
 
 import commonj.sdo.helper.HelperContext;
 import junit.framework.TestCase;
+import org.eclipse.persistence.sdo.SDOSystemProperties;
 import org.eclipse.persistence.sdo.helper.SDOHelperContext;
 
 import java.lang.reflect.Field;
@@ -39,17 +40,17 @@ public class SDOHelperContextTest extends TestCase {
     protected void setUp() throws Exception {
         super.setUp();
         getMap().clear();
-        strictTypeCheckingPropertyValueBackup = System.getProperty(SDOHelperContext.STRICT_TYPE_CHECKING_PROPERTY_NAME);
-        System.clearProperty(SDOHelperContext.STRICT_TYPE_CHECKING_PROPERTY_NAME);
+        strictTypeCheckingPropertyValueBackup = System.getProperty(SDOSystemProperties.SDO_STRICT_TYPE_CHECKING_PROPERTY_NAME);
+        System.clearProperty(SDOSystemProperties.SDO_STRICT_TYPE_CHECKING_PROPERTY_NAME);
     }
 
     @Override
     protected void tearDown() throws Exception {
         super.tearDown();
         if (strictTypeCheckingPropertyValueBackup != null) {
-            System.setProperty(SDOHelperContext.STRICT_TYPE_CHECKING_PROPERTY_NAME, strictTypeCheckingPropertyValueBackup);
+            System.setProperty(SDOSystemProperties.SDO_STRICT_TYPE_CHECKING_PROPERTY_NAME, strictTypeCheckingPropertyValueBackup);
         } else {
-            System.clearProperty(SDOHelperContext.STRICT_TYPE_CHECKING_PROPERTY_NAME);
+            System.clearProperty(SDOSystemProperties.SDO_STRICT_TYPE_CHECKING_PROPERTY_NAME);
         }
         strictTypeCheckingPropertyValueBackup = null;
     }
@@ -132,10 +133,10 @@ public class SDOHelperContextTest extends TestCase {
 
     /**
      * Checks setting {@link SDOHelperContext#isStrictTypeCheckingEnabled()}
-     * using {@link SDOHelperContext#STRICT_TYPE_CHECKING_PROPERTY_NAME} property.
+     * using {@link SDOSystemProperties#SDO_STRICT_TYPE_CHECKING_PROPERTY_NAME} property.
      */
     public void testTypeCheckingStrictnessFlagSystemPropertyFalse() {
-        System.setProperty(SDOHelperContext.STRICT_TYPE_CHECKING_PROPERTY_NAME, "false");
+        System.setProperty(SDOSystemProperties.SDO_STRICT_TYPE_CHECKING_PROPERTY_NAME, "false");
         SDOHelperContext ctx = new SDOHelperContext("testHelperContext");
         assertFalse("Expected value of SDOHelperContext#isStrictTypeCheckingEnabled() is false.",
                 ctx.isStrictTypeCheckingEnabled());
@@ -143,10 +144,10 @@ public class SDOHelperContextTest extends TestCase {
 
     /**
      * Checks setting {@link SDOHelperContext#isStrictTypeCheckingEnabled()}
-     * using {@link SDOHelperContext#STRICT_TYPE_CHECKING_PROPERTY_NAME} property.
+     * using {@link SDOSystemProperties#SDO_STRICT_TYPE_CHECKING_PROPERTY_NAME} property.
      */
     public void testTypeCheckingStrictnessFlagSystemPropertyTrue() {
-        System.setProperty(SDOHelperContext.STRICT_TYPE_CHECKING_PROPERTY_NAME, "true");
+        System.setProperty(SDOSystemProperties.SDO_STRICT_TYPE_CHECKING_PROPERTY_NAME, "true");
         SDOHelperContext ctx = new SDOHelperContext("testHelperContext");
         assertTrue("Expected value of SDOHelperContext#isStrictTypeCheckingEnabled() is true.",
                 ctx.isStrictTypeCheckingEnabled());

--- a/sdo/eclipselink.sdo.test/src/org/eclipse/persistence/testing/sdo/instanceclass/InstanceClassTestCases.java
+++ b/sdo/eclipselink.sdo.test/src/org/eclipse/persistence/testing/sdo/instanceclass/InstanceClassTestCases.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -20,6 +20,7 @@ import commonj.sdo.DataObject;
 import commonj.sdo.Type;
 import commonj.sdo.helper.HelperContext;
 
+import org.eclipse.persistence.sdo.SDOSystemProperties;
 import org.eclipse.persistence.sdo.helper.SDOHelperContext;
 import org.eclipse.persistence.sequencing.StandardSequence;
 import org.eclipse.persistence.testing.sdo.SDOTestCase;
@@ -40,17 +41,17 @@ public class InstanceClassTestCases extends SDOTestCase {
     @Override
     public void setUp() {
         super.setUp();
-        strictTypeCheckingPropertyValueBackup = System.getProperty(SDOHelperContext.STRICT_TYPE_CHECKING_PROPERTY_NAME);
-        System.clearProperty(SDOHelperContext.STRICT_TYPE_CHECKING_PROPERTY_NAME);
+        strictTypeCheckingPropertyValueBackup = System.getProperty(SDOSystemProperties.SDO_STRICT_TYPE_CHECKING_PROPERTY_NAME);
+        System.clearProperty(SDOSystemProperties.SDO_STRICT_TYPE_CHECKING_PROPERTY_NAME);
     }
 
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
         if (strictTypeCheckingPropertyValueBackup != null) {
-            System.setProperty(SDOHelperContext.STRICT_TYPE_CHECKING_PROPERTY_NAME, strictTypeCheckingPropertyValueBackup);
+            System.setProperty(SDOSystemProperties.SDO_STRICT_TYPE_CHECKING_PROPERTY_NAME, strictTypeCheckingPropertyValueBackup);
         } else {
-            System.clearProperty(SDOHelperContext.STRICT_TYPE_CHECKING_PROPERTY_NAME);
+            System.clearProperty(SDOSystemProperties.SDO_STRICT_TYPE_CHECKING_PROPERTY_NAME);
         }
         strictTypeCheckingPropertyValueBackup = null;
     }
@@ -148,7 +149,7 @@ public class InstanceClassTestCases extends SDOTestCase {
      * This tests works only with {@link SDOHelperContext} and subclasses (otherwise tests nothing).
      */
     public void testInterfaceWithIncorrectGettersAndRelaxedTypeCheckingByProperty() {
-        System.setProperty(SDOHelperContext.STRICT_TYPE_CHECKING_PROPERTY_NAME, "false");
+        System.setProperty(SDOSystemProperties.SDO_STRICT_TYPE_CHECKING_PROPERTY_NAME, "false");
         SDOHelperContext helperContext = new SDOHelperContext();
         InputStream xsd = Thread.currentThread().getContextClassLoader().getResourceAsStream(XML_SCHEMA_INTEFACE_INCORRECT_GETTER);
         helperContext.getXSDHelper().define(xsd, null);

--- a/sdo/org.eclipse.persistence.sdo/src/org/eclipse/persistence/sdo/SDOSystemProperties.java
+++ b/sdo/org.eclipse.persistence.sdo/src/org/eclipse/persistence/sdo/SDOSystemProperties.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - 4.0.x - initial implementation
+package org.eclipse.persistence.sdo;
+
+/**
+ * This class provides the list of System properties that are recognized by EclipseLink SDO component.
+ * @author rfelcman
+ */
+public final class SDOSystemProperties {
+
+    private SDOSystemProperties() {
+    }
+
+    /**
+     * Property controls strictness of {@link commonj.sdo.Type#getInstanceClass()} type checking.
+     *
+     * <p>
+     * See {@link org.eclipse.persistence.sdo.helper.SDOHelperContext#isStrictTypeCheckingEnabled()} for more details.
+     * By this property, the initial value can be changed.
+     * Default value is {@code true}.
+     * </p>
+     */
+    public static final String SDO_STRICT_TYPE_CHECKING_PROPERTY_NAME = "eclipselink.sdo.strict.type.checking";
+
+    /**
+     * Property controls maximum size of helperContexts map.
+     * This is way how Least Recently Used (LRU) strategy will be intensive. It should help with used Java heap size issues
+     * if there is so many SDOClassLoader instances with so many defined classes.
+     * Default value is {@code 1 000 000}.
+     */
+    public static final String SDO_HELPER_CONTEXTS_MAX_SIZE = "eclipselink.sdo.helper.contexts.max.size";
+}


### PR DESCRIPTION
This change solve potential memory leak if SDO component is used in JEE environment. There is refactor of SDOHelperContext.helperContexts map content (nested map). Instead of current ConcurrentHashMap is CacheIdentityMap used which supports Least Recently Used (LRU) strategy. This one should be controlled by new SDO system property eclipselink.sdo.helper.contexts.max.size.