### PR TITLE
[3.0] SDO potential memory leak fix 2.0 - backport from master

### DIFF
--- a/sdo/org.eclipse.persistence.sdo/src/main/java/org/eclipse/persistence/sdo/SDOSystemProperties.java
+++ b/sdo/org.eclipse.persistence.sdo/src/main/java/org/eclipse/persistence/sdo/SDOSystemProperties.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - 4.0.x - initial implementation
+package org.eclipse.persistence.sdo;
+
+/**
+ * This class provides the list of System properties that are recognized by EclipseLink SDO component.
+ * @author rfelcman
+ */
+public final class SDOSystemProperties {
+
+    private SDOSystemProperties() {
+    }
+
+    /**
+     * Property controls strictness of {@link commonj.sdo.Type#getInstanceClass()} type checking.
+     *
+     * <p>
+     * See {@link org.eclipse.persistence.sdo.helper.SDOHelperContext#isStrictTypeCheckingEnabled()} for more details.
+     * By this property, the initial value can be changed.
+     * Default value is {@code true}.
+     * </p>
+     */
+    public static final String SDO_STRICT_TYPE_CHECKING_PROPERTY_NAME = "eclipselink.sdo.strict.type.checking";
+
+    /**
+     * Property controls maximum size of helperContexts map.
+     * This is way how Least Recently Used (LRU) strategy will be intensive. It should help with used Java heap size issues
+     * if there is so many SDOClassLoader instances with so many defined classes.
+     * Default value is {@code 1 000 000}.
+     */
+    public static final String SDO_HELPER_CONTEXTS_MAX_SIZE = "eclipselink.sdo.helper.contexts.max.size";
+}

--- a/sdo/org.eclipse.persistence.sdo/src/main/java/org/eclipse/persistence/sdo/helper/SDOHelperContext.java
+++ b/sdo/org.eclipse.persistence.sdo/src/main/java/org/eclipse/persistence/sdo/helper/SDOHelperContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -42,10 +42,12 @@ import javax.naming.NamingException;
 
 import org.eclipse.persistence.exceptions.SDOException;
 import org.eclipse.persistence.internal.helper.Helper;
+import org.eclipse.persistence.internal.identitymaps.CacheIdentityMap;
 import org.eclipse.persistence.internal.security.PrivilegedAccessHelper;
 import org.eclipse.persistence.internal.security.PrivilegedGetMethod;
 import org.eclipse.persistence.sdo.SDOConstants;
 import org.eclipse.persistence.sdo.SDOResolvable;
+import org.eclipse.persistence.sdo.SDOSystemProperties;
 import org.eclipse.persistence.sdo.helper.delegates.SDODataFactoryDelegate;
 import org.eclipse.persistence.sdo.helper.delegates.SDOTypeHelperDelegate;
 import org.eclipse.persistence.sdo.helper.delegates.SDOTypeHelperDelegate.SDOWrapperTypeId;
@@ -93,7 +95,7 @@ public class SDOHelperContext implements HelperContext {
     private String identifier;
     private Map<String, Object> properties;
     private boolean isStrictTypeCheckingEnabled = PrivilegedAccessHelper.getSystemPropertyBoolean(
-            STRICT_TYPE_CHECKING_PROPERTY_NAME, true);
+            SDOSystemProperties.SDO_STRICT_TYPE_CHECKING_PROPERTY_NAME, true);
 
     /**
      * Property controls strictness of {@link Type#getInstanceClass()} type checking.
@@ -103,12 +105,19 @@ public class SDOHelperContext implements HelperContext {
      * By this property, the initial value can be changed.
      * Default value is <code>true</code>.
      * </p>
+     *
+     * @deprecated
+     * @see org.eclipse.persistence.sdo.SDOSystemProperties.SDO_STRICT_TYPE_CHECKING_PROPERTY_NAME
+     * Moved to {@link org.eclipse.persistence.sdo.SDOSystemProperties}.     *
      */
-    public static final String STRICT_TYPE_CHECKING_PROPERTY_NAME = "eclipselink.sdo.strict.type.checking";
+    @Deprecated
+    public static final String STRICT_TYPE_CHECKING_PROPERTY_NAME = SDOSystemProperties.SDO_STRICT_TYPE_CHECKING_PROPERTY_NAME;
+
+    private static int helperContextsMaxSize = Integer.parseInt(PrivilegedAccessHelper.getSystemProperty(SDOSystemProperties.SDO_HELPER_CONTEXTS_MAX_SIZE, "1000000"));
 
     // Each application will have its own helper context - it is assumed that application
     // names/loaders are unique within each active server instance
-    private static ConcurrentHashMap<Object, ConcurrentHashMap<String, HelperContext>> helperContexts = new ConcurrentHashMap<Object, ConcurrentHashMap<String, HelperContext>>();
+    private static ConcurrentHashMap<Object, CacheIdentityMap> helperContexts = new ConcurrentHashMap<Object, CacheIdentityMap>();
     // Each application will have a Map of alias' to identifiers
     private static ConcurrentHashMap<Object, ConcurrentHashMap<String, String>> aliasMap = new ConcurrentHashMap<Object, ConcurrentHashMap<String, String>>();
     // Each application could have separate HelperContextResolver
@@ -494,15 +503,17 @@ public class SDOHelperContext implements HelperContext {
         if (helperContext != null) {
             return helperContext;
         }
-        ConcurrentMap<String, HelperContext> contextMap = getContextMap();
-        helperContext = contextMap.get(identifier);
+        CacheIdentityMap contextMap = getContextMap();
+        helperContext = (HelperContext)contextMap.get(identifier);
         if (null == helperContext) {
             LOGGER.fine("helperContext not found.");
             helperContext = getHelperContextResolver().getHelperContext(identifier, classLoader);
-            HelperContext existingContext = contextMap.putIfAbsent(identifier, helperContext);
+            HelperContext existingContext = (HelperContext)contextMap.get(identifier);
             if (existingContext != null) {
                 LOGGER.fine(String.format("contextMap already has context for id: %s. Existing one will be used.", identifier));
                 helperContext = existingContext;
+            } else {
+                contextMap.put(identifier, helperContext, false, 0);
             }
         }
         return helperContext;
@@ -512,7 +523,7 @@ public class SDOHelperContext implements HelperContext {
      * Returns the map of helper contexts, keyed on Identifier, for the current application
      * @return
      */
-    static ConcurrentMap<String, HelperContext> getContextMap() {
+    static CacheIdentityMap getContextMap() {
         ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
         String classLoaderName = contextClassLoader.getClass().getName();
         // get a MapKeyLookupResult instance based on the context loader
@@ -522,7 +533,7 @@ public class SDOHelperContext implements HelperContext {
         ClassLoader appLoader = hCtxMapKey.getLoader();
         // we will use the application name as the map key if set; otherwise we use the loader
         Object contextMapKey = appName != null ? appName : appLoader;
-        ConcurrentHashMap<String, HelperContext> contextMap = helperContexts.get(contextMapKey);
+        CacheIdentityMap contextMap = helperContexts.get(contextMapKey);
 
         // handle possible redeploy
         // the following block only applies to WAS - hence the loader name check
@@ -541,9 +552,9 @@ public class SDOHelperContext implements HelperContext {
 
         // may need to add a new entry
         if (null == contextMap) {
-            contextMap = new ConcurrentHashMap<String, HelperContext>();
+            contextMap = new CacheIdentityMap(helperContextsMaxSize, null, null, false);
             // use putIfAbsent to avoid concurrent entries in the map
-            ConcurrentHashMap existingMap = helperContexts.putIfAbsent(contextMapKey, contextMap);
+            CacheIdentityMap existingMap = helperContexts.putIfAbsent(contextMapKey, contextMap);
             if (existingMap != null) {
                 // if a new entry was just added, use it instead of the one we just created
                 contextMap = existingMap;
@@ -582,7 +593,7 @@ public class SDOHelperContext implements HelperContext {
             // The global HelperContext cannot be replaced
             return;
         }
-        getContextMap().put(identifier, ctx);
+        getContextMap().put(identifier, ctx, false, 0);
         // identifier may have been an alias at one point
         getAliasMap().remove(identifier);
     }
@@ -1032,10 +1043,10 @@ public class SDOHelperContext implements HelperContext {
         ClassLoader appLoader = hCtxMapKey.getLoader();
         Object contextMapKey = appName != null ? appName : appLoader;
 
-        ConcurrentHashMap<String, HelperContext> contexts = helperContexts.get(contextMapKey);
+        CacheIdentityMap contexts = helperContexts.get(contextMapKey);
         if (contexts == null) {
-            contexts = new ConcurrentHashMap<String, HelperContext>();
-            ConcurrentHashMap<String, HelperContext> existingContexts = helperContexts.putIfAbsent(contextMapKey, contexts);
+            contexts = new CacheIdentityMap(helperContextsMaxSize, null, null, false);
+            CacheIdentityMap existingContexts = helperContexts.putIfAbsent(contextMapKey, contexts);
             if (existingContexts != null) {
                 contexts = existingContexts;
             } else if (appName != null) {
@@ -1043,7 +1054,7 @@ public class SDOHelperContext implements HelperContext {
             }
         }
         this.identifier = GLOBAL_HELPER_IDENTIFIER;
-        contexts.put(GLOBAL_HELPER_IDENTIFIER, this);
+        contexts.put(GLOBAL_HELPER_IDENTIFIER, this, false, 0);
     }
 
     /**
@@ -1290,7 +1301,7 @@ public class SDOHelperContext implements HelperContext {
         }
 
         // lastly, check the Map of identifiers to helperContexts
-        ConcurrentHashMap<String, HelperContext> contextMap = helperContexts.get(appKey);
+        CacheIdentityMap contextMap = helperContexts.get(appKey);
         return (contextMap != null && contextMap.containsKey(id));
     }
 
@@ -1329,7 +1340,7 @@ public class SDOHelperContext implements HelperContext {
         if (null == alias) {
             alias = new ConcurrentHashMap<String, String>();
             // use putIfAbsent to avoid concurrent entries in the map
-            ConcurrentHashMap existingMap = aliasMap.putIfAbsent(mapKey, alias);
+            ConcurrentHashMap<String, String> existingMap = aliasMap.putIfAbsent(mapKey, alias);
             if (existingMap != null) {
                 // if a new entry was just added, use it instead of the one we just created
                 alias = existingMap;

--- a/sdo/org.eclipse.persistence.sdo/src/test/java/org/eclipse/persistence/testing/sdo/helper/SDOHelperContextTest.java
+++ b/sdo/org.eclipse.persistence.sdo/src/test/java/org/eclipse/persistence/testing/sdo/helper/SDOHelperContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,6 +16,7 @@ package org.eclipse.persistence.testing.sdo.helper;
 
 import commonj.sdo.helper.HelperContext;
 import junit.framework.TestCase;
+import org.eclipse.persistence.sdo.SDOSystemProperties;
 import org.eclipse.persistence.sdo.helper.SDOHelperContext;
 
 import java.lang.reflect.Field;
@@ -39,17 +40,17 @@ public class SDOHelperContextTest extends TestCase {
     protected void setUp() throws Exception {
         super.setUp();
         getMap().clear();
-        strictTypeCheckingPropertyValueBackup = System.getProperty(SDOHelperContext.STRICT_TYPE_CHECKING_PROPERTY_NAME);
-        System.clearProperty(SDOHelperContext.STRICT_TYPE_CHECKING_PROPERTY_NAME);
+        strictTypeCheckingPropertyValueBackup = System.getProperty(SDOSystemProperties.SDO_STRICT_TYPE_CHECKING_PROPERTY_NAME);
+        System.clearProperty(SDOSystemProperties.SDO_STRICT_TYPE_CHECKING_PROPERTY_NAME);
     }
 
     @Override
     protected void tearDown() throws Exception {
         super.tearDown();
         if (strictTypeCheckingPropertyValueBackup != null) {
-            System.setProperty(SDOHelperContext.STRICT_TYPE_CHECKING_PROPERTY_NAME, strictTypeCheckingPropertyValueBackup);
+            System.setProperty(SDOSystemProperties.SDO_STRICT_TYPE_CHECKING_PROPERTY_NAME, strictTypeCheckingPropertyValueBackup);
         } else {
-            System.clearProperty(SDOHelperContext.STRICT_TYPE_CHECKING_PROPERTY_NAME);
+            System.clearProperty(SDOSystemProperties.SDO_STRICT_TYPE_CHECKING_PROPERTY_NAME);
         }
         strictTypeCheckingPropertyValueBackup = null;
     }
@@ -132,10 +133,10 @@ public class SDOHelperContextTest extends TestCase {
 
     /**
      * Checks setting {@link SDOHelperContext#isStrictTypeCheckingEnabled()}
-     * using {@link SDOHelperContext#STRICT_TYPE_CHECKING_PROPERTY_NAME} property.
+     * using {@link SDOSystemProperties#SDO_STRICT_TYPE_CHECKING_PROPERTY_NAME} property.
      */
     public void testTypeCheckingStrictnessFlagSystemPropertyFalse() {
-        System.setProperty(SDOHelperContext.STRICT_TYPE_CHECKING_PROPERTY_NAME, "false");
+        System.setProperty(SDOSystemProperties.SDO_STRICT_TYPE_CHECKING_PROPERTY_NAME, "false");
         SDOHelperContext ctx = new SDOHelperContext("testHelperContext");
         assertFalse("Expected value of SDOHelperContext#isStrictTypeCheckingEnabled() is false.",
                 ctx.isStrictTypeCheckingEnabled());
@@ -143,10 +144,10 @@ public class SDOHelperContextTest extends TestCase {
 
     /**
      * Checks setting {@link SDOHelperContext#isStrictTypeCheckingEnabled()}
-     * using {@link SDOHelperContext#STRICT_TYPE_CHECKING_PROPERTY_NAME} property.
+     * using {@link SDOSystemProperties#SDO_STRICT_TYPE_CHECKING_PROPERTY_NAME} property.
      */
     public void testTypeCheckingStrictnessFlagSystemPropertyTrue() {
-        System.setProperty(SDOHelperContext.STRICT_TYPE_CHECKING_PROPERTY_NAME, "true");
+        System.setProperty(SDOSystemProperties.SDO_STRICT_TYPE_CHECKING_PROPERTY_NAME, "true");
         SDOHelperContext ctx = new SDOHelperContext("testHelperContext");
         assertTrue("Expected value of SDOHelperContext#isStrictTypeCheckingEnabled() is true.",
                 ctx.isStrictTypeCheckingEnabled());

--- a/sdo/org.eclipse.persistence.sdo/src/test/java/org/eclipse/persistence/testing/sdo/instanceclass/InstanceClassTestCases.java
+++ b/sdo/org.eclipse.persistence.sdo/src/test/java/org/eclipse/persistence/testing/sdo/instanceclass/InstanceClassTestCases.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -20,6 +20,7 @@ import commonj.sdo.DataObject;
 import commonj.sdo.Type;
 import commonj.sdo.helper.HelperContext;
 
+import org.eclipse.persistence.sdo.SDOSystemProperties;
 import org.eclipse.persistence.sdo.helper.SDOHelperContext;
 import org.eclipse.persistence.sequencing.StandardSequence;
 import org.eclipse.persistence.testing.sdo.SDOTestCase;
@@ -40,17 +41,17 @@ public class InstanceClassTestCases extends SDOTestCase {
     @Override
     public void setUp() {
         super.setUp();
-        strictTypeCheckingPropertyValueBackup = System.getProperty(SDOHelperContext.STRICT_TYPE_CHECKING_PROPERTY_NAME);
-        System.clearProperty(SDOHelperContext.STRICT_TYPE_CHECKING_PROPERTY_NAME);
+        strictTypeCheckingPropertyValueBackup = System.getProperty(SDOSystemProperties.SDO_STRICT_TYPE_CHECKING_PROPERTY_NAME);
+        System.clearProperty(SDOSystemProperties.SDO_STRICT_TYPE_CHECKING_PROPERTY_NAME);
     }
 
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
         if (strictTypeCheckingPropertyValueBackup != null) {
-            System.setProperty(SDOHelperContext.STRICT_TYPE_CHECKING_PROPERTY_NAME, strictTypeCheckingPropertyValueBackup);
+            System.setProperty(SDOSystemProperties.SDO_STRICT_TYPE_CHECKING_PROPERTY_NAME, strictTypeCheckingPropertyValueBackup);
         } else {
-            System.clearProperty(SDOHelperContext.STRICT_TYPE_CHECKING_PROPERTY_NAME);
+            System.clearProperty(SDOSystemProperties.SDO_STRICT_TYPE_CHECKING_PROPERTY_NAME);
         }
         strictTypeCheckingPropertyValueBackup = null;
     }
@@ -148,7 +149,7 @@ public class InstanceClassTestCases extends SDOTestCase {
      * This tests works only with {@link SDOHelperContext} and subclasses (otherwise tests nothing).
      */
     public void testInterfaceWithIncorrectGettersAndRelaxedTypeCheckingByProperty() {
-        System.setProperty(SDOHelperContext.STRICT_TYPE_CHECKING_PROPERTY_NAME, "false");
+        System.setProperty(SDOSystemProperties.SDO_STRICT_TYPE_CHECKING_PROPERTY_NAME, "false");
         SDOHelperContext helperContext = new SDOHelperContext();
         InputStream xsd = Thread.currentThread().getContextClassLoader().getResourceAsStream(XML_SCHEMA_INTEFACE_INCORRECT_GETTER);
         helperContext.getXSDHelper().define(xsd, null);


### PR DESCRIPTION
This change solve potential memory leak if SDO component is used in JEE environment. There is refactor of SDOHelperContext.helperContexts map content (nested map). Instead of current ConcurrentHashMap is CacheIdentityMap used which supports Least Recently Used (LRU) strategy. This one should be controlled by new SDO system property eclipselink.sdo.helper.contexts.max.size.