### PR TITLE
[4.0] Oracle 23 platform - backport from master #1876

### DIFF
--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/QueryTimeoutConnectionReleasedTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/QueryTimeoutConnectionReleasedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -65,7 +65,7 @@ public class QueryTimeoutConnectionReleasedTest extends TestCase {
         preConnectionsAvailable = serverSession.getReadConnectionPool().getConnectionsAvailable().size();
         try {
             DataReadQuery query = new DataReadQuery();
-            String sqlString = "SELECT SUM(e.EMP_ID) from EMPLOYEE e , EMPLOYEE b, EMPLOYEE c, EMPLOYEE d, EMPLOYEE f, EMPLOYEE g, EMPLOYEE h";
+            String sqlString = "SELECT SUM(e.EMP_ID) from EMPLOYEE e , EMPLOYEE b, EMPLOYEE c, EMPLOYEE d, EMPLOYEE f, EMPLOYEE g, EMPLOYEE h, EMPLOYEE g";
             query.setSQLString(sqlString);
             query.setQueryTimeout(1);
             query.useCursoredStream(1, 1);

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/QueryTimeoutTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/queries/QueryTimeoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -46,7 +46,7 @@ public class QueryTimeoutTest extends TestCase {
         }
         try {
             DataReadQuery query = new DataReadQuery();
-            query.setSQLString("SELECT SUM(e.EMP_ID) from EMPLOYEE e , EMPLOYEE b, EMPLOYEE c, EMPLOYEE d, EMPLOYEE f, EMPLOYEE g, EMPLOYEE h");
+            query.setSQLString("SELECT SUM(e.EMP_ID) from EMPLOYEE e , EMPLOYEE b, EMPLOYEE c, EMPLOYEE d, EMPLOYEE f, EMPLOYEE g, EMPLOYEE h, EMPLOYEE g");
             query.setQueryTimeout(1);
             getSession().executeQuery(query);
         } catch (Exception e) {

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatasourcePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatasourcePlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, 2022 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -292,6 +292,13 @@ public class DatasourcePlatform implements Platform {
     @Override
     public void setConversionManager(ConversionManager conversionManager) {
         this.conversionManager = conversionManager;
+    }
+
+    /**
+     * Return the driver version.
+     */
+    public String getDriverVersion() {
+        return "";
     }
 
     /**
@@ -673,6 +680,11 @@ public class DatasourcePlatform implements Platform {
 
     @Override
     public boolean isOracle12() {
+        return false;
+    }
+
+    @Override
+    public boolean isOracle23() {
         return false;
     }
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/Platform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/Platform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -71,6 +71,11 @@ public interface Platform extends CorePlatform<ConversionManager>, Serializable,
     void setConversionManager(ConversionManager conversionManager);
 
     /**
+     * Return the driver version.
+     */
+    String getDriverVersion();
+
+    /**
      * Return the qualifier for the table. Required by some
      * databases such as Oracle and DB2
      */
@@ -130,6 +135,8 @@ public interface Platform extends CorePlatform<ConversionManager>, Serializable,
     boolean isOracle9();
 
     boolean isOracle12();
+
+    boolean isOracle23();
 
     boolean isPointBase();
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/Oracle23Platform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/Oracle23Platform.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.platform.database;
+
+public class Oracle23Platform extends Oracle21Platform {
+    public Oracle23Platform() {
+        super();
+    }
+}

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/oracle/plsql/PLSQLStoredProcedureCall.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/oracle/plsql/PLSQLStoredProcedureCall.java
@@ -56,6 +56,8 @@ import org.eclipse.persistence.internal.helper.Helper;
 import org.eclipse.persistence.internal.sessions.AbstractRecord;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
 import org.eclipse.persistence.mappings.structures.ObjectRelationalDatabaseField;
+import org.eclipse.persistence.platform.database.DatabasePlatform;
+import org.eclipse.persistence.platform.database.jdbc.JDBCTypes;
 import org.eclipse.persistence.platform.database.oracle.jdbc.OracleArrayType;
 import org.eclipse.persistence.queries.StoredProcedureCall;
 import org.eclipse.persistence.sessions.DatabaseRecord;
@@ -487,6 +489,7 @@ public class PLSQLStoredProcedureCall extends StoredProcedureCall {
     protected void assignIndices() {
         List<PLSQLargument> inArguments = getArguments(arguments, ParameterType.IN);
         List<PLSQLargument> inOutArguments = getArguments(arguments, ParameterType.INOUT);
+        DatabasePlatform platform = this.getQuery().getSession().getPlatform();
         inArguments.addAll(inOutArguments);
         int newIndex = 1;
         List<PLSQLargument> expandedArguments = new ArrayList<>();
@@ -508,6 +511,10 @@ public class PLSQLStoredProcedureCall extends StoredProcedureCall {
         }
         for (PLSQLargument inArg : inArguments) {
             DatabaseType type = inArg.databaseType;
+            if (platform.isOracle23() && type == OraclePLSQLTypes.PLSQLBoolean && Helper.compareVersions(platform.getDriverVersion(), "23.0.0") >= 0) {
+                type = JDBCTypes.BOOLEAN_TYPE;
+                inArg.databaseType = JDBCTypes.BOOLEAN_TYPE;
+            }
             String inArgName = inArg.name;
             if (!type.isComplexDatabaseType()) {
                 // for XMLType, we need to set type name parameter (will be "XMLTYPE")
@@ -561,6 +568,10 @@ public class PLSQLStoredProcedureCall extends StoredProcedureCall {
                 super.useNamedCursorOutputAsResultSet(outArgName);
             } else {
                 DatabaseType type = outArg.databaseType;
+                if (platform.isOracle23() && type == OraclePLSQLTypes.PLSQLBoolean && Helper.compareVersions(platform.getDriverVersion(), "23.0.0") >= 0) {
+                    type = JDBCTypes.BOOLEAN_TYPE;
+                    outArg.databaseType = JDBCTypes.BOOLEAN_TYPE;
+                }
                 if (!type.isComplexDatabaseType()) {
                     // for XMLType, we need to set type name parameter (will be "XMLTYPE")
                     if (type == XMLType) {

--- a/foundation/org.eclipse.persistence.core/src/main/resources/org/eclipse/persistence/internal/helper/VendorNameToPlatformMapping.properties
+++ b/foundation/org.eclipse.persistence.core/src/main/resources/org/eclipse/persistence/internal/helper/VendorNameToPlatformMapping.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 1998, 2019 IBM Corporation. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -36,6 +36,7 @@
 # to platform class entries should be placed before less specific entries. Each
 # platform entry must be on its own line, an entry cannot span multiple lines.
 
+(?is)oracle.*23.*=org.eclipse.persistence.platform.database.oracle.Oracle23Platform
 (?is)oracle.*21.*=org.eclipse.persistence.platform.database.oracle.Oracle21Platform
 (?is)oracle.*19.*=org.eclipse.persistence.platform.database.oracle.Oracle19Platform
 (?is)oracle.*18.*=org.eclipse.persistence.platform.database.oracle.Oracle18Platform
@@ -43,6 +44,7 @@
 (?is)oracle.*11.*=org.eclipse.persistence.platform.database.oracle.Oracle11Platform
 (?is)oracle.*10.*=org.eclipse.persistence.platform.database.oracle.Oracle10Platform
 (?is)oracle.*9.*=org.eclipse.persistence.platform.database.oracle.Oracle9Platform
+(?is)core.oracle.*23.*=org.eclipse.persistence.platform.database.Oracle23Platform
 (?is)core.oracle.*21.*=org.eclipse.persistence.platform.database.Oracle21Platform
 (?is)core.oracle.*19.*=org.eclipse.persistence.platform.database.Oracle19Platform
 (?is)core.oracle.*18.*=org.eclipse.persistence.platform.database.Oracle18Platform

--- a/foundation/org.eclipse.persistence.oracle/src/main/java/org/eclipse/persistence/platform/database/oracle/Oracle23Platform.java
+++ b/foundation/org.eclipse.persistence.oracle/src/main/java/org/eclipse/persistence/platform/database/oracle/Oracle23Platform.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.platform.database.oracle;
+
+/**
+ * <p><b>Purpose:</b>
+ * Supports certain new Oracle 23c data types, and usage of certain Oracle JDBC specific APIs.
+ * <p> Supports Oracle JSON data type.
+ * <p> Supports Oracle OracleJsonValue derived Java types.
+ */
+public class Oracle23Platform extends Oracle21Platform {
+
+    /**
+     * Creates an instance of Oracle 23c database platform.
+     */
+    public Oracle23Platform() {
+        super();
+    }
+
+
+    /**
+     * INTERNAL:
+     * Check whether current platform is Oracle 23c or later.
+     * @return Always returns {@code true} for instances of Oracle 23c platform.
+     * @since 4.0.2
+     */
+    @Override
+    public boolean isOracle23() {
+        return true;
+    }
+}

--- a/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.plsql/src/test/java/org/eclipse/persistence/testing/tests/jpa/plsql/PLSQLTest.java
+++ b/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.plsql/src/test/java/org/eclipse/persistence/testing/tests/jpa/plsql/PLSQLTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -20,6 +20,7 @@ import junit.framework.Test;
 import junit.framework.TestSuite;
 import org.eclipse.persistence.internal.databaseaccess.DatabaseCall;
 import org.eclipse.persistence.internal.helper.DatabaseType;
+import org.eclipse.persistence.internal.helper.Helper;
 import org.eclipse.persistence.internal.jpa.EJBQueryImpl;
 import org.eclipse.persistence.platform.database.oracle.annotations.OracleArray;
 import org.eclipse.persistence.platform.database.oracle.jdbc.OracleArrayType;
@@ -329,9 +330,16 @@ public class PLSQLTest extends JUnitTestCase {
             query.setParameter("P_POSITIVEN", 1);
             query.setParameter("P_SIGNTYPE", 1);
             query.setParameter("P_NUMBER", 1);
-            int result = (Integer)query.getSingleResult();
-            if (result != 1) {
-                fail("Incorrect result.");
+            if (getPlatform().isOracle23() &&  Helper.compareVersions(getPlatform().getDriverVersion(), "23.0.0") >= 0) {
+                boolean result = (Boolean) query.getSingleResult();
+                if (!result) {
+                    fail("Incorrect result.");
+                }
+            } else {
+                int result = (Integer) query.getSingleResult();
+                if (result != 1) {
+                    fail("Incorrect result.");
+                }
             }
         } finally {
             closeEntityManagerAndTransaction(em);

--- a/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.plsql/src/test/java/org/eclipse/persistence/testing/tests/jpa/plsql/XMLPLSQLTest.java
+++ b/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.plsql/src/test/java/org/eclipse/persistence/testing/tests/jpa/plsql/XMLPLSQLTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@
         <pgsql.version>42.5.3</pgsql.version>
         <!-- CQ #21139, 21140 -->
         <logback.version>1.4.5</logback.version>
-        <oracle.jdbc.version>21.8.0.0</oracle.jdbc.version>
+        <oracle.jdbc.version>23.2.0.0</oracle.jdbc.version>
         <!-- CQ #2437 -->
         <oracle.aqapi.version>21.3.0.0</oracle.aqapi.version>
         <oracle.fmw.version>12.2.1-2-0</oracle.fmw.version>


### PR DESCRIPTION
This PR adds support for a new Oracle 23c database.
It doesn't implement any new features yet.
There are two changes:

- Oracle 23c database has some performance improvement in case of Cartesian product so there is some change in `QueryTimeout` tests
- New Oracle JDBC driver 23.2.0.0 has, in some cases, different behaviour for boolean type. There are changes in PL/SQL calls. 

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>
(cherry picked from commit 0a12012e8a8e8f088d37fc988f3abebc0c12f30a)