### PR TITLE
[4.0] Oracle AQ API upgrade to com.oracle.database.messaging/aqapi-jakarta@23.2.0.0 - backport from master #1882

### DIFF
--- a/foundation/org.eclipse.persistence.oracle.nosql/pom.xml
+++ b/foundation/org.eclipse.persistence.oracle.nosql/pom.xml
@@ -70,7 +70,7 @@
         </dependency>
         <dependency>
             <groupId>com.oracle.database.messaging</groupId>
-            <artifactId>aqapi</artifactId>
+            <artifactId>aqapi-jakarta</artifactId>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
@@ -282,9 +282,8 @@
                     <scope>test</scope>
                 </dependency>
                 <dependency>
-                    <groupId>javax.jms</groupId>
-                    <artifactId>javax.jms-api</artifactId>
-                    <version>2.0.1</version>
+                    <groupId>jakarta.jms</groupId>
+                    <artifactId>jakarta.jms-api</artifactId>
                     <scope>test</scope>
                 </dependency>
                 <dependency>

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/eis/aq/AuthenticationTest.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/eis/aq/AuthenticationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -120,7 +120,7 @@ public class AuthenticationTest {
             session.login();
             session.logout();
         } catch (Exception ex) {
-            if (ex.getMessage().indexOf("invalid username/password") == -1) {
+            if (ex.getMessage().indexOf("invalid credential or not authorized; logon denied") == -1) {
                 throw ex;
             }
             failure = true;
@@ -144,7 +144,7 @@ public class AuthenticationTest {
             session.login();
             session.logout();
         } catch (Exception ex) {
-            if (ex.getMessage().indexOf("invalid username/password") == -1) {
+            if (ex.getMessage().indexOf("invalid credential or not authorized; logon denied") == -1) {
                 throw ex;
             }
             failure = true;
@@ -168,7 +168,7 @@ public class AuthenticationTest {
             session.login();
             session.logout();
         } catch (Exception ex) {
-            if (ex.getMessage().indexOf("invalid username/password") == -1) {
+            if (ex.getMessage().indexOf("invalid credential or not authorized; logon denied") == -1) {
                 throw ex;
             }
             failure = true;
@@ -192,7 +192,7 @@ public class AuthenticationTest {
             session.login();
             session.logout();
         } catch (Exception ex) {
-            if (ex.getMessage().indexOf("invalid username/password") == -1) {
+            if (ex.getMessage().indexOf("invalid credential or not authorized; logon denied") == -1) {
                 throw ex;
             }
             failure = true;

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/eis/aq/JMSDirectConnectTest.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/eis/aq/JMSDirectConnectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,21 +16,21 @@
 //       - 490677: Database connection properties made configurable in test.properties
 package org.eclipse.persistence.testing.tests.eis.aq;
 
-import javax.jms.JMSException;
-import javax.jms.QueueConnection;
-import javax.jms.QueueConnectionFactory;
-import javax.jms.QueueSession;
-import javax.jms.Session;
-import javax.jms.TopicConnection;
-import javax.jms.TopicConnectionFactory;
-import javax.jms.TopicSession;
+import jakarta.jms.JMSException;
+import jakarta.jms.QueueConnection;
+import jakarta.jms.QueueConnectionFactory;
+import jakarta.jms.QueueSession;
+import jakarta.jms.Session;
+import jakarta.jms.TopicConnection;
+import jakarta.jms.TopicConnectionFactory;
+import jakarta.jms.TopicSession;
 
 import org.eclipse.persistence.testing.framework.junit.LogTestExecution;
 import org.eclipse.persistence.testing.tests.nosql.NoSQLProperties;
 import org.junit.Rule;
 import org.junit.Test;
 
-import oracle.jms.AQjmsFactory;
+import oracle.jakarta.jms.AQjmsFactory;
 
 /**
  * Test connecting directly through the AQ JMS driver. Requires AQ installed on this database.

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/eis/aq/JMSDirectInteractionTest.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/eis/aq/JMSDirectInteractionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,18 +16,18 @@
 //       - 490677: Database connection properties made configurable in test.properties
 package org.eclipse.persistence.testing.tests.eis.aq;
 
-import javax.jms.Queue;
-import javax.jms.QueueConnection;
-import javax.jms.QueueReceiver;
-import javax.jms.QueueSender;
-import javax.jms.QueueSession;
-import javax.jms.Session;
-import javax.jms.TextMessage;
-import javax.jms.Topic;
-import javax.jms.TopicConnection;
-import javax.jms.TopicPublisher;
-import javax.jms.TopicSession;
-import javax.jms.TopicSubscriber;
+import jakarta.jms.Queue;
+import jakarta.jms.QueueConnection;
+import jakarta.jms.QueueReceiver;
+import jakarta.jms.QueueSender;
+import jakarta.jms.QueueSession;
+import jakarta.jms.Session;
+import jakarta.jms.TextMessage;
+import jakarta.jms.Topic;
+import jakarta.jms.TopicConnection;
+import jakarta.jms.TopicPublisher;
+import jakarta.jms.TopicSession;
+import jakarta.jms.TopicSubscriber;
 
 import org.eclipse.persistence.logging.AbstractSessionLog;
 import org.eclipse.persistence.logging.SessionLog;
@@ -42,7 +42,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-import oracle.jms.AQjmsSession;
+import oracle.jakarta.jms.AQjmsSession;
 
 /**
  * Test direct interactions through the AQ JMS driver. Requires AQ installed on this database.

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/eis/aq/JavaDirectInteractionTest.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/eis/aq/JavaDirectInteractionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -32,13 +32,13 @@ import org.eclipse.persistence.testing.tests.nosql.SessionHelper;
 import org.junit.Rule;
 import org.junit.Test;
 
-import oracle.AQ.AQDequeueOption;
-import oracle.AQ.AQDriverManager;
-import oracle.AQ.AQEnqueueOption;
-import oracle.AQ.AQMessage;
-import oracle.AQ.AQQueue;
-import oracle.AQ.AQRawPayload;
-import oracle.AQ.AQSession;
+import oracle.jakarta.AQ.AQDequeueOption;
+import oracle.jakarta.AQ.AQDriverManager;
+import oracle.jakarta.AQ.AQEnqueueOption;
+import oracle.jakarta.AQ.AQMessage;
+import oracle.jakarta.AQ.AQQueue;
+import oracle.jakarta.AQ.AQRawPayload;
+import oracle.jakarta.AQ.AQSession;
 
 /**
  * Test direct interactions through the AQ Java driver. Requires AQ installed on this database.
@@ -75,8 +75,8 @@ public class JavaDirectInteractionTest {
         Connection connection = null;
         AQSession session = null;
         try {
-            final Class<?> driver = Class.forName("oracle.AQ.AQOracleDriver");
-            assertNotNull("Driver class oracle.AQ.AQOracleDriver was not found", driver);
+            final Class<?> driver = Class.forName("oracle.jakarta.AQ.AQOracleDriver");
+            assertNotNull("Driver class oracle.jakarta.AQ.AQOracleDriver was not found", driver);
             connection = getConnection();
             connection.setAutoCommit(false);
             session = AQDriverManager.createAQSession(connection);
@@ -104,7 +104,7 @@ public class JavaDirectInteractionTest {
         try {
             connection = getConnection();
             connection.setAutoCommit(false);
-            Class.forName("oracle.AQ.AQOracleDriver");
+            Class.forName("oracle.jakarta.AQ.AQOracleDriver");
             session = AQDriverManager.createAQSession(connection);
             AQQueue queue = session.getQueue(NoSQLProperties.getDBUserName(), "raw_order_queue");
             LOG.log(SessionLog.FINEST, queue.toString());

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/eis/aq/OrderQueueTest.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/it/java/org/eclipse/persistence/testing/tests/eis/aq/OrderQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -40,7 +40,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-import oracle.AQ.AQDequeueOption;
+import oracle.jakarta.AQ.AQDequeueOption;
 
 /**
  * Tests based on {@link Order} and {@link Address} entities and {@code raw_order_queue} model.

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/it/resources/org/eclipse/persistence/testing/models/order/eis/aq/order-project.xml
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/it/resources/org/eclipse/persistence/testing/models/order/eis/aq/order-project.xml
@@ -1,7 +1,7 @@
 <?xml version = '1.0' encoding = 'UTF-8'?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -172,7 +172,7 @@
          </attribute-mappings>
          <descriptor-type>independent</descriptor-type>
          <amendment>
-            <amendment-class>org.eclipse.persistence.testing.models.order.eis.aq.OrderAmendments</amendment-class>
+            <amendment-class>org.eclipse.persistence.testing.models.eis.aq.OrderAmendments</amendment-class>
             <amendment-method>addToOrderDescriptor</amendment-method>
          </amendment>
          <instantiation/>

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/it/resources/org/eclipse/persistence/testing/models/order/eis/nosql/order-project.xml
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/it/resources/org/eclipse/persistence/testing/models/order/eis/nosql/order-project.xml
@@ -1,7 +1,7 @@
 <?xml version = '1.0' encoding = 'UTF-8'?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -172,7 +172,7 @@
          </attribute-mappings>
          <descriptor-type>independent</descriptor-type>
          <amendment>
-            <amendment-class>org.eclipse.persistence.testing.models.order.eis.aq.OrderAmendments</amendment-class>
+            <amendment-class>org.eclipse.persistence.testing.models.eis.aq.OrderAmendments</amendment-class>
             <amendment-method>addToOrderDescriptor</amendment-method>
          </amendment>
          <instantiation/>

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/it/resources/org/eclipse/persistence/testing/models/order/eis/nosql/order-project.xml
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/it/resources/org/eclipse/persistence/testing/models/order/eis/nosql/order-project.xml
@@ -172,7 +172,7 @@
          </attribute-mappings>
          <descriptor-type>independent</descriptor-type>
          <amendment>
-            <amendment-class>org.eclipse.persistence.testing.models.eis.aq.OrderAmendments</amendment-class>
+            <amendment-class>org.eclipse.persistence.testing.models.order.eis.aq.OrderAmendments</amendment-class>
             <amendment-method>addToOrderDescriptor</amendment-method>
          </amendment>
          <instantiation/>

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/eis/adapters/aq/AQPlatform.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/eis/adapters/aq/AQPlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -21,7 +21,8 @@ import org.eclipse.persistence.eis.*;
 import org.eclipse.persistence.eis.interactions.*;
 import org.eclipse.persistence.internal.eis.adapters.aq.*;
 import org.eclipse.persistence.internal.sessions.AbstractRecord;
-import oracle.AQ.*;
+import oracle.jakarta.AQ.AQDequeueOption;
+import oracle.jakarta.AQ.AQEnqueueOption;
 
 /**
  * Platform for Oracle AQ JCA adapter.

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/eis/adapters/aq/AQConnection.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/eis/adapters/aq/AQConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,7 +16,7 @@ package org.eclipse.persistence.internal.eis.adapters.aq;
 
 import jakarta.resource.*;
 import jakarta.resource.cci.*;
-import oracle.AQ.*;
+import oracle.jakarta.AQ.AQSession;
 import org.eclipse.persistence.exceptions.ValidationException;
 
 /**

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/eis/adapters/aq/AQConnectionFactory.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/eis/adapters/aq/AQConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -20,7 +20,8 @@ import javax.sql.DataSource;
 import javax.naming.*;
 import jakarta.resource.*;
 import jakarta.resource.cci.*;
-import oracle.AQ.*;
+import oracle.jakarta.AQ.AQSession;
+import oracle.jakarta.AQ.AQDriverManager;
 import org.eclipse.persistence.internal.security.PrivilegedAccessHelper;
 import org.eclipse.persistence.internal.security.PrivilegedClassForName;
 
@@ -58,9 +59,9 @@ public class AQConnectionFactory implements ConnectionFactory {
                 connection.setAutoCommit(false);
             }
             if (PrivilegedAccessHelper.shouldUsePrivilegedAccess()){
-                AccessController.doPrivileged(new PrivilegedClassForName<>("oracle.AQ.AQOracleDriver", true, this.getClass().getClassLoader()));
+                AccessController.doPrivileged(new PrivilegedClassForName<>("oracle.jakarta.AQ.AQOracleDriver", true, this.getClass().getClassLoader()));
             }else{
-                PrivilegedAccessHelper.getClassForName("oracle.AQ.AQOracleDriver", true, this.getClass().getClassLoader());
+                PrivilegedAccessHelper.getClassForName("oracle.jakarta.AQ.AQOracleDriver", true, this.getClass().getClassLoader());
             }
             session = AQDriverManager.createAQSession(connection);
         } catch (Exception exception) {

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/eis/adapters/aq/AQDequeueInteractionSpec.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/eis/adapters/aq/AQDequeueInteractionSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,7 +14,7 @@
 //     Oracle - initial API and implementation from Oracle TopLink
 package org.eclipse.persistence.internal.eis.adapters.aq;
 
-import oracle.AQ.*;
+import oracle.jakarta.AQ.AQDequeueOption;
 
 /**
  * Interaction spec for AQ JCA adapter.

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/eis/adapters/aq/AQEnqueueInteractionSpec.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/eis/adapters/aq/AQEnqueueInteractionSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,7 +14,7 @@
 //     Oracle - initial API and implementation from Oracle TopLink
 package org.eclipse.persistence.internal.eis.adapters.aq;
 
-import oracle.AQ.*;
+import oracle.jakarta.AQ.AQEnqueueOption;
 
 /**
  * Interaction spec for AQ JCA adapter.

--- a/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/eis/adapters/aq/AQInteraction.java
+++ b/foundation/org.eclipse.persistence.oracle.nosql/src/main/java/org/eclipse/persistence/internal/eis/adapters/aq/AQInteraction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,7 +16,11 @@ package org.eclipse.persistence.internal.eis.adapters.aq;
 
 import jakarta.resource.*;
 import jakarta.resource.cci.*;
-import oracle.AQ.*;
+import oracle.jakarta.AQ.AQDequeueOption;
+import oracle.jakarta.AQ.AQEnqueueOption;
+import oracle.jakarta.AQ.AQMessage;
+import oracle.jakarta.AQ.AQQueue;
+import oracle.jakarta.AQ.AQRawPayload;
 import org.eclipse.persistence.eis.EISException;
 
 /**

--- a/foundation/org.eclipse.persistence.oracle.test/pom.xml
+++ b/foundation/org.eclipse.persistence.oracle.test/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -98,15 +98,14 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.jms</groupId>
-            <artifactId>javax.jms-api</artifactId>
-            <version>2.0.1</version>
+            <groupId>jakarta.jms</groupId>
+            <artifactId>jakarta.jms-api</artifactId>
             <scope>test</scope>
         </dependency>
         <!--Oracle proprietary dependencies-->
         <dependency>
             <groupId>com.oracle.database.messaging</groupId>
-            <artifactId>aqapi</artifactId>
+            <artifactId>aqapi-jakarta</artifactId>
             <scope>test</scope>
         </dependency>
         <!--Other modules-->

--- a/foundation/org.eclipse.persistence.oracle.test/src/it/java/org/eclipse/persistence/testing/tests/dbchangenotification/CacheInvalidationHandler.java
+++ b/foundation/org.eclipse.persistence.oracle.test/src/it/java/org/eclipse/persistence/testing/tests/dbchangenotification/CacheInvalidationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -20,7 +20,7 @@ import org.eclipse.persistence.sessions.Session;
 
 public class CacheInvalidationHandler {
     Session session;
-    javax.jms.Connection connection;
+    jakarta.jms.Connection connection;
     long timeToWait;
     CacheInvalidator invalidator;
 
@@ -31,13 +31,13 @@ public class CacheInvalidationHandler {
     long timeDead = -1;
     long timeLastMessageWasReceived;
 
-    public CacheInvalidationHandler(Session session, javax.jms.Connection connection) {
+    public CacheInvalidationHandler(Session session, jakarta.jms.Connection connection) {
         this(session, connection, 1000);
     }
 
     // each timeToWait the handler checks whether it shouldStop (should be positive)
 
-    public CacheInvalidationHandler(Session session, javax.jms.Connection connection, long timeToWait) {
+    public CacheInvalidationHandler(Session session, jakarta.jms.Connection connection, long timeToWait) {
         this.session = session;
         this.connection = connection;
         this.timeToWait = timeToWait;

--- a/foundation/org.eclipse.persistence.oracle.test/src/it/java/org/eclipse/persistence/testing/tests/dbchangenotification/CacheInvalidationMessageListener.java
+++ b/foundation/org.eclipse.persistence.oracle.test/src/it/java/org/eclipse/persistence/testing/tests/dbchangenotification/CacheInvalidationMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,18 +16,18 @@ package org.eclipse.persistence.testing.tests.dbchangenotification;
 
 import org.eclipse.persistence.sessions.Session;
 
-public class CacheInvalidationMessageListener extends CacheInvalidationHandler implements javax.jms.MessageListener {
+public class CacheInvalidationMessageListener extends CacheInvalidationHandler implements jakarta.jms.MessageListener {
 
-    public CacheInvalidationMessageListener(Session session, javax.jms.Connection connection) {
+    public CacheInvalidationMessageListener(Session session, jakarta.jms.Connection connection) {
         super(session, connection);
     }
 
-    public CacheInvalidationMessageListener(Session session, javax.jms.Connection connection, long timeToWait) {
+    public CacheInvalidationMessageListener(Session session, jakarta.jms.Connection connection, long timeToWait) {
         super(session, connection, timeToWait);
     }
 
     @Override
-    public void onMessage(javax.jms.Message message) {
+    public void onMessage(jakarta.jms.Message message) {
         try {
             invalidator.invalidateObject(session, message);
             messageCount++;
@@ -48,7 +48,7 @@ public class CacheInvalidationMessageListener extends CacheInvalidationHandler i
         } finally {
             try {
                 connection.close();
-            } catch (javax.jms.JMSException jmsException) {
+            } catch (jakarta.jms.JMSException jmsException) {
             }
         }
     }

--- a/foundation/org.eclipse.persistence.oracle.test/src/it/java/org/eclipse/persistence/testing/tests/dbchangenotification/CacheInvalidationRunnable.java
+++ b/foundation/org.eclipse.persistence.oracle.test/src/it/java/org/eclipse/persistence/testing/tests/dbchangenotification/CacheInvalidationRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,7 +14,7 @@
 //     Oracle - initial API and implementation from Oracle TopLink
 package org.eclipse.persistence.testing.tests.dbchangenotification;
 
-import javax.jms.*;
+import jakarta.jms.*;
 
 import org.eclipse.persistence.sessions.Session;
 

--- a/foundation/org.eclipse.persistence.oracle.test/src/it/java/org/eclipse/persistence/testing/tests/dbchangenotification/CacheInvalidator.java
+++ b/foundation/org.eclipse.persistence.oracle.test/src/it/java/org/eclipse/persistence/testing/tests/dbchangenotification/CacheInvalidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -145,7 +145,7 @@ CacheInvalidator {
 
     // invalidates in tjhe cache the object corresponding to the massage
 
-    public void invalidateObject(Session session, javax.jms.Message msg) throws javax.jms.JMSException {
+    public void invalidateObject(Session session, jakarta.jms.Message msg) throws jakarta.jms.JMSException {
         String tableName = msg.getStringProperty("TABLE");
         if (tableName == null) {
             return;

--- a/foundation/org.eclipse.persistence.oracle.test/src/it/java/org/eclipse/persistence/testing/tests/dbchangenotification/DbChangeNotificationTest.java
+++ b/foundation/org.eclipse.persistence.oracle.test/src/it/java/org/eclipse/persistence/testing/tests/dbchangenotification/DbChangeNotificationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -70,12 +70,12 @@ public class DbChangeNotificationTest extends TestCase {
 
     @Override
     protected void setup() throws Exception {
-        javax.jms.TopicConnectionFactory topicConnectionFactory = null;
-        javax.jms.QueueConnectionFactory queueConnectionFactory = null;
+        jakarta.jms.TopicConnectionFactory topicConnectionFactory = null;
+        jakarta.jms.QueueConnectionFactory queueConnectionFactory = null;
         if (useMultipleConsumers) {
-            topicConnectionFactory = oracle.jms.AQjmsFactory.getTopicConnectionFactory(getSession().getLogin().getConnectionString(), null);
+            topicConnectionFactory = oracle.jakarta.jms.AQjmsFactory.getTopicConnectionFactory(getSession().getLogin().getConnectionString(), null);
         } else {
-            queueConnectionFactory = oracle.jms.AQjmsFactory.getQueueConnectionFactory(getSession().getLogin().getConnectionString(), null);
+            queueConnectionFactory = oracle.jakarta.jms.AQjmsFactory.getQueueConnectionFactory(getSession().getLogin().getConnectionString(), null);
         }
         for (int i = 0; i < n; i++) {
             DatabaseLogin login = (DatabaseLogin)getSession().getLogin().clone();
@@ -93,19 +93,19 @@ public class DbChangeNotificationTest extends TestCase {
             //        String selector = "(JMSXUserID IS NULL) OR (JMSXUserID <> " + "'" + session[i].getName() + "')";
             String selector = "(APP IS NULL) OR (APP <> " + "'" + session[i].getName() + "')";
 
-            javax.jms.Connection jmsConnection;
-            javax.jms.MessageConsumer messageConsumer;
+            jakarta.jms.Connection jmsConnection;
+            jakarta.jms.MessageConsumer messageConsumer;
             if (useMultipleConsumers) {
-                javax.jms.TopicConnection topicConnection = topicConnectionFactory.createTopicConnection(aqUser, aqPassword);
+                jakarta.jms.TopicConnection topicConnection = topicConnectionFactory.createTopicConnection(aqUser, aqPassword);
                 jmsConnection = topicConnection;
-                javax.jms.TopicSession topicSession = topicConnection.createTopicSession(false, javax.jms.Session.AUTO_ACKNOWLEDGE);
-                javax.jms.Topic topic = ((oracle.jms.AQjmsSession)topicSession).getTopic(aqUser, queueName);
+                jakarta.jms.TopicSession topicSession = topicConnection.createTopicSession(false, jakarta.jms.Session.AUTO_ACKNOWLEDGE);
+                jakarta.jms.Topic topic = ((oracle.jakarta.jms.AQjmsSession)topicSession).getTopic(aqUser, queueName);
                 messageConsumer = topicSession.createSubscriber(topic, selector, false);
             } else {
-                javax.jms.QueueConnection queueConnection = queueConnectionFactory.createQueueConnection(aqUser, aqPassword);
+                jakarta.jms.QueueConnection queueConnection = queueConnectionFactory.createQueueConnection(aqUser, aqPassword);
                 jmsConnection = queueConnection;
-                javax.jms.QueueSession queueSession = queueConnection.createQueueSession(false, javax.jms.Session.AUTO_ACKNOWLEDGE);
-                javax.jms.Queue queue = ((oracle.jms.AQjmsSession)queueSession).getQueue(aqUser, queueName);
+                jakarta.jms.QueueSession queueSession = queueConnection.createQueueSession(false, jakarta.jms.Session.AUTO_ACKNOWLEDGE);
+                jakarta.jms.Queue queue = ((oracle.jakarta.jms.AQjmsSession)queueSession).getQueue(aqUser, queueName);
                 messageConsumer = queueSession.createReceiver(queue, selector);
             }
             jmsConnection.start();

--- a/foundation/org.eclipse.persistence.oracle.test/src/it/java/org/eclipse/persistence/testing/tests/distributedservers/rcm/jms/JMSSetupHelper.java
+++ b/foundation/org.eclipse.persistence.oracle.test/src/it/java/org/eclipse/persistence/testing/tests/distributedservers/rcm/jms/JMSSetupHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,18 +16,18 @@ package org.eclipse.persistence.testing.tests.distributedservers.rcm.jms;
 
 import java.util.Properties;
 
-import javax.jms.ObjectMessage;
-import javax.jms.Topic;
-import javax.jms.TopicConnection;
-import javax.jms.TopicConnectionFactory;
-import javax.jms.TopicPublisher;
-import javax.jms.TopicSession;
+import jakarta.jms.ObjectMessage;
+import jakarta.jms.Topic;
+import jakarta.jms.TopicConnection;
+import jakarta.jms.TopicConnectionFactory;
+import jakarta.jms.TopicPublisher;
+import jakarta.jms.TopicSession;
 
 import javax.naming.Context;
 import javax.naming.InitialContext;
 
-import oracle.jms.AQjmsFactory;
-import oracle.jms.AQjmsSession;
+import oracle.jakarta.jms.AQjmsFactory;
+import oracle.jakarta.jms.AQjmsSession;
 
 import org.eclipse.persistence.exceptions.RemoteCommandManagerException;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
@@ -114,7 +114,7 @@ public class JMSSetupHelper extends BroadcastSetupHelper {
 
         TopicConnectionFactory topicConnectionFactory = AQjmsFactory.getTopicConnectionFactory(oracleDataSource);
         TopicConnection topicConnection = topicConnectionFactory.createTopicConnection();
-        TopicSession topicSession = topicConnection.createTopicSession(false, javax.jms.Session.AUTO_ACKNOWLEDGE);
+        TopicSession topicSession = topicConnection.createTopicSession(false, jakarta.jms.Session.AUTO_ACKNOWLEDGE);
         Topic topic = ((AQjmsSession)topicSession).getTopic(user, queueName);
         topicSession.close();
         topicConnection.close();
@@ -223,7 +223,7 @@ public class JMSSetupHelper extends BroadcastSetupHelper {
         TopicConnection topicConnection = topicConnectionFactory.createTopicConnection();
         try {
             Topic topic = (Topic)context.lookup(this.topicJndiName);
-            TopicSession session = topicConnection.createTopicSession(false, javax.jms.Session.AUTO_ACKNOWLEDGE);
+            TopicSession session = topicConnection.createTopicSession(false, jakarta.jms.Session.AUTO_ACKNOWLEDGE);
             TopicPublisher publisher = session.createPublisher(topic);
             ObjectMessage objectMessage = session.createObjectMessage();
             publisher.publish(objectMessage);

--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,7 @@
         <logback.version>1.4.5</logback.version>
         <oracle.jdbc.version>21.8.0.0</oracle.jdbc.version>
         <!-- CQ #2437 -->
-        <oracle.aqapi.version>21.3.0.0</oracle.aqapi.version>
+        <oracle.aqapi.version>23.2.0.0</oracle.aqapi.version>
         <oracle.fmw.version>12.2.1-2-0</oracle.fmw.version>
         <!-- CQ #21141 -->
         <oracle.nosql.version>18.3.10</oracle.nosql.version>
@@ -890,7 +890,7 @@
             -->
             <dependency>
                 <groupId>com.oracle.database.messaging</groupId>
-                <artifactId>aqapi</artifactId>
+                <artifactId>aqapi-jakarta</artifactId>
                 <version>${oracle.aqapi.version}</version>
             </dependency>
             <!--Test dependencies-->


### PR DESCRIPTION
This upgrade leads into:

- code changes as there are package name changes `oracle.jms.*` -> `oracle.jakarta.jms.*` and `oracle.AQ.*` -> `oracle.jakarta.AQ.*`
- test dependency `javax.jms:javax.jms-api` was replaced by project default `jakarta.jms:jakarta.jms-api`
- test dependency `javax.transaction-api` still remains due

``
[ERROR] org.eclipse.persistence.testing.tests.eis.aq.JMSDirectInteractionTest.testQueue  Time elapsed: 0.471 s  <<< ERROR!
java.lang.NoClassDefFoundError: javax/transaction/Synchronization
	at oracle.jakarta.jms.AQjmsSession.<init>(AQjmsSession.java:561)
	at oracle.jakarta.jms.AQjmsConnection.createQueueSession(AQjmsConnection.java:704)
	at org.eclipse.persistence.testing.tests.eis.aq.JMSDirectInteractionTest.testQueue(JMSDirectI
``
Signed-off-by: Radek Felcman <radek.felcman@oracle.com>
(cherry picked from commit 0767bf40a716c7159a3de034f86221b836a4a629)