### PR TITLE
[4.0] maven-surefire-report-plugin title settings change

### DIFF
--- a/bundles/nightly/pom.xml
+++ b/bundles/nightly/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -72,7 +72,7 @@
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
                     <execution>
-                        <phase>process-resources</phase>
+                        <phase>generate-resources</phase>
                         <goals>
                             <goal>run</goal>
                         </goals>
@@ -113,7 +113,7 @@
                 <executions>
                     <execution>
                         <id>generate-test-summary-html-report</id>
-                        <phase>package</phase>
+                        <phase>generate-resources</phase>
                         <goals>
                             <goal>failsafe-report-only</goal>
                         </goals>
@@ -123,7 +123,30 @@
                             </reportsDirectories>
                             <outputDirectory>${project.build.directory}/jpa-test-reports/${project.build.testReports.subdirectory}</outputDirectory>
                             <outputName>${project.build.testReports.summaryFile}</outputName>
-                            <title>EclipseLink JPA Test - Test Summary (more details on ${env.BUILD_URL} )</title>
+                            <customBundle>${project.basedir}/src/site/custom/surefire-report.properties</customBundle>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>prepare-nightly-build-dir-test-reports-resources</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <copy todir="${project.build.directory}${nightlyDir}/Eclipse/css/">
+                                    <fileset dir="../../foundation/eclipselink.core.test/target/${project.build.testReports.subdirectory}/css/"/>
+                                </copy>
+                                <copy todir="${project.build.directory}${nightlyDir}/Eclipse/images/">
+                                    <fileset dir="../../foundation/eclipselink.core.test/target/${project.build.testReports.subdirectory}/images/"/>
+                                </copy>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>
@@ -134,7 +157,7 @@
                 <executions>
                     <execution>
                         <id>prepare-nightly-build-dir-test-reports</id>
-                        <phase>package</phase>
+                        <phase>generate-resources</phase>
                         <goals>
                             <goal>copy</goal>
                         </goals>
@@ -217,7 +240,7 @@
                     </execution>
                     <execution>
                         <id>prepare-nightly-build-dir-binaries</id>
-                        <phase>package</phase>
+                        <phase>process-resources</phase>
                         <goals>
                             <goal>copy</goal>
                         </goals>
@@ -274,6 +297,31 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>fix-test-reports</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <!-- Fix some non-XML valid sequence in test reports -->
+                                <replace dir="${project.build.directory}${nightlyDir}/Eclipse/">
+                                    <include name="**/*.html"/>
+                                    <replacefilter>
+                                        <replacetoken><![CDATA[&&]]></replacetoken>
+                                        <replacevalue><![CDATA[&amp;&amp;]]></replacevalue>
+                                    </replacefilter>
+                                </replace>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.gmaven</groupId>
                 <artifactId>groovy-maven-plugin</artifactId>
                 <executions>
@@ -289,9 +337,10 @@
                                 import javax.xml.xpath.XPathFactory
                                 import javax.xml.parsers.DocumentBuilderFactory
 
-                                final NO_OF_TESTS_XPATH = "/html/body/div[@id='bodyColumn']/div/section[2]/table/tr[2]/td[1]/text()"
-                                final NO_OF_ERRORS_XPATH = "/html/body/div[@id='bodyColumn']/div/section[2]/table/tr[2]/td[2]/text()"
-                                final NO_OF_FAILURES_XPATH = "/html/body/div[@id='bodyColumn']/div/section[2]/table/tr[2]/td[3]/text()"
+                                final NO_OF_TESTS_XPATH = "/html/body/div[@id='bodyColumn']/div[@id='contentBox']/section[2]/table/tr[2]/td[1]/text()"
+                                final NO_OF_ERRORS_XPATH = "/html/body/div[@id='bodyColumn']/div[@id='contentBox']/section[2]/table/tr[2]/td[2]/text()"
+                                final NO_OF_FAILURES_XPATH = "/html/body/div[@id='bodyColumn']/div[@id='contentBox']/section[2]/table/tr[2]/td[3]/text()"
+
                                 final OUTPUT_FILE = "ResultSummary.dat"
 
                                 def resultSummaryFile = new File(properties["nightlyTestReportsDir"] + "/" + OUTPUT_FILE)
@@ -318,18 +367,21 @@
                                 }
                                 File[] files = reportDir.listFiles()
                                 for (File file : files) {
-                                    try {
-                                        noOfTests = processXml(file.text, NO_OF_TESTS_XPATH)
-                                        noOfNewTests = noOfTests
-                                        noOfErrors = processXml(file.text, NO_OF_ERRORS_XPATH) +
-                                                processXml(file.text, NO_OF_FAILURES_XPATH)
-                                    } catch (Exception e) {
-                                        log.warn "File: " + file.getName() + " can't be parsed. Result will be marked as a failed test!"
-                                        noOfTests = 1
-                                        noOfNewTests = 1
-                                        noOfErrors = 1
+                                    if (file.isFile()) {
+                                        try {
+                                            noOfTests = processXml(file.text, NO_OF_TESTS_XPATH)
+                                            noOfNewTests = noOfTests
+                                            noOfErrors = processXml(file.text, NO_OF_ERRORS_XPATH) + processXml(file.text, NO_OF_FAILURES_XPATH)
+                                        } catch (Exception e) {
+                                            log.warn "Error cause: ${e}"
+                                            log.warn "File: " + file.getName() + " can't be parsed. Result will be marked as a failed test!"
+                                            noOfTests = 1
+                                            noOfNewTests = 1
+                                            noOfErrors = 1
+                                        }
+                                        resultSummaryFile.append file.
+                                                getName() + ":" + noOfTests + ":" + noOfNewTests + ":" + noOfErrors + "\n"
                                     }
-                                    resultSummaryFile.append file.getName() + ":" + noOfTests + ":" + noOfNewTests + ":" + noOfErrors + "\n"
                                 }
                                 println resultSummaryFile.text
                                 ]]>

--- a/bundles/nightly/src/site/custom/surefire-report.properties
+++ b/bundles/nightly/src/site/custom/surefire-report.properties
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0,
+# or the Eclipse Distribution License v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+
+report.failsafe.description=EclipseLink JPA Test - Test Summary (more details on ${env.BUILD_URL} )
+report.failsafe.name=EclipseLink JPA Test - Test Summary (more details on ${env.BUILD_URL} )
+report.failsafe.title=EclipseLink JPA Test - Test Summary (more details on ${env.BUILD_URL} )
+report.surefire.description=EclipseLink JPA Test - Test Summary (more details on ${env.BUILD_URL} )
+report.surefire.name=EclipseLink JPA Test - Test Summary (more details on ${env.BUILD_URL} )
+report.surefire.title=EclipseLink JPA Test - Test Summary (more details on ${env.BUILD_URL} )

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,7 @@
         <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
         <build.qualifier>v${maven.build.timestamp}</build.qualifier>
         <bundle.version>${project.version}.${build.qualifier}</bundle.version>
+        <project.build.testReports.settings>test-report-settings/surefire-report.properties</project.build.testReports.settings>
         <project.build.testReports.subdirectory>test-reports</project.build.testReports.subdirectory>
         <project.build.testReports.summaryFile>test-summary</project.build.testReports.summaryFile>
         <project.build.licenceResourceDirectory>${project.build.directory}/license</project.build.licenceResourceDirectory>
@@ -151,6 +152,7 @@
         <test.properties.file>${user.home}/${test.derby.properties.file}</test.properties.file>
         <test.properties.fileName>${test.derby.properties.file}</test.properties.fileName>
         <test.properties.default.directory>${project.build.directory}/test-default-properties</test.properties.default.directory>
+        <test.report.properties.default.directory>${project.build.directory}/test-report-properties</test.report.properties.default.directory>
         <test.database>derby</test.database>
         <!--false: to start In-Memory database, true: not start (MySQL, Oracle)-->
         <test.skip.in-memory.db>false</test.skip.in-memory.db>
@@ -1436,6 +1438,7 @@
                             <descriptors>
                                 <descriptor>src/main/assembly/common-license.xml</descriptor>
                                 <descriptor>src/main/assembly/test-defaults.xml</descriptor>
+                                <descriptor>src/main/assembly/test-report.xml</descriptor>
                                 <descriptor>src/main/assembly/spotbugs-filter.xml</descriptor>
                             </descriptors>
                         </configuration>
@@ -1480,6 +1483,25 @@
                                     <classifier>test-defaults</classifier>
                                     <type>zip</type>
                                     <outputDirectory>${test.properties.default.directory}</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>unpack-test-report-properties</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>${project.groupId}</groupId>
+                                    <artifactId>org.eclipse.persistence.parent</artifactId>
+                                    <version>${project.version}</version>
+                                    <classifier>test-report</classifier>
+                                    <type>zip</type>
+                                    <outputDirectory>${test.report.properties.default.directory}</outputDirectory>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>
@@ -1759,7 +1781,7 @@
                             </reportsDirectories>
                             <outputDirectory>${project.build.directory}/${project.build.testReports.subdirectory}</outputDirectory>
                             <outputName>${project.build.testReports.summaryFile}</outputName>
-                            <title>${project.name} - Test Summary (more details on ${env.BUILD_URL} )</title>
+                            <customBundle>${test.report.properties.default.directory}/surefire-report.properties</customBundle>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/main/assembly/test-report.xml
+++ b/src/main/assembly/test-report.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0,
+    or the Eclipse Distribution License v. 1.0 which is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+
+    SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+-->
+
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+    <id>test-report</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>${project.basedir}/src/site/custom</directory>
+            <outputDirectory>.</outputDirectory>
+            <includes>
+                <include>*.properties</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/src/site/custom/surefire-report.properties
+++ b/src/site/custom/surefire-report.properties
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0,
+# or the Eclipse Distribution License v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+
+report.failsafe.description=${project.name} - Test Summary (more details on ${env.BUILD_URL} )
+report.failsafe.name=${project.name} - Test Summary (more details on ${env.BUILD_URL} )
+report.failsafe.title=${project.name} - Test Summary (more details on ${env.BUILD_URL} )
+report.surefire.description=${project.name} - Test Summary (more details on ${env.BUILD_URL} )
+report.surefire.name=${project.name} - Test Summary (more details on ${env.BUILD_URL} )
+report.surefire.title=${project.name} - Test Summary (more details on ${env.BUILD_URL} )


### PR DESCRIPTION
This change fixes different location (XPath) in test HTML reports as maven-surefire-report-plugin uses different site skin.