### PR TITLE
[4.0] Nightly build reports - permission change

### DIFF
--- a/bundles/nightly/pom.xml
+++ b/bundles/nightly/pom.xml
@@ -316,6 +316,9 @@
                                         <replacevalue><![CDATA[&amp;&amp;]]></replacevalue>
                                     </replacefilter>
                                 </replace>
+                                <chmod dir="${project.build.directory}${nightlyDir}/Eclipse/" perm="644">
+                                    <include name="**/*.html"/>
+                                </chmod>
                             </target>
                         </configuration>
                     </execution>


### PR DESCRIPTION
This is fix to prevents access issue to the test reports like:
https://download.eclipse.org/rt/eclipselink/nightly/4.0.2/20230612/Eclipse/eclipselink-core-lrg-4.0.2.v20230612-96c4af71c2.html

```
Access Forbidden
The file permissions are either wrong, or there is no default index file for this directory.
Please consider filing [a bug](https://bugs.eclipse.org/bugs/) against the project to let them know.
```