### PR TITLE
[2.7] Ant build - MOXy tests fix 2.0

### DIFF
--- a/moxy/eclipselink.moxy.test/antbuild.xml
+++ b/moxy/eclipselink.moxy.test/antbuild.xml
@@ -541,13 +541,18 @@
             <mkdir dir="${report.dir}/jaxb"/>
             <mkdir dir="${build.dir}/${test.dir}/${tmp.dir}"/>
             <!-- Can be set e.g. in test.properties to add VM options for a particular platform/driver  -->
-            <property name="additional.jvmargs" value="-Ddummy2=dummy --add-opens java.base/java.math=ALL-UNNAMED"/>
+            <property name="additional.jvmargs" value="--add-opens java.base/java.math=ALL-UNNAMED"/>
+            <condition property="additional.jvmargs.merged.internal"
+                       value="${additional.jvmargs} --add-opens java.base/java.math=ALL-UNNAMED"
+                       else="--add-opens java.base/java.math=ALL-UNNAMED">
+                <isset property="additional.jvmargs"/>
+            </condition>
             <junit jvm="${test.junit.jvm.exec}" failureproperty="junit.failed.jaxb" logfailedtests="true"
                    printsummary="yes" fork="true" dir="${build.dir}/${test.dir}" tempdir="${build.dir}/${test.dir}" showoutput="yes" maxmemory="1024m">
                 <!--<jvmarg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"/>-->
                 <jvmarg value="-ea"/>
                 <jvmarg value="-javaagent:${jmockit.lib}"/>
-                <jvmarg line="${additional.jvmargs}"/>
+                <jvmarg line="${additional.jvmargs.merged.internal}"/>
                 <env key="T_WORK" value="${tmp.dir}"/>
                 <sysproperty key="platformType" value="SAX"/>
                 <sysproperty key="metadataType" value="JAVA"/>

--- a/moxy/eclipselink.moxy.test/antbuild.xml
+++ b/moxy/eclipselink.moxy.test/antbuild.xml
@@ -541,13 +541,13 @@
             <mkdir dir="${report.dir}/jaxb"/>
             <mkdir dir="${build.dir}/${test.dir}/${tmp.dir}"/>
             <!-- Can be set e.g. in test.properties to add VM options for a particular platform/driver  -->
-            <property name="additional.jvmargs.merged" value="${additional.jvmargs} -Ddummy2=dummy --add-opens java.base/java.math=ALL-UNNAMED"/>
+            <property name="additional.jvmargs" value="-Ddummy2=dummy --add-opens java.base/java.math=ALL-UNNAMED"/>
             <junit jvm="${test.junit.jvm.exec}" failureproperty="junit.failed.jaxb" logfailedtests="true"
                    printsummary="yes" fork="true" dir="${build.dir}/${test.dir}" tempdir="${build.dir}/${test.dir}" showoutput="yes" maxmemory="1024m">
                 <!--<jvmarg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"/>-->
                 <jvmarg value="-ea"/>
                 <jvmarg value="-javaagent:${jmockit.lib}"/>
-                <jvmarg line="${additional.jvmargs.merged}"/>
+                <jvmarg line="${additional.jvmargs}"/>
                 <env key="T_WORK" value="${tmp.dir}"/>
                 <sysproperty key="platformType" value="SAX"/>
                 <sysproperty key="metadataType" value="JAVA"/>
@@ -619,11 +619,11 @@
             <mkdir dir="${report.dir}/srg/jaxb"/>
             <mkdir dir="${build.dir}/${test.dir}/${tmp.dir}"/>
             <!-- Can be set e.g. in test.properties to add VM options for a particular platform/driver  -->
-            <property name="additional.jvmargs.merged" value="${additional.jvmargs} -Ddummy2=dummy"/>
+            <property name="additional.jvmargs" value="-Ddummy2=dummy"/>
             <junit jvm="${test.junit.jvm.exec}" failureproperty="junit.failed.jaxb_srg" logfailedtests="true"
                    printsummary="yes" fork="true" dir="${build.dir}/${test.dir}" tempdir="${build.dir}/${test.dir}" showoutput="yes" maxmemory="1024m">
                 <jvmarg value="-ea"/>
-                <jvmarg line="${additional.jvmargs.merged}"/>
+                <jvmarg line="${additional.jvmargs}"/>
                 <env key="T_WORK" value="${tmp.dir}"/>
                 <sysproperty key="platformType" value="SAX"/>
                 <sysproperty key="metadataType" value="JAVA"/>


### PR DESCRIPTION
Merge JVM arguments from internal store (antbuild.xml) and outside (passed with '-Dadditional.jvmargs=....' command line parameter).
There was issue with previous fix, that Ant will initialize undefined property automatically during calls like `value="${additional.jvmargs}..."` into value `'${additional.jvmargs}'`.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>