### PR TITLE
[4.0] Bugfix for - Missing error message when calling JpaHelper.getReportQuery() with wrong argument - backport

### DIFF
--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/jpa/JpaHelper.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/jpa/JpaHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -91,7 +91,7 @@ public class JpaHelper {
             return (ReportQuery)dbQuery;
         }
 
-        throw new IllegalArgumentException(ExceptionLocalization.buildMessage("jpa_helper_invalid_report_query" + query.getClass()));
+        throw new IllegalArgumentException(ExceptionLocalization.buildMessage("jpa_helper_invalid_report_query",  new Object[]{query.getClass()}));
     }
 
     /**
@@ -102,7 +102,7 @@ public class JpaHelper {
             return ((JpaQuery)query).getDatabaseQuery();
         }
 
-        throw new IllegalArgumentException(ExceptionLocalization.buildMessage("jpa_helper_invalid_query" + query.getClass()));
+        throw new IllegalArgumentException(ExceptionLocalization.buildMessage("jpa_helper_invalid_query",  new Object[]{query.getClass()}));
     }
 
     /**
@@ -119,7 +119,7 @@ public class JpaHelper {
             return (ReadAllQuery)dbQuery;
         }
 
-        throw new IllegalArgumentException(ExceptionLocalization.buildMessage("jpa_helper_invalid_read_all_query" + query.getClass()));
+        throw new IllegalArgumentException(ExceptionLocalization.buildMessage("jpa_helper_invalid_read_all_query", new Object[]{query.getClass()}));
     }
 
     /**


### PR DESCRIPTION
Fixes #1893

Backport from  #1911

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>
(cherry picked from commit 6d59a82a5b2be5b7e5403a95ce436b071fa744ad)