### PR TITLE
Configuration of CACHE_QUERY_FORCE_DEFERRED_LOCKS - fix [2.7]

### DIFF
--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
@@ -1456,6 +1456,8 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
         if ((queryCache != null) && queryCache.equalsIgnoreCase("true")) {
             session.getProject().setDefaultQueryResultsCachePolicy(new QueryResultsCachePolicy());
         }
+        String queryCacheForceDeferredLocks = getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.CACHE_QUERY_FORCE_DEFERRED_LOCKS, m, session);
+        session.getProject().setQueryCacheForceDeferredLocks("true".equalsIgnoreCase(queryCacheForceDeferredLocks));
 
         Map typeMap = PropertiesHandler.getPrefixValuesLogDebug(PersistenceUnitProperties.CACHE_TYPE_, m, session);
         Map sizeMap = PropertiesHandler.getPrefixValuesLogDebug(PersistenceUnitProperties.CACHE_SIZE_, m, session);
@@ -1463,8 +1465,6 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
         if(typeMap.isEmpty() && sizeMap.isEmpty() && sharedMap.isEmpty()) {
             return;
         }
-        String queryCacheForceDeferredLocks = getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.CACHE_QUERY_FORCE_DEFERRED_LOCKS, m, session);
-        session.getProject().setQueryCacheForceDeferredLocks("true".equalsIgnoreCase(queryCacheForceDeferredLocks));
 
         String defaultTypeName = (String)typeMap.remove(PersistenceUnitProperties.DEFAULT);
         if (defaultTypeName != null) {


### PR DESCRIPTION
Fixes #1920
This fix is limited on 2.7 branch. In master, 4.0, 3.0 is `setQueryCacheForceDeferredLocks...` placed before possible return.
Reported bug contains two parts

- move `setQueryCacheForceDeferredLocks...` before possible `return`. It's done in this PR
- Change default value in `org.eclipse.persistence.queries.ObjectBuildingQuery.ObjectBuildingQuery()` `this.requiresDeferredLocks = true;` .  Unfortunately this change we can't accept as it will change default behavior and break backward compatibility -> should leads into regressions.