### PR TITLE
Update JPA API dependency to 3.2-B01

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/ExceptionLocalizationResource.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/ExceptionLocalizationResource.java
@@ -83,6 +83,7 @@ public class ExceptionLocalizationResource extends ListResourceBundle {
                                            { "bean_definition_vector_arguments_are_of_different_sizes", "Bean definition vector arguments are of different sizes" },
                                            { "missing_toplink_bean_definition_for", "Missing TopLink bean definition for {0}" },
                                            { "argument_collection_was_null", "Argument collection was null" },
+                                           { "entity_manager_with_connection_failed", "Execution of user code failed: {0}"},
                                            { "no_entities_retrieved_for_get_single_result", "getSingleResult() did not retrieve any entities." },
                                            { "no_entities_retrieved_for_get_reference", "Could not find Entity for id: {0}" },
                                            { "too_many_results_for_get_single_result", "More than one result was returned from Query.getSingleResult()" },

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/LoggingLocalizationResource.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/LoggingLocalizationResource.java
@@ -411,6 +411,7 @@ public class LoggingLocalizationResource extends ListResourceBundle {
         { "osgi_initializer", "Using OSGi initializer: [{0}]."},
         { "entity_manager_ignores_nonjta_data_source", "Persistence unit uses JTA, therefore the EntityManager ignores non jta data source. "},
         { "entity_manager_ignores_jta_data_source", "Persistence unit does not use JTA, therefore the EntityManager ignores jta data source. "},
+        { "entity_manager_has_multiple_connections", "Persistence unit has multiple connections, returning the first one from the list."},
         { "problem_registering_mbean", "Problem while registering MBean: {0}" },
         { "problem_unregistering_mbean", "Problem while unregistering MBean: {0}" },
         { "session_key_for_mbean_name_is_null", "Session name used for the MBean registration cannot be null." },

--- a/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/dynamic/DynamicTestHelper.java
+++ b/jpa/eclipselink.jpa.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/dynamic/DynamicTestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -24,6 +24,7 @@ package org.eclipse.persistence.testing.tests.jpa.dynamic;
 //javase imports
 
 import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.PersistenceConfiguration;
 import jakarta.persistence.spi.PersistenceProvider;
 import jakarta.persistence.spi.PersistenceUnitInfo;
 import jakarta.persistence.spi.ProviderUtil;
@@ -128,6 +129,13 @@ public class DynamicTestHelper {
                     return null;
                 }
             }
+
+            // Not used, added in JPA 3.2
+            @Override
+            public EntityManagerFactory createEntityManagerFactory(PersistenceConfiguration configuration) {
+                return null;
+            }
+
             @Override
             public ProviderUtil getProviderUtil() {
                 return null;

--- a/jpa/eclipselink.jpa.testapps/jpa.test.metamodel/src/test/java/org/eclipse/persistence/testing/tests/jpa/metamodel/MetamodelTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.metamodel/src/test/java/org/eclipse/persistence/testing/tests/jpa/metamodel/MetamodelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -5681,7 +5681,7 @@ public class MetamodelTest extends MetamodelTestBase {
             // test variant path: null causes IAE
             expectedIAExceptionThrown = false;
         try {
-            EntityType<Manufacturer> aType = metamodel.entity(null);
+            EntityType<Manufacturer> aType = metamodel.entity((Class<Manufacturer>) null);
         } catch (IllegalArgumentException iae) {
             expectedIAExceptionThrown = true;
             }

--- a/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/main/java/org/eclipse/persistence/testing/models/jpa/persistence32/Pokemon.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/main/java/org/eclipse/persistence/testing/models/jpa/persistence32/Pokemon.java
@@ -30,8 +30,8 @@ import jakarta.persistence.Table;
 @NamedQuery(name="Pokemon.get", query="SELECT p FROM Pokemon p WHERE p.id = :id")
 public class Pokemon {
 
+    // ID is assigned in tests to avoid collisions
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
 
     private String name;

--- a/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/test/java/org/eclipse/persistence/testing/tests/jpa/persistence32/EntityManagerFactoryTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/test/java/org/eclipse/persistence/testing/tests/jpa/persistence32/EntityManagerFactoryTest.java
@@ -12,10 +12,6 @@
 
 package org.eclipse.persistence.testing.tests.jpa.persistence32;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityTransaction;
 import junit.framework.Test;
@@ -24,7 +20,6 @@ import org.eclipse.persistence.internal.jpa.EntityManagerFactoryImpl;
 import org.eclipse.persistence.jpa.JpaEntityManagerFactory;
 import org.eclipse.persistence.testing.framework.jpa.junit.JUnitTestCase;
 import org.eclipse.persistence.testing.models.jpa.persistence32.Persistence32TableCreator;
-import org.eclipse.persistence.testing.models.jpa.persistence32.Pokemon;
 import org.eclipse.persistence.testing.models.jpa.persistence32.Type;
 
 public class EntityManagerFactoryTest extends JUnitTestCase {
@@ -59,10 +54,10 @@ public class EntityManagerFactoryTest extends JUnitTestCase {
         TestSuite suite = new TestSuite();
         suite.setName("EntityManagerFactoryTest");
         suite.addTest(new EntityManagerFactoryTest("testSetup"));
-        suite.addTest(new EntityManagerFactoryTest("testWithApplicationManagedTransaction"));
-        suite.addTest(new EntityManagerFactoryTest("testWithApplicationManagedTransactionVoid"));
-        suite.addTest(new EntityManagerFactoryTest("testWithUserManagedTransaction"));
-        suite.addTest(new EntityManagerFactoryTest("testWithUserManagedTransactionVoid"));
+//        suite.addTest(new EntityManagerFactoryTest("testWithApplicationManagedTransaction"));
+//        suite.addTest(new EntityManagerFactoryTest("testWithApplicationManagedTransactionVoid"));
+//        suite.addTest(new EntityManagerFactoryTest("testWithUserManagedTransaction"));
+//        suite.addTest(new EntityManagerFactoryTest("testWithUserManagedTransactionVoid"));
         return suite;
     }
 
@@ -113,6 +108,8 @@ public class EntityManagerFactoryTest extends JUnitTestCase {
         }
     }
 
+    // TODO-API-3.2 - rewrite using new API
+    /*
     public void testWithApplicationManagedTransaction() {
         Pokemon pokemon = emf.withTransaction((em -> {
             Map<Integer, Type> types = new HashMap<>(24);
@@ -179,5 +176,5 @@ public class EntityManagerFactoryTest extends JUnitTestCase {
         }));
         verifyObjectInEntityManager(pokemon[0], getPersistenceUnitName());
     }
-
+    */
 }

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/jpql/query/Alias.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/jpql/query/Alias.java
@@ -14,6 +14,7 @@ package jpql.query;
 
 import java.util.Date;
 import java.util.Map;
+
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -42,6 +43,7 @@ public class Alias {
     private String alias;
     @ElementCollection
     @Temporal(TemporalType.DATE)
+    @SuppressWarnings("deprecation")
     private Map<String, Date> ids;
     private Customer customer;
     @JoinColumn(name="ID", referencedColumnName="ALIAS.ALIAS")

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/jpql/query/LargeProject.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/jpql/query/LargeProject.java
@@ -13,6 +13,7 @@
 package jpql.query;
 
 import java.util.Date;
+
 import jakarta.persistence.Basic;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToOne;
@@ -27,6 +28,7 @@ public class LargeProject extends Project {
 
     @Basic
     @Temporal(TemporalType.DATE)
+    @SuppressWarnings("deprecation")
     private Date endDate;
 
     @OneToOne
@@ -34,6 +36,7 @@ public class LargeProject extends Project {
 
     @Basic
     @Temporal(TemporalType.DATE)
+    @SuppressWarnings("deprecation")
     private Date startDate;
 
     public LargeProject() {

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/jpql/query/ShelfLife.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/jpql/query/ShelfLife.java
@@ -13,6 +13,7 @@
 package jpql.query;
 
 import java.util.Date;
+
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
@@ -21,6 +22,7 @@ import jakarta.persistence.TemporalType;
 public class ShelfLife {
 
     @Temporal(TemporalType.DATE)
+    @SuppressWarnings("deprecation")
     private Date soldDate;
 
     public Date getSoldDate() {

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EJBQueryImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EJBQueryImpl.java
@@ -400,6 +400,12 @@ public class EJBQueryImpl<X> extends QueryImpl implements JpaQuery<X> {
         return (X) super.getSingleResult();
     }
 
+    // TODO-API-3.2
+    //@Override
+    public X getSingleResultOrNull() {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
     /**
      * Set the position of the first result to retrieve.
      *

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EJBQueryImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EJBQueryImpl.java
@@ -300,61 +300,30 @@ public class EJBQueryImpl<X> extends QueryImpl implements JpaQuery<X> {
         return (EJBQueryImpl) super.setLockMode(lockMode);
     }
 
-    /**
-     * The cache retrieval mode that will be in effect during query execution.
-     *
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public CacheRetrieveMode getCacheRetrieveMode() {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
-    /**
-     * Set the cache retrieval mode that is in effect during query execution.
-     * This cache retrieval mode overrides the cache retrieve mode in use by the entity manager.
-     *
-     * @param cacheRetrieveMode cache retrieval mode
-     * @return the same query instance
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public TypedQuery<X> setCacheRetrieveMode(CacheRetrieveMode cacheRetrieveMode) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
-    /**
-     * The cache storage mode that will be in effect during query execution.
-     *
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public CacheStoreMode getCacheStoreMode() {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
-    /**
-     * Set the cache storage mode that is in effect during query execution.
-     * This cache storage mode overrides the cache storage mode in use by the entity manager.
-     *
-     * @param cacheStoreMode cache storage mode
-     * @return the same query instance
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public TypedQuery<X> setCacheStoreMode(CacheStoreMode cacheStoreMode) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
-    /**
-     * The query timeout.
-     *
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public Integer getTimeout() {
@@ -478,7 +447,7 @@ public class EJBQueryImpl<X> extends QueryImpl implements JpaQuery<X> {
     }
 
     // TODO-API-3.2
-    //@Override
+    @Override
     public X getSingleResultOrNull() {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EJBQueryImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EJBQueryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -21,6 +21,8 @@
 //       - 350487: JPA 2.1 Specification defined support for Stored Procedure Calls
 //     08/11/2012-2.5 Guy Pelletier
 //       - 393867: Named queries do not work when using EM level Table Per Tenant Multitenancy.
+//     08/23/2023: Tomas Kraus
+//       - New Jakarta Persistence 3.2 Features
 package org.eclipse.persistence.internal.jpa;
 
 import java.util.ArrayList;
@@ -31,6 +33,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import jakarta.persistence.CacheRetrieveMode;
+import jakarta.persistence.CacheStoreMode;
 import jakarta.persistence.FlushModeType;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.LockTimeoutException;
@@ -294,6 +298,79 @@ public class EJBQueryImpl<X> extends QueryImpl implements JpaQuery<X> {
     @Override
     public EJBQueryImpl setLockMode(LockModeType lockMode) {
         return (EJBQueryImpl) super.setLockMode(lockMode);
+    }
+
+    /**
+     * The cache retrieval mode that will be in effect during query execution.
+     *
+     * @since 4.1
+     */
+    // TODO-API-3.2
+    @Override
+    public CacheRetrieveMode getCacheRetrieveMode() {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    /**
+     * Set the cache retrieval mode that is in effect during query execution.
+     * This cache retrieval mode overrides the cache retrieve mode in use by the entity manager.
+     *
+     * @param cacheRetrieveMode cache retrieval mode
+     * @return the same query instance
+     * @since 4.1
+     */
+    // TODO-API-3.2
+    @Override
+    public TypedQuery<X> setCacheRetrieveMode(CacheRetrieveMode cacheRetrieveMode) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    /**
+     * The cache storage mode that will be in effect during query execution.
+     *
+     * @since 4.1
+     */
+    // TODO-API-3.2
+    @Override
+    public CacheStoreMode getCacheStoreMode() {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    /**
+     * Set the cache storage mode that is in effect during query execution.
+     * This cache storage mode overrides the cache storage mode in use by the entity manager.
+     *
+     * @param cacheStoreMode cache storage mode
+     * @return the same query instance
+     * @since 4.1
+     */
+    // TODO-API-3.2
+    @Override
+    public TypedQuery<X> setCacheStoreMode(CacheStoreMode cacheStoreMode) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    /**
+     * The query timeout.
+     *
+     * @since 4.1
+     */
+    // TODO-API-3.2
+    @Override
+    public Integer getTimeout() {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    /**
+     * Set the query timeout.
+     *
+     * @param timeout the timeout, or {@code null} to indicate no timeout
+     * @return the same query instance
+     * @since 4.1
+     */
+    @Override
+    public TypedQuery<X> setTimeout(Integer timeout) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
     /**

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityGraphImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityGraphImpl.java
@@ -192,7 +192,7 @@ public class EntityGraphImpl<X> extends AttributeNodeImpl<X> implements EntityGr
         return addTreatedSubgraph((Class)type);
     }
 
-    // TODO-API-3.2: alias pro addSubgraph se st. attr
+    // TODO-API-3.2
     @Override
     public <Y> Subgraph<Y> addTreatedSubgraph(Attribute<? super X, ? super Y> attribute, Class<Y> type) {
         return addSubgraph(attribute.getName(), type);

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityGraphImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityGraphImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,6 +13,8 @@
 // Contributors:
 //     09 Jan 2013-2.5 Gordon Yorke
 //       - 397772: JPA 2.1 Entity Graph Support
+//     08/23/2023: Tomas Kraus
+//       - New Jakarta Persistence 3.2 Features
 package org.eclipse.persistence.internal.jpa;
 
 import java.util.ArrayList;
@@ -79,12 +81,18 @@ public class EntityGraphImpl<X> extends AttributeNodeImpl<X> implements EntityGr
     }
 
     // TODO-API-3.2
-    //@Override
+    @Override
     public void addAttributeNode(String attributeName) {
         if (!isMutable) {
             throw new IllegalStateException(ExceptionLocalization.buildMessage("immutable_entitygraph"));
         }
         addAttributeNodeImpl(attributeName);
+    }
+
+    // TODO-API-3.2
+    @Override
+    public void removeAttributeNode(String attributeName) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
     @Override
@@ -98,12 +106,18 @@ public class EntityGraphImpl<X> extends AttributeNodeImpl<X> implements EntityGr
     }
 
     // TODO-API-3.2
-    //@Override
+    @Override
     public void addAttributeNode(Attribute<? super X, ?> attribute) {
         if (!isMutable) {
             throw new IllegalStateException(ExceptionLocalization.buildMessage("immutable_entitygraph"));
         }
         addAttributeNodeImpl(attribute.getName());
+    }
+
+    // TODO-API-3.2
+    @Override
+    public void removeAttributeNode(Attribute<? super X, ?> attribute) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
     @Override
@@ -115,6 +129,12 @@ public class EntityGraphImpl<X> extends AttributeNodeImpl<X> implements EntityGr
         for (Attribute<? super X, ?> attribute : attributes) {
             addAttributeNodeImpl(attribute.getName());
         }
+    }
+
+    // TODO-API-3.2
+    @Override
+    public void removeAttributeNodes(Attribute.PersistentAttributeType nodeTypes) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
     // Add an attribute node of given name to the entity graph.
@@ -146,8 +166,8 @@ public class EntityGraphImpl<X> extends AttributeNodeImpl<X> implements EntityGr
         return addSubgraph(attribute.getName(), type);
     }
 
-    // TODO-API-3.2: Implementace sem!
-    //@Override
+    // TODO-API-3.2
+    @Override
     public <S extends X> Subgraph<S> addTreatedSubgraph(Class<S> type) {
         if (!this.isMutable) {
             throw new IllegalStateException(ExceptionLocalization.buildMessage("immutable_entitygraph"));
@@ -173,7 +193,7 @@ public class EntityGraphImpl<X> extends AttributeNodeImpl<X> implements EntityGr
     }
 
     // TODO-API-3.2: alias pro addSubgraph se st. attr
-    //@Override
+    @Override
     public <Y> Subgraph<Y> addTreatedSubgraph(Attribute<? super X, ? super Y> attribute, Class<Y> type) {
         return addSubgraph(attribute.getName(), type);
     }

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityGraphImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityGraphImpl.java
@@ -24,6 +24,7 @@ import jakarta.persistence.AttributeNode;
 import jakarta.persistence.EntityGraph;
 import jakarta.persistence.Subgraph;
 import jakarta.persistence.metamodel.Attribute;
+import jakarta.persistence.metamodel.MapAttribute;
 import jakarta.persistence.metamodel.PluralAttribute;
 
 import org.eclipse.persistence.descriptors.ClassDescriptor;
@@ -78,6 +79,24 @@ public class EntityGraphImpl<X> extends AttributeNodeImpl<X> implements EntityGr
         return attributeGroup.getName();
     }
 
+    // TODO-API-3.2
+    //@Override
+    public <S extends X> Subgraph<S> addTreatedSubgraph(Class<S> aClass) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    // TODO-API-3.2
+    //@Override
+    public void addAttributeNode(String s) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    // TODO-API-3.2
+    //@Override
+    public void addAttributeNode(Attribute<? super X, ?> attribute) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
     @Override
     public void addAttributeNodes(String... attributeNames) {
         if (!this.isMutable) {
@@ -103,11 +122,11 @@ public class EntityGraphImpl<X> extends AttributeNodeImpl<X> implements EntityGr
     }
 
     @Override
-    public void addAttributeNodes(Attribute<X, ?>... attribute) {
+    public void addAttributeNodes(Attribute<? super X, ?>... attribute) {
         if (!this.isMutable) {
             throw new IllegalStateException("immutable_entitygraph");
         }
-        for (Attribute<X, ?> attrNode : attribute) {
+        for (Attribute<? super X, ?> attrNode : attribute) {
             this.addAttributeNodeImpl(new AttributeNodeImpl<X>(attrNode.getName()));
             //order is important here, must add attribute node to node list before adding to group or it will appear in node list twice.
             this.attributeGroup.addAttribute(attrNode.getName());
@@ -115,7 +134,7 @@ public class EntityGraphImpl<X> extends AttributeNodeImpl<X> implements EntityGr
     }
 
     @Override
-    public <T> Subgraph<T> addSubgraph(Attribute<X, T> attribute) {
+    public <T> Subgraph<T> addSubgraph(Attribute<? super X, T> attribute) {
         Class<T> type = attribute.getJavaType();
         if (attribute.isCollection()) {
             type = ((PluralAttribute) attribute).getBindableJavaType();
@@ -124,7 +143,13 @@ public class EntityGraphImpl<X> extends AttributeNodeImpl<X> implements EntityGr
     }
 
     @Override
-    public <T> Subgraph<? extends T> addSubgraph(Attribute<X, T> attribute, Class<? extends T> type) {
+    public <Y> Subgraph<Y> addTreatedSubgraph(Attribute<? super X, ? super Y> attribute, Class<Y> aClass) {
+        return null;
+    }
+
+    @Override
+    @SuppressWarnings("removal")
+    public <T> Subgraph<? extends T> addSubgraph(Attribute<? super X, T> attribute, Class<? extends T> type) {
         return addSubgraph(attribute.getName(), type);
     }
 
@@ -169,7 +194,38 @@ public class EntityGraphImpl<X> extends AttributeNodeImpl<X> implements EntityGr
     }
 
     @Override
-    public <T> Subgraph<T> addKeySubgraph(Attribute<X, T> attribute) {
+    public <E> Subgraph<E> addElementSubgraph(PluralAttribute<? super X, ?, E> pluralAttribute) {
+        return null;
+    }
+
+    @Override
+    public <E> Subgraph<E> addTreatedElementSubgraph(PluralAttribute<? super X, ?, ? super E> pluralAttribute, Class<E> aClass) {
+        return null;
+    }
+
+    @Override
+    public <X1> Subgraph<X1> addElementSubgraph(String s) {
+        return null;
+    }
+
+    @Override
+    public <X1> Subgraph<X1> addElementSubgraph(String s, Class<X1> aClass) {
+        return null;
+    }
+
+    @Override
+    public <K> Subgraph<K> addMapKeySubgraph(MapAttribute<? super X, K, ?> mapAttribute) {
+        return null;
+    }
+
+    @Override
+    public <K> Subgraph<K> addTreatedMapKeySubgraph(MapAttribute<? super X, ? super K, ?> mapAttribute, Class<K> aClass) {
+        return null;
+    }
+
+    @Override
+    @SuppressWarnings("removal")
+    public <T> Subgraph<T> addKeySubgraph(Attribute<? super X, T> attribute) {
         if (!this.isMutable) {
             throw new IllegalStateException("immutable_entitygraph");
         }
@@ -181,7 +237,8 @@ public class EntityGraphImpl<X> extends AttributeNodeImpl<X> implements EntityGr
     }
 
     @Override
-    public <T> Subgraph<? extends T> addKeySubgraph(Attribute<X, T> attribute, Class<? extends T> type) {
+    @SuppressWarnings("removal")
+    public <T> Subgraph<? extends T> addKeySubgraph(Attribute<? super X, T> attribute, Class<? extends T> type) {
         return addKeySubgraph(attribute.getName(), type);
     }
 
@@ -229,6 +286,7 @@ public class EntityGraphImpl<X> extends AttributeNodeImpl<X> implements EntityGr
     }
 
     @Override
+    @SuppressWarnings("removal")
     public <T> Subgraph<? extends T> addSubclassSubgraph(Class<? extends T> type) {
         if (!this.isMutable) {
             throw new IllegalStateException("immutable_entitygraph");

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerFactoryDelegate.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerFactoryDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2021 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -29,6 +29,8 @@
 //       - 489787: Fixed NullPointerException when specifying non-entity object to PersistenceUnitUtil.isLoaded
 //     09/02/2019-3.0 Alexandre Jacob
 //        - 527415: Fix code when locale is tr, az or lt
+//     08/23/2023: Tomas Kraus
+//       - New Jakarta Persistence 3.2 Features
 package org.eclipse.persistence.internal.jpa;
 
 import java.util.Collections;
@@ -36,6 +38,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 import jakarta.persistence.Cache;
 import jakarta.persistence.EntityGraph;
@@ -45,6 +49,7 @@ import jakarta.persistence.FlushModeType;
 import jakarta.persistence.PersistenceException;
 import jakarta.persistence.PersistenceUnitUtil;
 import jakarta.persistence.Query;
+import jakarta.persistence.SchemaManager;
 import jakarta.persistence.SynchronizationType;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.metamodel.Attribute;
@@ -549,6 +554,19 @@ public class EntityManagerFactoryDelegate implements EntityManagerFactory, Persi
     }
 
     /**
+     * Return interface providing access to schema management operations for the persistence unit.
+     *
+     * @return <code>SchemaManager</code> interface
+     * @throws IllegalStateException if the entity manager factory has been closed
+     * @since 4.1
+     */
+    // TODO-API-3.2
+    @Override
+    public SchemaManager getSchemaManager() {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    /**
      * Set default property to avoid discover new objects in unit of work if
      * application always uses persist.
      */
@@ -797,6 +815,22 @@ public class EntityManagerFactoryDelegate implements EntityManagerFactory, Persi
     }
 
     /**
+     * Return the version of the entity.
+     * A generated version is not guaranteed to be available until after the database insert has occurred.
+     * Returns null if the entity does not yet have an id.
+     *
+     * @param entity  entity instance
+     * @return id of the entity
+     * @throws IllegalArgumentException if the object is found not to be an entity
+     * @since 4.1
+     */
+    // TODO-API-3.2
+    @Override
+    public Object getVersion(Object entity) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    /**
      * Return if updates should be ordered by primary key, to avoid potential database deadlocks.
      */
     public CommitOrderType getCommitOrder() {
@@ -850,6 +884,68 @@ public class EntityManagerFactoryDelegate implements EntityManagerFactory, Persi
         group.setName(graphName);
         this.getAbstractSession().getAttributeGroups().put(graphName, group);
         this.getAbstractSession().getDescriptor(((EntityGraphImpl)entityGraph).getClassType()).addAttributeGroup(group);
+    }
+
+    /**
+     * Create a new application-managed {@code EntityManager} with an active
+     * transaction, and execute the given function, passing the {@code EntityManager}
+     * to the function.
+     * <p>
+     * If the transaction type of the persistence unit is JTA, and there is a JTA
+     * transaction already associated with the caller, then the {@code EntityManager}
+     * is associated with this current transaction. If the given function throws an
+     * exception, the JTA transaction is marked for rollback, and the exception is
+     * rethrown.
+     * <p>
+     * Otherwise, if the transaction type of the persistence unit is resource-local,
+     * or if there is no JTA transaction already associated with the caller, then
+     * the {@code EntityManager} is associated with a new transaction. If the given
+     * function returns without throwing an exception, this transaction is committed.
+     * If the function does throw an exception, the transaction is rolled back, and
+     * the exception is rethrown.
+     * <p>
+     * Finally, the {@code EntityManager} is closed before this method returns
+     * control to the client.
+     *
+     * @param work a function to be executed in the scope of the transaction
+     * @since 4.1
+     */
+    // TODO-API-3.2
+    @Override
+    public void runInTransaction(Consumer<EntityManager> work) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    /**
+     * Create a new application-managed {@code EntityManager} with an active
+     * transaction, and call the given function, passing the {@code EntityManager}
+     * to the function.
+     * <p>
+     * If the transaction type of the persistence unit is JTA, and there is a JTA
+     * transaction already associated with the caller, then the {@code EntityManager}
+     * is associated with this current transaction. If the given function returns
+     * without throwing an exception, the result of the function is returned. If the
+     * given function throws an exception, the JTA transaction is marked for rollback,
+     * and the exception is rethrown.
+     * <p>
+     * Otherwise, if the transaction type of the persistence unit is resource-local,
+     * or if there is no JTA transaction already associated with the caller, then
+     * the {@code EntityManager} is associated with a new transaction. If the given
+     * function returns without throwing an exception, this transaction is committed
+     * and the result of the function is returned. If the function does throw an
+     * exception, the transaction is rolled back, and the exception is rethrown.
+     * <p>
+     * Finally, the {@code EntityManager} is closed before this method returns
+     * control to the client.
+     *
+     * @param work a function to be called in the scope of the transaction
+     * @return the value returned by the given function
+     * @since 4.1
+     */
+    // TODO-API-3.2
+    @Override
+    public <R> R callInTransaction(Function<EntityManager, R> work) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
 }

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerFactoryDelegate.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerFactoryDelegate.java
@@ -47,6 +47,7 @@ import jakarta.persistence.PersistenceUnitUtil;
 import jakarta.persistence.Query;
 import jakarta.persistence.SynchronizationType;
 import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.metamodel.Attribute;
 import jakarta.persistence.metamodel.Metamodel;
 
 import org.eclipse.persistence.config.EntityManagerProperties;
@@ -364,6 +365,7 @@ public class EntityManagerFactoryDelegate implements EntityManagerFactory, Persi
     }
 
     @Override
+    @SuppressWarnings("removal")
     protected void finalize() throws Throwable {
         if (isOpen()) {
             close();
@@ -717,6 +719,12 @@ public class EntityManagerFactoryDelegate implements EntityManagerFactory, Persi
         return false;
     }
 
+    // TODO-API-3.2
+    //@Override
+    public <E> boolean isLoaded(E e, Attribute<? super E, ?> attribute) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
     /**
      * Determine the load state of an entity belonging to the persistence unit.
      * This method can be used to determine the load state of an entity passed
@@ -736,6 +744,36 @@ public class EntityManagerFactoryDelegate implements EntityManagerFactory, Persi
             return true;
         }
         return false;
+    }
+
+    // TODO-API-3.2
+    //@Override
+    public void load(Object o, String s) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    // TODO-API-3.2
+    //@Override
+    public <E> void load(E e, Attribute<? super E, ?> attribute) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    // TODO-API-3.2
+    //@Override
+    public void load(Object o) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    // TODO-API-3.2
+    //@Override
+    public boolean isInstance(Object o, Class<?> aClass) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    // TODO-API-3.2
+    //@Override
+    public <T> Class<? extends T> getClass(T t) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
     /**

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerFactoryImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerFactoryImpl.java
@@ -37,6 +37,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.FlushModeType;
 import jakarta.persistence.PersistenceException;
+import jakarta.persistence.PersistenceUnitTransactionType;
 import jakarta.persistence.PersistenceUnitUtil;
 import jakarta.persistence.Query;
 import jakarta.persistence.SchemaManager;
@@ -453,13 +454,12 @@ public class EntityManagerFactoryImpl implements EntityManagerFactory, Persisten
         return delegate.getPersistenceUnitUtil();
     }
 
-    /**
-     * Return interface providing access to schema management operations for the persistence unit.
-     *
-     * @return <code>SchemaManager</code> interface
-     * @throws IllegalStateException if the entity manager factory has been closed
-     * @since 4.1
-     */
+    // TODO-API-3.2
+    @Override
+    public PersistenceUnitTransactionType getTransactionType() {
+        return delegate.getTransactionType();
+    }
+
     // TODO-API-3.2
     @Override
     public SchemaManager getSchemaManager() {
@@ -604,9 +604,9 @@ public class EntityManagerFactoryImpl implements EntityManagerFactory, Persisten
     }
 
     // TODO-API-3.2
-    //@Override
+    @Override
     public <E> boolean isLoaded(E e, Attribute<? super E, ?> attribute) {
-        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+        return delegate.isLoaded(e, attribute);
     }
 
     /**
@@ -628,33 +628,33 @@ public class EntityManagerFactoryImpl implements EntityManagerFactory, Persisten
     }
 
     // TODO-API-3.2
-    //@Override
-    public void load(Object o, String s) {
-        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    @Override
+    public void load(Object entity, String attributeName) {
+        delegate.load(entity, attributeName);
     }
 
     // TODO-API-3.2
-    //@Override
-    public <E> void load(E e, Attribute<? super E, ?> attribute) {
-        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    @Override
+    public <E> void load(E entity, Attribute<? super E, ?> attribute) {
+        delegate.load(entity, attribute);
     }
 
     // TODO-API-3.2
-    //@Override
-    public void load(Object o) {
-        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    @Override
+    public void load(Object entity) {
+        delegate.load(entity);
     }
 
     // TODO-API-3.2
-    //@Override
-    public boolean isInstance(Object o, Class<?> aClass) {
-        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    @Override
+    public boolean isInstance(Object entity, Class<?> entityClass) {
+        return delegate.isInstance(entity, entityClass);
     }
 
     // TODO-API-3.2
-    //@Override
-    public <T> Class<? extends T> getClass(T t) {
-        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    @Override
+    public <T> Class<? extends T> getClass(T entity) {
+        return delegate.getClass(entity);
     }
 
     /**
@@ -671,16 +671,6 @@ public class EntityManagerFactoryImpl implements EntityManagerFactory, Persisten
         return delegate.getIdentifier(entity);
     }
 
-    /**
-     * Return the version of the entity.
-     * A generated version is not guaranteed to be available until after the database insert has occurred.
-     * Returns null if the entity does not yet have an id.
-     *
-     * @param entity  entity instance
-     * @return id of the entity
-     * @throws IllegalArgumentException if the object is found not to be an entity
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public Object getVersion(Object entity) {
@@ -741,62 +731,12 @@ public class EntityManagerFactoryImpl implements EntityManagerFactory, Persisten
         this.getServerSession().getDescriptor(((EntityGraphImpl)entityGraph).getClassType()).addAttributeGroup(group);
     }
 
-    /**
-     * Create a new application-managed {@code EntityManager} with an active
-     * transaction, and execute the given function, passing the {@code EntityManager}
-     * to the function.
-     * <p>
-     * If the transaction type of the persistence unit is JTA, and there is a JTA
-     * transaction already associated with the caller, then the {@code EntityManager}
-     * is associated with this current transaction. If the given function throws an
-     * exception, the JTA transaction is marked for rollback, and the exception is
-     * rethrown.
-     * <p>
-     * Otherwise, if the transaction type of the persistence unit is resource-local,
-     * or if there is no JTA transaction already associated with the caller, then
-     * the {@code EntityManager} is associated with a new transaction. If the given
-     * function returns without throwing an exception, this transaction is committed.
-     * If the function does throw an exception, the transaction is rolled back, and
-     * the exception is rethrown.
-     * <p>
-     * Finally, the {@code EntityManager} is closed before this method returns
-     * control to the client.
-     *
-     * @param work a function to be executed in the scope of the transaction
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public void runInTransaction(Consumer<EntityManager> work) {
         delegate.runInTransaction(work);
     }
 
-    /**
-     * Create a new application-managed {@code EntityManager} with an active
-     * transaction, and call the given function, passing the {@code EntityManager}
-     * to the function.
-     * <p>
-     * If the transaction type of the persistence unit is JTA, and there is a JTA
-     * transaction already associated with the caller, then the {@code EntityManager}
-     * is associated with this current transaction. If the given function returns
-     * without throwing an exception, the result of the function is returned. If the
-     * given function throws an exception, the JTA transaction is marked for rollback,
-     * and the exception is rethrown.
-     * <p>
-     * Otherwise, if the transaction type of the persistence unit is resource-local,
-     * or if there is no JTA transaction already associated with the caller, then
-     * the {@code EntityManager} is associated with a new transaction. If the given
-     * function returns without throwing an exception, this transaction is committed
-     * and the result of the function is returned. If the function does throw an
-     * exception, the transaction is rolled back, and the exception is rethrown.
-     * <p>
-     * Finally, the {@code EntityManager} is closed before this method returns
-     * control to the client.
-     *
-     * @param work a function to be called in the scope of the transaction
-     * @return the value returned by the given function
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public <R> R callInTransaction(Function<EntityManager, R> work) {

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerFactoryImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerFactoryImpl.java
@@ -26,17 +26,21 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 
 import jakarta.persistence.Cache;
 import jakarta.persistence.EntityGraph;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityTransaction;
 import jakarta.persistence.FlushModeType;
 import jakarta.persistence.PersistenceException;
 import jakarta.persistence.PersistenceUnitUtil;
 import jakarta.persistence.Query;
 import jakarta.persistence.SynchronizationType;
 import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.metamodel.Attribute;
 import jakarta.persistence.metamodel.Metamodel;
 
 import org.eclipse.persistence.config.ReferenceMode;
@@ -584,6 +588,12 @@ public class EntityManagerFactoryImpl implements EntityManagerFactory, Persisten
         return delegate.isLoaded(entity, attributeName);
     }
 
+    // TODO-API-3.2
+    //@Override
+    public <E> boolean isLoaded(E e, Attribute<? super E, ?> attribute) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
     /**
      * Determine the load state of an entity belonging to the persistence unit.
      * This method can be used to determine the load state of an entity passed
@@ -600,6 +610,36 @@ public class EntityManagerFactoryImpl implements EntityManagerFactory, Persisten
     @Override
     public boolean isLoaded(Object entity) {
         return delegate.isLoaded(entity);
+    }
+
+    // TODO-API-3.2
+    //@Override
+    public void load(Object o, String s) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    // TODO-API-3.2
+    //@Override
+    public <E> void load(E e, Attribute<? super E, ?> attribute) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    // TODO-API-3.2
+    //@Override
+    public void load(Object o) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    // TODO-API-3.2
+    //@Override
+    public boolean isInstance(Object o, Class<?> aClass) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    // TODO-API-3.2
+    //@Override
+    public <T> Class<? extends T> getClass(T t) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
     /**

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerImpl.java
@@ -831,119 +831,12 @@ public class EntityManagerImpl implements org.eclipse.persistence.jpa.JpaEntityM
         }
     }
 
-    /**
-     * Find an instance of the given entity class by primary key,
-     * using the specified {@linkplain FindOption options}.
-     * Search for an entity with the specified class and primary key.
-     * If the given options include a {@link LockModeType}, lock it
-     * with respect to the specified lock type.
-     * If the entity instance is contained in the persistence context,
-     * it is returned from there.
-     * <p>If the entity is found within the persistence context and
-     * the lock mode type is pessimistic and the entity has a version
-     * attribute, the persistence provider must perform optimistic
-     * version checks when obtaining the database lock.  If these checks
-     * fail, the <code>OptimisticLockException</code> will be thrown.
-     * <p>If the lock mode type is pessimistic and the entity instance
-     * is found but cannot be locked:
-     * <ul>
-     * <li> the <code>PessimisticLockException</code> will be thrown
-     *      if the database locking failure causes transaction-level
-     *      rollback
-     * <li> the <code>LockTimeoutException</code> will be thrown if
-     *      the database locking failure causes only statement-level
-     *      rollback
-     * </ul>
-     * <p>If a vendor-specific {@linkplain FindOption option} is not
-     * recognized, it is silently ignored.
-     * <p>Portable applications should not rely on the standard
-     * {@linkplain jakarta.persistence.Timeout timeout option}. Depending on the database
-     * in use and the locking mechanisms used by the provider, this
-     * option may or may not be observed.
-     * @param entityClass  entity class
-     * @param primaryKey  primary key
-     * @param options  standard and vendor-specific options
-     * @return the found entity instance or null if the entity does
-     *         not exist
-     * @throws IllegalArgumentException if there are contradictory
-     *         options, if the first argument does not denote an entity
-     *         type belonging to the persistence unit, or if the second
-     *         argument is not a valid non-null instance of the entity
-     *         primary key type
-     * @throws TransactionRequiredException if there is no transaction
-     *         and a lock mode other than <code>NONE</code> is
-     *         specified or if invoked on an entity manager which has
-     *         not been joined to the current transaction and a lock
-     *         mode other than <code>NONE</code> is specified
-     * @throws OptimisticLockException if the optimistic version check
-     *         fails
-     * @throws PessimisticLockException if pessimistic locking fails
-     *         and the transaction is rolled back
-     * @throws LockTimeoutException if pessimistic locking fails and
-     *         only the statement is rolled back
-     * @throws PersistenceException if an unsupported lock call is made
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public <T> T find(Class<T> entityClass, Object primaryKey, FindOption... options) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
-    /**
-     * Find an instance of the root entity of the given {@link EntityGraph}
-     * by primary key, using the specified {@linkplain FindOption options},
-     * and interpreting the {@code EntityGraph} as a load graph.
-     * Search for an entity with the specified type and primary key.
-     * If the given options include a {@link LockModeType}, lock it
-     * with respect to the specified lock type.
-     * If the entity instance is contained in the persistence context,
-     * it is returned from there.
-     * <p> If the entity is found within the persistence context and
-     * the lock mode type is pessimistic and the entity has a version
-     * attribute, the persistence provider must perform optimistic
-     * version checks when obtaining the database lock.  If these checks
-     * fail, the <code>OptimisticLockException</code> will be thrown.
-     * <p>If the lock mode type is pessimistic and the entity instance
-     * is found but cannot be locked:
-     * <ul>
-     * <li> the <code>PessimisticLockException</code> will be thrown
-     *      if the database locking failure causes transaction-level
-     *      rollback
-     * <li> the <code>LockTimeoutException</code> will be thrown if
-     *      the database locking failure causes only statement-level
-     *      rollback
-     * </ul>
-     * <p>If a vendor-specific {@linkplain FindOption option} is not
-     * recognized, it is silently ignored.
-     * <p>Portable applications should not rely on the standard
-     * {@linkplain jakarta.persistence.Timeout timeout option}. Depending on the database
-     * in use and the locking mechanisms used by the provider, this
-     * option may or may not be observed.
-     * @param entityGraph  entity graph interpreted as a load graph
-     * @param primaryKey  primary key
-     * @param options  standard and vendor-specific options
-     * @return the found entity instance or null if the entity does
-     *         not exist
-     * @throws IllegalArgumentException if there are contradictory
-     *         options, if the first argument does not denote an entity
-     *         type belonging to the persistence unit, or if the second
-     *         argument is not a valid non-null instance of the entity
-     *         primary key type
-     * @throws TransactionRequiredException if there is no transaction
-     *         and a lock mode other than <code>NONE</code> is
-     *         specified or if invoked on an entity manager which has
-     *         not been joined to the current transaction and a lock
-     *         mode other than <code>NONE</code> is specified
-     * @throws OptimisticLockException if the optimistic version check
-     *         fails
-     * @throws PessimisticLockException if pessimistic locking fails
-     *         and the transaction is rolled back
-     * @throws LockTimeoutException if pessimistic locking fails and
-     *         only the statement is rolled back
-     * @throws PersistenceException if an unsupported lock call is made
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public <T> T find(EntityGraph<T> entityGraph, Object primaryKey, FindOption... options) {
@@ -1276,49 +1169,6 @@ public class EntityManagerImpl implements org.eclipse.persistence.jpa.JpaEntityM
         }
     }
 
-    /**
-     * Refresh the state of the given entity instance from the
-     * database, using the specified {@linkplain RefreshOption options},
-     * overwriting changes made to the entity, if any. If the supplied
-     * options include a {@link LockModeType}, lock the given entity with
-     * respect to the specified lock type.
-     * <p>If the lock mode type is pessimistic and the entity instance is
-     * found but cannot be locked:
-     * <ul>
-     * <li> the <code>PessimisticLockException</code> will be thrown if
-     *      the database locking failure causes transaction-level rollback
-     * <li> the <code>LockTimeoutException</code> will be thrown if the
-     *      database locking failure causes only statement-level rollback
-     * </ul>
-     * <p>If a vendor-specific {@link RefreshOption} is not recognized,
-     * it is silently ignored.
-     * <p>Portable applications should not rely on the standard
-     * {@linkplain jakarta.persistence.Timeout timeout option}. Depending on the database in
-     * use and the locking mechanisms used by the provider, the hint may
-     * or may not be observed.
-     *
-     * @param entity  entity instance
-     * @param options  standard and vendor-specific options
-     * @throws IllegalArgumentException if the instance is not an entity
-     *         or the entity is not managed
-     * @throws TransactionRequiredException if invoked on a
-     *         container-managed entity manager of type
-     *         <code>PersistenceContextType.TRANSACTION</code> when there
-     *         is no transaction; if invoked on an extended entity manager
-     *         when there is no transaction and a lock mode other than
-     *         <code>NONE</code> has been specified; or if invoked on an
-     *         extended entity manager that has not been joined to the
-     *         current transaction and a lock mode other than
-     *         <code>NONE</code> has been specified
-     * @throws EntityNotFoundException if the entity no longer exists in
-     *         the database
-     * @throws PessimisticLockException if pessimistic locking fails and
-     *         the transaction is rolled back
-     * @throws LockTimeoutException if pessimistic locking fails and only
-     *         the statement is rolled back
-     * @throws PersistenceException if an unsupported lock call is made
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public void refresh(Object entity, RefreshOption... options) {
@@ -1603,23 +1453,6 @@ public class EntityManagerImpl implements org.eclipse.persistence.jpa.JpaEntityM
         }
     }
 
-    /**
-     * Execute the given action using the database connection underlying this
-     * {@code EntityManager}. Usually, the connection is a JDBC connection, but a
-     * provider might support some other native connection type, and is not required
-     * to support {@code java.sql.Connection}. If this {@code EntityManager} is
-     * associated with a transaction, the action is executed in the context of the
-     * transaction. The given action should close any resources it creates, but should
-     * not close the connection itself, nor commit or roll back the transaction. If
-     * the given action throws an exception, the persistence provider must mark the
-     * transaction for rollback.
-     *
-     * @param action the action
-     * @param <C> the connection type, usually {@code java.sql.Connection}
-     * @throws PersistenceException wrapping the checked {@link Exception} thrown by
-     *         {@link ConnectionConsumer#accept}, if any
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public <C> void runWithConnection(ConnectionConsumer<C> action) {
@@ -1638,25 +1471,6 @@ public class EntityManagerImpl implements org.eclipse.persistence.jpa.JpaEntityM
         }
     }
 
-    /**
-     * Call the given function and return its result using the database connection
-     * underlying this {@code EntityManager}. Usually, the connection is a JDBC
-     * connection, but a provider might support some other native connection type,
-     * and is not required to support {@code java.sql.Connection}. If this
-     * {@code EntityManager} is associated with a transaction, the function is
-     * executed in the context of the transaction. The given function should close
-     * any resources it creates, but should not close the connection itself, nor
-     * commit or roll back the transaction. If the given action throws an exception,
-     * the persistence provider must mark the transaction for rollback.
-     *
-     * @param function the function
-     * @param <C> the connection type, usually {@code java.sql.Connection}
-     * @param <T> the type of result returned by the function
-     * @return the value returned by {@link ConnectionFunction#apply}.
-     * @throws PersistenceException wrapping the checked {@link Exception} thrown by
-     *         {@link ConnectionFunction#apply}, if any
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public <C, T> T callWithConnection(ConnectionFunction<C, T> function) {
@@ -1759,6 +1573,12 @@ public class EntityManagerImpl implements org.eclipse.persistence.jpa.JpaEntityM
             setRollbackOnly();
             throw exception;
         }
+    }
+
+    // TODO-API-3.2
+    @Override
+    public <T> T getReference(T t) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
     /**
@@ -2284,52 +2104,6 @@ public class EntityManagerImpl implements org.eclipse.persistence.jpa.JpaEntityM
         }
     }
 
-    /**
-     * Lock an entity instance that is contained in the persistence
-     * context with the specified lock mode type, using specified
-     * {@linkplain LockOption options}.
-     * <p>If a pessimistic lock mode type is specified and the entity
-     * contains a version attribute, the persistence provider must
-     * also perform optimistic version checks when obtaining the
-     * database lock. If these checks fail, the
-     * <code>OptimisticLockException</code> will be thrown.
-     * <p>If the lock mode type is pessimistic and the entity instance
-     * is found but cannot be locked:
-     * <ul>
-     * <li> the <code>PessimisticLockException</code> will be thrown
-     *      if the database locking failure causes transaction-level
-     *      rollback
-     * <li> the <code>LockTimeoutException</code> will be thrown if
-     *      the database locking failure causes only statement-level
-     *      rollback
-     * </ul>
-     * <p>If a vendor-specific {@link LockOption} is not recognized,
-     * it is silently ignored.
-     * <p>Portable applications should not rely on the standard
-     * {@linkplain jakarta.persistence.Timeout timeout option}. Depending on the database
-     * in use and the locking mechanisms used by the provider, the
-     * option may or may not be observed.
-     *
-     * @param entity  entity instance
-     * @param lockMode  lock mode
-     * @param options  standard and vendor-specific options
-     * @throws IllegalArgumentException if the instance is not an
-     *         entity or is a detached entity
-     * @throws TransactionRequiredException if there is no
-     *         transaction or if invoked on an entity manager which
-     *         has not been joined to the current transaction
-     * @throws EntityNotFoundException if the entity does not exist
-     *         in the database when pessimistic locking is
-     *         performed
-     * @throws OptimisticLockException if the optimistic version
-     *         check fails
-     * @throws PessimisticLockException if pessimistic locking fails
-     *         and the transaction is rolled back
-     * @throws LockTimeoutException if pessimistic locking fails and
-     *         only the statement is rolled back
-     * @throws PersistenceException if an unsupported lock call is made
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public void lock(Object entity, LockModeType lockMode, LockOption... options) {
@@ -3136,47 +2910,24 @@ public class EntityManagerImpl implements org.eclipse.persistence.jpa.JpaEntityM
         }
     }
 
-    /**
-     * The cache retrieval mode for this persistence context.
-     *
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public CacheRetrieveMode getCacheRetrieveMode() {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
-    /**
-     * Set the cache retrieval mode that is in effect during query execution.
-     * This cache retrieval mode overrides the cache retrieve mode in use by the entity manager.
-     *
-     * @param cacheRetrieveMode cache retrieval mode
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public void setCacheRetrieveMode(CacheRetrieveMode cacheRetrieveMode) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
-    /**
-     * The cache storage mode for this persistence context.
-     *
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public CacheStoreMode getCacheStoreMode() {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
-    /**
-     * Set the default cache storage mode for this persistence context.
-     *
-     * @param cacheStoreMode cache storage mode
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public void setCacheStoreMode(CacheStoreMode cacheStoreMode) {

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerImpl.java
@@ -1623,7 +1623,19 @@ public class EntityManagerImpl implements org.eclipse.persistence.jpa.JpaEntityM
     // TODO-API-3.2
     @Override
     public <C> void runWithConnection(ConnectionConsumer<C> action) {
-        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+        if (getAbstractSession().getAccessors().size() > 1) {
+            getAbstractSession().log(SessionLog.WARNING, SessionLog.CONNECTION, "entity_manager_has_multiple_connections");
+        }
+        @SuppressWarnings("unchecked")
+        C connection = (C) getAbstractSession().getAccessor().getDatasourceConnection();
+        try {
+            action.accept(connection);
+        } catch (Exception e) {
+            transaction.setRollbackOnlyInternal();
+            throw new PersistenceException(
+                    ExceptionLocalization.buildMessage(
+                            "entity_manager_with_connection_failed", new String[] {e.getLocalizedMessage()}), e);
+        }
     }
 
     /**
@@ -1648,7 +1660,19 @@ public class EntityManagerImpl implements org.eclipse.persistence.jpa.JpaEntityM
     // TODO-API-3.2
     @Override
     public <C, T> T callWithConnection(ConnectionFunction<C, T> function) {
-        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+        if (getAbstractSession().getAccessors().size() > 1) {
+            getAbstractSession().log(SessionLog.WARNING, SessionLog.CONNECTION, "entity_manager_has_multiple_connections");
+        }
+        @SuppressWarnings("unchecked")
+        C connection = (C) getAbstractSession().getAccessor().getDatasourceConnection();
+        try {
+            return function.apply(connection);
+        } catch (Exception e) {
+            transaction.setRollbackOnlyInternal();
+            throw new PersistenceException(
+                    ExceptionLocalization.buildMessage(
+                            "entity_manager_with_connection_failed", new String[] {e.getLocalizedMessage()}), e);
+        }
     }
 
     /**

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/StoredProcedureQueryImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/StoredProcedureQueryImpl.java
@@ -407,6 +407,7 @@ public class StoredProcedureQueryImpl extends QueryImpl implements StoredProcedu
      * Finalize method in case the query is not closed.
      */
     @Override
+    @SuppressWarnings("removal")
     public void finalize() {
         close();
     }
@@ -695,6 +696,12 @@ public class StoredProcedureQueryImpl extends QueryImpl implements StoredProcedu
         } finally {
             close(); // Close the connection once we're done.
         }
+    }
+
+    // TODO-API-3.2
+    //@Override
+    public Object getSingleResultOrNull() {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
     /**

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/StoredProcedureQueryImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/StoredProcedureQueryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, 2022 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -32,6 +32,8 @@
 //       - 350487: JPA 2.1 Specification defined support for Stored Procedure Calls
 //     11/05/2012-2.5 Guy Pelletier
 //       - 350487: JPA 2.1 Specification defined support for Stored Procedure Calls
+//     08/23/2023: Tomas Kraus
+//       - New Jakarta Persistence 3.2 Features
 package org.eclipse.persistence.internal.jpa;
 
 import java.sql.CallableStatement;
@@ -46,6 +48,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Vector;
 
+import jakarta.persistence.CacheRetrieveMode;
+import jakarta.persistence.CacheStoreMode;
 import jakarta.persistence.FlushModeType;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.LockTimeoutException;
@@ -875,6 +879,79 @@ public class StoredProcedureQueryImpl extends QueryImpl implements StoredProcedu
     @Override
     public StoredProcedureQueryImpl setFlushMode(FlushModeType flushMode) {
         return (StoredProcedureQueryImpl) super.setFlushMode(flushMode);
+    }
+
+    /**
+     * The cache retrieval mode that will be in effect during query execution.
+     *
+     * @since 4.1
+     */
+    // TODO-API-3.2
+    @Override
+    public CacheRetrieveMode getCacheRetrieveMode() {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    /**
+     * Set the cache retrieval mode that is in effect during query execution.
+     * This cache retrieval mode overrides the cache retrieve mode in use by the entity manager.
+     *
+     * @param cacheRetrieveMode cache retrieval mode
+     * @return the same query instance
+     * @since 4.1
+     */
+    // TODO-API-3.2
+    @Override
+    public StoredProcedureQueryImpl setCacheRetrieveMode(CacheRetrieveMode cacheRetrieveMode) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    /**
+     * The cache storage mode that will be in effect during query execution.
+     *
+     * @since 4.1
+     */
+    // TODO-API-3.2
+    @Override
+    public CacheStoreMode getCacheStoreMode() {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    /**
+     * Set the cache storage mode that is in effect during query execution.
+     * This cache storage mode overrides the cache storage mode in use by the entity manager.
+     *
+     * @param cacheStoreMode cache storage mode
+     * @return the same query instance
+     * @since 4.1
+     */
+    // TODO-API-3.2
+    @Override
+    public StoredProcedureQueryImpl setCacheStoreMode(CacheStoreMode cacheStoreMode) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    /**
+     * The query timeout.
+     *
+     * @since 4.1
+     */
+    // TODO-API-3.2
+    @Override
+    public Integer getTimeout() {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    /**
+     * Set the query timeout.
+     *
+     * @param timeout the timeout, or {@code null} to indicate no timeout
+     * @return the same query instance
+     * @since 4.1
+     */
+    @Override
+    public StoredProcedureQueryImpl setTimeout(Integer timeout) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
     /**

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/StoredProcedureQueryImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/StoredProcedureQueryImpl.java
@@ -703,7 +703,7 @@ public class StoredProcedureQueryImpl extends QueryImpl implements StoredProcedu
     }
 
     // TODO-API-3.2
-    //@Override
+    @Override
     public Object getSingleResultOrNull() {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
@@ -881,74 +881,37 @@ public class StoredProcedureQueryImpl extends QueryImpl implements StoredProcedu
         return (StoredProcedureQueryImpl) super.setFlushMode(flushMode);
     }
 
-    /**
-     * The cache retrieval mode that will be in effect during query execution.
-     *
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public CacheRetrieveMode getCacheRetrieveMode() {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
-    /**
-     * Set the cache retrieval mode that is in effect during query execution.
-     * This cache retrieval mode overrides the cache retrieve mode in use by the entity manager.
-     *
-     * @param cacheRetrieveMode cache retrieval mode
-     * @return the same query instance
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public StoredProcedureQueryImpl setCacheRetrieveMode(CacheRetrieveMode cacheRetrieveMode) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
-    /**
-     * The cache storage mode that will be in effect during query execution.
-     *
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public CacheStoreMode getCacheStoreMode() {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
-    /**
-     * Set the cache storage mode that is in effect during query execution.
-     * This cache storage mode overrides the cache storage mode in use by the entity manager.
-     *
-     * @param cacheStoreMode cache storage mode
-     * @return the same query instance
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public StoredProcedureQueryImpl setCacheStoreMode(CacheStoreMode cacheStoreMode) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
-    /**
-     * The query timeout.
-     *
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public Integer getTimeout() {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
-    /**
-     * Set the query timeout.
-     *
-     * @param timeout the timeout, or {@code null} to indicate no timeout
-     * @return the same query instance
-     * @since 4.1
-     */
+    // TODO-API-3.2
     @Override
     public StoredProcedureQueryImpl setTimeout(Integer timeout) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metamodel/MetamodelImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metamodel/MetamodelImpl.java
@@ -185,15 +185,6 @@ public class MetamodelImpl implements Metamodel, Serializable {
         }
     }
 
-    /**
-     *  Return the metamodel entity type representing the entity.
-     *
-     *  @param entityName the name of the represented entity
-     *  @return the metamodel entity type
-     *  @throws IllegalArgumentException if not an entity
-     *  @see jakarta.persistence.Entity#name
-     *  @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public EntityType<?> entity(String entityName) {

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metamodel/MetamodelImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metamodel/MetamodelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -34,6 +34,8 @@
 //     03/06/2011-2.3 mobrien 338837 - Metamodel entity processing requires specified entities in persistence.xml
 //        to avoid IllegalArgumentException when accessing an EntityType|EmbeddableType|ManagedType
 //        "The type [null] is not the expected [EntityType] for the key class" will result in certain managed persistence contexts
+//     08/23/2023: Tomas Kraus
+//       - New Jakarta Persistence 3.2 Features
 package org.eclipse.persistence.internal.jpa.metamodel;
 
 import java.io.Serializable;
@@ -181,6 +183,21 @@ public class MetamodelImpl implements Metamodel, Serializable {
                         new Object[] { clazz, metamodelTypeName, aType}));
             }
         }
+    }
+
+    /**
+     *  Return the metamodel entity type representing the entity.
+     *
+     *  @param entityName the name of the represented entity
+     *  @return the metamodel entity type
+     *  @throws IllegalArgumentException if not an entity
+     *  @see jakarta.persistence.Entity#name
+     *  @since 4.1
+     */
+    // TODO-API-3.2
+    @Override
+    public EntityType<?> entity(String entityName) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
     /**

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/AbstractQueryImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/AbstractQueryImpl.java
@@ -147,6 +147,7 @@ public abstract class AbstractQueryImpl<T> extends CommonAbstractCriteriaImpl<T>
      *
      * @param restrictions zero or more restriction predicates
      * @return the modified query
+     * @since 4.1
      */
     // TODO-API-3.2: Prototype is missing in API
     //@Override

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/AbstractQueryImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/AbstractQueryImpl.java
@@ -139,18 +139,8 @@ public abstract class AbstractQueryImpl<T> extends CommonAbstractCriteriaImpl<T>
         return having(restrictions != null ? List.of(restrictions) : null);
     }
 
-    /**
-     * Specify restrictions over the groups of the query according the
-     * conjunction of the specified restriction predicates. Replaces the
-     * previously added restriction(s), if any. If no restrictions are
-     * specified, any previously added restrictions are simply removed.
-     *
-     * @param restrictions zero or more restriction predicates
-     * @return the modified query
-     * @since 4.1
-     */
-    // TODO-API-3.2: Prototype is missing in API
-    //@Override
+    // TODO-API-3.2
+    @Override
     public AbstractQuery<T> having(List<Predicate> restrictions) {
         Predicate predicate = queryBuilder.and(restrictions);
         findRootAndParameters(predicate);
@@ -315,18 +305,7 @@ public abstract class AbstractQueryImpl<T> extends CommonAbstractCriteriaImpl<T>
         return (AbstractQuery<T>) super.where(restrictions);
     }
 
-    /**
-     * Modify the query to restrict the query result according to the
-     * conjunction of the specified restriction predicates. Replaces the
-     * previously added restriction(s), if any. If no restrictions are
-     * specified, any previously added restrictions are simply removed. This
-     * method only overrides the return type of the corresponding AbstractQuery
-     * method.
-     *
-     * @param restrictions zero or more restriction predicates
-     * @return the modified query
-     * @throws NullPointerException when restrictions {@link List} is {@code null}
-     */
+    // TODO-API-3.2
     @Override
     @SuppressWarnings("unchecked")
     public AbstractQuery<T> where(List<Predicate> restrictions) {

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/BasicCollectionJoinImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/BasicCollectionJoinImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -57,47 +57,21 @@ public class BasicCollectionJoinImpl<Z, E> extends CollectionJoinImpl<Z, E> {
         super(parentPath, null, metamodel, javaClass, expressionNode, modelArtifact, joinType);
     }
 
-    /**
-     * Return the path corresponding to the referenced non-collection valued
-     * attribute.
-     *
-     * @param att
-     *            attribute
-     * @return path corresponding to the referenced attribute
-     */
     @Override
     public <Y> Path<Y> get(SingularAttribute<? super E, Y> att){
         throw new IllegalStateException(ExceptionLocalization.buildMessage("pathnode_is_primitive_node"));
     }
 
-    /**
-     * Return the path corresponding to the referenced collection-valued
-     * attribute.
-     *
-     * @param collection collection-valued attribute
-     * @return expression corresponding to the referenced attribute
-     */
     @Override
     public <Y, C extends java.util.Collection<Y>> Expression<C> get(PluralAttribute<? super E, C, Y> collection){
         throw new IllegalStateException(ExceptionLocalization.buildMessage("pathnode_is_primitive_node"));
     }
 
-    /**
-     * Return the path corresponding to the referenced map-valued attribute.
-     *
-     * @param map map-valued attribute
-     * @return expression corresponding to the referenced attribute
-     */
     @Override
     public <L, W, M extends java.util.Map<L, W>> Expression<M> get(MapAttribute<? super E, L, W> map){
         throw new IllegalStateException(ExceptionLocalization.buildMessage("pathnode_is_primitive_node"));
     }
 
-    /**
-     * Return an expression corresponding to the type of the path.
-     *
-     * @return expression corresponding to the type of the path
-     */
     @Override
     public Expression<Class<? extends E>> type(){
         throw new IllegalStateException(ExceptionLocalization.buildMessage("pathnode_is_primitive_type_does_not_apply"));

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/BasicCollectionJoinImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/BasicCollectionJoinImpl.java
@@ -74,24 +74,22 @@ public class BasicCollectionJoinImpl<Z, E> extends CollectionJoinImpl<Z, E> {
      * Return the path corresponding to the referenced collection-valued
      * attribute.
      *
-     * @param collection
-     *            collection-valued attribute
+     * @param collection collection-valued attribute
      * @return expression corresponding to the referenced attribute
      */
     @Override
-    public <Y, C extends java.util.Collection<Y>> Expression<C> get(PluralAttribute<E, C, Y> collection){
+    public <Y, C extends java.util.Collection<Y>> Expression<C> get(PluralAttribute<? super E, C, Y> collection){
         throw new IllegalStateException(ExceptionLocalization.buildMessage("pathnode_is_primitive_node"));
     }
 
     /**
      * Return the path corresponding to the referenced map-valued attribute.
      *
-     * @param map
-     *            map-valued attribute
+     * @param map map-valued attribute
      * @return expression corresponding to the referenced attribute
      */
     @Override
-    public <L, W, M extends java.util.Map<L, W>> Expression<M> get(MapAttribute<E, L, W> map){
+    public <L, W, M extends java.util.Map<L, W>> Expression<M> get(MapAttribute<? super E, L, W> map){
         throw new IllegalStateException(ExceptionLocalization.buildMessage("pathnode_is_primitive_node"));
     }
 

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/BasicListJoinImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/BasicListJoinImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -57,47 +57,21 @@ public class BasicListJoinImpl<Z, E> extends ListJoinImpl<Z, E> {
         super(parentPath, null, metamodel, javaClass, expressionNode, modelArtifact, joinType);
     }
 
-    /**
-     * Return the path corresponding to the referenced non-collection valued
-     * attribute.
-     *
-     * @param att
-     *            attribute
-     * @return path corresponding to the referenced attribute
-     */
     @Override
     public <Y> Path<Y> get(SingularAttribute<? super E, Y> att){
         throw new IllegalStateException(ExceptionLocalization.buildMessage("pathnode_is_primitive_node"));
     }
 
-    /**
-     * Return the path corresponding to the referenced collection-valued
-     * attribute.
-     *
-     * @param collection collection-valued attribute
-     * @return expression corresponding to the referenced attribute
-     */
     @Override
     public <Y, C extends java.util.Collection<Y>> Expression<C> get(PluralAttribute<? super E, C, Y> collection){
         throw new IllegalStateException(ExceptionLocalization.buildMessage("pathnode_is_primitive_node"));
     }
 
-    /**
-     * Return the path corresponding to the referenced map-valued attribute.
-     *
-     * @param map map-valued attribute
-     * @return expression corresponding to the referenced attribute
-     */
     @Override
     public <L, W, M extends java.util.Map<L, W>> Expression<M> get(MapAttribute<? super E, L, W> map){
         throw new IllegalStateException(ExceptionLocalization.buildMessage("pathnode_is_primitive_node"));
     }
 
-    /**
-     * Return an expression corresponding to the type of the path.
-     *
-     * @return expression corresponding to the type of the path
-     */
     @Override
     public Expression<Class<? extends E>> type(){
         throw new IllegalStateException(ExceptionLocalization.buildMessage("pathnode_is_primitive_type_does_not_apply"));

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/BasicListJoinImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/BasicListJoinImpl.java
@@ -74,24 +74,22 @@ public class BasicListJoinImpl<Z, E> extends ListJoinImpl<Z, E> {
      * Return the path corresponding to the referenced collection-valued
      * attribute.
      *
-     * @param collection
-     *            collection-valued attribute
+     * @param collection collection-valued attribute
      * @return expression corresponding to the referenced attribute
      */
     @Override
-    public <Y, C extends java.util.Collection<Y>> Expression<C> get(PluralAttribute<E, C, Y> collection){
+    public <Y, C extends java.util.Collection<Y>> Expression<C> get(PluralAttribute<? super E, C, Y> collection){
         throw new IllegalStateException(ExceptionLocalization.buildMessage("pathnode_is_primitive_node"));
     }
 
     /**
      * Return the path corresponding to the referenced map-valued attribute.
      *
-     * @param map
-     *            map-valued attribute
+     * @param map map-valued attribute
      * @return expression corresponding to the referenced attribute
      */
     @Override
-    public <L, W, M extends java.util.Map<L, W>> Expression<M> get(MapAttribute<E, L, W> map){
+    public <L, W, M extends java.util.Map<L, W>> Expression<M> get(MapAttribute<? super E, L, W> map){
         throw new IllegalStateException(ExceptionLocalization.buildMessage("pathnode_is_primitive_node"));
     }
 

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/BasicMapJoinImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/BasicMapJoinImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -56,47 +56,21 @@ public class BasicMapJoinImpl<Z, K, E> extends MapJoinImpl<Z, K, E> {
         super(parentPath, null, metamodel, javaClass, expressionNode, modelArtifact, joinType);
     }
 
-    /**
-     * Return the path corresponding to the referenced non-collection valued
-     * attribute.
-     *
-     * @param att
-     *            attribute
-     * @return path corresponding to the referenced attribute
-     */
     @Override
     public <Y> Path<Y> get(SingularAttribute<? super E, Y> att){
         throw new IllegalStateException(ExceptionLocalization.buildMessage("pathnode_is_primitive_node"));
     }
 
-    /**
-     * Return the path corresponding to the referenced collection-valued
-     * attribute.
-     *
-     * @param collection collection-valued attribute
-     * @return expression corresponding to the referenced attribute
-     */
     @Override
     public <Y, C extends java.util.Collection<Y>> Expression<C> get(PluralAttribute<? super E, C, Y> collection){
         throw new IllegalStateException(ExceptionLocalization.buildMessage("pathnode_is_primitive_node"));
     }
 
-    /**
-     * Return the path corresponding to the referenced map-valued attribute.
-     *
-     * @param map map-valued attribute
-     * @return expression corresponding to the referenced attribute
-     */
     @Override
     public <L, W, M extends java.util.Map<L, W>> Expression<M> get(MapAttribute<? super E, L, W> map){
         throw new IllegalStateException(ExceptionLocalization.buildMessage("pathnode_is_primitive_node"));
     }
 
-    /**
-     * Return an expression corresponding to the type of the path.
-     *
-     * @return expression corresponding to the type of the path
-     */
     @Override
     public Expression<Class<? extends E>> type(){
         throw new IllegalStateException(ExceptionLocalization.buildMessage("pathnode_is_primitive_type_does_not_apply"));

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/BasicMapJoinImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/BasicMapJoinImpl.java
@@ -73,24 +73,22 @@ public class BasicMapJoinImpl<Z, K, E> extends MapJoinImpl<Z, K, E> {
      * Return the path corresponding to the referenced collection-valued
      * attribute.
      *
-     * @param collection
-     *            collection-valued attribute
+     * @param collection collection-valued attribute
      * @return expression corresponding to the referenced attribute
      */
     @Override
-    public <Y, C extends java.util.Collection<Y>> Expression<C> get(PluralAttribute<E, C, Y> collection){
+    public <Y, C extends java.util.Collection<Y>> Expression<C> get(PluralAttribute<? super E, C, Y> collection){
         throw new IllegalStateException(ExceptionLocalization.buildMessage("pathnode_is_primitive_node"));
     }
 
     /**
      * Return the path corresponding to the referenced map-valued attribute.
      *
-     * @param map
-     *            map-valued attribute
+     * @param map map-valued attribute
      * @return expression corresponding to the referenced attribute
      */
     @Override
-    public <L, W, M extends java.util.Map<L, W>> Expression<M> get(MapAttribute<E, L, W> map){
+    public <L, W, M extends java.util.Map<L, W>> Expression<M> get(MapAttribute<? super E, L, W> map){
         throw new IllegalStateException(ExceptionLocalization.buildMessage("pathnode_is_primitive_node"));
     }
 

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/BasicSetJoinImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/BasicSetJoinImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -57,47 +57,21 @@ public class BasicSetJoinImpl<Z, E> extends SetJoinImpl<Z, E> {
         super(parentPath, null, metamodel, javaClass, expressionNode, modelArtifact, joinType);
     }
 
-    /**
-     * Return the path corresponding to the referenced non-collection valued
-     * attribute.
-     *
-     * @param att
-     *            attribute
-     * @return path corresponding to the referenced attribute
-     */
     @Override
     public <Y> Path<Y> get(SingularAttribute<? super E, Y> att){
         throw new IllegalStateException(ExceptionLocalization.buildMessage("pathnode_is_primitive_node"));
     }
 
-    /**
-     * Return the path corresponding to the referenced collection-valued
-     * attribute.
-     *
-     * @param collection collection-valued attribute
-     * @return expression corresponding to the referenced attribute
-     */
     @Override
     public <Y, C extends java.util.Collection<Y>> Expression<C> get(PluralAttribute<? super E, C, Y> collection){
         throw new IllegalStateException(ExceptionLocalization.buildMessage("pathnode_is_primitive_node"));
     }
 
-    /**
-     * Return the path corresponding to the referenced map-valued attribute.
-     *
-     * @param map map-valued attribute
-     * @return expression corresponding to the referenced attribute
-     */
     @Override
     public <L, W, M extends java.util.Map<L, W>> Expression<M> get(MapAttribute<? super E, L, W> map){
         throw new IllegalStateException(ExceptionLocalization.buildMessage("pathnode_is_primitive_node"));
     }
 
-    /**
-     * Return an expression corresponding to the type of the path.
-     *
-     * @return expression corresponding to the type of the path
-     */
     @Override
     public Expression<Class<? extends E>> type(){
         throw new IllegalStateException(ExceptionLocalization.buildMessage("pathnode_is_primitive_type_does_not_apply"));

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/BasicSetJoinImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/BasicSetJoinImpl.java
@@ -74,24 +74,22 @@ public class BasicSetJoinImpl<Z, E> extends SetJoinImpl<Z, E> {
      * Return the path corresponding to the referenced collection-valued
      * attribute.
      *
-     * @param collection
-     *            collection-valued attribute
+     * @param collection collection-valued attribute
      * @return expression corresponding to the referenced attribute
      */
     @Override
-    public <Y, C extends java.util.Collection<Y>> Expression<C> get(PluralAttribute<E, C, Y> collection){
+    public <Y, C extends java.util.Collection<Y>> Expression<C> get(PluralAttribute<? super E, C, Y> collection){
         throw new IllegalStateException(ExceptionLocalization.buildMessage("pathnode_is_primitive_node"));
     }
 
     /**
      * Return the path corresponding to the referenced map-valued attribute.
      *
-     * @param map
-     *            map-valued attribute
+     * @param map map-valued attribute
      * @return expression corresponding to the referenced attribute
      */
     @Override
-    public <L, W, M extends java.util.Map<L, W>> Expression<M> get(MapAttribute<E, L, W> map){
+    public <L, W, M extends java.util.Map<L, W>> Expression<M> get(MapAttribute<? super E, L, W> map){
         throw new IllegalStateException(ExceptionLocalization.buildMessage("pathnode_is_primitive_node"));
     }
 

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/CommonAbstractCriteriaImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/CommonAbstractCriteriaImpl.java
@@ -209,6 +209,7 @@ public abstract class CommonAbstractCriteriaImpl<T> implements CommonAbstractCri
      *
      * @return the query parameters
      */
+    @Override
     public Set<ParameterExpression<?>> getParameters() {
         if (this.parameters == null) {
             this.parameters = new HashSet<ParameterExpression<?>>();

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/CommonAbstractCriteriaImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/CommonAbstractCriteriaImpl.java
@@ -159,6 +159,7 @@ public abstract class CommonAbstractCriteriaImpl<T> implements CommonAbstractCri
      *
      * @param restrictions zero or more restriction predicates
      * @return the modified query
+     * @since 4.1
      */
     public CommonAbstractCriteria where(List<Predicate> restrictions) {
         Predicate predicate = queryBuilder.and(restrictions);

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/CommonAbstractCriteriaImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/CommonAbstractCriteriaImpl.java
@@ -179,6 +179,12 @@ public abstract class CommonAbstractCriteriaImpl<T> implements CommonAbstractCri
         return new SubQueryImpl<U>(metamodel, type, queryBuilder, this);
     }
 
+    // TODO-API-3.2
+    @Override
+    public <U> Subquery<U> subquery(EntityType<U> type) {
+        return subquery(type.getJavaType());
+    }
+
     /**
      *  Used to use a root from a different query.
      */

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/CriteriaBuilderImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/CriteriaBuilderImpl.java
@@ -24,6 +24,7 @@ package org.eclipse.persistence.internal.jpa.querydef;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.temporal.Temporal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -50,6 +51,7 @@ import jakarta.persistence.criteria.Root;
 import jakarta.persistence.criteria.Selection;
 import jakarta.persistence.criteria.SetJoin;
 import jakarta.persistence.criteria.Subquery;
+import jakarta.persistence.criteria.TemporalField;
 import jakarta.persistence.metamodel.EntityType;
 import jakarta.persistence.metamodel.Metamodel;
 import jakarta.persistence.metamodel.Type.PersistenceType;
@@ -181,14 +183,6 @@ public class CriteriaBuilderImpl implements JpaCriteriaBuilder, Serializable {
         return new OrderImpl(x);
     }
 
-    /**
-     * Create an ordering by the ascending value of the expression.
-     *
-     * @param expression  expression used to define the ordering
-     * @param nullPrecedence  the precedence of null values
-     * @return ascending ordering corresponding to the expression
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public Order asc(Expression<?> expression, Nulls nullPrecedence) {
@@ -211,15 +205,6 @@ public class CriteriaBuilderImpl implements JpaCriteriaBuilder, Serializable {
         return order;
     }
 
-
-    /**
-     * Create an ordering by the descending value of the expression.
-     *
-     * @param expression  expression used to define the ordering
-     * @param nullPrecedence  the precedence of null values
-     * @return descending ordering corresponding to the expression
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public Order desc(Expression<?> expression, Nulls nullPrecedence) {
@@ -488,14 +473,6 @@ public class CriteriaBuilderImpl implements JpaCriteriaBuilder, Serializable {
         return and(restrictions != null ?  List.of(restrictions) : null);
     }
 
-    /**
-     * Create a conjunction of the given restriction predicates.
-     * A conjunction of {@code null} or zero predicates is {@code true}.
-     *
-     * @param restrictions a list of zero or more restriction predicates
-     * @return and predicate
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public Predicate and(List<Predicate> restrictions) {
@@ -528,14 +505,6 @@ public class CriteriaBuilderImpl implements JpaCriteriaBuilder, Serializable {
         return or(restrictions != null ?  List.of(restrictions) : null);
     }
 
-    /**
-     * Create a disjunction of the given restriction predicates.
-     * A disjunction of {@code null} or zero predicates is {@code false}.
-     *
-     * @param restrictions a list of zero or more restriction predicates
-     * @return or predicate
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public Predicate or(List<Predicate> restrictions) {
@@ -1933,14 +1902,6 @@ public class CriteriaBuilderImpl implements JpaCriteriaBuilder, Serializable {
         return this.notLike(x, this.internalLiteral(pattern), this.internalLiteral(escapeChar));
     }
 
-    /**
-     * Create an expression for {@link String} concatenation.
-     * If the given list of expressions is {@code null} or empty, returns an expression equivalent to {@code literal("")}.
-     *
-     * @param expressions {@link String} expressions
-     * @return expression corresponding to concatenation
-     * @sincde 4.1
-     */
     // TODO-API-3.2
     @Override
     public Expression<String> concat(List<Expression<String>> expressions) {
@@ -2212,116 +2173,48 @@ public class CriteriaBuilderImpl implements JpaCriteriaBuilder, Serializable {
         return new FunctionExpressionImpl(metamodel, ClassConstants.INTEGER, ((InternalSelection)x).getCurrentNode().length(), buildList(x), "length");
     }
 
-    /**
-     * Create an expression for the leftmost substring of a string.
-     *
-     * @param expression string expression
-     * @param len length of the substring to return
-     * @return expression for the leftmost substring
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public Expression<String> left(Expression<String> expression, int len) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
-    /**
-     * Create an expression for the rightmost substring of a string.
-     *
-     * @param expression string expression
-     * @param len length of the substring to return
-     * @return expression for the rightmost substring
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public Expression<String> right(Expression<String> expression, int len) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
-    /**
-     * Create an expression for the leftmost substring of a string.
-     *
-     * @param expression  string expression
-     * @param len  length of the substring to return
-     * @return expression for the leftmost substring
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public Expression<String> left(Expression<String> expression, Expression<Integer> len) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
-    /**
-     * Create an expression for the rightmost substring of a string
-     *
-     * @param expression  string expression
-     * @param len  length of the substring to return
-     * @return expression for the rightmost substring
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public Expression<String> right(Expression<String> expression, Expression<Integer> len) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
-    /**
-     * Create an expression replacing every occurrence of a substring within a string.
-     *
-     * @param expression  string expression
-     * @param substring  the literal substring to replace
-     * @param replacement  the replacement string
-     * @return expression for the resulting string
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public Expression<String> replace(Expression<String> expression, Expression<String> substring, Expression<String> replacement) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
-    /**
-     * Create an expression replacing every occurrence of a substring within a string.
-     *
-     * @param expression  string expression
-     * @param substring  the literal substring to replace
-     * @param replacement  the replacement string
-     * @return expression for the resulting string
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public Expression<String> replace(Expression<String> expression, String substring, Expression<String> replacement) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
-    /**
-     * Create an expression replacing every occurrence of a substring within a string.
-     *
-     * @param expression  string expression
-     * @param substring  the literal substring to replace
-     * @param replacement  the replacement string
-     * @return expression for the resulting string
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public Expression<String> replace(Expression<String> expression, Expression<String> substring, String replacement) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
-    /**
-     * Create an expression replacing every occurrence of a substring within a string.
-     *
-     * @param expression  string expression
-     * @param substring  the literal substring to replace
-     * @param replacement  the replacement string
-     * @return expression for the resulting string
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public Expression<String> replace(Expression<String> expression, String substring, String replacement) {
@@ -2459,6 +2352,12 @@ public class CriteriaBuilderImpl implements JpaCriteriaBuilder, Serializable {
     @Override
     public Expression<java.time.LocalTime> localTime() {
         return new ExpressionImpl(metamodel, ClassConstants.LOCAL_TIME, new ExpressionBuilder().localTime());
+    }
+
+    // TODO-API-3.2
+    @Override
+    public <N, T extends Temporal> Expression<N> extract(TemporalField<N, T> field, Expression<T> temporal) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
     /**
@@ -3077,93 +2976,36 @@ public class CriteriaBuilderImpl implements JpaCriteriaBuilder, Serializable {
         return new RootImpl<T>(entity, this.metamodel, type, parentRoot.currentNode.treat(type), entity);
     }
 
-    /**
-     * Create a query which is the union of the given queries.
-     *
-     * @param first first query
-     * @param second second query
-     * @param <T> the type of the {@link CriteriaQuery} result
-     * @return a new criteria query which returns the union of the results of the given queries
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public <T> CriteriaQuery<T> union(CriteriaQuery<? extends T> first, CriteriaQuery<? extends T> second) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
-    /**
-     * Create a query which is the union of the given queries, without elimination of duplicate results.
-     * @return a new criteria query which returns the union of the results of the given queries
-     *
-     * @param first first query
-     * @param second second query
-     * @param <T> the type of the {@link CriteriaQuery} result
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public <T> CriteriaQuery<T> unionAll(CriteriaQuery<? extends T> first, CriteriaQuery<? extends T> second) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
-    /**
-     * Create a query which is the intersection of the given queries.
-     *
-     * @param first first query
-     * @param second second query
-     * @param <T> the type of the {@link CriteriaQuery} result
-     * @return a new criteria query which returns the intersection of the results of the given queries
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public <T> CriteriaQuery<T> intersect(CriteriaQuery<? super T> first, CriteriaQuery<? super T> second) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
-    /**
-     * Create a query which is the intersection of the given queries, without elimination of duplicate results.
-     *
-     * @param first first query
-     * @param second second query
-     * @param <T> the type of the {@link CriteriaQuery} result
-     * @return a new criteria query which returns the intersection of the results of the given queries
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public <T> CriteriaQuery<T> intersectAll(CriteriaQuery<? super T> first, CriteriaQuery<? super T> second) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
-    /**
-     * Create a query by (setwise) subtraction of the second query from the first query.
-     *
-     * @param first first query
-     * @param second second query
-     * @param <T> the type of the {@link CriteriaQuery} result
-     * @return a new criteria query which returns the result of subtracting the results of the second query
-     *         from the results of the first query
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public <T> CriteriaQuery<T> except(CriteriaQuery<T> first, CriteriaQuery<?> second) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
-    /**
-     * Create a query by (setwise) subtraction of the second query from the first query, without elimination
-     * of duplicate results.
-     *
-     * @param first first query
-     * @param second second query
-     * @param <T> the type of the {@link CriteriaQuery} result
-     * @return a new criteria query which returns the result of subtracting the results of the second query
-     *         from the results of the first query
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public <T> CriteriaQuery<T> exceptAll(CriteriaQuery<T> first, CriteriaQuery<?> second) {

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/CriteriaBuilderImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/CriteriaBuilderImpl.java
@@ -181,9 +181,17 @@ public class CriteriaBuilderImpl implements JpaCriteriaBuilder, Serializable {
         return new OrderImpl(x);
     }
 
+    /**
+     * Create an ordering by the ascending value of the expression.
+     *
+     * @param expression  expression used to define the ordering
+     * @param nullPrecedence  the precedence of null values
+     * @return ascending ordering corresponding to the expression
+     * @since 4.1
+     */
     // TODO-API-3.2
-    //@Override
-    public Order asc(Expression<?> expression, Nulls nulls) {
+    @Override
+    public Order asc(Expression<?> expression, Nulls nullPrecedence) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
@@ -204,9 +212,17 @@ public class CriteriaBuilderImpl implements JpaCriteriaBuilder, Serializable {
     }
 
 
+    /**
+     * Create an ordering by the descending value of the expression.
+     *
+     * @param expression  expression used to define the ordering
+     * @param nullPrecedence  the precedence of null values
+     * @return descending ordering corresponding to the expression
+     * @since 4.1
+     */
     // TODO-API-3.2
-    //@Override
-    public Order desc(Expression<?> expression, Nulls nulls) {
+    @Override
+    public Order desc(Expression<?> expression, Nulls nullPrecedence) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
@@ -478,9 +494,10 @@ public class CriteriaBuilderImpl implements JpaCriteriaBuilder, Serializable {
      *
      * @param restrictions a list of zero or more restriction predicates
      * @return and predicate
+     * @since 4.1
      */
     // TODO-API-3.2
-    //@Override
+    @Override
     public Predicate and(List<Predicate> restrictions) {
         // PERF: Build simple cases directly
         switch (restrictions != null ? restrictions.size() : 0) {
@@ -517,9 +534,10 @@ public class CriteriaBuilderImpl implements JpaCriteriaBuilder, Serializable {
      *
      * @param restrictions a list of zero or more restriction predicates
      * @return or predicate
+     * @since 4.1
      */
     // TODO-API-3.2
-    //@Override
+    @Override
     public Predicate or(List<Predicate> restrictions) {
         // PERF: Build simple cases directly
         switch (restrictions != null ? restrictions.size() : 0) {
@@ -1916,14 +1934,15 @@ public class CriteriaBuilderImpl implements JpaCriteriaBuilder, Serializable {
     }
 
     /**
-     *  Create an expression for {@link String} concatenation.
-     *  If the given list of expressions is {@code null} or empty, returns an expression equivalent to {@code literal("")}.
+     * Create an expression for {@link String} concatenation.
+     * If the given list of expressions is {@code null} or empty, returns an expression equivalent to {@code literal("")}.
      *
-     *  @param expressions {@link String} expressions
-     *  @return expression corresponding to concatenation
+     * @param expressions {@link String} expressions
+     * @return expression corresponding to concatenation
+     * @sincde 4.1
      */
     // TODO-API-3.2
-    //@Override
+    @Override
     public Expression<String> concat(List<Expression<String>> expressions) {
         switch(expressions != null ? expressions.size() : 0) {
             case 0:
@@ -2193,53 +2212,119 @@ public class CriteriaBuilderImpl implements JpaCriteriaBuilder, Serializable {
         return new FunctionExpressionImpl(metamodel, ClassConstants.INTEGER, ((InternalSelection)x).getCurrentNode().length(), buildList(x), "length");
     }
 
+    /**
+     * Create an expression for the leftmost substring of a string.
+     *
+     * @param expression string expression
+     * @param len length of the substring to return
+     * @return expression for the leftmost substring
+     * @since 4.1
+     */
     // TODO-API-3.2
-    //@Override
-    public Expression<String> left(Expression<String> expression, int i) {
+    @Override
+    public Expression<String> left(Expression<String> expression, int len) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
+    /**
+     * Create an expression for the rightmost substring of a string.
+     *
+     * @param expression string expression
+     * @param len length of the substring to return
+     * @return expression for the rightmost substring
+     * @since 4.1
+     */
     // TODO-API-3.2
-    //@Override
-    public Expression<String> right(Expression<String> expression, int i) {
+    @Override
+    public Expression<String> right(Expression<String> expression, int len) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
+    /**
+     * Create an expression for the leftmost substring of a string.
+     *
+     * @param expression  string expression
+     * @param len  length of the substring to return
+     * @return expression for the leftmost substring
+     * @since 4.1
+     */
     // TODO-API-3.2
-    //@Override
-    public Expression<String> left(Expression<String> expression, Expression<Integer> expression1) {
+    @Override
+    public Expression<String> left(Expression<String> expression, Expression<Integer> len) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
+    /**
+     * Create an expression for the rightmost substring of a string
+     *
+     * @param expression  string expression
+     * @param len  length of the substring to return
+     * @return expression for the rightmost substring
+     * @since 4.1
+     */
     // TODO-API-3.2
-    //@Override
-    public Expression<String> right(Expression<String> expression, Expression<Integer> expression1) {
+    @Override
+    public Expression<String> right(Expression<String> expression, Expression<Integer> len) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
+    /**
+     * Create an expression replacing every occurrence of a substring within a string.
+     *
+     * @param expression  string expression
+     * @param substring  the literal substring to replace
+     * @param replacement  the replacement string
+     * @return expression for the resulting string
+     * @since 4.1
+     */
     // TODO-API-3.2
-    //@Override
-    public Expression<String> replace(Expression<String> expression,
-                                      Expression<String> expression1,
-                                      Expression<String> expression2) {
+    @Override
+    public Expression<String> replace(Expression<String> expression, Expression<String> substring, Expression<String> replacement) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
+    /**
+     * Create an expression replacing every occurrence of a substring within a string.
+     *
+     * @param expression  string expression
+     * @param substring  the literal substring to replace
+     * @param replacement  the replacement string
+     * @return expression for the resulting string
+     * @since 4.1
+     */
     // TODO-API-3.2
-    //@Override
-    public Expression<String> replace(Expression<String> expression, String s, Expression<String> expression1) {
+    @Override
+    public Expression<String> replace(Expression<String> expression, String substring, Expression<String> replacement) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
+    /**
+     * Create an expression replacing every occurrence of a substring within a string.
+     *
+     * @param expression  string expression
+     * @param substring  the literal substring to replace
+     * @param replacement  the replacement string
+     * @return expression for the resulting string
+     * @since 4.1
+     */
     // TODO-API-3.2
-    //@Override
-    public Expression<String> replace(Expression<String> expression, Expression<String> expression1, String s) {
+    @Override
+    public Expression<String> replace(Expression<String> expression, Expression<String> substring, String replacement) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
+    /**
+     * Create an expression replacing every occurrence of a substring within a string.
+     *
+     * @param expression  string expression
+     * @param substring  the literal substring to replace
+     * @param replacement  the replacement string
+     * @return expression for the resulting string
+     * @since 4.1
+     */
     // TODO-API-3.2
-    //@Override
-    public Expression<String> replace(Expression<String> expression, String s, String s1) {
+    @Override
+    public Expression<String> replace(Expression<String> expression, String substring, String replacement) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
@@ -2991,5 +3076,99 @@ public class CriteriaBuilderImpl implements JpaCriteriaBuilder, Serializable {
         EntityType<T> entity = this.metamodel.entity(type);
         return new RootImpl<T>(entity, this.metamodel, type, parentRoot.currentNode.treat(type), entity);
     }
+
+    /**
+     * Create a query which is the union of the given queries.
+     *
+     * @param first first query
+     * @param second second query
+     * @param <T> the type of the {@link CriteriaQuery} result
+     * @return a new criteria query which returns the union of the results of the given queries
+     * @since 4.1
+     */
+    // TODO-API-3.2
+    @Override
+    public <T> CriteriaQuery<T> union(CriteriaQuery<? extends T> first, CriteriaQuery<? extends T> second) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    /**
+     * Create a query which is the union of the given queries, without elimination of duplicate results.
+     * @return a new criteria query which returns the union of the results of the given queries
+     *
+     * @param first first query
+     * @param second second query
+     * @param <T> the type of the {@link CriteriaQuery} result
+     * @since 4.1
+     */
+    // TODO-API-3.2
+    @Override
+    public <T> CriteriaQuery<T> unionAll(CriteriaQuery<? extends T> first, CriteriaQuery<? extends T> second) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    /**
+     * Create a query which is the intersection of the given queries.
+     *
+     * @param first first query
+     * @param second second query
+     * @param <T> the type of the {@link CriteriaQuery} result
+     * @return a new criteria query which returns the intersection of the results of the given queries
+     * @since 4.1
+     */
+    // TODO-API-3.2
+    @Override
+    public <T> CriteriaQuery<T> intersect(CriteriaQuery<? super T> first, CriteriaQuery<? super T> second) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    /**
+     * Create a query which is the intersection of the given queries, without elimination of duplicate results.
+     *
+     * @param first first query
+     * @param second second query
+     * @param <T> the type of the {@link CriteriaQuery} result
+     * @return a new criteria query which returns the intersection of the results of the given queries
+     * @since 4.1
+     */
+    // TODO-API-3.2
+    @Override
+    public <T> CriteriaQuery<T> intersectAll(CriteriaQuery<? super T> first, CriteriaQuery<? super T> second) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    /**
+     * Create a query by (setwise) subtraction of the second query from the first query.
+     *
+     * @param first first query
+     * @param second second query
+     * @param <T> the type of the {@link CriteriaQuery} result
+     * @return a new criteria query which returns the result of subtracting the results of the second query
+     *         from the results of the first query
+     * @since 4.1
+     */
+    // TODO-API-3.2
+    @Override
+    public <T> CriteriaQuery<T> except(CriteriaQuery<T> first, CriteriaQuery<?> second) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    /**
+     * Create a query by (setwise) subtraction of the second query from the first query, without elimination
+     * of duplicate results.
+     *
+     * @param first first query
+     * @param second second query
+     * @param <T> the type of the {@link CriteriaQuery} result
+     * @return a new criteria query which returns the result of subtracting the results of the second query
+     *         from the results of the first query
+     * @since 4.1
+     */
+    // TODO-API-3.2
+    @Override
+    public <T> CriteriaQuery<T> exceptAll(CriteriaQuery<T> first, CriteriaQuery<?> second) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
 }
 

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/CriteriaBuilderImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/CriteriaBuilderImpl.java
@@ -38,6 +38,7 @@ import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.ListJoin;
 import jakarta.persistence.criteria.MapJoin;
+import jakarta.persistence.criteria.Nulls;
 import jakarta.persistence.criteria.Order;
 import jakarta.persistence.criteria.ParameterExpression;
 import jakarta.persistence.criteria.Path;
@@ -178,6 +179,12 @@ public class CriteriaBuilderImpl implements JpaCriteriaBuilder, Serializable {
         return new OrderImpl(x);
     }
 
+    // TODO-API-3.2
+    //@Override
+    public Order asc(Expression<?> expression, Nulls nulls) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
     /**
      * Create an ordering by the descending value of the expression.
      *
@@ -192,6 +199,13 @@ public class CriteriaBuilderImpl implements JpaCriteriaBuilder, Serializable {
         }
         OrderImpl order = new OrderImpl(x, false);
         return order;
+    }
+
+
+    // TODO-API-3.2
+    //@Override
+    public Order desc(Expression<?> expression, Nulls nulls) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
     // aggregate functions:
@@ -465,6 +479,12 @@ public class CriteriaBuilderImpl implements JpaCriteriaBuilder, Serializable {
         return a;
     }
 
+    // TODO-API-3.2
+    //@Override
+    public Predicate and(List<Predicate> list) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
     /**
      * Create a disjunction of the given restriction predicates. A disjunction
      * of zero predicates is false.
@@ -484,6 +504,12 @@ public class CriteriaBuilderImpl implements JpaCriteriaBuilder, Serializable {
             a = this.or(a, restrictions[i]);
         }
         return a;
+    }
+
+    // TODO-API-3.2
+    //@Override
+    public Predicate or(List<Predicate> list) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
     /**
@@ -1863,6 +1889,12 @@ public class CriteriaBuilderImpl implements JpaCriteriaBuilder, Serializable {
         return this.notLike(x, this.internalLiteral(pattern), this.internalLiteral(escapeChar));
     }
 
+    // TODO-API-3.2
+    //@Override
+    public Expression<String> concat(List<Expression<String>> list) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
     /**
      * String concatenation operation.
      *
@@ -2113,6 +2145,56 @@ public class CriteriaBuilderImpl implements JpaCriteriaBuilder, Serializable {
     @Override
     public Expression<Integer> length(Expression<String> x){
         return new FunctionExpressionImpl(metamodel, ClassConstants.INTEGER, ((InternalSelection)x).getCurrentNode().length(), buildList(x), "length");
+    }
+
+    // TODO-API-3.2
+    //@Override
+    public Expression<String> left(Expression<String> expression, int i) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    // TODO-API-3.2
+    //@Override
+    public Expression<String> right(Expression<String> expression, int i) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    // TODO-API-3.2
+    //@Override
+    public Expression<String> left(Expression<String> expression, Expression<Integer> expression1) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    // TODO-API-3.2
+    //@Override
+    public Expression<String> right(Expression<String> expression, Expression<Integer> expression1) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    // TODO-API-3.2
+    //@Override
+    public Expression<String> replace(Expression<String> expression,
+                                      Expression<String> expression1,
+                                      Expression<String> expression2) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    // TODO-API-3.2
+    //@Override
+    public Expression<String> replace(Expression<String> expression, String s, Expression<String> expression1) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    // TODO-API-3.2
+    //@Override
+    public Expression<String> replace(Expression<String> expression, Expression<String> expression1, String s) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    // TODO-API-3.2
+    //@Override
+    public Expression<String> replace(Expression<String> expression, String s, String s1) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
     /**

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/CriteriaQueryImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/CriteriaQueryImpl.java
@@ -254,9 +254,9 @@ public class CriteriaQueryImpl<T> extends AbstractQueryImpl<T> implements Criter
      * This method only overrides the return type of the corresponding
      * AbstractQuery method.
      *
-     * @param restriction
-     *            a simple or compound boolean expression
+     * @param restriction a simple or compound boolean expression
      * @return the modified query
+     * @throws NullPointerException when restriction expression is {@code null}
      */
     @Override
     public CriteriaQuery<T> where(Expression<Boolean> restriction) {
@@ -271,19 +271,31 @@ public class CriteriaQueryImpl<T> extends AbstractQueryImpl<T> implements Criter
      * method only overrides the return type of the corresponding AbstractQuery
      * method.
      *
-     * @param restrictions
-     *            zero or more restriction predicates
+     * @param restrictions zero or more restriction predicates
      * @return the modified query
+     * @throws NullPointerException when restrictions array is {@code null}
      */
     @Override
     public CriteriaQuery<T> where(Predicate... restrictions) {
         return (CriteriaQuery<T>) super.where(restrictions);
     }
 
+    /**
+     * Modify the query to restrict the query result according to the
+     * conjunction of the specified restriction predicates. Replaces the
+     * previously added restriction(s), if any. If no restrictions are
+     * specified, any previously added restrictions are simply removed. This
+     * method only overrides the return type of the corresponding AbstractQuery
+     * method.
+     *
+     * @param restrictions zero or more restriction predicates
+     * @return the modified query
+     * @throws NullPointerException when restrictions {@link List} is {@code null}
+     */
     // TODO-API-3.2
     //@Override
-    public CriteriaQuery<T> where(List<Predicate> list) {
-        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    public CriteriaQuery<T> where(List<Predicate> restrictions) {
+        return (CriteriaQuery<T>) super.where(restrictions);
     }
 
     /**
@@ -325,9 +337,9 @@ public class CriteriaQueryImpl<T> extends AbstractQueryImpl<T> implements Criter
      * having restriction(s), if any. This method only overrides the return type
      * of the corresponding AbstractQuery method.
      *
-     * @param restriction
-     *            a simple or compound boolean expression
+     * @param restriction a simple or compound boolean expression
      * @return the modified query
+     * @throws NullPointerException when restriction expression is {@code null}
      */
     @Override
     public CriteriaQuery<T> having(Expression<Boolean> restriction) {
@@ -343,8 +355,7 @@ public class CriteriaQueryImpl<T> extends AbstractQueryImpl<T> implements Criter
      * method only overrides the return type of the corresponding AbstractQuery
      * method.
      *
-     * @param restrictions
-     *            zero or more restriction predicates
+     * @param restrictions zero or more restriction predicates
      * @return the modified query
      */
     @Override
@@ -353,10 +364,22 @@ public class CriteriaQueryImpl<T> extends AbstractQueryImpl<T> implements Criter
         return this;
     }
 
+    /**
+     * Specify restrictions over the groups of the query according the
+     * conjunction of the specified restriction predicates. Replaces the
+     * previously added restriction(s), if any. If no restrictions are
+     * specified, any previously added restrictions are simply removed. This
+     * method only overrides the return type of the corresponding AbstractQuery
+     * method.
+     *
+     * @param restrictions zero or more restriction predicates
+     * @return the modified query
+     */
     // TODO-API-3.2
     //@Override
-    public CriteriaQuery<T> having(List<Predicate> list) {
-        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    public CriteriaQuery<T> having(List<Predicate> restrictions) {
+        super.having(restrictions);
+        return this;
     }
 
     /**

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/CriteriaQueryImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/CriteriaQueryImpl.java
@@ -280,6 +280,12 @@ public class CriteriaQueryImpl<T> extends AbstractQueryImpl<T> implements Criter
         return (CriteriaQuery<T>) super.where(restrictions);
     }
 
+    // TODO-API-3.2
+    //@Override
+    public CriteriaQuery<T> where(List<Predicate> list) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
     /**
      * Specify the expressions that are used to form groups over the query
      * results. Replaces the previous specified grouping expressions, if any. If
@@ -345,6 +351,12 @@ public class CriteriaQueryImpl<T> extends AbstractQueryImpl<T> implements Criter
     public CriteriaQuery<T> having(Predicate... restrictions) {
         super.having(restrictions);
         return this;
+    }
+
+    // TODO-API-3.2
+    //@Override
+    public CriteriaQuery<T> having(List<Predicate> list) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
     /**

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/CriteriaQueryImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/CriteriaQueryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, 2022 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -68,15 +68,6 @@ public class CriteriaQueryImpl<T> extends AbstractQueryImpl<T> implements Criter
         super(metamodel, queryResult, queryBuilder, result);
     }
 
-    /**
-     * Specify the item that is to be returned in the query result. Replaces the
-     * previously specified selection, if any.
-     *
-     * @param selection
-     *            selection specifying the item that is to be returned in the
-     *            query result
-     * @return the modified query
-     */
     @Override
     public CriteriaQuery<T> select(Selection<? extends T> selection) {
         this.selection = (SelectionImpl<? extends T>) selection;
@@ -248,52 +239,18 @@ public class CriteriaQueryImpl<T> extends AbstractQueryImpl<T> implements Criter
     }
 
     // override the return type only:
-    /**
-     * Modify the query to restrict the query result according to the specified
-     * boolean expression. Replaces the previously added restriction(s), if any.
-     * This method only overrides the return type of the corresponding
-     * AbstractQuery method.
-     *
-     * @param restriction a simple or compound boolean expression
-     * @return the modified query
-     * @throws NullPointerException when restriction expression is {@code null}
-     */
     @Override
     public CriteriaQuery<T> where(Expression<Boolean> restriction) {
         return (CriteriaQuery<T>) super.where(restriction);
     }
 
-    /**
-     * Modify the query to restrict the query result according to the
-     * conjunction of the specified restriction predicates. Replaces the
-     * previously added restriction(s), if any. If no restrictions are
-     * specified, any previously added restrictions are simply removed. This
-     * method only overrides the return type of the corresponding AbstractQuery
-     * method.
-     *
-     * @param restrictions zero or more restriction predicates
-     * @return the modified query
-     * @throws NullPointerException when restrictions array is {@code null}
-     */
     @Override
     public CriteriaQuery<T> where(Predicate... restrictions) {
         return (CriteriaQuery<T>) super.where(restrictions);
     }
 
-    /**
-     * Modify the query to restrict the query result according to the
-     * conjunction of the specified restriction predicates. Replaces the
-     * previously added restriction(s), if any. If no restrictions are
-     * specified, any previously added restrictions are simply removed. This
-     * method only overrides the return type of the corresponding AbstractQuery
-     * method.
-     *
-     * @param restrictions zero or more restriction predicates
-     * @return the modified query
-     * @throws NullPointerException when restrictions {@link List} is {@code null}
-     */
     // TODO-API-3.2
-    //@Override
+    @Override
     public CriteriaQuery<T> where(List<Predicate> restrictions) {
         return (CriteriaQuery<T>) super.where(restrictions);
     }
@@ -332,51 +289,20 @@ public class CriteriaQueryImpl<T> extends AbstractQueryImpl<T> implements Criter
         return this;
     }
 
-    /**
-     * Specify a restriction over the groups of the query. Replaces the previous
-     * having restriction(s), if any. This method only overrides the return type
-     * of the corresponding AbstractQuery method.
-     *
-     * @param restriction a simple or compound boolean expression
-     * @return the modified query
-     * @throws NullPointerException when restriction expression is {@code null}
-     */
     @Override
     public CriteriaQuery<T> having(Expression<Boolean> restriction) {
         super.having(restriction);
         return this;
     }
 
-    /**
-     * Specify restrictions over the groups of the query according the
-     * conjunction of the specified restriction predicates. Replaces the
-     * previously added restriction(s), if any. If no restrictions are
-     * specified, any previously added restrictions are simply removed. This
-     * method only overrides the return type of the corresponding AbstractQuery
-     * method.
-     *
-     * @param restrictions zero or more restriction predicates
-     * @return the modified query
-     */
     @Override
     public CriteriaQuery<T> having(Predicate... restrictions) {
         super.having(restrictions);
         return this;
     }
 
-    /**
-     * Specify restrictions over the groups of the query according the
-     * conjunction of the specified restriction predicates. Replaces the
-     * previously added restriction(s), if any. If no restrictions are
-     * specified, any previously added restrictions are simply removed. This
-     * method only overrides the return type of the corresponding AbstractQuery
-     * method.
-     *
-     * @param restrictions zero or more restriction predicates
-     * @return the modified query
-     */
     // TODO-API-3.2
-    //@Override
+    @Override
     public CriteriaQuery<T> having(List<Predicate> restrictions) {
         super.having(restrictions);
         return this;
@@ -447,6 +373,7 @@ public class CriteriaQueryImpl<T> extends AbstractQueryImpl<T> implements Criter
         }
         Constructor constructor = null;
         try {
+            // TODO: Remove AccessController.doPrivileged
             if (PrivilegedAccessHelper.shouldUsePrivilegedAccess()) {
                 constructor = AccessController.doPrivileged(new PrivilegedGetConstructorFor<>(class1, constructorArgs, false));
             } else {

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/ExpressionImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/ExpressionImpl.java
@@ -72,8 +72,39 @@ public class ExpressionImpl<X> extends SelectionImpl<X> implements Expression<X>
         return (Expression<T>) this;
     }
 
+    // TODO-API-3.2
+    //@Override
+    public <X1> Expression<X1> cast(Class<X1> type) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
     protected <T> Expression<T> buildExpressionForAs(Class<T> type) {
         return (Expression<T>) this;
+    }
+
+
+    // TODO-API-3.2
+    //@Override
+    public Predicate equalTo(Expression<?> value) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    // TODO-API-3.2
+    //@Override
+    public Predicate equalTo(Object value) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    // TODO-API-3.2
+    //@Override
+    public Predicate notEqualTo(Expression<?> value) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    // TODO-API-3.2
+    //@Override
+    public Predicate notEqualTo(Object value) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
     @Override
@@ -153,7 +184,6 @@ public class ExpressionImpl<X> extends SelectionImpl<X> implements Expression<X>
         list.add(this);
         return new CompoundExpressionImpl(this.metamodel, this.currentNode.notNull(), list, "not null");
     }
-
 
     @Override
     public Predicate isNull() {

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/ExpressionImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/ExpressionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -73,7 +73,7 @@ public class ExpressionImpl<X> extends SelectionImpl<X> implements Expression<X>
     }
 
     // TODO-API-3.2
-    //@Override
+    @Override
     public <X1> Expression<X1> cast(Class<X1> type) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
@@ -84,25 +84,25 @@ public class ExpressionImpl<X> extends SelectionImpl<X> implements Expression<X>
 
 
     // TODO-API-3.2
-    //@Override
+    @Override
     public Predicate equalTo(Expression<?> value) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
     // TODO-API-3.2
-    //@Override
+    @Override
     public Predicate equalTo(Object value) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
     // TODO-API-3.2
-    //@Override
+    @Override
     public Predicate notEqualTo(Expression<?> value) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
     // TODO-API-3.2
-    //@Override
+    @Override
     public Predicate notEqualTo(Object value) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/FromImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/FromImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -38,6 +38,7 @@ import jakarta.persistence.metamodel.Attribute;
 import jakarta.persistence.metamodel.Attribute.PersistentAttributeType;
 import jakarta.persistence.metamodel.Bindable;
 import jakarta.persistence.metamodel.CollectionAttribute;
+import jakarta.persistence.metamodel.EntityType;
 import jakarta.persistence.metamodel.ListAttribute;
 import jakarta.persistence.metamodel.ManagedType;
 import jakarta.persistence.metamodel.MapAttribute;
@@ -122,7 +123,6 @@ public class FromImpl<Z, X>  extends PathImpl<X> implements jakarta.persistence.
         }
         return this.correlatedParent;
     }
-
 
     /**
      * Fetch join to the specified attribute using an inner join.
@@ -284,13 +284,6 @@ public class FromImpl<Z, X>  extends PathImpl<X> implements jakarta.persistence.
         }
     }
 
-    /**
-     * Return the path corresponding to the referenced collection-valued
-     * attribute.
-     *
-     * @param collection collection-valued attribute
-     * @return expression corresponding to the referenced attribute
-     */
     @Override
     public <E, C extends Collection<E>> Expression<C> get(PluralAttribute<? super X, C, E> collection) {
 
@@ -298,12 +291,6 @@ public class FromImpl<Z, X>  extends PathImpl<X> implements jakarta.persistence.
         return new ExpressionImpl<C>(this.metamodel, (Class<C>) ((Class<E>) Class.class) ,this.currentNode.anyOf(collection.getName()));
     }
 
-    /**
-     * Return the path corresponding to the referenced map-valued attribute.
-     *
-     * @param map map-valued attribute
-     * @return expression corresponding to the referenced attribute
-     */
     @Override
     public <K, V, M extends Map<K, V>> Expression<M> get(MapAttribute<? super X, K, V> map) {
         return new ExpressionImpl<M>(this.metamodel, (Class<M>) ((Class<?>) Class.class) ,this.currentNode.anyOf(map.getName()));
@@ -536,6 +523,30 @@ public class FromImpl<Z, X>  extends PathImpl<X> implements jakarta.persistence.
         }else{
             return join(((SingularAttribute)attribute), jt);
         }
+    }
+
+    // TODO-API-3.2
+    @Override
+    public <Y> Join<X, Y> join(Class<Y> entityClass) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    // TODO-API-3.2
+    @Override
+    public <Y> Join<X, Y> join(Class<Y> entityClass, JoinType joinType) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    // TODO-API-3.2
+    @Override
+    public <Y> Join<X, Y> join(EntityType<Y> entity) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    // TODO-API-3.2
+    @Override
+    public <Y> Join<X, Y> join(EntityType<Y> entity, JoinType joinType) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
     @Override

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/FromImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/FromImpl.java
@@ -288,12 +288,11 @@ public class FromImpl<Z, X>  extends PathImpl<X> implements jakarta.persistence.
      * Return the path corresponding to the referenced collection-valued
      * attribute.
      *
-     * @param collection
-     *            collection-valued attribute
+     * @param collection collection-valued attribute
      * @return expression corresponding to the referenced attribute
      */
     @Override
-    public <E, C extends java.util.Collection<E>> Expression<C> get(PluralAttribute<X, C, E> collection){
+    public <E, C extends Collection<E>> Expression<C> get(PluralAttribute<? super X, C, E> collection) {
 
         // This is a special Expression that represents just the collection for member of etc...
         return new ExpressionImpl<C>(this.metamodel, (Class<C>) ((Class<E>) Class.class) ,this.currentNode.anyOf(collection.getName()));
@@ -302,12 +301,11 @@ public class FromImpl<Z, X>  extends PathImpl<X> implements jakarta.persistence.
     /**
      * Return the path corresponding to the referenced map-valued attribute.
      *
-     * @param map
-     *            map-valued attribute
+     * @param map map-valued attribute
      * @return expression corresponding to the referenced attribute
      */
     @Override
-    public <K, V, M extends java.util.Map<K, V>> Expression<M> get(MapAttribute<X, K, V> map){
+    public <K, V, M extends Map<K, V>> Expression<M> get(MapAttribute<? super X, K, V> map) {
         return new ExpressionImpl<M>(this.metamodel, (Class<M>) ((Class<?>) Class.class) ,this.currentNode.anyOf(map.getName()));
     }
 

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/OrderImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/OrderImpl.java
@@ -18,6 +18,7 @@ package org.eclipse.persistence.internal.jpa.querydef;
 import java.io.Serializable;
 
 import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Nulls;
 import jakarta.persistence.criteria.Order;
 
 public class OrderImpl implements Order, Serializable{
@@ -42,6 +43,12 @@ public class OrderImpl implements Order, Serializable{
     @Override
     public boolean isAscending() {
         return this.isAscending;
+    }
+
+    // TODO-API-3.2
+    //@Override
+    public Nulls getNullPrecedence() {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
     @Override

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/OrderImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/OrderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -46,7 +46,7 @@ public class OrderImpl implements Order, Serializable{
     }
 
     // TODO-API-3.2
-    //@Override
+    @Override
     public Nulls getNullPrecedence() {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/PathImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/PathImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -89,23 +89,11 @@ public class PathImpl<X> extends ExpressionImpl<X> implements Path<X>, Cloneable
         throw new IllegalStateException(ExceptionLocalization.buildMessage("pathnode_is_primitive_node"));
     }
 
-    /**
-    * Return the path corresponding to the referenced collection-valued attribute.
-    *
-    * @param collection collection-valued attribute
-    * @return expression corresponding to the referenced attribute
-    */
     @Override
     public <E, C extends Collection<E>> Expression<C> get(PluralAttribute<? super X, C, E> collection) {
         throw new IllegalStateException(ExceptionLocalization.buildMessage("pathnode_is_primitive_node"));
     }
 
-    /**
-     * Return the path corresponding to the referenced map-valued attribute.
-     *
-     * @param map map-valued attribute
-     * @return expression corresponding to the referenced attribute
-     */
     @Override
     public <K, V, M extends Map<K, V>> Expression<M> get(MapAttribute<? super X, K, V> map) {
         throw new IllegalStateException(ExceptionLocalization.buildMessage("pathnode_is_primitive_node"));

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/PathImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/PathImpl.java
@@ -16,6 +16,9 @@
 
 package org.eclipse.persistence.internal.jpa.querydef;
 
+import java.util.Collection;
+import java.util.Map;
+
 import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.Path;
 import jakarta.persistence.metamodel.Bindable;
@@ -87,27 +90,24 @@ public class PathImpl<X> extends ExpressionImpl<X> implements Path<X>, Cloneable
     }
 
     /**
-     * Return the path corresponding to the referenced collection-valued
-     * attribute.
-     *
-     * @param collection
-     *            collection-valued attribute
-     * @return expression corresponding to the referenced attribute
-     */
+    * Return the path corresponding to the referenced collection-valued attribute.
+    *
+    * @param collection collection-valued attribute
+    * @return expression corresponding to the referenced attribute
+    */
     @Override
-    public <E, C extends java.util.Collection<E>> Expression<C> get(PluralAttribute<X, C, E> collection){
+    public <E, C extends Collection<E>> Expression<C> get(PluralAttribute<? super X, C, E> collection) {
         throw new IllegalStateException(ExceptionLocalization.buildMessage("pathnode_is_primitive_node"));
     }
 
     /**
      * Return the path corresponding to the referenced map-valued attribute.
      *
-     * @param map
-     *            map-valued attribute
+     * @param map map-valued attribute
      * @return expression corresponding to the referenced attribute
      */
     @Override
-    public <K, V, M extends java.util.Map<K, V>> Expression<M> get(MapAttribute<X, K, V> map){
+    public <K, V, M extends Map<K, V>> Expression<M> get(MapAttribute<? super X, K, V> map) {
         throw new IllegalStateException(ExceptionLocalization.buildMessage("pathnode_is_primitive_node"));
     }
 

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/SubQueryImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/SubQueryImpl.java
@@ -532,6 +532,29 @@ public class SubQueryImpl<T> extends AbstractQueryImpl<T> implements Subquery<T>
         return new CompoundExpressionImpl(this.metamodel, this.currentNode.notNull(), list, "not null");
     }
 
+    // TODO-API-3.2
+    //@Override
+    public Predicate equalTo(Expression<?> expression) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    // TODO-API-3.2
+    //@Override
+    public Predicate equalTo(Object o) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    // TODO-API-3.2
+    //@Override
+    public Predicate notEqualTo(Expression<?> expression) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
+    // TODO-API-3.2
+    //@Override
+    public Predicate notEqualTo(Object o) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
 
     @Override
     public Predicate isNull() {
@@ -676,4 +699,11 @@ public class SubQueryImpl<T> extends AbstractQueryImpl<T> implements Subquery<T>
     public DatabaseQuery getDatabaseQuery() {
         return this.subQuery;
     }
+
+    // TODO-API-3.2
+    //@Override
+    public <X> Expression<X> cast(Class<X> aClass) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
+    }
+
 }

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/SubQueryImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/querydef/SubQueryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011, 2018 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -138,49 +138,28 @@ public class SubQueryImpl<T> extends AbstractQueryImpl<T> implements Subquery<T>
         }
         return this;
     }
+
     // override the return type only:
-    /**
-     * Modify the query to restrict the query result according to the specified
-     * boolean expression. Replaces the previously added restriction(s), if any.
-     * This method only overrides the return type of the corresponding
-     * AbstractQuery method.
-     *
-     * @param restriction
-     *            a simple or compound boolean expression
-     * @return the modified query
-     */
     @Override
     public Subquery<T> where(Expression<Boolean> restriction){
         super.where(restriction);
-        org.eclipse.persistence.expressions.Expression currentNode = ((InternalSelection)this.where).getCurrentNode();
-        for(org.eclipse.persistence.expressions.Expression exp: this.correlations){
-            currentNode = currentNode.and(exp);
-        }
-        this.subQuery.setSelectionCriteria(currentNode);
-        for (Iterator<Root<?>> iterator = this.getRoots().iterator(); iterator.hasNext();){
-            findJoins((FromImpl)iterator.next());
-        }
-        for (Iterator<Join<?, ?>> iterator = this.getCorrelatedJoins().iterator(); iterator.hasNext();){
-            findJoins((FromImpl)iterator.next());
-        }
+        setWhereInternal();
         return this;
     }
 
-    /**
-     * Modify the query to restrict the query result according to the
-     * conjunction of the specified restriction predicates. Replaces the
-     * previously added restriction(s), if any. If no restrictions are
-     * specified, any previously added restrictions are simply removed. This
-     * method only overrides the return type of the corresponding AbstractQuery
-     * method.
-     *
-     * @param restrictions
-     *            zero or more restriction predicates
-     * @return the modified query
-     */
     @Override
-    public Subquery<T> where(Predicate... restrictions){
+    public Subquery<T> where(Predicate... restrictions) {
+        return where(restrictions != null ? List.of(restrictions) : null);
+    }
+
+    @Override
+    public Subquery<T> where(List<Predicate> restrictions) {
         super.where(restrictions);
+        setWhereInternal();
+        return this;
+    }
+
+    private void setWhereInternal() {
         org.eclipse.persistence.expressions.Expression currentNode = ((InternalSelection)this.where).getCurrentNode();
         for(org.eclipse.persistence.expressions.Expression exp: this.correlations){
             currentNode = currentNode.and(exp);
@@ -192,7 +171,6 @@ public class SubQueryImpl<T> extends AbstractQueryImpl<T> implements Subquery<T>
         for (Iterator<Join<?, ?>> iterator = this.getCorrelatedJoins().iterator(); iterator.hasNext();){
             findJoins((FromImpl)iterator.next());
         }
-        return this;
     }
 
     /**
@@ -237,47 +215,31 @@ public class SubQueryImpl<T> extends AbstractQueryImpl<T> implements Subquery<T>
         return this;
     }
 
-    /**
-     * Specify a restriction over the groups of the query. Replaces the previous
-     * having restriction(s), if any. This method only overrides the return type
-     * of the corresponding AbstractQuery method.
-     *
-     * @param restriction
-     *            a simple or compound boolean expression
-     * @return the modified query
-     */
     @Override
     public Subquery<T> having(Expression<Boolean> restriction){
         super.having(restriction);
-        if (this.havingClause != null){
-            this.subQuery.setHavingExpression(((InternalSelection)restriction).getCurrentNode());
-        }else{
-            this.subQuery.setHavingExpression(null);
-        }
+        setHavingClauseInternal(((InternalSelection)restriction).getCurrentNode());
         return this;
     }
 
-    /**
-     * Specify restrictions over the groups of the query according the
-     * conjunction of the specified restriction predicates. Replaces the
-     * previously added restriction(s), if any. If no restrictions are
-     * specified, any previously added restrictions are simply removed. This
-     * method only overrides the return type of the corresponding AbstractQuery
-     * method.
-     *
-     * @param restrictions
-     *            zero or more restriction predicates
-     * @return the modified query
-     */
     @Override
     public Subquery<T> having(Predicate... restrictions) {
+        return having(restrictions != null ? List.of(restrictions) : null);
+    }
+
+    @Override
+    public Subquery<T> having(List<Predicate> restrictions) {
         super.having(restrictions);
-        if (this.havingClause != null){
-            this.subQuery.setHavingExpression(((InternalSelection) this.havingClause).getCurrentNode());
-        }else{
+        setHavingClauseInternal(((InternalSelection) this.havingClause).getCurrentNode());
+        return this;
+    }
+
+    private void setHavingClauseInternal(org.eclipse.persistence.expressions.Expression currentNode) {
+        if (this.havingClause != null) {
+            this.subQuery.setHavingExpression(currentNode);
+        } else {
             this.subQuery.setHavingExpression(null);
         }
-        return this;
     }
 
     /**
@@ -533,25 +495,25 @@ public class SubQueryImpl<T> extends AbstractQueryImpl<T> implements Subquery<T>
     }
 
     // TODO-API-3.2
-    //@Override
+    @Override
     public Predicate equalTo(Expression<?> expression) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
     // TODO-API-3.2
-    //@Override
+    @Override
     public Predicate equalTo(Object o) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
     // TODO-API-3.2
-    //@Override
+    @Override
     public Predicate notEqualTo(Expression<?> expression) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
     // TODO-API-3.2
-    //@Override
+    @Override
     public Predicate notEqualTo(Object o) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
@@ -701,7 +663,7 @@ public class SubQueryImpl<T> extends AbstractQueryImpl<T> implements Subquery<T>
     }
 
     // TODO-API-3.2
-    //@Override
+    @Override
     public <X> Expression<X> cast(Class<X> aClass) {
         throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/jpa/JpaEntityManagerFactory.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/jpa/JpaEntityManagerFactory.java
@@ -16,14 +16,10 @@
 //       - 494610: Session Properties map should be Map<String, Object>
 package org.eclipse.persistence.jpa;
 
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.EntityManagerFactory;
 import java.util.Map;
-import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
 
-import jakarta.persistence.EntityTransaction;
-import jakarta.persistence.PersistenceException;
+import jakarta.persistence.EntityManagerFactory;
+
 import org.eclipse.persistence.internal.jpa.EntityManagerFactoryDelegate;
 import org.eclipse.persistence.internal.sessions.DatabaseSessionImpl;
 import org.eclipse.persistence.sessions.broker.SessionBroker;
@@ -72,128 +68,6 @@ public interface JpaEntityManagerFactory extends EntityManagerFactory, AutoClose
      * to be bootstrapped.  Existing EntityManagers will continue to use the old implementation
      */
     void refreshMetadata(Map<String, Object> properties);
-
-    // TODO-API-3.2: To be replaced
-    /**
-     * Create a new application-managed {@code EntityManager}, start a resource-local
-     * transaction, and call the given function, passing both the {@code EntityManager}
-     * and the {@code EntityTransaction}.
-     * The given function is responsible for finishing the transaction by calling {@code commit}
-     * or {@code rollback} method.
-     *
-     * @param work a function to be called in the scope of the transaction
-     */
-    default void withTransaction(BiConsumer<EntityManager, EntityTransaction> work) {
-        try (EntityManager em = this.createEntityManager()) {
-            EntityTransaction t = em.getTransaction();
-            t.begin();
-            work.accept(em, t);
-        }
-    }
-
-    // TODO-API-3.2: To be replaced
-    /**
-     * Create a new application-managed {@code EntityManager}, start a resource-local
-     * transaction, and call the given function, passing both the {@code EntityManager}
-     * and the {@code EntityTransaction}.
-     * The given function is responsible for finishing the transaction by calling {@code commit}
-     * or {@code rollback} method.
-     *
-     * @param work a function to be called in the scope of the transaction
-     * @return the value returned by the given function
-     */
-    default <R> R withTransaction(BiFunction<EntityManager, EntityTransaction, R> work) {
-        try (EntityManager em = this.createEntityManager()) {
-            EntityTransaction t = em.getTransaction();
-            t.begin();
-            return work.apply(em, t);
-        }
-    }
-
-    // TODO-API-3.2: To be replaced
-    /**
-     * Create a new application-managed {@code EntityManager}, start a resource-local
-     * transaction, and call the given function, passing the {@code EntityManager}.
-     * If the given function does not throw an exception, commit the transaction and
-     * return the result of the function. If the function does throw an exception,
-     * roll back the transaction and rethrow the exception. Finally, close the
-     * {@code EntityManager}.
-     *
-     * @param work a function to be called in the scope of the transaction
-     */
-    default void withTransaction(TransactionVoidWork work) {
-        try (EntityManager em = this.createEntityManager()) {
-            EntityTransaction t = em.getTransaction();
-            try {
-                t.begin();
-                work.work(em);
-                t.commit();
-            } catch (Exception e) {
-                t.rollback();
-                throw new PersistenceException("Application-managed transaction failed", e);
-            }
-        }
-    }
-
-    // TODO-API-3.2: To be replaced
-    /**
-     * Create a new application-managed {@code EntityManager}, start a resource-local
-     * transaction, and call the given function, passing the {@code EntityManager}.
-     * If the given function does not throw an exception, commit the transaction and
-     * return the result of the function. If the function does throw an exception,
-     * roll back the transaction and rethrow the exception. Finally, close the
-     * {@code EntityManager}.
-     *
-     * @param work a function to be called in the scope of the transaction
-     * @return the value returned by the given function
-     */
-    default <R> R withTransaction(TransactionWork<R> work) {
-        try (EntityManager em = this.createEntityManager()) {
-            EntityTransaction t = em.getTransaction();
-            try {
-                t.begin();
-                R result = work.work(em);
-                t.commit();
-                return result;
-            } catch (Exception e) {
-                t.rollback();
-                throw new PersistenceException("Application-managed transaction failed", e);
-            }
-        }
-    }
-
-    /**
-     * A task that runs in a transaction, returns no result and may throw an exception.
-     * Implementors define a single method with {@link EntityManager} argument called {@code work}.
-     */
-    @FunctionalInterface
-    interface TransactionVoidWork {
-        /**
-         * Executes the function. Throws an exception if unable to do so.
-         *
-         * @param em the application-managed {@link EntityManager} instance
-         * @throws Exception when unable to compute a result
-         */
-        void work(EntityManager em) throws Exception;
-    }
-
-    /**
-     * A task that runs in a transaction, returns result and may throw an exception.
-     * Implementors define a single method with {@link EntityManager} argument called {@code work}.
-     *
-     * @param <R> the result type of method {@code work}
-     */
-    @FunctionalInterface
-    interface TransactionWork<R> {
-        /**
-         * Executes the function. Throws an exception if unable to do so.
-         *
-         * @param em the application-managed {@link EntityManager} instance
-         * @return the computed result
-         * @throws Exception when unable to compute a result
-         */
-        R work(EntityManager em) throws Exception;
-    }
 
 }
 

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/jpa/JpaEntityManagerFactory.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/jpa/JpaEntityManagerFactory.java
@@ -73,6 +73,7 @@ public interface JpaEntityManagerFactory extends EntityManagerFactory, AutoClose
      */
     void refreshMetadata(Map<String, Object> properties);
 
+    // TODO-API-3.2: To be replaced
     /**
      * Create a new application-managed {@code EntityManager}, start a resource-local
      * transaction, and call the given function, passing both the {@code EntityManager}
@@ -90,6 +91,7 @@ public interface JpaEntityManagerFactory extends EntityManagerFactory, AutoClose
         }
     }
 
+    // TODO-API-3.2: To be replaced
     /**
      * Create a new application-managed {@code EntityManager}, start a resource-local
      * transaction, and call the given function, passing both the {@code EntityManager}
@@ -108,6 +110,7 @@ public interface JpaEntityManagerFactory extends EntityManagerFactory, AutoClose
         }
     }
 
+    // TODO-API-3.2: To be replaced
     /**
      * Create a new application-managed {@code EntityManager}, start a resource-local
      * transaction, and call the given function, passing the {@code EntityManager}.
@@ -132,6 +135,7 @@ public interface JpaEntityManagerFactory extends EntityManagerFactory, AutoClose
         }
     }
 
+    // TODO-API-3.2: To be replaced
     /**
      * Create a new application-managed {@code EntityManager}, start a resource-local
      * transaction, and call the given function, passing the {@code EntityManager}.

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/jpa/PersistenceProvider.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/jpa/PersistenceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2021 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -28,6 +28,8 @@
 //       - 458462: generateSchema throws a ClassCastException within a container
 //     02/17/2015-2.6 Rick Curtis
 //       - 460138: Change method visibility.
+//     08/23/2023: Tomas Kraus
+//       - New Jakarta Persistence 3.2 Features
 package org.eclipse.persistence.jpa;
 
 import java.util.HashMap;
@@ -35,6 +37,7 @@ import java.util.Iterator;
 import java.util.Map;
 
 import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.PersistenceConfiguration;
 import jakarta.persistence.PersistenceException;
 import jakarta.persistence.spi.ClassTransformer;
 import jakarta.persistence.spi.LoadState;
@@ -169,17 +172,13 @@ public class PersistenceProvider implements jakarta.persistence.spi.PersistenceP
     }
 
     /**
-     * Called by Persistence class when an EntityManagerFactory
-     * is to be created.
+     * Called by Persistence class when an EntityManagerFactory is to be created.
      *
      * @param emName The name of the persistence unit
-     * @param properties A Map of properties for use by the
-     * persistence provider. These properties may be used to
-     * override the values of the corresponding elements in
-     * the persistence.xml file or specify values for
-     * properties not specified in the persistence.xml.
-     * @return EntityManagerFactory for the persistence unit,
-     * or null if the provider is not the right provider
+     * @param properties A Map of properties for use by the persistence provider. These properties may be used
+     *                   to override the values of the corresponding elements in the {@code persistence.xml} file
+     *                   or specify values for properties not specified in the {@code persistence.xml}.
+     * @return EntityManagerFactory for the persistence unit, or {@code null} if the provider is not the right provider
      */
     @Override
     public EntityManagerFactory createEntityManagerFactory(String emName, Map properties){
@@ -193,6 +192,22 @@ public class PersistenceProvider implements jakarta.persistence.spi.PersistenceP
 
         // Not EclipseLink so return null;
         return null;
+    }
+
+    /**
+     * Called by <code>Persistence</code> class when an <code>EntityManagerFactory</code> is to be created.
+     *
+     * @param configuration  the configuration of the persistence unit
+     * @return EntityManagerFactory for the persistence unit, or {@code null} if the provider is not the right provider
+     * @throws IllegalStateException if required configuration is missing
+     *
+     * @see jakarta.persistence.Persistence#createEntityManagerFactory(PersistenceConfiguration)
+     * @since 4.1
+     */
+    // TODO-API-3.2
+    @Override
+    public EntityManagerFactory createEntityManagerFactory(PersistenceConfiguration configuration) {
+        throw new UnsupportedOperationException("Jakarta Persistence 3.2 API was not implemented yet");
     }
 
     /**

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/jpa/PersistenceProvider.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/jpa/PersistenceProvider.java
@@ -171,15 +171,6 @@ public class PersistenceProvider implements jakarta.persistence.spi.PersistenceP
         return null;
     }
 
-    /**
-     * Called by Persistence class when an EntityManagerFactory is to be created.
-     *
-     * @param emName The name of the persistence unit
-     * @param properties A Map of properties for use by the persistence provider. These properties may be used
-     *                   to override the values of the corresponding elements in the {@code persistence.xml} file
-     *                   or specify values for properties not specified in the {@code persistence.xml}.
-     * @return EntityManagerFactory for the persistence unit, or {@code null} if the provider is not the right provider
-     */
     @Override
     public EntityManagerFactory createEntityManagerFactory(String emName, Map properties){
         Map nonNullProperties = (properties == null) ? new HashMap<>() : properties;
@@ -194,16 +185,6 @@ public class PersistenceProvider implements jakarta.persistence.spi.PersistenceP
         return null;
     }
 
-    /**
-     * Called by <code>Persistence</code> class when an <code>EntityManagerFactory</code> is to be created.
-     *
-     * @param configuration  the configuration of the persistence unit
-     * @return EntityManagerFactory for the persistence unit, or {@code null} if the provider is not the right provider
-     * @throws IllegalStateException if required configuration is missing
-     *
-     * @see jakarta.persistence.Persistence#createEntityManagerFactory(PersistenceConfiguration)
-     * @since 4.1
-     */
     // TODO-API-3.2
     @Override
     public EntityManagerFactory createEntityManagerFactory(PersistenceConfiguration configuration) {

--- a/jpa/org.eclipse.persistence.jpars/src/it/java/org/eclipse/persistence/jpars/test/model/employee/Certification.java
+++ b/jpa/org.eclipse.persistence.jpars/src/it/java/org/eclipse/persistence/jpars/test/model/employee/Certification.java
@@ -14,21 +14,21 @@
 //      gonural - initial
 package org.eclipse.persistence.jpars.test.model.employee;
 
-import static jakarta.persistence.TemporalType.TIMESTAMP;
-
 import java.util.Calendar;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
 
 @Embeddable
 public class Certification {
     @Column(name = "NAME")
     private String name;
 
-    @Temporal(TIMESTAMP)
+    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "ISSUE_DATE")
+    @SuppressWarnings("deprecation")
     private Calendar issueDate;
 
     public String getName() {

--- a/jpa/org.eclipse.persistence.jpars/src/it/java/org/eclipse/persistence/jpars/test/model/employee/EmploymentPeriod.java
+++ b/jpa/org.eclipse.persistence.jpars/src/it/java/org/eclipse/persistence/jpars/test/model/employee/EmploymentPeriod.java
@@ -12,19 +12,20 @@
 
 package org.eclipse.persistence.jpars.test.model.employee;
 
-import static jakarta.persistence.TemporalType.DATE;
-
 import java.util.Calendar;
 
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
 
 @Embeddable
 public class EmploymentPeriod {
 
-    @Temporal(DATE)
+    @Temporal(TemporalType.DATE)
+    @SuppressWarnings("deprecation")
     private Calendar startDate;
-    @Temporal(DATE)
+    @Temporal(TemporalType.DATE)
+    @SuppressWarnings("deprecation")
     private Calendar endDate;
 
     public Calendar getStartDate() {

--- a/jpa/org.eclipse.persistence.jpars/src/it/java/org/eclipse/persistence/jpars/test/model/employee/LargeProject.java
+++ b/jpa/org.eclipse.persistence.jpars/src/it/java/org/eclipse/persistence/jpars/test/model/employee/LargeProject.java
@@ -12,8 +12,6 @@
 
 package org.eclipse.persistence.jpars.test.model.employee;
 
-import static jakarta.persistence.TemporalType.TIMESTAMP;
-
 import java.util.Calendar;
 
 import jakarta.persistence.Basic;
@@ -21,6 +19,7 @@ import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
 
 @Entity
 @Table(name = "JPARS_LPROJECT")
@@ -29,7 +28,8 @@ public class LargeProject extends Project {
     @Basic
     private double budget;
     @Basic
-    @Temporal(TIMESTAMP)
+    @Temporal(TemporalType.TIMESTAMP)
+    @SuppressWarnings("deprecation")
     private Calendar milestone = Calendar.getInstance();
 
     public LargeProject() {

--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@
         <jersey.version>3.1.2</jersey.version>
         <jms.version>3.1.0</jms.version>
         <json.version>2.1.2</json.version>
-        <jpa.api.version>3.1.0</jpa.api.version>
+        <jpa.api.version>3.2.0-B01</jpa.api.version>
         <mail-api.version>2.1.2</mail-api.version>
         <angus-mail.version>2.0.2</angus-mail.version>
         <oracle.ddlparser.version>3.0.1</oracle.ddlparser.version>


### PR DESCRIPTION
Update JPA API dependency to 3.2-B01
jakartaee/persistence#414 - Add EntityManagerFactory.runInTransaction()/callInTransaction()
jakartaee/persistence#430 - Fix signatures of operations of entity graphs
jakartaee/persistence#433 - Add EntityManager.runWithConnection()/callWithConnection()
jakartaee/persistence#441 - Pull getParameters() up from CriteriaQuery to CommonAbstractCriteria
jakartaee/persistence#442 - Overload where(), having(), concat(), and() and or() to accept 