### PR TITLE
Allow escaping of '?' using '??' in SQL expression

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/expressions/Expression.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/expressions/Expression.java
@@ -1994,6 +1994,14 @@ public abstract class Expression implements Serializable, Cloneable {
             v.add(sql.substring(start, sql.length()));
         }
         anOperator.printsAs(v);
+        //Postgres expects '??' as an escape mechanism for '?' in parameterized queries
+        //https://jdbc.postgresql.org/documentation/query/#using-the-statement-or-preparedstatement-interface
+        //On other platforms, replace ?? with ? in code which is passed as a part of SQL into DB
+        if (getSession() == null || !getSession().getPlatform().isPostgreSQL()) {
+            for (int i = 0; i < anOperator.getDatabaseStrings().length; i++) {
+                anOperator.getDatabaseStrings()[i] = anOperator.getDatabaseStrings()[i].replace("??", "?");
+            }
+        }
         anOperator.bePrefix();
         anOperator.setNodeClass(ClassConstants.FunctionExpression_Class);
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/expressions/Expression.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/expressions/Expression.java
@@ -1981,6 +1981,11 @@ public abstract class Expression implements Serializable, Cloneable {
         int start = 0;
         int index = sql.indexOf('?');
         while (index != -1) {
+            // ? can be escaped as ?? to support ? as a native SQL operator (e.g. on Postgres)
+            if (index < sql.length() - 1 && sql.charAt(index + 1) == '?') {
+                index = sql.indexOf('?', index + 2);
+                continue;
+            }
             v.add(sql.substring(start, index));
             start = index + 1;
             index = sql.indexOf('?', start);

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/jpa/jpql/ExpressionBuilderVisitor.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/jpa/jpql/ExpressionBuilderVisitor.java
@@ -1099,6 +1099,8 @@ final class ExpressionBuilderVisitor implements EclipseLinkExpressionVisitor {
                 }
 
                 queryExpression = queryExpressions.remove(0);
+                // ensure the session is set for the 'SQL' operator
+                queryExpression.getBuilder().setSession(queryContext.getSession());
 
                 // SQL
                 if (identifier == org.eclipse.persistence.jpa.jpql.parser.Expression.SQL) {

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/json/TestJson.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/json/TestJson.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -272,7 +272,7 @@ public class TestJson implements JsonTestConverter.ConverterStatus {
                 em.clear();
 
                 JsonEntity dbValue = em.createQuery(
-                    "SELECT v.value FROM JsonEntity v WHERE SQL('JSON_EXISTS(?, ''$??(@.id == 1007)'')', v.value)", JsonEntity.class)
+                    "SELECT v FROM JsonEntity v WHERE SQL('JSON_EXISTS(?, ''$??(@.id == 1007)'')', v.value)", JsonEntity.class)
                     .getSingleResult();
                 Assert.assertEquals(value, dbValue.getValue());
             } finally {

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/json/TestJson.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/json/TestJson.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/json/TestJson.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/json/TestJson.java
@@ -30,6 +30,7 @@ import org.eclipse.persistence.jpa.test.framework.DDLGen;
 import org.eclipse.persistence.jpa.test.framework.Emf;
 import org.eclipse.persistence.jpa.test.framework.EmfRunner;
 import org.eclipse.persistence.jpa.test.framework.Property;
+import org.eclipse.persistence.sessions.Session;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;


### PR DESCRIPTION
Using [SQL operator,](https://wiki.eclipse.org/EclipseLink/UserGuide/JPA/Basic_JPA_Development/Querying/JPQL#SQL) it is not possible to use '?' as a native operator (e.g. on Postgres). This PR is to allow using '??' as an escape mechanism, similar to the escaping mechanism used by [Postgres JDBC](https://jdbc.postgresql.org/documentation/query/#using-the-statement-or-preparedstatement-interface).

This is to fix issue #836