### PR TITLE
Fix slightly inaccurate QUERY_TIMEOUT hint's javadoc

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/QueryHints.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/QueryHints.java
@@ -388,7 +388,7 @@ public class QueryHints {
      * "jakarta.persistence.query.timeout"
      * <p>Configures the default query timeout value per the JPA specification.
      * Valid values are strings containing a zero or greater integer value
-     * Defaults to use seconds as the unit of time.
+     * Defaults to use milliseconds as the unit of time.
      * @see org.eclipse.persistence.queries.DatabaseQuery#setQueryTimeout(int)
      */
     public static final String QUERY_TIMEOUT = "jakarta.persistence.query.timeout";


### PR DESCRIPTION
Javadoc states that `seconds` is the default unit of time, but the actual default value seem to be `milliseconds`:

https://github.com/eclipse-ee4j/eclipselink/blob/master/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/descriptors/DescriptorQueryManager.java#L135