### PR TITLE
[master] fix #1950: Duplicate objects in UnitOfWorkImpl.primaryKeyToNewObjects

### DIFF
--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/UOWPrimaryKeyToNewObjectsDuplicateObjectsTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/UOWPrimaryKeyToNewObjectsDuplicateObjectsTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.persistence.testing.tests.unitofwork;
+
+import org.eclipse.persistence.internal.sessions.UnitOfWorkImpl;
+import org.eclipse.persistence.sessions.Session;
+import org.eclipse.persistence.testing.framework.TestCase;
+import org.eclipse.persistence.testing.models.employee.domain.Employee;
+
+import java.util.IdentityHashMap;
+
+/**
+ * This test is in response to issue 1950: Duplicate objects in UnitOfWorkImpl.primaryKeyToNewObjects
+ *
+ * When a new object is registered for persist by calling registerNewObjectForPersist
+ * the object is potentially added twice to primaryKeyToNewObjects. Once during assignSequenceNumber and
+ * then in registerNewObjectClone. This test verifies that the object is contained only once in primaryKeyToNewObjects.
+ */
+public class UOWPrimaryKeyToNewObjectsDuplicateObjectsTest extends TestCase {
+    public UOWPrimaryKeyToNewObjectsDuplicateObjectsTest() {
+        setDescription("This test verifies that no duplicates exist in primaryKeyToNewObjects after registering a new object");
+    }
+
+    @Override
+    public void reset() {
+        getAbstractSession().rollbackTransaction();
+        getSession().getIdentityMapAccessor().initializeAllIdentityMaps();
+    }
+
+    @Override
+    public void setup() {
+        getAbstractSession().beginTransaction();
+    }
+
+    @Override
+    public void test() {
+        Session session = getSession();
+        UnitOfWorkImpl uow = (UnitOfWorkImpl) session.acquireUnitOfWork();
+        Employee emp = new Employee();
+        emp.setFirstName("UOWPrimaryKeyToNewObjectsDuplicateObjectsTest");
+        uow.registerNewObjectForPersist(emp, new IdentityHashMap<>());
+        // there should be only one object in primaryKeyToNewObjects
+        assertEquals("Unexpected amount of entities in primaryKeyToNewObjects", 1,
+                uow.getPrimaryKeyToNewObjects().get(emp.getId()).size());
+    }
+}

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/UOWPrimaryKeyToNewObjectsDuplicateObjectsTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/UOWPrimaryKeyToNewObjectsDuplicateObjectsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/UnitOfWorkTestSuite.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/UnitOfWorkTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -69,6 +69,9 @@ public class UnitOfWorkTestSuite extends TestSuite {
         addTest(buildRefreshDeletedObjectTest());
 
         addTest(new UnregisterUnitOfWorkTest());
+
+        // Issue 1950 - Duplicate objects in UnitOfWorkImpl.primaryKeyToNewObjects
+        addTest(new UOWPrimaryKeyToNewObjectsDuplicateObjectsTest());
 
         // EL Bug 252047 - Mutable attributes are not cloned when isMutable is enabled on a Direct Mapping
         addTest(new CloneAttributeIfMutableTest());

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
@@ -157,7 +157,7 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
     /**
      * Map of primary key to list of new objects. Used to speedup in-memory querying.
      */
-    protected Map<Object, List<Object>> primaryKeyToNewObjects;
+    protected Map<Object, IdentityHashSet> primaryKeyToNewObjects;
     /**
      * Stores a map from the clone to the original merged object, as a different instance is used as the original for merges.
      */
@@ -547,8 +547,6 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
             ObjectBuilder builder = descriptor.getObjectBuilder();
             try {
                 value = builder.assignSequenceNumber(object, this);
-                getPrimaryKeyToNewObjects().putIfAbsent(value, new ArrayList<>());
-                getPrimaryKeyToNewObjects().get(value).add(object);
             } catch (RuntimeException exception) {
                 handleException(exception);
             } finally {
@@ -2405,7 +2403,7 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
      * The primaryKeyToNewObjects stores a list of objects for every primary key.
      * It is used to speed up in-memory-querying.
      */
-    public Map<Object, List<Object>> getPrimaryKeyToNewObjects() {
+    public Map<Object, IdentityHashSet> getPrimaryKeyToNewObjects() {
         if (primaryKeyToNewObjects == null) {
             primaryKeyToNewObjects = new HashMap<>();
         }
@@ -2562,7 +2560,7 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
         boolean readSubclassesOrNoInheritance = (!descriptor.hasInheritance() || descriptor.getInheritancePolicy().shouldReadSubclasses());
 
         ObjectBuilder objectBuilder = descriptor.getObjectBuilder();
-        for (Iterator newObjectsEnum = getPrimaryKeyToNewObjects().getOrDefault(selectionKey, new ArrayList<>(0)).iterator();
+        for (Iterator newObjectsEnum = getPrimaryKeyToNewObjects().getOrDefault(selectionKey, new IdentityHashSet(0)).iterator();
              newObjectsEnum.hasNext(); ) {
             Object object = newObjectsEnum.next();
             // bug 327900
@@ -5052,7 +5050,7 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
         ObjectBuilder objectBuilder = descriptor.getObjectBuilder();
         Object pk = objectBuilder.extractPrimaryKeyFromObject(newObject, this, true);
         if(pk!=null) {
-            getPrimaryKeyToNewObjects().putIfAbsent(pk, new ArrayList<>());
+            getPrimaryKeyToNewObjects().putIfAbsent(pk, new IdentityHashSet());
             getPrimaryKeyToNewObjects().get(pk).add(newObject);
         }
     }
@@ -5072,9 +5070,9 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
      * Removes an object from primaryKeyToNewObjects.
      */
     protected void removeObjectFromPrimaryKeyToNewObjects(Object object, Object primaryKey){
-        Map<Object, List<Object>> pkToNewObjects = getPrimaryKeyToNewObjects();
+        Map<Object, IdentityHashSet> pkToNewObjects = getPrimaryKeyToNewObjects();
         if (pkToNewObjects.containsKey(primaryKey)) {
-            List<Object> newObjects = pkToNewObjects.get(primaryKey);
+            IdentityHashSet newObjects = pkToNewObjects.get(primaryKey);
             newObjects.remove(object);
             if (newObjects.isEmpty()) {
                pkToNewObjects.remove(primaryKey);

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
@@ -547,6 +547,8 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
             ObjectBuilder builder = descriptor.getObjectBuilder();
             try {
                 value = builder.assignSequenceNumber(object, this);
+                getPrimaryKeyToNewObjects().putIfAbsent(value, new IdentityHashSet());
+                getPrimaryKeyToNewObjects().get(value).add(object);
             } catch (RuntimeException exception) {
                 handleException(exception);
             } finally {


### PR DESCRIPTION
- Fixes #1950 

~Objects are now no longer added to `primaryKeyToNewObjects` in `assignSequenceNumber`.~
I've refactored the code to use an `IdentityHashSet` instead of `ArrayList` for `primaryKeyToNewObjects` to prevent duplicates in the future.
Additionally I added two UnitTests. One verifies that calling `registerNewObjectForPersist` does not result in duplicates in `primaryKeyToNewObjects`. The other tests the complete `EntityManager` persist, remove, find workflow from the original issue.