### PR TITLE
[2.7] Eclipselink.jar - JPMS fixes

### DIFF
--- a/antbuild.properties
+++ b/antbuild.properties
@@ -286,6 +286,7 @@ about-file=about.html
 readme-file=readme.html
 license-files=license.*
 module-info-file=module-info.class
+module-info-file.src=module-info.java
 setenv-scripts=setenv.*
 package-rename-scripts=packageRename.*
 jaxb-compiler-scripts=jaxb-compiler.*

--- a/antbuild.xml
+++ b/antbuild.xml
@@ -1304,6 +1304,10 @@
                 <exclude name="*jpars*.jar"/>
                 <exclude name="*nosql*.jar"/>
             </zipgroupfileset>
+            <!-- Include module-info.class -->
+            <fileset dir="${eclipselink.features.base}/bundles/eclipselink/${src.dir}">
+                <include name="${module-info-file.src}"/>
+            </fileset>
         </jar>
     </target>
 

--- a/features/bundles/eclipselink/src/module-info.java
+++ b/features/bundles/eclipselink/src/module-info.java
@@ -223,6 +223,7 @@ module eclipselink {
     exports org.eclipse.persistence.internal.jpa.rs.metadata.model.v2;
     exports org.eclipse.persistence.internal.libraries.asm;
     exports org.eclipse.persistence.internal.localization;
+    exports org.eclipse.persistence.internal.localization.i18n;
     exports org.eclipse.persistence.internal.oxm;
     exports org.eclipse.persistence.internal.oxm.mappings;
     exports org.eclipse.persistence.internal.oxm.record;
@@ -289,6 +290,10 @@ module eclipselink {
     exports org.eclipse.persistence.internal.sessions.factories.model.transport.discovery;
     exports org.eclipse.persistence.internal.sessions.factories.model.transport.naming;
     exports org.eclipse.persistence.internal.xr.sxf;
+
+    opens org.eclipse.persistence.internal.helper;
+    opens org.eclipse.persistence.jaxb.xmlmodel;
+    opens org.eclipse.persistence.jpa.jpql;
 
     uses org.eclipse.persistence.jpa.rs.PersistenceContextFactoryProvider;
 


### PR DESCRIPTION
This change contains two fixes:
- opens some packages in module-info.java as there are some resource files needed to read
- eclipselink source bundle to include there correct module-info.java file