### PR TITLE
[master] JPA Test Advanced fix

### DIFF
--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced/pom.xml
@@ -83,6 +83,7 @@
                             <includes>
                                 <include>**/JPAAdvancedTestModel</include>
                                 <include>**/advanced/*Test</include>
+                                <include>**/advanced/EntityManagerJUnitTestSuite</include>
                             </includes>
                         </configuration>
                     </execution>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced/src/main/resources/META-INF/persistence.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced/src/main/resources/META-INF/persistence.xml
@@ -80,4 +80,18 @@
         </properties>
     </persistence-unit>
 
+    <persistence-unit name="customizeAddTarget">
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+        <exclude-unlisted-classes>false</exclude-unlisted-classes>
+        <properties>
+            <property name="eclipselink.logging.level" value="OFF"/>
+            <property name="eclipselink.descriptor.customizer.Employee" value="org.eclipse.persistence.testing.models.jpa.advanced.AddTargetCustomizer"/>
+            <!-- Since we don't exclude unlisted classes here, we will       -->
+            <!-- eventually hit the multitenant entities which turn native   -->
+            <!-- sql queries off by default, so we need to be explicit here  -->
+            <!--  and turn them on                                           -->
+            <property name="eclipselink.jdbc.allow-native-sql-queries" value="true"/>
+        </properties>
+    </persistence-unit>
+
 </persistence>


### PR DESCRIPTION
It seems, that after transformation from `jpa.test` to `jpa.testapps` `EntityManagerJUnitTestSuite` from `jpa.testapps.advanced` was excluded from the execution. This change returns this suite back.