### PR TITLE
Fix for ConcurrentModificationException seen in CollectionContainerPolicy

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/queries/CollectionContainerPolicy.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/queries/CollectionContainerPolicy.java
@@ -19,6 +19,7 @@ import org.eclipse.persistence.internal.helper.ClassConstants;
 import org.eclipse.persistence.internal.helper.Helper;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Vector;
 
@@ -181,7 +182,12 @@ public class CollectionContainerPolicy extends InterfaceContainerPolicy {
      */
     @Override
     public Object iteratorFor(Object container) {
-        return ((Collection)container).iterator();
+        if (container.getClass() == ArrayList.class) {
+            Object clonedContainer = cloneFor(container);
+            return ((Collection)clonedContainer).iterator();
+        } else {
+            return ((Collection)container).iterator();
+        }
     }
 
     /**


### PR DESCRIPTION
The following error was intermittently thrown when running the stress test

Caused by: java.util.ConcurrentModificationException
        at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:911)
        at java.util.ArrayList$Itr.next(ArrayList.java:861)
        at org.eclipse.persistence.internal.queries.InterfaceContainerPolicy.next(InterfaceContainerPolicy.java:301)
        at org.eclipse.persistence.internal.queries.ContainerPolicy.next(ContainerPolicy.java:1173)
        at org.eclipse.persistence.internal.queries.ContainerPolicy.next(ContainerPolicy.java:1)
        at org.eclipse.persistence.internal.oxm.XMLCompositeCollectionMappingNodeValue.marshal(XMLCompositeCollectionMappingNodeValue.java:103)
        at org.eclipse.persistence.internal.oxm.NodeValue.marshal(NodeValue.java:149)
        at org.eclipse.persistence.internal.oxm.NodeValue.marshal(NodeValue.java:102)
        at org.eclipse.persistence.internal.oxm.record.ObjectMarshalContext.marshal(ObjectMarshalContext.java:59)
....

It appears that org/eclipse/persistence/internal/queries/CollectionContainerPolicy is not thread-safe as concurrent access to iteratorFor and addInto method can lead to ConcurrentModificationException

So I have made a fix where in iteratorFor method I am making a clonedList by calling cloneFor method and then returning iterator on that clonedList
In this way, add and iterator method will be independently called on original list and its clonedList respectively and will not cause ConcurrentModificationException

Signed-off-by: Vaibhav Vishal <vaibhav.vishal@oracle.com>