### PR TITLE
Allow an incremental build to perform less weaving

### DIFF
--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/tools/weaving/jpa/StaticWeaveProcessor.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/tools/weaving/jpa/StaticWeaveProcessor.java
@@ -12,6 +12,7 @@
 
 // Contributors:
 //     Oracle - initial API and implementation from Oracle TopLink
+//     Billforward - added fileNeedsProcessingPredicate for incremental build support
 package org.eclipse.persistence.tools.weaving.jpa;
 
 import java.io.ByteArrayOutputStream;
@@ -26,6 +27,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Iterator;
+import java.util.function.Predicate;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 
@@ -57,6 +59,7 @@ public class StaticWeaveProcessor {
     private Writer logWriter;
     private ClassLoader classLoader;
     private int logLevel = SessionLog.OFF;
+    private Predicate<String> fileNeedsProcessingPredicate;
 
     private static final int NUMBER_OF_BYTES = 1024;
 
@@ -256,6 +259,12 @@ public class StaticWeaveProcessor {
                 Iterator<String> entries = sourceArchive.getEntries();
                 while (entries.hasNext()){
                     String entryName = entries.next();
+
+                    if (fileNeedsProcessingPredicate != null &&
+                            !fileNeedsProcessingPredicate.test(entryName)) {
+                        continue;
+                    }
+                    
                     InputStream entryInputStream = sourceArchive.getEntry(entryName);
 
                     // Add a directory entry
@@ -371,5 +380,9 @@ public class StaticWeaveProcessor {
             return new URL[]{this.persistenceInfo};
         }
         return new URL[]{};
+    }
+
+    public void setFileNeedsProcessingPredicate(Predicate<String> fileNeedsProcessingPredicate) {
+        this.fileNeedsProcessingPredicate = fileNeedsProcessingPredicate;
     }
 }


### PR DESCRIPTION
This change allows for defining a Gradle plugin that will only perform Weaving or copying on classes that have changed their inputs. I have put some of the code for the Gradle plugin (available under the same license) in the comments below, but I couldn't see where this could be added to the Eclipselink codebase.