### PR TITLE
[2.7] JDK 11 build and test fix

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
@@ -809,7 +809,11 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
         // these are the objects remaining in the UnitOfWork privateOwnedObjects map
         if (hasPrivateOwnedObjects()) {
             Collection<Set> values = getPrivateOwnedObjects().values();
-            Map visitedObjects = new IdentityHashMap(values.stream().collect(Collectors.summingInt(Set::size)));
+            int initialSize = 0;
+            for (Set value: values) {
+                initialSize += value.size();
+            }
+            Map visitedObjects = new IdentityHashMap(initialSize);
             for (Set privateOwnedObjects : values) {
                 for (Object objectToRemove : privateOwnedObjects) {
                     performRemovePrivateOwnedObjectFromChangeSet(objectToRemove, visitedObjects);


### PR DESCRIPTION
It seems, that code change introduced in #1959 doesn't work correctly on JDK 11 (17 and 21 works).
It's about following line
`Map visitedObjects = new IdentityHashMap(values.stream().collect(Collectors.summingInt(Set::size)));`

Issue is presented by following EL test error:

```
NestedUnitOfWorkDeleteNestedNewObjectTest

Exception Description: Fatal error occurred. Internal Exception: java.lang.ClassCastException: class java.lang.Integer cannot be cast to class java.util.Map (java.lang.Integer and java.util.Map are in module java.base of loader 'bootstrap')

Local Exception Stack:
Exception [EclipseLink-0] (Eclipse Persistence Services - 2.7.14.qualifier): org.eclipse.persistence.testing.framework.TestErrorException
Exception Description: Fatal error occurred.
Internal Exception: java.lang.ClassCastException: class java.lang.Integer cannot be cast to class java.util.Map (java.lang.Integer and java.util.Map are in module java.base of loader 'bootstrap')
at org.eclipse.persistence.testing.framework.TestCase.execute(TestCase.java:168)
at org.eclipse.persistence.testing.framework.TestCase.runBare(TestCase.java:267)
at org.eclipse.persistence.testing.framework.TestExecutor.execute(TestExecutor.java:250)
at org.eclipse.persistence.testing.framework.TestSuite.execute(TestSuite.java:82)
at org.eclipse.persistence.testing.framework.TestCollection.run(TestCollection.java:315)
at org.eclipse.persistence.testing.framework.TestExecutor.execute(TestExecutor.java:250)
at org.eclipse.persistence.testing.framework.TestModel.execute(TestModel.java:213)
at org.eclipse.persistence.testing.framework.TestCollection.run(TestCollection.java:315)
at org.eclipse.persistence.testing.framework.TestExecutor.execute(TestExecutor.java:250)
at org.eclipse.persistence.testing.framework.TestModel.execute(TestModel.java:213)
at org.eclipse.persistence.testing.framework.TestCollection.run(TestCollection.java:315)
Caused by: java.lang.ClassCastException: class java.lang.Integer cannot be cast to class java.util.Map (java.lang.Integer and java.util.Map are in module java.base of loader 'bootstrap')
at org.eclipse.persistence.internal.sessions.UnitOfWorkImpl.calculateChanges(UnitOfWorkImpl.java:812)
at org.eclipse.persistence.internal.sessions.UnitOfWorkImpl.commitNestedUnitOfWork(UnitOfWorkImpl.java:1389)
at org.eclipse.persistence.internal.sessions.UnitOfWorkImpl.commit(UnitOfWorkImpl.java:1184)
at org.eclipse.persistence.testing.tests.unitofwork.NestedUnitOfWorkDeleteNestedNewObjectTest.test(NestedUnitOfWorkDeleteNestedNewObjectTest.java:44)
at org.eclipse.persistence.testing.framework.TestCase.executeTest(TestCase.java:547)
at org.eclipse.persistence.testing.framework.TestCase.execute(TestCase.java:158) 
```

it happens only if product (EclipseLink) is build by JDK 11.
Test itself should be called with any JDK (11, 17, 21).
Origin lambda is refactored into more "classical" style.