### PR TITLE
[master] fix #1240: SessionEventListener: add pre/post flush() events

### DIFF
--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/events/SessionEventTestCase.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/events/SessionEventTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -43,6 +43,7 @@ public class SessionEventTestCase extends TransactionalTestCase {
         UnitOfWork uow = getSession().acquireUnitOfWork();
         Employee emp = (Employee)uow.readObject(Employee.class);
         emp.setFirstName(emp.getFirstName() + "-modified");
+        uow.writeChanges();
         uow.commit();
     }
 
@@ -59,6 +60,12 @@ public class SessionEventTestCase extends TransactionalTestCase {
         }
         if (this.listener.postAcquireClientSession) {
             throw new TestErrorException("The post acquire event was not raised but should not have been.");
+        }
+        if(!this.listener.preFlushUnitOfWork) {
+            throw new TestErrorException("The pre UnitOfWork flush event did not fire");
+        }
+        if(!this.listener.postFlushUnitOfWork) {
+            throw new TestErrorException("The post UnitOfWork flush event did not fire");
         }
     }
 }

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/events/TestSessionListener.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/events/TestSessionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -22,6 +22,18 @@ public class TestSessionListener extends SessionEventAdapter {
     public boolean preBeginTransaction;
     public boolean postCalculateUnitOfWork;
     public boolean preCalculateUnitOfWork;
+    public boolean preFlushUnitOfWork;
+    public boolean postFlushUnitOfWork;
+
+    @Override
+    public void postFlushUnitOfWork(SessionEvent event) {
+       postFlushUnitOfWork = true;
+    }
+
+    @Override
+    public void preFlushUnitOfWork(SessionEvent event) {
+        preFlushUnitOfWork = true;
+    }
 
     /**
      * TestSessionListener constructor comment.

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/PostFlushUnitOfWorkTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/PostFlushUnitOfWorkTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.persistence.testing.tests.unitofwork;
+
+import org.eclipse.persistence.sessions.SessionEvent;
+import org.eclipse.persistence.sessions.SessionEventAdapter;
+import org.eclipse.persistence.sessions.UnitOfWork;
+import org.eclipse.persistence.testing.framework.TestErrorException;
+
+public class PostFlushUnitOfWorkTest extends UnitOfWorkEventTest {
+    @Override
+    public void setup() {
+        super.setup();
+        setDescription("Test the postFlushUnitOfWork Event");
+        SessionEventAdapter tvAdapter = new SessionEventAdapter() {
+                // Listen for PostFlushUnitOfWorkEvents
+
+                @Override
+                public void postFlushUnitOfWork(SessionEvent event) {
+                    setEventTriggered(true);
+                }
+            };
+        getSession().getEventManager().addListener(tvAdapter);
+    }
+
+    @Override
+    public void test() {
+        UnitOfWork tvUnitOfWork = getSession().acquireUnitOfWork();
+        tvUnitOfWork.writeChanges();
+    }
+
+    @Override
+    public void verify() {
+        if (!isEventTriggered()) {
+            throw new TestErrorException("The preFlushUnitOfWork event was not triggered.");
+        }
+    }
+}

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/PreFlushUnitOfWorkTest.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/PreFlushUnitOfWorkTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.persistence.testing.tests.unitofwork;
+
+import org.eclipse.persistence.sessions.SessionEvent;
+import org.eclipse.persistence.sessions.SessionEventAdapter;
+import org.eclipse.persistence.sessions.UnitOfWork;
+import org.eclipse.persistence.testing.framework.TestErrorException;
+
+public class PreFlushUnitOfWorkTest extends UnitOfWorkEventTest {
+    @Override
+    public void setup() {
+        super.setup();
+        setDescription("Test the preFlushUnitOfWork Event");
+        SessionEventAdapter tvAdapter = new SessionEventAdapter() {
+                // Listen for PreFlushUnitOfWorkEvents
+
+                @Override
+                public void preFlushUnitOfWork(SessionEvent event) {
+                    setEventTriggered(true);
+                }
+            };
+        getSession().getEventManager().addListener(tvAdapter);
+    }
+
+    @Override
+    public void test() {
+        UnitOfWork tvUnitOfWork = getSession().acquireUnitOfWork();
+        tvUnitOfWork.writeChanges();
+    }
+
+    @Override
+    public void verify() {
+        if (!isEventTriggered()) {
+            throw new TestErrorException("The preFlushUnitOfWork event was not triggered.");
+        }
+    }
+}

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/UnitOfWorkEventTestSuite.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/UnitOfWorkEventTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -28,6 +28,12 @@ public class UnitOfWorkEventTestSuite extends org.eclipse.persistence.testing.fr
 
         // PreCommitUnitOfWork
         addTest(new PreCommitUnitOfWorkTest());
+
+        // PreFlushUnitOfWork
+        addTest(new PreFlushUnitOfWorkTest());
+
+        // PostFlushUnitOfWork
+        addTest(new PostFlushUnitOfWorkTest());
 
         // PrepareUnitOfWork
         addTest(new PrepareUnitOfWorkTest());

--- a/foundation/org.eclipse.persistence.core.test.framework/src/main/java/org/eclipse/persistence/testing/framework/SessionEventTracker.java
+++ b/foundation/org.eclipse.persistence.core.test.framework/src/main/java/org/eclipse/persistence/testing/framework/SessionEventTracker.java
@@ -415,6 +415,17 @@ public class SessionEventTracker implements SessionEventListener {
     }
 
     /**
+     * PUBLIC: This event is raised on the unit of work after a flush.
+     */
+    @Override
+    public void postFlushUnitOfWork(SessionEvent event) {
+        if (!isTrackingEvent(event)) {
+            return;
+        }
+        log(event);
+    }
+
+    /**
      * PUBLIC:
      * This event is raised after the session connects to the database.
      * In a server session this event is raised on every new connection established.
@@ -562,6 +573,17 @@ public class SessionEventTracker implements SessionEventListener {
      */
     @Override
     public void preCommitUnitOfWork(SessionEvent event) {
+        if (!isTrackingEvent(event)) {
+            return;
+        }
+        log(event);
+    }
+
+    /**
+     * PUBLIC: This event is raised on the unit of work before a flush.
+     */
+    @Override
+    public void preFlushUnitOfWork(SessionEvent event) {
         if (!isTrackingEvent(event)) {
             return;
         }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/RepeatableWriteUnitOfWork.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/RepeatableWriteUnitOfWork.java
@@ -441,6 +441,9 @@ public class RepeatableWriteUnitOfWork extends UnitOfWorkImpl {
             return;
         }
         log(SessionLog.FINER, SessionLog.TRANSACTION, "begin_unit_of_work_flush");
+        if(eventManager != null) {
+            eventManager.preFlushUnitOfWork();
+        }
 
         // 256277: stop any nested flushing - there should only be one level
         this.isWithinFlush = true; // set before calculateChanges as a PrePersist callback may contain a query that requires a pre flush()
@@ -465,6 +468,9 @@ public class RepeatableWriteUnitOfWork extends UnitOfWorkImpl {
                 writesCompleted();
                 //return if there were no changes in the change set.
                 log(SessionLog.FINER, SessionLog.TRANSACTION, "end_unit_of_work_flush");
+                if(eventManager != null) {
+                    eventManager.postFlushUnitOfWork();
+                }
                 return;
             }
             // Write changes to the database.
@@ -485,6 +491,9 @@ public class RepeatableWriteUnitOfWork extends UnitOfWorkImpl {
             this.cumulativeUOWChangeSet.mergeUnitOfWorkChangeSet(changeSet, this, true);
         }
         log(SessionLog.FINER, SessionLog.TRANSACTION, "end_unit_of_work_flush");
+        if(eventManager != null) {
+            eventManager.postFlushUnitOfWork();
+        }
 
         resumeUnitOfWork();
         log(SessionLog.FINER, SessionLog.TRANSACTION, "resume_unit_of_work");

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
@@ -5856,10 +5856,11 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
             throw ValidationException.writeChangesOnNestedUnitOfWork();
         }
         log(SessionLog.FINER, SessionLog.TRANSACTION, "begin_unit_of_work_flush");
-        mergeBmpAndWsEntities();
         if (this.eventManager != null) {
-            this.eventManager.preCommitUnitOfWork();
+            this.eventManager.preFlushUnitOfWork();
         }
+        mergeBmpAndWsEntities();
+
         setLifecycle(CommitPending);
         try {
             commitToDatabaseWithChangeSet(false);
@@ -5871,6 +5872,9 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
         }
         setLifecycle(CommitTransactionPending);
         log(SessionLog.FINER, SessionLog.TRANSACTION, "end_unit_of_work_flush");
+        if (this.eventManager != null) {
+            this.eventManager.postFlushUnitOfWork();
+        }
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/remote/RemoteUnitOfWork.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/remote/RemoteUnitOfWork.java
@@ -225,6 +225,9 @@ public class RemoteUnitOfWork extends RepeatableWriteUnitOfWork {
             return;
         }
         log(SessionLog.FINER, SessionLog.TRANSACTION, "begin_unit_of_work_flush");
+        if(eventManager != null) {
+            eventManager.preFlushUnitOfWork();
+        }
 
         // PERF: If this is an empty unit of work, do nothing (but still may need to commit SQL changes).
         boolean hasChanges = (this.unitOfWorkChangeSet != null) || hasCloneMapping() || hasDeletedObjects() || hasModifyAllQueries() || hasDeferredModifyAllQueries();
@@ -238,6 +241,9 @@ public class RemoteUnitOfWork extends RepeatableWriteUnitOfWork {
         }
         if (!hasChanges) {
             log(SessionLog.FINER, SessionLog.TRANSACTION, "end_unit_of_work_flush");
+            if(eventManager != null) {
+                eventManager.postFlushUnitOfWork();
+            }
             return;
         }
 
@@ -268,6 +274,9 @@ public class RemoteUnitOfWork extends RepeatableWriteUnitOfWork {
         remoteUnitOfWork.commitIntoRemoteUnitOfWork();
 
         log(SessionLog.FINER, SessionLog.TRANSACTION, "end_unit_of_work_flush");
+        if(eventManager != null) {
+            eventManager.postFlushUnitOfWork();
+        }
 
         resumeUnitOfWork();
         log(SessionLog.FINER, SessionLog.TRANSACTION, "resume_unit_of_work");

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/SessionEvent.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/SessionEvent.java
@@ -69,6 +69,10 @@ public class SessionEvent extends EventObject {
     public static final int PrepareUnitOfWork = 14;
     public static final int PostResumeUnitOfWork = 15;
 
+    public static final int PreFlushUnitOfWork = 38;
+
+    public static final int PostFlushUnitOfWork = 39;
+
     // Three-tier events, only raised on server/client session.
     public static final int PostAcquireClientSession = 16;
     public static final int PreReleaseClientSession = 17;

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/SessionEventAdapter.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/SessionEventAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -66,6 +66,9 @@ public abstract class SessionEventAdapter implements SessionEventListener {
     public void postCommitUnitOfWork(SessionEvent event) { }
 
     @Override
+    public void postFlushUnitOfWork(SessionEvent event) { }
+
+    @Override
     public void postDistributedMergeUnitOfWorkChangeSet(SessionEvent event) { }
 
     @Override
@@ -100,6 +103,9 @@ public abstract class SessionEventAdapter implements SessionEventListener {
 
     @Override
     public void preCommitUnitOfWork(SessionEvent event) { }
+
+    @Override
+    public void preFlushUnitOfWork(SessionEvent event) { }
 
     @Override
     public void preExecuteCall(SessionEvent event) { }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/SessionEventListener.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/SessionEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -125,6 +125,11 @@ public interface SessionEventListener extends CoreSessionEventListener {
     void postCommitUnitOfWork(SessionEvent event);
 
     /**
+     * PUBLIC: This event is raised on the unit of work after a flush.
+     */
+    void postFlushUnitOfWork(SessionEvent event);
+
+    /**
      * PUBLIC:
      * This event is raised after the session connects to the database.
      * In a server session this event is raised on every new connection established.
@@ -206,6 +211,11 @@ public interface SessionEventListener extends CoreSessionEventListener {
      * This will be raised on nest units of work.
      */
     void preCommitUnitOfWork(SessionEvent event);
+
+    /**
+     * PUBLIC: This event is raised on the unit of work before a flush.
+     */
+    void preFlushUnitOfWork(SessionEvent event);
 
     /**
      * PUBLIC:

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/SessionEventManager.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/SessionEventManager.java
@@ -359,6 +359,23 @@ public class SessionEventManager extends CoreSessionEventManager<SessionEventLis
 
     /**
      * INTERNAL:
+     * Post flush unit of work.
+     */
+    public void postFlushUnitOfWork() {
+        if (!hasListeners()) {
+            return;
+        }
+        startOperationProfile();
+        SessionEvent event = new SessionEvent(SessionEvent.PostFlushUnitOfWork, getSession());
+        List<SessionEventListener> listeners = this.listeners;
+        for (SessionEventListener listener : listeners) {
+            listener.postFlushUnitOfWork(event);
+        }
+        endOperationProfile();
+    }
+
+    /**
+     * INTERNAL:
      * Raised after connecting.
      */
     public void postConnect(Accessor accessor) {
@@ -613,6 +630,23 @@ public class SessionEventManager extends CoreSessionEventManager<SessionEventLis
         int size = listeners.size();
         for (int index = 0; index < size; index++) {
             listeners.get(index).preCommitUnitOfWork(event);
+        }
+        endOperationProfile();
+    }
+
+    /**
+     * INTERNAL:
+     * Pre flush unit of work.
+     */
+    public void preFlushUnitOfWork() {
+        if (!hasListeners()) {
+            return;
+        }
+        startOperationProfile();
+        SessionEvent event = new SessionEvent(SessionEvent.PreFlushUnitOfWork, getSession());
+        List<SessionEventListener> listeners = this.listeners;
+        for (SessionEventListener listener : listeners) {
+            listener.preFlushUnitOfWork(event);
         }
         endOperationProfile();
     }


### PR DESCRIPTION
fix #1240 
- Added preFlushUnitOfWork/postFlushUnitOfWork events
- Removed preCommitUnitOfWork event from flush in UnitOfWorkImpl, since triggering a commit event for a flush seems wrong to me.