### PR TITLE
[master] Set JDK 21 as a compiler release switch

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,7 +45,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         distribution: 'zulu'
-        java-version: 17
+        java-version: 21
 
     - name: Checkout repository
       uses: actions/checkout@v3

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -31,7 +31,7 @@ jobs:
 
     strategy:
       matrix:
-        java_version: [ 17, 21 ]
+        java_version: [ 21 ]
 
     steps:
       - name: Start MySQL Database

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -25,7 +25,7 @@ queries:
 extraction:
   java:
     index:
-      java_version: 11
+      java_version: 21
       maven:
         version: 3.6.3
       build_command: "mvn -DskipTests -Denforcer.skip clean package -Pstaging"

--- a/bundles/eclipselink/pom.xml
+++ b/bundles/eclipselink/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.bundles</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bundles/moxy-standalone/pom.xml
+++ b/bundles/moxy-standalone/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.bundles</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bundles/nightly/pom.xml
+++ b/bundles/nightly/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.bundles</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bundles/others/pom.xml
+++ b/bundles/others/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.bundles</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bundles/p2site/pom.xml
+++ b/bundles/p2site/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.bundles</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bundles/tests/pom.xml
+++ b/bundles/tests/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.bundles</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/dbws/eclipselink.dbws.test.oracle/pom.xml
+++ b/dbws/eclipselink.dbws.test.oracle/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/dbws/org.eclipse.persistence.dbws/pom.xml
+++ b/dbws/org.eclipse.persistence.dbws/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/docs/docs.concepts/pom.xml
+++ b/docs/docs.concepts/pom.xml
@@ -24,13 +24,13 @@
     <description>EclipseLink Documentation for the WebSite - Concepts</description>
     <groupId>org.eclipse.persistence</groupId>
     <artifactId>org.eclipse.persistence.documentation.concepts</artifactId>
-    <version>4.1.0-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.documentation</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/docs.dbws/pom.xml
+++ b/docs/docs.dbws/pom.xml
@@ -24,13 +24,13 @@
     <description>EclipseLink Documentation for the WebSite - DBWS</description>
     <groupId>org.eclipse.persistence</groupId>
     <artifactId>org.eclipse.persistence.documentation.dbws</artifactId>
-    <version>4.1.0-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.documentation</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/docs.jpa/pom.xml
+++ b/docs/docs.jpa/pom.xml
@@ -24,13 +24,13 @@
     <description>EclipseLink Documentation for the WebSite - JPA Extensions</description>
     <groupId>org.eclipse.persistence</groupId>
     <artifactId>org.eclipse.persistence.documentation.jpaextensions</artifactId>
-    <version>4.1.0-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.documentation</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/docs.moxy/pom.xml
+++ b/docs/docs.moxy/pom.xml
@@ -24,13 +24,13 @@
     <description>EclipseLink Documentation for the WebSite - MOXy</description>
     <groupId>org.eclipse.persistence</groupId>
     <artifactId>org.eclipse.persistence.documentation.moxy</artifactId>
-    <version>4.1.0-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.documentation</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/docs.solutions/pom.xml
+++ b/docs/docs.solutions/pom.xml
@@ -24,13 +24,13 @@
     <description>EclipseLink Documentation for the WebSite - Solutions</description>
     <groupId>org.eclipse.persistence</groupId>
     <artifactId>org.eclipse.persistence.documentation.solutions</artifactId>
-    <version>4.1.0-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.documentation</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -24,13 +24,13 @@
     <description>EclipseLink Documentation for the WebSite</description>
     <groupId>org.eclipse.persistence</groupId>
     <artifactId>org.eclipse.persistence.documentation</artifactId>
-    <version>4.1.0-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/etc/jenkins/build.groovy
+++ b/etc/jenkins/build.groovy
@@ -104,7 +104,7 @@ spec:
     }
     tools {
         maven 'apache-maven-latest'
-        jdk 'openjdk-jdk17-latest'
+        jdk 'openjdk-jdk21-latest'
     }
     stages {
         // Initialize build environment

--- a/etc/jenkins/pr_verify.groovy
+++ b/etc/jenkins/pr_verify.groovy
@@ -95,7 +95,7 @@ spec:
     }
     tools {
         maven 'apache-maven-latest'
-        jdk 'openjdk-jdk17-latest'
+        jdk 'openjdk-jdk21-latest'
     }
     stages {
         // Initialize build environment

--- a/etc/jenkins/release.groovy
+++ b/etc/jenkins/release.groovy
@@ -101,7 +101,7 @@ spec:
     }
     tools {
         maven 'apache-maven-latest'
-        jdk 'openjdk-jdk17-latest'
+        jdk 'openjdk-jdk21-latest'
     }
     stages {
 

--- a/foundation/eclipselink.core.test/pom.xml
+++ b/foundation/eclipselink.core.test/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/foundation/org.eclipse.persistence.corba/pom.xml
+++ b/foundation/org.eclipse.persistence.corba/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/foundation/org.eclipse.persistence.core.test.framework/pom.xml
+++ b/foundation/org.eclipse.persistence.core.test.framework/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/foundation/org.eclipse.persistence.core/pom.xml
+++ b/foundation/org.eclipse.persistence.core/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/WriteLockManager.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/WriteLockManager.java
@@ -425,7 +425,7 @@ public class WriteLockManager {
                                 // linked list for quick removal upon
                                 // acquiring all locks
                                 synchronized (this.prevailingQueue) {
-                                    mergeManager.setQueueNode(this.prevailingQueue.addLast(mergeManager));
+                                    mergeManager.setQueueNode(this.prevailingQueue.addLastElement(mergeManager));
                                 }
                             }
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/linkedlist/ExposedNodeLinkedList.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/linkedlist/ExposedNodeLinkedList.java
@@ -205,7 +205,17 @@ public class ExposedNodeLinkedList implements List {
      *
      * @param o the contents to be inserted at the beginning of this list.
      */
-    public LinkedNode addFirst(Object o) {
+    public void addFirst(Object o) {
+        addAfter(o, header);
+    }
+
+    /**
+     * Inserts the given contents at the beginning of this list.
+     *
+     * @param o the contents to be inserted at the beginning of this list.
+     * @return <code>LinkedNode</code> with the specified content.
+     */
+    public LinkedNode addFirstElement(Object o) {
         return addAfter(o, header);
     }
 
@@ -215,7 +225,18 @@ public class ExposedNodeLinkedList implements List {
      *
      * @param o the contents to be inserted at the end of this list.
      */
-    public LinkedNode addLast(Object o) {
+    public void addLast(Object o) {
+        addAfter(o, header.previous);
+    }
+
+    /**
+     * Appends the given contents to the end of this list.  (Identical in
+     * function to the <code>add</code> method; included only for consistency.)
+     *
+     * @param o the contents to be inserted at the end of this list.
+     * @return <code>LinkedNode</code> with the specified content.
+     */
+    public LinkedNode addLastElement(Object o) {
         return addAfter(o, header.previous);
     }
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/identitymaps/HardCacheWeakIdentityMap.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/identitymaps/HardCacheWeakIdentityMap.java
@@ -155,7 +155,7 @@ public class HardCacheWeakIdentityMap extends WeakIdentityMap {
             synchronized (referenceCache) {
                 // If reference node is null, add to start (new cache key).
                 if (this.referenceNode == null) {
-                    this.referenceNode = referenceCache.addFirst(buildReference(getObject()));
+                    this.referenceNode = referenceCache.addFirstElement(buildReference(getObject()));
                 } else {
                     // This is a fast constant time operations because of the linked list usage.
                     referenceCache.moveFirst(getReferenceCacheNode());

--- a/foundation/org.eclipse.persistence.extension/pom.xml
+++ b/foundation/org.eclipse.persistence.extension/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/foundation/org.eclipse.persistence.json/pom.xml
+++ b/foundation/org.eclipse.persistence.json/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/foundation/org.eclipse.persistence.nosql/pom.xml
+++ b/foundation/org.eclipse.persistence.nosql/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/foundation/org.eclipse.persistence.oracle.nosql/pom.xml
+++ b/foundation/org.eclipse.persistence.oracle.nosql/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/foundation/org.eclipse.persistence.oracle.test/pom.xml
+++ b/foundation/org.eclipse.persistence.oracle.test/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/foundation/org.eclipse.persistence.oracle/pom.xml
+++ b/foundation/org.eclipse.persistence.oracle/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/foundation/org.eclipse.persistence.pgsql/pom.xml
+++ b/foundation/org.eclipse.persistence.pgsql/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/jpa/eclipselink.jaxrs.test/pom.xml
+++ b/jpa/eclipselink.jaxrs.test/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.test.server.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../testing/server/pom.xml</relativePath>
     </parent>
 

--- a/jpa/eclipselink.jpa.spring.test/pom.xml
+++ b/jpa/eclipselink.jpa.spring.test/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/jpa/eclipselink.jpa.test.jse/pom.xml
+++ b/jpa/eclipselink.jpa.test.jse/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/jpa/eclipselink.jpa.test/pom.xml
+++ b/jpa/eclipselink.jpa.test/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.test.server.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../testing/server/pom.xml</relativePath>
     </parent>
 

--- a/jpa/eclipselink.jpa.testapps.nosql/jpa.test.nosql.mongo/pom.xml
+++ b/jpa/eclipselink.jpa.testapps.nosql/jpa.test.nosql.mongo/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps.nosql</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps.nosql/pom.xml
+++ b/jpa/eclipselink.jpa.testapps.nosql/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../eclipselink.jpa.testapps/pom.xml</relativePath>
     </parent>
 

--- a/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.customfeatures/pom.xml
+++ b/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.customfeatures/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps.oracle</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.dcn/pom.xml
+++ b/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.dcn/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps.oracle</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.partitioned/pom.xml
+++ b/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.partitioned/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps.oracle</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.plsql/pom.xml
+++ b/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.plsql/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps.oracle</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.proxyauthentication/pom.xml
+++ b/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.proxyauthentication/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps.oracle</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.spatial/pom.xml
+++ b/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.spatial/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps.oracle</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.timestamptz/pom.xml
+++ b/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.timestamptz/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps.oracle</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps.oracle/pom.xml
+++ b/jpa/eclipselink.jpa.testapps.oracle/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../eclipselink.jpa.testapps/pom.xml</relativePath>
     </parent>
 

--- a/jpa/eclipselink.jpa.testapps.oracle/test.oracle.spatial/pom.xml
+++ b/jpa/eclipselink.jpa.testapps.oracle/test.oracle.spatial/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps.oracle</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/README.md
+++ b/jpa/eclipselink.jpa.testapps/README.md
@@ -46,7 +46,7 @@ if no customized descriptor is provided in `src/main/resources-ejb/META-INF/pers
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -242,7 +242,7 @@ datasources on the server need to point to different MySQL DB schemas from those
 ```
 WILDFLY_HOME=...
 REPO_HOME=$HOME/.m2/repository/org/eclipse/persistence
-VERSION=4.1.0-SNAPSHOT
+VERSION=5.0.0-SNAPSHOT
 ASM_VERSION=9.4.0
 
 WR=$WILDFLY_HOME/modules/system/layers/base/org/eclipse/persistence/main

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced.additionalcriteria/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced.additionalcriteria/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced.cacheimpl/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced.cacheimpl/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced.cascadepersist/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced.cascadepersist/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced.compositepk/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced.compositepk/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced.customer/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced.customer/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced.derivedid/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced.derivedid/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced.embeddable/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced.embeddable/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced.fetchgroup/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced.fetchgroup/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced.multitenant/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced.multitenant/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced2/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced2/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.beanvalidation.dynamic/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.beanvalidation.dynamic/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.beanvalidation/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.beanvalidation/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.cacheable/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.cacheable/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.cascadedeletes/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.cascadedeletes/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.complexaggregate/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.complexaggregate/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.composite.advanced/common/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.composite.advanced/common/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.composite.advanced/member_1/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.composite.advanced/member_1/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.composite.advanced/member_2/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.composite.advanced/member_2/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.composite.advanced/member_3/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.composite.advanced/member_3/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.composite.advanced/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.composite.advanced/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.criteria/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.criteria/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.datatypes/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.datatypes/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.datetime/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.datetime/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.ddlgeneration/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.ddlgeneration/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.delimited/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.delimited/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.diagnostic/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.diagnostic/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.extensibility/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.extensibility/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.fetchgroups/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.fetchgroups/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.fieldaccess.advanced/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.fieldaccess.advanced/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.fieldaccess.relationships/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.fieldaccess.relationships/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.identity/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.identity/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.inheritance/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.inheritance/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.inherited/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.inherited/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.jpaadvancedproperties/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.jpaadvancedproperties/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.jpql/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.jpql/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.jta/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.jta/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.lob/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.lob/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.memory/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.memory/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.metamodel.apectj/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.metamodel.apectj/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.metamodel/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.metamodel/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.orphanremoval/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.orphanremoval/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.partitioned/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.partitioned/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.performance/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.performance/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.performance2/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.performance2/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.privateowned/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.privateowned/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.pu with spaces/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.pu with spaces/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.relationships/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.relationships/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.remote/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.remote/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.sessionbean.ha/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.sessionbean.ha/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.sessionbean/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.sessionbean/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.validation/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.validation/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.weaving/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.weaving/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/common/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/common/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/member_1/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/member_1/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/member_2/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/member_2/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/member_3/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/member_3/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended.composite.advanced/member_1/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended.composite.advanced/member_1/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended.composite.advanced/member_2/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended.composite.advanced/member_2/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended.composite.advanced/member_3/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended.composite.advanced/member_3/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended.composite.advanced/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended.composite.advanced/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2022, 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.advanced.additionalcriteria/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.advanced.additionalcriteria/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.advanced.dynamic/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.advanced.dynamic/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.advanced.fetchgroup/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.advanced.fetchgroup/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2022, 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.advanced/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.advanced/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.complexaggregate/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.complexaggregate/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2022, 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.inheritance/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.inheritance/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.relationships/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.relationships/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.merge/jpa.test.xml.merge.advanced/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.merge/jpa.test.xml.merge.advanced/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.merge/jpa.test.xml.merge.incompletemappings.nonowning/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.merge/jpa.test.xml.merge.incompletemappings.nonowning/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.merge/jpa.test.xml.merge.incompletemappings.owning/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.merge/jpa.test.xml.merge.incompletemappings.owning/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.merge/jpa.test.xml.merge.inherited/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.merge/jpa.test.xml.merge.inherited/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.merge/jpa.test.xml.merge.relationships/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.merge/jpa.test.xml.merge.relationships/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.advanced.multitenant/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.advanced.multitenant/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.advanced/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.advanced/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.cacheable/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.cacheable/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.inheritance/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.inheritance/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.inherited/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.inherited/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.metadatacomplete/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.metadatacomplete/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.relationships.unidirectional/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.relationships.unidirectional/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.relationships/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.relationships/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.xmlmetadatacomplete/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.xmlmetadatacomplete/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/nativeapi/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/nativeapi/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.parent</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/jpa/eclipselink.jpa.testapps/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/pom.xml
@@ -319,7 +319,9 @@
         <module>jpa.test.lob</module>
         <module>jpa.test.memory</module>
         <module>jpa.test.metamodel</module>
+<!--Temporary disabled as AspectJ is no ready for JDK21 yet
         <module>jpa.test.metamodel.apectj</module>
+        -->
         <module>jpa.test.orphanremoval</module>
         <module>jpa.test.partitioned</module>
         <module>jpa.test.performance</module>

--- a/jpa/eclipselink.jpa.wdf.test/pom.xml
+++ b/jpa/eclipselink.jpa.wdf.test/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/jpa/eclipselink.jpars.test/pom.xml
+++ b/jpa/eclipselink.jpars.test/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.test.server.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../testing/server/pom.xml</relativePath>
     </parent>
 

--- a/jpa/org.eclipse.persistence.jpa.jpql/pom.xml
+++ b/jpa/org.eclipse.persistence.jpa.jpql/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/org/eclipse/persistence/jpa/tests/jpql/parser/JPQLExpressionTurkishLocaleTest.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/org/eclipse/persistence/jpa/tests/jpql/parser/JPQLExpressionTurkishLocaleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -33,7 +33,7 @@ public class JPQLExpressionTurkishLocaleTest {
     public void testJPQLExpressionWithTurkishLocale() {
         Locale current = Locale.getDefault();
         try {
-            Locale.setDefault(new Locale("tr", "TR"));
+            Locale.setDefault(Locale.of("tr", "TR"));
 
             JPQLGrammar grammar = DefaultEclipseLinkJPQLGrammar.instance();
             JPQLExpression expression = new JPQLExpression(

--- a/jpa/org.eclipse.persistence.jpa.modelgen/pom.xml
+++ b/jpa/org.eclipse.persistence.jpa.modelgen/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/jpa/org.eclipse.persistence.jpa.test.framework/pom.xml
+++ b/jpa/org.eclipse.persistence.jpa.test.framework/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/jpa/org.eclipse.persistence.jpa/pom.xml
+++ b/jpa/org.eclipse.persistence.jpa/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/jpa/org.eclipse.persistence.jpars.server/pom.xml
+++ b/jpa/org.eclipse.persistence.jpars.server/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/jpa/org.eclipse.persistence.jpars/pom.xml
+++ b/jpa/org.eclipse.persistence.jpars/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/moxy/org.eclipse.persistence.moxy.utils.xjc/pom.xml
+++ b/moxy/org.eclipse.persistence.moxy.utils.xjc/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/moxy/org.eclipse.persistence.moxy/pom.xml
+++ b/moxy/org.eclipse.persistence.moxy/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/performance/eclipselink.perf.test/pom.xml
+++ b/performance/eclipselink.perf.test/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.parent</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -96,8 +96,8 @@
 
     <properties>
         <!-- Minimum required JDK version -->
-        <maven.compiler.release>17</maven.compiler.release>
-        <maven.compiler.testRelease>17</maven.compiler.testRelease>
+        <maven.compiler.release>21</maven.compiler.release>
+        <maven.compiler.testRelease>21</maven.compiler.testRelease>
 
         <!-- TOOL Properties -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -1654,7 +1654,7 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>[17,)</version>
+                                    <version>[21,)</version>
                                 </requireJavaVersion>
                                 <requireMavenVersion>
                                     <version>[3.6.3,)</version>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <description>Comprehensive and universal persistence framework for Java.</description>
     <groupId>org.eclipse.persistence</groupId>
     <artifactId>org.eclipse.persistence.parent</artifactId>
-    <version>4.1.0-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>

--- a/sdo/eclipselink.sdo.test.server/pom.xml
+++ b/sdo/eclipselink.sdo.test.server/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.test.server.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../testing/server/pom.xml</relativePath>
     </parent>
 

--- a/sdo/org.eclipse.persistence.sdo/pom.xml
+++ b/sdo/org.eclipse.persistence.sdo/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/server-oracle/pom.xml
+++ b/testing/server-oracle/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/server/pom.xml
+++ b/testing/server/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.parent</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/utils/eclipselink.dbws.builder.test.oracle.server/pom.xml
+++ b/utils/eclipselink.dbws.builder.test.oracle.server/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.oracle.test.server.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../testing/server-oracle/pom.xml</relativePath>
     </parent>
 

--- a/utils/eclipselink.dbws.builder.test.oracle/pom.xml
+++ b/utils/eclipselink.dbws.builder.test.oracle/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/utils/eclipselink.utils.rename/pom.xml
+++ b/utils/eclipselink.utils.rename/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/utils/eclipselink.utils.sigcompare/pom.xml
+++ b/utils/eclipselink.utils.sigcompare/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/utils/org.eclipse.persistence.dbws.builder/pom.xml
+++ b/utils/org.eclipse.persistence.dbws.builder/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
It leads into following minimal changes to pass a build:

- refactor call `new Locale(...)` into `Locale.of(...)`
- resolve `addFirst(...), addLast(...)` collision in `org.eclipse.persistence.internal.helper.linkedlist.ExposedNodeLinkedList` with `java.util.List` [this is incompatible change, but limited to \"internal\" classes
- disable `jpa.test.metamodel.apectj` Maven module as AspectJ 1.9.20.1 is not JDK 21 ready
	waiting for a new relase (see https://github.com/eclipse-aspectj/aspectj/pull/261)