### PR TITLE
[2.7] Installer and OSGi test fixes

### DIFF
--- a/moxy/eclipselink.moxy.test/pom.xml
+++ b/moxy/eclipselink.moxy.test/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -25,16 +25,16 @@
 
     <properties>
         <!-- CQ #21132 -->
-        <apache.felix.framework.version>6.0.3</apache.felix.framework.version>
+        <apache.felix.framework.version>7.0.5</apache.felix.framework.version>
         <!-- CQ #21134, 21135, 21136, 21137 -->
-        <exam.version>4.13.1</exam.version>
+        <exam.version>4.13.4</exam.version>
         <!-- CQ #3571 -->
         <hibernate.version>6.1.0.Final</hibernate.version>
         <jaxb.version>2.3.2</jaxb.version>
         <log4j.version>2.16.0</log4j.version>
         <!-- CQ #21139, 21140 -->
         <logback.version>1.3.0-alpha5</logback.version>
-        <url.version>2.6.7</url.version>
+        <url.version>2.6.14</url.version>
         <validation.version>2.0.2</validation.version>
         <eclipselink.version>2.7.14-SNAPSHOT</eclipselink.version>
     </properties>

--- a/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/installer/JaxbCompilerTestCase.java
+++ b/moxy/eclipselink.moxy.test/src/org/eclipse/persistence/testing/jaxb/installer/JaxbCompilerTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,7 +14,10 @@
 //     Martin Vojtek - 2.6.0 - initial implementation
 package org.eclipse.persistence.testing.jaxb.installer;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.InputStreamReader;
+import java.util.stream.Collectors;
 import java.util.logging.Logger;
 
 /**
@@ -53,9 +56,15 @@ public class JaxbCompilerTestCase extends junit.framework.TestCase {
         File compilerFile = new File(binDir, jaxbCompiler);
 
         Process process = Runtime.getRuntime().exec(new String[] { compilerFile.getAbsolutePath(), resourceFile.getAbsolutePath() }, null, binDir);
+        String stdInput = new BufferedReader(new InputStreamReader(process.getInputStream()))
+                .lines()
+                .collect(Collectors.joining("\n"));
+        String stdError = new BufferedReader(new InputStreamReader(process.getErrorStream()))
+                .lines()
+                .collect(Collectors.joining("\n"));
         int result = process.waitFor();
 
-        assertTrue("Process has not completed successfully.", result == 0);
+        assertTrue("Process has not completed successfully with:\nStdOut:\n" + stdInput + "\nStdError:\n" + stdError, result == 0);
 
         String packagePrefix = "perf" + File.separator + "testing" + File.separator + "persistence" + File.separator + "eclipse" + File.separator + "org" + File.separator + "workitem";
 


### PR DESCRIPTION
- Installer test is more responsive now and prints in case of failure STDOUT and STDERR
- Remove some warning messages in OSGi test on JDK 21 by tes dependencies update