### PR TITLE
[2.7] Oracle 23C platform - backport from master

### DIFF
--- a/buildsystem/compdeps/pom.xml
+++ b/buildsystem/compdeps/pom.xml
@@ -112,8 +112,8 @@
         <!-- CQ #21122 -->
         <org.jgroups.version>4.1.8.Final</org.jgroups.version>
         <!-- CQ #21154 -->
-        <oracle.jdbc.version>21.7.0.0</oracle.jdbc.version>
-        <oracle.apapi.version>21.3.0.0</oracle.apapi.version>
+        <oracle.jdbc.version>23.3.0.23.09</oracle.jdbc.version>
+        <oracle.apapi.version>23.2.0.0</oracle.apapi.version>
         <!-- CQ #21141 -->
         <oracle.nosql.version>18.3.10</oracle.nosql.version>
         <!-- CQ #22994 -->

--- a/foundation/org.eclipse.persistence.core/resource/org/eclipse/persistence/internal/helper/VendorNameToPlatformMapping.properties
+++ b/foundation/org.eclipse.persistence.core/resource/org/eclipse/persistence/internal/helper/VendorNameToPlatformMapping.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 1998, 2019 IBM Corporation. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -36,6 +36,7 @@
 # to platform class entries should be placed before less specific entries. Each
 # platform entry must be on its own line, an entry cannot span multiple lines.
 
+(?is)oracle.*23.*=org.eclipse.persistence.platform.database.oracle.Oracle23Platform
 (?is)oracle.*21.*=org.eclipse.persistence.platform.database.oracle.Oracle21Platform
 (?is)oracle.*19.*=org.eclipse.persistence.platform.database.oracle.Oracle19Platform
 (?is)oracle.*18.*=org.eclipse.persistence.platform.database.oracle.Oracle18Platform
@@ -43,6 +44,7 @@
 (?is)oracle.*11.*=org.eclipse.persistence.platform.database.oracle.Oracle11Platform
 (?is)oracle.*10.*=org.eclipse.persistence.platform.database.oracle.Oracle10Platform
 (?is)oracle.*9.*=org.eclipse.persistence.platform.database.oracle.Oracle9Platform
+(?is)core.oracle.*23.*=org.eclipse.persistence.platform.database.Oracle23Platform
 (?is)core.oracle.*21.*=org.eclipse.persistence.platform.database.Oracle21Platform
 (?is)core.oracle.*19.*=org.eclipse.persistence.platform.database.Oracle19Platform
 (?is)core.oracle.*18.*=org.eclipse.persistence.platform.database.Oracle18Platform

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/core/databaseaccess/CorePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/core/databaseaccess/CorePlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,7 +14,9 @@
 //     Blaise Doughan - 2.5 - initial implementation
 package org.eclipse.persistence.internal.core.databaseaccess;
 
+import org.eclipse.persistence.exceptions.ConversionException;
 import org.eclipse.persistence.internal.core.helper.CoreConversionManager;
+import org.eclipse.persistence.internal.sessions.AbstractSession;
 
 public interface CorePlatform<CONVERSION_MANAGER extends CoreConversionManager> {
 
@@ -27,6 +29,17 @@ public interface CorePlatform<CONVERSION_MANAGER extends CoreConversionManager> 
      * @return - the newly converted object
      */
     Object convertObject(Object sourceObject, Class javaClass);
+
+    /**
+     * Convert the object to the appropriate type by invoking the appropriate
+     * ConversionManager method.
+     * @param sourceObject the object that must be converted
+     * @param javaClass the class that the object must be converted to
+     * @param session current database session
+     * @exception ConversionException all exceptions will be thrown as this type.
+     * @return the newly converted object
+     */
+    Object convertObject(Object sourceObject, Class javaClass, AbstractSession session) throws ConversionException;
 
     /**
      * The platform hold its own instance of conversion manager to allow customization.

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatasourcePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatasourcePlatform.java
@@ -245,6 +245,20 @@ public class DatasourcePlatform implements Platform {
     }
 
     /**
+     * Convert the object to the appropriate type by invoking the appropriate
+     * ConversionManager method.
+     * @param sourceObject the object that must be converted
+     * @param javaClass the class that the object must be converted to
+     * @param session current database session
+     * @exception ConversionException all exceptions will be thrown as this type.
+     * @return the newly converted object
+     */
+    @Override
+    public Object convertObject(Object sourceObject, Class javaClass, AbstractSession session) throws ConversionException {
+        return convertObject(sourceObject, javaClass);
+    }
+
+    /**
      * Copy the state into the new platform.
      */
     @Override
@@ -284,6 +298,13 @@ public class DatasourcePlatform implements Platform {
     @Override
     public void setConversionManager(ConversionManager conversionManager) {
         this.conversionManager = conversionManager;
+    }
+
+    /**
+     * Return the driver version.
+     */
+    public String getDriverVersion() {
+        return "";
     }
 
     /**
@@ -642,6 +663,11 @@ public class DatasourcePlatform implements Platform {
 
     @Override
     public boolean isOracle9() {
+        return false;
+    }
+
+    @Override
+    public boolean isOracle23() {
         return false;
     }
 

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/Platform.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/Platform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019 IBM Corporation. All rights reserved.
  * 
  * This program and the accompanying materials are made available under the
@@ -48,6 +48,17 @@ public interface Platform extends CorePlatform<ConversionManager>, Serializable,
     public Object convertObject(Object sourceObject, Class javaClass) throws ConversionException;
 
     /**
+     * Convert the object to the appropriate type by invoking the appropriate
+     * ConversionManager method.
+     * @param sourceObject the object that must be converted
+     * @param javaClass the class that the object must be converted to
+     * @param session current database session
+     * @exception ConversionException all exceptions will be thrown as this type.
+     * @return the newly converted object
+     */
+    public Object convertObject(Object sourceObject, Class javaClass, AbstractSession session) throws ConversionException;
+
+    /**
      * Copy the state into the new platform.
      */
     public void copyInto(Platform platform);
@@ -62,6 +73,11 @@ public interface Platform extends CorePlatform<ConversionManager>, Serializable,
      * The platform hold its own instance of conversion manager to allow customization.
      */
     public void setConversionManager(ConversionManager conversionManager);
+
+    /**
+     * Return the driver version.
+     */
+    public String getDriverVersion();
 
     /**
      * Return the qualifier for the table. Required by some
@@ -112,6 +128,8 @@ public interface Platform extends CorePlatform<ConversionManager>, Serializable,
     public boolean isOracle();
 
     public boolean isOracle9();
+
+    public boolean isOracle23();
 
     public boolean isPointBase();
 

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/mappings/converters/TypeConversionConverter.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/mappings/converters/TypeConversionConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -207,7 +207,12 @@ public class TypeConversionConverter implements Converter, ClassNameConversionRe
      */
     public Object convertObjectValueToDataValue(Object attributeValue, Session session) {
         try {
-            return ((AbstractSession)session).getDatasourcePlatform().convertObject(attributeValue, getDataClass());
+            if (session.isConnected()) {
+                //Should handle conversions where DB connection is needed like String -> java.sql.Clob
+                return session.getDatasourcePlatform().convertObject(attributeValue, getDataClass(), (AbstractSession)session);
+            } else {
+                return session.getDatasourcePlatform().convertObject(attributeValue, getDataClass());
+            }
         } catch (ConversionException e) {
             throw ConversionException.couldNotBeConverted(mapping, mapping.getDescriptor(), e);
         }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/Oracle23Platform.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/Oracle23Platform.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.platform.database;
+
+import org.eclipse.persistence.exceptions.ConversionException;
+import org.eclipse.persistence.exceptions.DatabaseException;
+import org.eclipse.persistence.internal.databaseaccess.FieldTypeDefinition;
+import org.eclipse.persistence.internal.helper.ClassConstants;
+import org.eclipse.persistence.internal.sessions.AbstractSession;
+
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Hashtable;
+
+import static org.eclipse.persistence.internal.helper.StringHelper.EMPTY_STRING;
+
+public class Oracle23Platform extends Oracle21Platform {
+	public Oracle23Platform() {
+		super();
+	}
+
+	@Override
+	protected Hashtable<Class<?>, FieldTypeDefinition> buildFieldTypes() {
+		Hashtable<Class<?>, FieldTypeDefinition> fieldTypes = super.buildFieldTypes();
+		fieldTypes.put(java.time.LocalDateTime.class, new FieldTypeDefinition("TIMESTAMP", 9));
+		fieldTypes.put(java.time.LocalTime.class, new FieldTypeDefinition("TIMESTAMP", 9));
+		return fieldTypes;
+	}
+
+	/**
+	 * INTERNAL:
+	 * Check whether current platform is Oracle 23c or later.
+	 * @return Always returns {@code true} for instances of Oracle 23c platform.
+	 * @since 2.7.14
+	 */
+	@Override
+	public boolean isOracle23() {
+		return true;
+	}
+
+	/**
+	 * INTERNAL:
+	 * Allow for conversion from the Oracle type to the Java type. Used in cases when DB connection is needed like BLOB, CLOB.
+	 */
+	@Override
+	public Object convertObject(Object sourceObject, Class javaClass, AbstractSession session) throws ConversionException, DatabaseException {
+		//Handle special case when empty String ("") is passed from the entity into CLOB type column
+		if (ClassConstants.CLOB.equals(javaClass) && sourceObject instanceof String && EMPTY_STRING.equals(sourceObject)) {
+			Connection connection = session.getAccessor().getConnection();
+			Clob clob = null;
+			try {
+				clob = connection.createClob();
+				clob.setString(1, (String)sourceObject);
+			} catch (SQLException e) {
+				throw ConversionException.couldNotBeConvertedToClass(sourceObject, ClassConstants.CLOB, e);
+			}
+			return clob;
+		}
+		return super.convertObject(sourceObject, javaClass);
+	}
+}

--- a/foundation/org.eclipse.persistence.oracle/src/org/eclipse/persistence/platform/database/oracle/Oracle23Platform.java
+++ b/foundation/org.eclipse.persistence.oracle/src/org/eclipse/persistence/platform/database/oracle/Oracle23Platform.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.platform.database.oracle;
+
+import org.eclipse.persistence.exceptions.ConversionException;
+import org.eclipse.persistence.exceptions.DatabaseException;
+import org.eclipse.persistence.internal.databaseaccess.FieldTypeDefinition;
+import org.eclipse.persistence.internal.helper.ClassConstants;
+import org.eclipse.persistence.internal.sessions.AbstractSession;
+
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Hashtable;
+
+import static org.eclipse.persistence.internal.helper.StringHelper.EMPTY_STRING;
+
+/**
+ * <p><b>Purpose:</b>
+ * Supports certain new Oracle 23c data types, and usage of certain Oracle JDBC specific APIs.
+ * <p> Supports Oracle JSON data type.
+ * <p> Supports Oracle OracleJsonValue derived Java types.
+ */
+public class Oracle23Platform extends Oracle21Platform {
+
+    /**
+     * Creates an instance of Oracle 23c database platform.
+     */
+    public Oracle23Platform() {
+        super();
+    }
+
+    /**
+     * INTERNAL:
+     * Check whether current platform is Oracle 23c or later.
+     * @return Always returns {@code true} for instances of Oracle 23c platform.
+     * @since 4.0.2
+     */
+    @Override
+    public boolean isOracle23() {
+        return true;
+    }
+
+    @Override
+    protected Hashtable<Class<?>, FieldTypeDefinition> buildFieldTypes() {
+        Hashtable<Class<?>, FieldTypeDefinition> fieldTypes = super.buildFieldTypes();
+        fieldTypes.put(java.time.LocalDateTime.class, new FieldTypeDefinition("TIMESTAMP", 9));
+        fieldTypes.put(java.time.LocalTime.class, new FieldTypeDefinition("TIMESTAMP", 9));
+        return fieldTypes;
+    }
+
+    /**
+     * INTERNAL:
+     * Allow for conversion from the Oracle type to the Java type. Used in cases when DB connection is needed like BLOB, CLOB.
+     */
+    @Override
+    public Object convertObject(Object sourceObject, Class javaClass, AbstractSession session) throws ConversionException, DatabaseException {
+        //Handle special case when empty String ("") is passed from the entity into CLOB type column
+        if (ClassConstants.CLOB.equals(javaClass) && sourceObject instanceof String && EMPTY_STRING.equals(sourceObject)) {
+            Connection connection = session.getAccessor().getConnection();
+            Clob clob = null;
+            try {
+                clob = connection.createClob();
+                clob.setString(1, (String)sourceObject);
+            } catch (SQLException e) {
+                throw ConversionException.couldNotBeConvertedToClass(sourceObject, ClassConstants.CLOB, e);
+            }
+            return clob;
+        }
+        return super.convertObject(sourceObject, javaClass);
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/oraclefeatures/TestOracleLOBLocatorFeature.java
+++ b/jpa/eclipselink.jpa.test.jse/src/org/eclipse/persistence/jpa/test/oraclefeatures/TestOracleLOBLocatorFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -163,7 +163,8 @@ public class TestOracleLOBLocatorFeature {
         notAllowedPlatforms.add("org.eclipse.persistence.platform.database.Oracle8Platform");
         notAllowedPlatforms.add("org.eclipse.persistence.platform.database.Oracle9Platform");
         notAllowedPlatforms.add("org.eclipse.persistence.platform.database.Oracle10Platform");
-        
+        notAllowedPlatforms.add("org.eclipse.persistence.platform.database.Oracle23Platform");
+        notAllowedPlatforms.add("org.eclipse.persistence.platform.database.oracle.Oracle23Platform");
         
         if (!checkIsOracle() || notAllowedPlatforms.contains(getPlatform(emfNoSessionCustomizer).getClass().getName())) {
             // Skip if not testing against Oracle

--- a/jpa/eclipselink.jpa.test/antbuild.xml
+++ b/jpa/eclipselink.jpa.test/antbuild.xml
@@ -2507,8 +2507,12 @@
 
         <!-- Can be set e.g. in test.properties to add VM options for a particular platform/driver  -->
         <!--<property name="additional.jvmargs" value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8787"/>-->
-        <property name="additional.jvmargs" value="-Ddummy2=dummy"/>
-
+        <property name="additional.jvmargs" value="--add-opens java.base/java.lang=ALL-UNNAMED"/>
+        <condition property="additional.jvmargs.merged.internal"
+                   value="${additional.jvmargs} --add-opens java.base/java.math=ALL-UNNAMED"
+                   else="--add-opens java.base/java.math=ALL-UNNAMED">
+            <isset property="additional.jvmargs"/>
+        </condition>
         <junit jvm="${test.junit.jvm.exec}" printsummary="yes" haltonfailure="${test.haltonfailure}" failureproperty="junit.failed" logfailedtests="true"
                fork="yes" forkmode="once" showoutput="true" maxmemory="${max.heap.memory}" dir="${run.dir}">
             <sysproperty key="proxy.user.name" value="PAS_PROXY"/>
@@ -2517,7 +2521,7 @@
             <sysproperty key="pa.proxyuser" value="${pa.proxyuser}"/>
             <sysproperty key="pa.proxyuser2" value="${pa.proxyuser2}"/>
             <sysproperty key="javax.xml.bind.JAXBContextFactory" value="org.eclipse.persistence.jaxb.JAXBContextFactory"/>
-            <jvmarg line="${additional.jvmargs}"/>
+            <jvmarg line="${additional.jvmargs.merged.internal}"/>
             <jvmarg value="${TEST_AGENT}"/>
             <jvmarg value="${TEST_WEAVING}"/>
             <jvmarg value="${TEST_WEAVING_OPTION}"/>

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/plsql/PLSQLTestSuite.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/plsql/PLSQLTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -25,6 +25,7 @@ import junit.framework.*;
 
 import org.eclipse.persistence.internal.databaseaccess.DatabaseCall;
 import org.eclipse.persistence.internal.helper.DatabaseType;
+import org.eclipse.persistence.internal.helper.Helper;
 import org.eclipse.persistence.internal.jpa.EJBQueryImpl;
 import org.eclipse.persistence.platform.database.oracle.annotations.OracleArray;
 import org.eclipse.persistence.platform.database.oracle.annotations.PLSQLParameter;
@@ -331,9 +332,16 @@ public class PLSQLTestSuite extends JUnitTestCase {
             query.setParameter("P_POSITIVEN", 1);
             query.setParameter("P_SIGNTYPE", 1);
             query.setParameter("P_NUMBER", 1);
-            int result = (Integer)query.getSingleResult();
-            if (result != 1) {
-                fail("Incorrect result.");
+            if (getPlatform().isOracle23() &&  Helper.compareVersions(getPlatform().getDriverVersion(), "23.0.0") >= 0) {
+                boolean result = (Boolean) query.getSingleResult();
+                if (!result) {
+                    fail("Incorrect result.");
+                }
+            } else {
+                int result = (Integer) query.getSingleResult();
+                if (result != 1) {
+                    fail("Incorrect result.");
+                }
             }
         } finally {
             closeEntityManagerAndTransaction(em);

--- a/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/metadata/converters/LobMetadata.java
+++ b/jpa/org.eclipse.persistence.jpa/src/org/eclipse/persistence/internal/jpa/metadata/converters/LobMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -119,10 +119,14 @@ public class LobMetadata extends MetadataConverter {
         // referenceClass type.
         if (isValidClobType(referenceClass)) {
             setFieldClassification(mapping, java.sql.Clob.class, isForMapKey);
-            setConverter(mapping, new TypeConversionConverter(mapping), isForMapKey);
+            TypeConversionConverter typeConversionConverter = new TypeConversionConverter(mapping);
+            typeConversionConverter.setDataClass(java.sql.Clob.class);
+            setConverter(mapping, typeConversionConverter, isForMapKey);
         } else if (isValidBlobType(referenceClass)) {
             setFieldClassification(mapping, java.sql.Blob.class, isForMapKey);
-            setConverter(mapping, new TypeConversionConverter(mapping), isForMapKey);
+            TypeConversionConverter typeConversionConverter = new TypeConversionConverter(mapping);
+            typeConversionConverter.setDataClass(java.sql.Blob.class);
+            setConverter(mapping, typeConversionConverter, isForMapKey);
         } else if (referenceClass.extendsInterface(Serializable.class)) {
             setFieldClassification(mapping, java.sql.Blob.class, isForMapKey);
             setConverter(mapping, new SerializedObjectConverter(mapping), isForMapKey);


### PR DESCRIPTION
Adds support for Oracle 23c database.
There are following changes
- `Oracle23Platform` platform classes added
- New Oracle JDBC driver 23.x.x.x has, in some cases, different behaviour for boolean type. There are changes in PL/SQL calls.
- Fix when empty String (`""`) is inserted into table column like `...CLOBDATA CLOB NOT NULL...` Solution is based on conversion into `java.sql.Clob`, because solution based on `SimpleAppendCallCustomParameter("empty_clob()")` and `DatabasePlatform.appendParameter()` leads into another test failures.
- Fix for loss of precision if DB table is automatically created if entity using `java.time.LocalDateTime`, `java.time.LocalTime`.
- JDBC Driver update

This PR is based on backports from #1876 and  #1969.