### PR TITLE
[2.7] DatabasePlatform.wasFailureCommunicationBased() fix - backport from master

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2022 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -3231,7 +3231,7 @@ public class DatabasePlatform extends DatasourcePlatform {
              // By default use the JDBC isValid API unless a ping SQL has been set.
              // The ping SQL is set by most platforms, but user could set to null to used optimized JDBC check if desired.
              try {
-                 return connection.isValid(IS_VALID_TIMEOUT);
+                 return !connection.isValid(IS_VALID_TIMEOUT);
              } catch (Throwable failed) {
                  // Catch throwable as old JDBC drivers may not support isValid.
                  return false;


### PR DESCRIPTION
Fixes #1970 .
This bug should happens is no pingSQL DB platform property is specified and query execution fails.