### PR TITLE
[2.7] Close #1806 - Have to the ability to dynamically set the Validation Group during a transaction

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/EntityManagerProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/EntityManagerProperties.java
@@ -323,17 +323,17 @@ public class EntityManagerProperties {
     /**
      * Overrides the Bean Validation Group(s) that will execute during a prePersist event. This should be a class or class[].
      */
-    public static final String VALIDATION_GROUP_PRE_PERSIST = "eclipselink.validation.group.prePersist";
+    public static final String VALIDATION_GROUP_PRE_UPDATET = "eclipselink.beanvalidation.group.pre-persist";
     
     /**
      * Overrides the Bean Validation Group(s) that will execute during a preUpdate event. This should be a class or class[].
      */
-    public static final String VALIDATION_GROUP_PRE_UPDATE = "eclipselink.validation.group.preUpdate";
+    public static final String VALIDATION_GROUP_PRE_UPDATE = "eclipselink.beanvalidation.group.pre-update";
     
     /**
      * Overrides the Bean Validation Group(s) that will execute during a preRemove event. This should be a class or class[].
      */
-    public static final String VALIDATION_GROUP_PRE_REMOVE = "eclipselink.validation.group.preRemove";
+    public static final String VALIDATION_GROUP_PRE_REMOVE = "eclipselink.beanvalidation.group.pre-remove";
 
     private static final Set<String> supportedProperties = new HashSet<String>() {
 

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/EntityManagerProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/EntityManagerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -319,6 +319,21 @@ public class EntityManagerProperties {
      * )
      */
     public static final String COMPOSITE_UNIT_PROPERTIES = PersistenceUnitProperties.COMPOSITE_UNIT_PROPERTIES;
+    
+    /**
+     * Overrides the Bean Validation Group(s) that will execute during a prePersist event. This should be a class or class[].
+     */
+    public static final String VALIDATION_GROUP_PRE_PERSIST = "eclipselink.validation.group.prePersist";
+    
+    /**
+     * Overrides the Bean Validation Group(s) that will execute during a preUpdate event. This should be a class or class[].
+     */
+    public static final String VALIDATION_GROUP_PRE_UPDATE = "eclipselink.validation.group.preUpdate";
+    
+    /**
+     * Overrides the Bean Validation Group(s) that will execute during a preRemove event. This should be a class or class[].
+     */
+    public static final String VALIDATION_GROUP_PRE_REMOVE = "eclipselink.validation.group.preRemove";
 
     private static final Set<String> supportedProperties = new HashSet<String>() {
 
@@ -344,6 +359,9 @@ public class EntityManagerProperties {
             add(PERSISTENCE_CONTEXT_COMMIT_ORDER);
             add(FLUSH_CLEAR_CACHE);
             add(COMPOSITE_UNIT_PROPERTIES);
+            add(VALIDATION_GROUP_PRE_PERSIST);
+            add(VALIDATION_GROUP_PRE_UPDATE);
+            add(VALIDATION_GROUP_PRE_REMOVE);
         }
     };
 

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/EntityManagerProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/config/EntityManagerProperties.java
@@ -323,7 +323,7 @@ public class EntityManagerProperties {
     /**
      * Overrides the Bean Validation Group(s) that will execute during a prePersist event. This should be a class or class[].
      */
-    public static final String VALIDATION_GROUP_PRE_UPDATET = "eclipselink.beanvalidation.group.pre-persist";
+    public static final String VALIDATION_GROUP_PRE_PERSIST = "eclipselink.beanvalidation.group.pre-persist";
     
     /**
      * Overrides the Bean Validation Group(s) that will execute during a preUpdate event. This should be a class or class[].

--- a/jpa/eclipselink.jpa.test/resource/eclipselink-beanvalidation-model/persistence.xml
+++ b/jpa/eclipselink.jpa.test/resource/eclipselink-beanvalidation-model/persistence.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -18,6 +18,7 @@
         <class>org.eclipse.persistence.testing.models.jpa.beanvalidation.Employee</class>
         <class>org.eclipse.persistence.testing.models.jpa.beanvalidation.Project</class>
         <class>org.eclipse.persistence.testing.models.jpa.beanvalidation.Address</class>
+        <class>org.eclipse.persistence.testing.models.jpa.beanvalidation.Phone</class>
         <validation-mode>CALLBACK</validation-mode>
     </persistence-unit>
 </persistence>

--- a/jpa/eclipselink.jpa.test/resource/eclipselink-beanvalidation-model/server/persistence.xml
+++ b/jpa/eclipselink.jpa.test/resource/eclipselink-beanvalidation-model/server/persistence.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -19,6 +19,7 @@
         <class>org.eclipse.persistence.testing.models.jpa.beanvalidation.Employee</class>
         <class>org.eclipse.persistence.testing.models.jpa.beanvalidation.Project</class>
         <class>org.eclipse.persistence.testing.models.jpa.beanvalidation.Address</class>
+        <class>org.eclipse.persistence.testing.models.jpa.beanvalidation.Phone</class>
         <validation-mode>CALLBACK</validation-mode>
         <properties>
             <property name="eclipselink.target-server" value="@server-platform@"/>

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/beanvalidation/BeanValidationTableCreator.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/beanvalidation/BeanValidationTableCreator.java
@@ -136,6 +136,16 @@ public class BeanValidationTableCreator extends TableCreator {
         fieldState.setIsIdentity(false);
         table.addField(fieldState);
 
+        FieldDefinition fieldPhone = new FieldDefinition();
+        fieldPhone.setName("PHONE");
+        fieldPhone.setTypeName("VARCHAR");
+        fieldPhone.setSize(40);
+        fieldPhone.setShouldAllowNull(true);
+        fieldPhone.setIsPrimaryKey(false);
+        fieldPhone.setUnique(false);
+        fieldPhone.setIsIdentity(false);
+        table.addField(fieldPhone);
+
         return table;
     }
 

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/beanvalidation/Employee.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/beanvalidation/Employee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -50,6 +50,10 @@ public class Employee {
     @Valid
     @Embedded
     private Address adress;
+    
+    @Valid
+    @Embedded
+    private Phone phone;
 
    // ===========================================================
    // getters and setters for the state fields
@@ -105,4 +109,11 @@ public class Employee {
         return "Employee {Id:" +  id + " name:" + name + "}";
     }
 
+    public Phone getPhone() {
+        return phone;
+    }
+
+    public void setPhone(Phone phone) {
+        this.phone = phone;
+    }
 }

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/beanvalidation/GermanPhone.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/beanvalidation/GermanPhone.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2009, 2025 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+
+package org.eclipse.persistence.testing.models.jpa.beanvalidation;
+
+public interface GermanPhone {
+
+}

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/beanvalidation/Phone.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/beanvalidation/Phone.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2009, 2025 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+
+package org.eclipse.persistence.testing.models.jpa.beanvalidation;
+
+import javax.persistence.Embeddable;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+
+@Embeddable
+public class Phone {
+    @Pattern(regexp = "^\\+1 \\([0-9]{3}\\) [0-9]{3}-[0-9]{4}$", groups = { USPhone.class })
+    @Pattern(regexp = "^\\+49 \\([1-9]\\d{1,4}\\) \\d{3,8}-\\d{4}$", groups = { GermanPhone.class })
+    String phone;
+
+    public Phone() {}
+
+    public Phone(String phone) {
+         this.phone = phone;
+    }
+}

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/beanvalidation/USPhone.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/beanvalidation/USPhone.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2009, 2025 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+
+package org.eclipse.persistence.testing.models.jpa.beanvalidation;
+
+public interface USPhone {
+
+}

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/beanvalidation/BeanValidationJunitTest.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/beanvalidation/BeanValidationJunitTest.java
@@ -74,6 +74,7 @@ public class BeanValidationJunitTest extends JUnitTestCase {
             suite.addTest(new BeanValidationJunitTest("testPersistGermanPhoneWithUSGroup"));
             suite.addTest(new BeanValidationJunitTest("testPersistGermanPhoneWithGermanGroup"));
             suite.addTest(new BeanValidationJunitTest("testRemoveGermanPhoneWithGermanGroup"));
+            suite.addTest(new BeanValidationJunitTest("testUpdateGermanPhoneWithGermanGroup"));
             suite.addTest(new BeanValidationJunitTest("testRemoveInvalidGermanPhoneWithGermanGroup"));
             suite.addTest(new BeanValidationJunitTest("testUpdateInvalidGermanPhoneWithGermanGroup"));
         }

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/beanvalidation/BeanValidationJunitTest.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/beanvalidation/BeanValidationJunitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -27,13 +27,17 @@ import javax.persistence.TypedQuery;
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
 
+import org.eclipse.persistence.config.EntityManagerProperties;
 import org.eclipse.persistence.logging.SessionLog;
 import org.eclipse.persistence.mappings.ForeignReferenceMapping;
 import org.eclipse.persistence.testing.framework.junit.JUnitTestCase;
 import org.eclipse.persistence.testing.models.jpa.beanvalidation.Address;
 import org.eclipse.persistence.testing.models.jpa.beanvalidation.BeanValidationTableCreator;
 import org.eclipse.persistence.testing.models.jpa.beanvalidation.Employee;
+import org.eclipse.persistence.testing.models.jpa.beanvalidation.GermanPhone;
+import org.eclipse.persistence.testing.models.jpa.beanvalidation.Phone;
 import org.eclipse.persistence.testing.models.jpa.beanvalidation.Project;
+import org.eclipse.persistence.testing.models.jpa.beanvalidation.USPhone;
 
 import junit.framework.Test;
 import junit.framework.TestSuite;
@@ -65,6 +69,13 @@ public class BeanValidationJunitTest extends JUnitTestCase {
             suite.addTest(new BeanValidationJunitTest("testTraversableResolverPreventsLoadingOfLazyRelationships"));
             suite.addTest(new BeanValidationJunitTest("testTraversableResolverPreventsTraversingRelationshipMultipleTimes"));
             suite.addTest(new BeanValidationJunitTest("testValidateChangedData"));
+            suite.addTest(new BeanValidationJunitTest("testPersistIrishPhoneNoGroups"));
+            suite.addTest(new BeanValidationJunitTest("testPersistUSPhoneWithGermanGroup"));
+            suite.addTest(new BeanValidationJunitTest("testPersistGermanPhoneWithUSGroup"));
+            suite.addTest(new BeanValidationJunitTest("testPersistGermanPhoneWithGermanGroup"));
+            suite.addTest(new BeanValidationJunitTest("testRemoveGermanPhoneWithGermanGroup"));
+            suite.addTest(new BeanValidationJunitTest("testRemoveInvalidGermanPhoneWithGermanGroup"));
+            suite.addTest(new BeanValidationJunitTest("testUpdateInvalidGermanPhoneWithGermanGroup"));
         }
         return suite;
     }
@@ -396,6 +407,241 @@ public class BeanValidationJunitTest extends JUnitTestCase {
         }
     }
 
+    public void testPersistIrishPhoneNoGroups() {
+      EntityManager em = createEntityManager();
+      boolean gotConstraintViolations = false;
+      try {
+          // Persist an object with Irish phone number (valid default-phone)
+          beginTransaction(em);
+          Employee e = new Employee();
+          e.setPhone(new Phone("+353 (1) 555-5678"));
+          em.persist(e);
+      } catch (ConstraintViolationException e) {
+          assertTrue("Transaction not marked for roll back when ConstraintViolation is thrown", getRollbackOnly(em));
+          gotConstraintViolations = true;
+      } finally {
+          if (isTransactionActive(em)) {
+              rollbackTransaction(em);
+          }
+          closeEntityManager(em);
+      }
+      assertFalse("Did not expect Constraint Violation while persisting IrishPhone without groups", gotConstraintViolations);
+    }
+    
+    public void testPersistUSPhoneWithGermanGroup() {
+      Map<String, Object> props = new HashMap<>();
+      props.put(EntityManagerProperties.VALIDATION_GROUP_PRE_PERSIST, new Class[]{ GermanPhone.class });
+      EntityManager em = createEntityManager(props);
+      boolean gotConstraintViolations = false;
+      try {
+          // Persist an object with US phone number
+          beginTransaction(em);
+          Employee e = new Employee();
+          e.setPhone(new Phone("+1 (316) 555-5555"));
+          em.persist(e);
+      } catch (ConstraintViolationException e) {
+          assertTrue("Transaction not marked for roll back when ConstraintViolation is thrown", getRollbackOnly(em));
+          gotConstraintViolations = true;
+      } finally {
+          if (isTransactionActive(em)) {
+              rollbackTransaction(em);
+          }
+          closeEntityManager(em);
+      }
+      assertTrue("Did not get Constraint Violation while persisting USPhone with German group active", gotConstraintViolations);
+    }
+
+    public void testPersistGermanPhoneWithUSGroup() {
+      Map<String, Object> props = new HashMap<>();
+      props.put(EntityManagerProperties.VALIDATION_GROUP_PRE_PERSIST, new Class[]{ USPhone.class });
+      EntityManager em = createEntityManager(props);
+      boolean gotConstraintViolations = false;
+      try {
+          // Persist an object with German phone number (invalid without German group)
+          beginTransaction(em);
+          Employee e = new Employee();
+          e.setPhone(new Phone("+49 (221) 1555-5678")); 
+          em.persist(e);
+      } catch (ConstraintViolationException e) {
+          assertTrue("Transaction not marked for roll back when ConstraintViolation is thrown", getRollbackOnly(em));
+          gotConstraintViolations = true;
+      } finally {
+          if (isTransactionActive(em)) {
+              rollbackTransaction(em);
+          }
+          closeEntityManager(em);
+      }
+      assertTrue("Did not get Constraint Violation while persisting GermanPhone with US group active", gotConstraintViolations);
+    }
+
+    public void testPersistGermanPhoneWithGermanGroup() {
+      Map<String, Object> props = new HashMap<>();
+      props.put(EntityManagerProperties.VALIDATION_GROUP_PRE_PERSIST, new Class[]{ GermanPhone.class });
+      EntityManager em = createEntityManager(props);
+      boolean gotConstraintViolations = false;
+      try {
+          // Persist an object with German phone number (valid DE-phone)
+          beginTransaction(em);
+          Employee e = new Employee();
+          e.setPhone(new Phone("+49 (221) 1555-5678"));
+          em.persist(e);
+      } catch (ConstraintViolationException e) {
+          assertTrue("Transaction not marked for roll back when ConstraintViolation is thrown", getRollbackOnly(em));
+          gotConstraintViolations = true;
+      } finally {
+          if (isTransactionActive(em)) {
+              rollbackTransaction(em);
+          }
+          closeEntityManager(em);
+      }
+      assertFalse("Did not expect Constraint Violation while persisting GermanPhone with German group active", gotConstraintViolations);
+    }
+    
+    public void testRemoveGermanPhoneWithGermanGroup() {
+      Map<String, Object> props = new HashMap<>();
+      props.put(EntityManagerProperties.VALIDATION_GROUP_PRE_REMOVE, new Class[]{ GermanPhone.class });
+      EntityManager em = createEntityManager(props);
+      boolean removeSuccessful = false;
+      final int PK = 200;
+
+      try {
+          beginTransaction(em);
+          Employee e1 = new Employee(PK, "name", "name", 1337);
+          e1.setPhone(new Phone("+49 (221) 1555-5678"));
+          em.persist(e1);
+          commitTransaction(em);
+      } catch (RuntimeException ex) {
+          if (isTransactionActive(em)) {
+              rollbackTransaction(em);
+          }
+          throw ex;
+      }
+
+      try {
+          beginTransaction(em);
+          Employee e = em.find(Employee.class, PK);
+          em.remove(e);
+          commitTransaction(em);
+          removeSuccessful = true;
+      } catch (RuntimeException ex) {
+          if (isTransactionActive(em)) {
+              rollbackTransaction(em);
+          }
+          throw ex;
+      }
+
+      closeEntityManager(em);
+      assertTrue("Automatic Validation should not be executed for remove with German group", removeSuccessful);
+    }
+
+    public void testUpdateGermanPhoneWithGermanGroup() {
+      Map<String, Object> props = new HashMap<>();
+      props.put(EntityManagerProperties.VALIDATION_GROUP_PRE_UPDATE, new Class[]{ GermanPhone.class });
+      EntityManager em = createEntityManager(props);
+      boolean updateSuccessful = false;
+      final int PK = 201;
+
+      try {
+          beginTransaction(em);
+          Employee e1 = new Employee(PK, "name", "name", 1337);
+          em.persist(e1);
+          commitTransaction(em);
+      } catch (RuntimeException ex) {
+          if (isTransactionActive(em)) {
+              rollbackTransaction(em);
+          }
+          throw ex;
+      }
+
+      try {
+          beginTransaction(em);
+          Employee e = em.find(Employee.class, PK);
+          e.setPhone(new Phone("+49 (221) 1555-5678"));
+          commitTransaction(em);
+          updateSuccessful = true;
+      } catch (RuntimeException ex) {
+          if (isTransactionActive(em)) {
+              rollbackTransaction(em);
+          }
+          throw ex;
+      }
+
+      closeEntityManager(em);
+      assertTrue("Automatic Validation should not be executed for update with German group", updateSuccessful);
+    }
+    
+    public void testRemoveInvalidGermanPhoneWithGermanGroup() {
+      Map<String, Object> props = new HashMap<>();
+      props.put(EntityManagerProperties.VALIDATION_GROUP_PRE_REMOVE, new Class[]{ GermanPhone.class });
+      EntityManager em = createEntityManager(props);
+      boolean gotConstraintViolations = false;
+      final int PK = 300;
+
+      // first persist with a valid German phone
+      try {
+          beginTransaction(em);
+          Employee e1 = new Employee(PK, "name", "name", 0);
+          e1.setPhone(new Phone("+49 (221) 1555-5678"));
+          em.persist(e1);
+          commitTransaction(em);
+      } catch (RuntimeException ex) {
+          if (isTransactionActive(em)) rollbackTransaction(em);
+          closeEntityManager(em);
+          throw ex;
+      }
+
+      // now change to a US phone and attempt remove
+      try {
+          beginTransaction(em);
+          Employee e = em.find(Employee.class, PK);
+          e.setPhone(new Phone("123-456-7890"));
+          em.remove(e);
+          commitTransaction(em);
+      } catch (ConstraintViolationException e) {
+          assertTrue("Transaction not marked for roll back when ConstraintViolation is thrown", getRollbackOnly(em));
+          gotConstraintViolations = true;
+      } finally {
+          if (isTransactionActive(em)) rollbackTransaction(em);
+          closeEntityManager(em);
+      }
+      assertTrue("Expected Constraint Violation while removing with invalid GermanPhone under German group", gotConstraintViolations);
+    }
+
+    public void testUpdateInvalidGermanPhoneWithGermanGroup() {
+      Map<String, Object> props = new HashMap<>();
+      props.put(EntityManagerProperties.VALIDATION_GROUP_PRE_UPDATE, new Class[]{ GermanPhone.class });
+      EntityManager em = createEntityManager(props);
+      boolean gotConstraintViolations = false;
+      final int PK = 301;
+
+      // first persist without phone
+      try {
+          beginTransaction(em);
+          Employee e1 = new Employee(PK, "name", "name", 0);
+          em.persist(e1);
+          commitTransaction(em);
+      } catch (RuntimeException ex) {
+          if (isTransactionActive(em)) rollbackTransaction(em);
+          closeEntityManager(em);
+          throw ex;
+      }
+
+      // now change to a US phone and attempt update
+      try {
+          beginTransaction(em);
+          Employee e = em.find(Employee.class, PK);
+          e.setPhone(new Phone("123-456-7890"));
+          commitTransaction(em);
+      } catch (ConstraintViolationException e) {
+          assertTrue("Transaction not marked for roll back when ConstraintViolation is thrown", getRollbackOnly(em));
+          gotConstraintViolations = true;
+      } finally {
+          if (isTransactionActive(em)) rollbackTransaction(em);
+          closeEntityManager(em);
+      }
+      assertTrue("Expected Constraint Violation while updating with invalid GermanPhone under German group", gotConstraintViolations);
+    }
+    
     //--------------------Helper Methods ---------------//
     private boolean isInstantiated(Object entityObject, String attributeName, org.eclipse.persistence.sessions.Project project) {
         ForeignReferenceMapping mapping = (ForeignReferenceMapping) project.getDescriptor(Employee.class).getObjectBuilder().getMappingForAttributeName(attributeName);

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/beanvalidation/BeanValidationJunitTest.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/beanvalidation/BeanValidationJunitTest.java
@@ -633,9 +633,17 @@ public class BeanValidationJunitTest extends JUnitTestCase {
           Employee e = em.find(Employee.class, PK);
           e.setPhone(new Phone("123-456-7890"));
           commitTransaction(em);
-      } catch (ConstraintViolationException e) {
-          assertTrue("Transaction not marked for roll back when ConstraintViolation is thrown", getRollbackOnly(em));
-          gotConstraintViolations = true;
+      } catch (RuntimeException e) {
+          assertFalse("Transaction not marked for roll back when ConstraintViolation is thrown", isTransactionActive(em));
+          Object cause = e.getCause();
+          while (cause != null) {
+              if (cause instanceof ConstraintViolationException) {
+                  gotConstraintViolations = true;
+                  break;
+              } else {
+                  cause = ((Throwable) cause).getCause();
+              }
+          }
       } finally {
           if (isTransactionActive(em)) rollbackTransaction(em);
           closeEntityManager(em);


### PR DESCRIPTION
Hello, this PR Close #1806 for the 2.7 branch. The goal here is to allow a user to specify a validation group that should be executed when persisting. I'm hoping to sort of model this how the schema-per-tenant properties work (Which is very handy btw).

I have a signed ECA, but this is my first PR for EclipseLink so I could use some feedback. If this gets merged, then I'll port the changes to the other branches seeing active development.

Thank you!