### PR TITLE
[master] Maven build: H2 database profile added to execute tests against H2

### DIFF
--- a/etc/archetypes/bug_test_case/jpa/src/main/resources/archetype-resources/pom.xml
+++ b/etc/archetypes/bug_test_case/jpa/src/main/resources/archetype-resources/pom.xml
@@ -35,7 +35,7 @@
         <junit.bug.version>${junit.version}</junit.bug.version>
 
         <derby.bug.version>${derby.version}</derby.bug.version>
-        <h2.bug.version>2.2.224</h2.bug.version>
+        <h2.bug.version>${h2.version}</h2.bug.version>
         <mssql.bug.version>${mssql.version}</mssql.bug.version>
         <mysql.bug.version>${mysql.version}</mysql.bug.version>
         <oracle.jdbc.bug.version>${oracle.jdbc.version}</oracle.jdbc.bug.version>

--- a/etc/el-test.h2.properties
+++ b/etc/el-test.h2.properties
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0,
+# or the Eclipse Distribution License v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+
+# DB Connection properties
+db.driver=org.h2.Driver
+db.xa.driver=org.h2.Driver
+db.url=jdbc:h2:~/h2/ecltests
+db.user=
+db.pwd=
+db.platform=org.eclipse.persistence.platform.database.H2Platform
+db.properties=url=jdbc:h2:~/h2/ecltests
+#db.ddl.debug=true
+datasource.type=java.sql.Driver
+#datasource.type=javax.sql.XADataSource
+datasource.transactionsupport=LOCAL_TRANSACTION
+#datasource.transactionsupport=XA_TRANSACTION
+
+# Logging option for debugging
+logging.level=info

--- a/foundation/org.eclipse.persistence.core.test.framework/src/main/java/org/eclipse/persistence/testing/tests/ClearDatabaseSchemaTest.java
+++ b/foundation/org.eclipse.persistence.core.test.framework/src/main/java/org/eclipse/persistence/testing/tests/ClearDatabaseSchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -56,6 +56,8 @@ public class ClearDatabaseSchemaTest extends TestCase {
             resetDerby(session);
         } else if (platform.isSQLServer()) {
             resetMSSQL(session);
+        } else if (platform.isH2()) {
+            resetH2(session);
         } else if (platform.isHSQL()) {
             resetHsql(session);
         } else if (platform.isPostgreSQL()) {
@@ -192,6 +194,10 @@ public class ClearDatabaseSchemaTest extends TestCase {
                 + "FROM pg_tables WHERE schemaname = current_schema();");
         List<String> toRetry = execStatements(session, result);
         assertTrue(toRetry + " statements failed", toRetry.isEmpty());
+    }
+
+    private void resetH2(AbstractSession session) {
+        session.executeNonSelectingSQL("DROP ALL OBJECTS;");
     }
 
     private List<String> execStatements(AbstractSession session, Vector<ArrayRecord> records) {

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,7 @@
         <installation.checksum.md5>56e2dd6f54e65603ada5659a06ad782b</installation.checksum.md5>
 
         <!--Test DB property file names-->
+        <test.h2.properties.file>el-test.h2.properties</test.h2.properties.file>
         <test.mysql.properties.file>el-test.mysql.properties</test.mysql.properties.file>
         <test.mariadb.properties.file>el-test.mariadb.properties</test.mariadb.properties.file>
         <test.oracle.properties.file>el-test.oracle.properties</test.oracle.properties.file>
@@ -225,6 +226,7 @@
         <commonj.sdo.version>2.1.1</commonj.sdo.version>
         <derby.version>10.17.1.0</derby.version>
         <db2.version>11.5.8.0</db2.version>
+        <h2.version>2.2.224</h2.version>
         <!-- CQ #21134, 21135, 21136, 21137 -->
         <exam.version>4.13.4</exam.version>
         <hamcrest.version>1.3</hamcrest.version>
@@ -982,6 +984,11 @@
                 <version>${springframework.version}</version>
             </dependency>
             <!--JDBC drivers-->
+            <dependency>
+                <groupId>com.h2database</groupId>
+                <artifactId>h2</artifactId>
+                <version>${h2.version}</version>
+            </dependency>
             <dependency>
                 <groupId>com.mysql</groupId>
                 <artifactId>mysql-connector-j</artifactId>
@@ -1853,6 +1860,18 @@
                 <db.driver.groupId>com.ibm.db2</db.driver.groupId>
                 <db.driver.artifactId>jcc</db.driver.artifactId>
                 <db.driver.version>${db2.version}</db.driver.version>
+                <test.skip.in-memory.db>true</test.skip.in-memory.db>
+            </properties>
+        </profile>
+        <profile>
+            <id>h2</id>
+            <properties>
+                <test.properties.file>${user.home}/${test.h2.properties.file}</test.properties.file>
+                <test.properties.fileName>${test.h2.properties.file}</test.properties.fileName>
+                <!--Used by sql-maven-plugin-->
+                <db.driver.groupId>com.h2database</db.driver.groupId>
+                <db.driver.artifactId>h2</db.driver.artifactId>
+                <db.driver.version>${h2.version}</db.driver.version>
                 <test.skip.in-memory.db>true</test.skip.in-memory.db>
             </properties>
         </profile>


### PR DESCRIPTION
Database default storage (persistent) specified in `db.url property` is `~/h2/ecltests` directory.
Not all tests passing now.