### PR TITLE
Jakarta Persistence 3.2: 6th batch

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/ExceptionLocalizationResource.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/ExceptionLocalizationResource.java
@@ -201,6 +201,7 @@ public class ExceptionLocalizationResource extends ListResourceBundle {
                                            { "jpa_persistence_util_non_persistent_class", "PersistenceUtil.getIdentifier(entity) was called with object [{0}] which is not a persistent object." },
                                            { "jpa_persistence_util_get_version_non_persistent_class", "PersistenceUtil.getVersion(entity) was called with object [{0}] which is not a persistent object." },
                                            { "jpa_persistence_util_get_version_no_version_in_class", "PersistenceUtil.getVersion(entity) was called with object [{0}] which has no version attribute." },
+                                           { "jpa_non_persistent_class", "Class [{0}] is not a persistent class." },
                                            { "metamodel_identifiable_type_has_no_idclass_attribute", "No @IdClass attributes exist on the IdentifiableType [{0}].  There still may be one or more @Id or an @EmbeddedId on type." },
                                            { "metamodel_identifiable_no_version_attribute_present", "No @Version attribute exists on the identifiable type [{0}]." },
                                            { "metamodel_identifiable_no_id_attribute_present", "No @Id attribute exists on the identifiable type [{0}]." },

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/ExceptionLocalizationResource.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/ExceptionLocalizationResource.java
@@ -282,7 +282,8 @@ public class ExceptionLocalizationResource extends ListResourceBundle {
                                            { "truncate_tables_failed", "Tables truncation failed"},
                                            { "find_option_class_unknown", "The FindOption implementing class {0} is not supported"},
                                            { "refresh_option_class_unknown", "The RefreshOption implementing class {0} is not supported"},
-                                           { "lock_option_class_unknown", "The LockOption implementing class {0} is not supported"}
+                                           { "lock_option_class_unknown", "The LockOption implementing class {0} is not supported"},
+                                           { "typed_query_reference_is_null", "Reference to a named query is null"}
                                         };
     /**
      * Return the lookup table.

--- a/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/main/java/org/eclipse/persistence/testing/models/jpa/persistence32/Pokemon.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/main/java/org/eclipse/persistence/testing/models/jpa/persistence32/Pokemon.java
@@ -21,8 +21,11 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.NamedAttributeNode;
+import jakarta.persistence.NamedEntityGraph;
 import jakarta.persistence.NamedNativeQuery;
 import jakarta.persistence.NamedQuery;
+import jakarta.persistence.NamedSubgraph;
 import jakarta.persistence.Table;
 import org.eclipse.persistence.annotations.FetchAttribute;
 import org.eclipse.persistence.annotations.FetchGroup;
@@ -36,6 +39,14 @@ import org.eclipse.persistence.annotations.FetchGroups;
 @FetchGroups({
         @FetchGroup(name = "FetchTypes", attributes = {@FetchAttribute(name = "types")})
 })
+@NamedEntityGraph(name = "Pokemon.fetchGraph",
+                  attributeNodes = {
+                        @NamedAttributeNode("name"),
+                        @NamedAttributeNode(value = "types", subgraph = "types")
+                  },
+                  subgraphs = @NamedSubgraph(name = "types",
+                                             attributeNodes = @NamedAttributeNode("name"))
+)
 public class Pokemon {
 
     // ID is assigned in tests to avoid collisions

--- a/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/main/java/org/eclipse/persistence/testing/models/jpa/persistence32/Team.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/main/java/org/eclipse/persistence/testing/models/jpa/persistence32/Team.java
@@ -16,10 +16,20 @@ import java.util.Objects;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.NamedNativeQuery;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.QueryHint;
 import jakarta.persistence.Table;
+import org.eclipse.persistence.config.CacheUsage;
+import org.eclipse.persistence.config.QueryHints;
 
 @Entity
 @Table(name="PERSISTENCE32_TEAM")
+@NamedQuery(name="Team.get",
+            query="SELECT t FROM Team t WHERE t.id = :id",
+            hints = {
+                    @QueryHint(name=QueryHints.CACHE_USAGE, value=CacheUsage.CheckCacheOnly),
+                    @QueryHint(name=QueryHints.QUERY_TIMEOUT, value="1000")
+            })
 @NamedNativeQuery(name="Team.deleteAll", query="DELETE FROM PERSISTENCE32_TEAM")
 public class Team {
 
@@ -64,9 +74,7 @@ public class Team {
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(id, name);
-        return result;
+        return Objects.hash(id, name);
     }
-
 
 }

--- a/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/main/java/org/eclipse/persistence/testing/models/jpa/persistence32/Trainer.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/main/java/org/eclipse/persistence/testing/models/jpa/persistence32/Trainer.java
@@ -17,8 +17,11 @@ import java.util.Objects;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.NamedAttributeNode;
+import jakarta.persistence.NamedEntityGraph;
 import jakarta.persistence.NamedNativeQuery;
 import jakarta.persistence.NamedQuery;
+import jakarta.persistence.NamedSubgraph;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
@@ -28,6 +31,14 @@ import static jakarta.persistence.FetchType.LAZY;
 @Table(name="PERSISTENCE32_TRAINER")
 @NamedQuery(name="Trainer.get", query="SELECT t FROM Trainer t WHERE t.id = :id")
 @NamedNativeQuery(name="Trainer.deleteAll", query="DELETE FROM PERSISTENCE32_TRAINER")
+@NamedEntityGraph(name = "Trainer.fetchGraph",
+                  attributeNodes = {
+                          @NamedAttributeNode("name"),
+                          @NamedAttributeNode(value = "team", subgraph = "team")
+                  },
+                  subgraphs = @NamedSubgraph(name = "team",
+                                             attributeNodes = @NamedAttributeNode("name"))
+)
 public class Trainer {
 
     // ID is assigned in tests to avoid collisions

--- a/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/test/java/org/eclipse/persistence/testing/tests/jpa/persistence32/EntityGraphTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/test/java/org/eclipse/persistence/testing/tests/jpa/persistence32/EntityGraphTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.persistence.testing.tests.jpa.persistence32;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import jakarta.persistence.AttributeNode;
+import jakarta.persistence.EntityGraph;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceUnitUtil;
+import jakarta.persistence.metamodel.Attribute;
+import jakarta.persistence.metamodel.ManagedType;
+import junit.framework.Test;
+import org.eclipse.persistence.config.QueryHints;
+import org.eclipse.persistence.testing.models.jpa.persistence32.Pokemon;
+
+/**
+ * Verify jakarta.persistence 3.2 API changes in {@link EntityGraph}.
+ */
+public class EntityGraphTest extends AbstractPokemon {
+
+    // Pokemons. Array index is ID value.
+    // Value of ID = 0 does not exist so it's array instance is set to null.
+    static final Pokemon[] POKEMONS = new Pokemon[] {
+            null, // Skip array index 0
+            new Pokemon(1, "Pidgey", List.of(TYPES[1], TYPES[3])),
+            new Pokemon(2, "Beedrill", List.of(TYPES[7], TYPES[4])),
+            new Pokemon(3, "Squirtle", List.of(TYPES[11])),
+            new Pokemon(4, "Caterpie", List.of(TYPES[7]))
+    };
+
+    public static Test suite() {
+        return suite(
+                "EntityGraphTest",
+                new EntityGraphTest("testRemoveAttributeNodesByPersistentAttributeType")
+        );
+    }
+
+    public EntityGraphTest() {
+    }
+
+    public EntityGraphTest(String name) {
+        super(name);
+        setPuName(getPersistenceUnitName());
+    }
+
+    // Initialize data
+    @Override
+    protected void suiteSetUp() {
+        super.suiteSetUp();
+        emf.runInTransaction(em -> {
+            for (int i = 1; i < POKEMONS.length; i++) {
+                em.persist(POKEMONS[i]);
+            }
+        });
+
+    }
+
+    // Test removeAttributeNodes(Attribute.PersistentAttributeType)
+    // This also tests addAttributeNode(Attribute<? super X, Y>), addAttributeNode(String)
+    // and removeAttributeNode(Attribute<? super X, ?>)
+    public void testRemoveAttributeNodesByPersistentAttributeType() {
+        try (EntityManager em = emf.createEntityManager()) {
+            EntityGraph<Pokemon> pokemonGraph = em.createEntityGraph(Pokemon.class);
+            ManagedType<Pokemon> managedType = emf.getMetamodel().managedType(Pokemon.class);
+            pokemonGraph.addAttributeNode(managedType.getAttribute("id"));
+            pokemonGraph.addAttributeNode(managedType.getAttribute("name"));
+            pokemonGraph.addSubgraph("types").addAttributeNode("name");
+            pokemonGraph.addSubgraph("trainer").addAttributeNode("name");
+            pokemonGraph.removeAttributeNodes(Attribute.PersistentAttributeType.MANY_TO_ONE);
+            // Trainer node, which is many-to-one, shall be gone now. Verify nodes content.
+            List<AttributeNode<?>> nodes = pokemonGraph.getAttributeNodes();
+            Set<String> checkNodes = new HashSet<>(List.of("id", "name", "types"));
+            assertEquals(3, nodes.size());
+            for (AttributeNode<?> node : nodes) {
+                if (checkNodes.contains(node.getAttributeName())) {
+                    checkNodes.remove(node.getAttributeName());
+                } else {
+                    fail(String.format("Node %s was not found in the EntityGraph.", node.getAttributeName()));
+                }
+            }
+            assertTrue(checkNodes.isEmpty());
+            // Verify attributes load status with database query
+            PersistenceUnitUtil util = em.getEntityManagerFactory().getPersistenceUnitUtil();
+            Pokemon pokemon = em.createQuery("SELECT p FROM Pokemon p WHERE p.id = :id", Pokemon.class)
+                    .setParameter("id", POKEMONS[1].getId())
+                    .setHint(QueryHints.JPA_FETCH_GRAPH, pokemonGraph)
+                    .getSingleResult();
+            assertTrue("Attribute id is present in EntityGraph but not in result", util.isLoaded(pokemon, "id"));
+            assertTrue("Attribute name is present in EntityGraph but not in result", util.isLoaded(pokemon, "name"));
+            pokemon.getTypes().stream().findFirst().ifPresent(
+                    type -> assertTrue("Attribute types is present in EntityGraph but not in result", util.isLoaded(type, "name")));
+            assertFalse("Attribute trainer is not present in EntityGraph but is present in result", util.isLoaded(pokemon.getTrainer(), "name"));
+        }
+    }
+
+}

--- a/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/test/java/org/eclipse/persistence/testing/tests/jpa/persistence32/EntityManagerFactoryTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/test/java/org/eclipse/persistence/testing/tests/jpa/persistence32/EntityManagerFactoryTest.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import jakarta.persistence.EntityGraph;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.EntityTransaction;
@@ -32,6 +33,7 @@ import junit.framework.Test;
 import org.eclipse.persistence.config.QueryHints;
 import org.eclipse.persistence.descriptors.ClassDescriptor;
 import org.eclipse.persistence.descriptors.FetchGroupManager;
+import org.eclipse.persistence.internal.jpa.EntityGraphImpl;
 import org.eclipse.persistence.jpa.JpaEntityManagerFactory;
 import org.eclipse.persistence.testing.models.jpa.persistence32.Pokemon;
 import org.eclipse.persistence.testing.models.jpa.persistence32.Team;
@@ -65,7 +67,9 @@ public class EntityManagerFactoryTest extends AbstractPokemon {
                 new EntityManagerFactoryTest("testGetVersionOnEntityWithVersion"),
                 new EntityManagerFactoryTest("testGetVersionOnEntityWithoutVersion"),
                 new EntityManagerFactoryTest("testGetNamedPokemonQueries"),
-                new EntityManagerFactoryTest("testGetNamedAllQueries")
+                new EntityManagerFactoryTest("testGetNamedAllQueries"),
+                new EntityManagerFactoryTest("testGetNamedPokemonEntityGraphs"),
+                new EntityManagerFactoryTest("testGetNamedAllEntityGraphs")
         );
     }
 
@@ -409,6 +413,32 @@ public class EntityManagerFactoryTest extends AbstractPokemon {
                     break;
                 default:
                     fail(String.format("Unknown named query %s found", query.getName()));
+            }
+        }
+    }
+
+    // All EntityGraphs for Pokemon entity in current PU
+    public void testGetNamedPokemonEntityGraphs() {
+        Map<String, EntityGraph<? extends Pokemon>> entityGraphs = emf.getNamedEntityGraphs(Pokemon.class);
+        assertEquals(1, entityGraphs.size());
+        EntityGraph<? extends Pokemon> pokemonGraph = entityGraphs.get("Pokemon.fetchGraph");
+        assertNotNull(pokemonGraph);
+    }
+
+    // All EntityGraphs in current PU
+    public void testGetNamedAllEntityGraphs() {
+        Map<String, EntityGraph<?>> entityGraphs = emf.getNamedEntityGraphs(Object.class);
+        assertEquals(2, entityGraphs.size());
+        for (EntityGraph<?> entityGraph : entityGraphs.values()) {
+            switch (entityGraph.getName()) {
+            case "Pokemon.fetchGraph":
+                assertEquals(Pokemon.class, ((EntityGraphImpl<?>)entityGraph).getClassType());
+                break;
+            case "Trainer.fetchGraph":
+                assertEquals(Trainer.class, ((EntityGraphImpl<?>)entityGraph).getClassType());
+                break;
+            default:
+                fail(String.format("Unknown EntityGraph %s found", entityGraph.getName()));
             }
         }
     }

--- a/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/test/java/org/eclipse/persistence/testing/tests/jpa/persistence32/QueryTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/test/java/org/eclipse/persistence/testing/tests/jpa/persistence32/QueryTest.java
@@ -12,7 +12,6 @@
 package org.eclipse.persistence.testing.tests.jpa.persistence32;
 
 import java.util.List;
-import java.util.Map;
 
 import jakarta.persistence.NoResultException;
 import jakarta.persistence.NonUniqueResultException;
@@ -46,8 +45,6 @@ public class QueryTest extends AbstractPokemon {
                 new QueryTest("testGetSingleResultOrNullWithMultipleResults")
         );
     }
-
-    Map<Integer, Pokemon> pokemons = null;
 
     public QueryTest() {
     }

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerFactoryDelegate.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerFactoryDelegate.java
@@ -862,7 +862,7 @@ public class EntityManagerFactoryDelegate implements EntityManagerFactory, Persi
 
     @Override
     public <E> Map<String, EntityGraph<? extends E>> getNamedEntityGraphs(Class<E> entityType) {
-        return EntityManagerFactoryImpl.getNamedEntityGraphs(entityType, getAbstractSession());
+        return EntityManagerFactoryImpl.getNamedEntityGraphs(entityType, getAbstractSession(), getMetamodel());
     }
 
     @Override

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerFactoryDelegate.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerFactoryDelegate.java
@@ -55,6 +55,7 @@ import jakarta.persistence.PersistenceUnitUtil;
 import jakarta.persistence.Query;
 import jakarta.persistence.SchemaManager;
 import jakarta.persistence.SynchronizationType;
+import jakarta.persistence.TypedQueryReference;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.metamodel.Attribute;
 import jakarta.persistence.metamodel.Metamodel;
@@ -70,7 +71,6 @@ import org.eclipse.persistence.internal.sessions.AbstractSession;
 import org.eclipse.persistence.internal.sessions.DatabaseSessionImpl;
 import org.eclipse.persistence.internal.sessions.PropertiesHandler;
 import org.eclipse.persistence.jpa.JpaEntityManagerFactory;
-import org.eclipse.persistence.queries.AttributeGroup;
 import org.eclipse.persistence.queries.DatabaseQuery;
 import org.eclipse.persistence.queries.ObjectLevelReadQuery;
 import org.eclipse.persistence.queries.ReadQuery;
@@ -561,6 +561,7 @@ public class EntityManagerFactoryDelegate implements EntityManagerFactory, Persi
 
     // TODO-API-3.2 - SEPersistenceUnitInfo must return new PersistenceUnitTransactionType instead of old spi
     @Override
+    @SuppressWarnings("removal")
     public PersistenceUnitTransactionType getTransactionType() {
         // Temporary mapping between old and new PersistenceUnitTransactionType
         return switch (setupImpl.getPersistenceUnitInfo().getTransactionType()) {
@@ -832,6 +833,11 @@ public class EntityManagerFactoryDelegate implements EntityManagerFactory, Persi
     }
 
     @Override
+    public <R> Map<String, TypedQueryReference<R>> getNamedQueries(Class<R> resultType) {
+        return EntityManagerFactoryImpl.getNamedQueries(resultType, getAbstractSession());
+    }
+
+    @Override
     public <T> T unwrap(Class<T> cls) {
         if (cls.equals(JpaEntityManagerFactory.class) || cls.equals(EntityManagerFactoryImpl.class)) {
             return (T) this;
@@ -851,10 +857,12 @@ public class EntityManagerFactoryDelegate implements EntityManagerFactory, Persi
 
     @Override
     public <T> void addNamedEntityGraph(String graphName, EntityGraph<T> entityGraph) {
-        AttributeGroup group = ((EntityGraphImpl)entityGraph).getAttributeGroup().clone();
-        group.setName(graphName);
-        this.getAbstractSession().getAttributeGroups().put(graphName, group);
-        this.getAbstractSession().getDescriptor(((EntityGraphImpl)entityGraph).getClassType()).addAttributeGroup(group);
+        EntityManagerFactoryImpl.addNamedEntityGraph(graphName, entityGraph, getAbstractSession());
+    }
+
+    @Override
+    public <E> Map<String, EntityGraph<? extends E>> getNamedEntityGraphs(Class<E> entityType) {
+        return EntityManagerFactoryImpl.getNamedEntityGraphs(entityType, getAbstractSession());
     }
 
     @Override

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerFactoryImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerFactoryImpl.java
@@ -920,7 +920,7 @@ public class EntityManagerFactoryImpl implements EntityManagerFactory, Persisten
                             "jpa_non_persistent_class", new String[] {entityType.getName()}));
                 }
                 session.getDescriptor(entityType);
-                result.put(name, new EntityGraphImpl<>(attributeGroup, metamodel, descriptor));
+                result.put(name, new EntityGraphImpl<>(attributeGroup, descriptor));
             }
         });
         return result;

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerFactoryImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerFactoryImpl.java
@@ -602,7 +602,6 @@ public class EntityManagerFactoryImpl implements EntityManagerFactory, Persisten
         return delegate.getTransactionType();
     }
 
-    // TODO-API-3.2
     @Override
     public SchemaManager getSchemaManager() {
         return delegate.getSchemaManager();

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerImpl.java
@@ -55,6 +55,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.WeakHashMap;
 
@@ -83,6 +84,7 @@ import jakarta.persistence.StoredProcedureQuery;
 import jakarta.persistence.SynchronizationType;
 import jakarta.persistence.TransactionRequiredException;
 import jakarta.persistence.TypedQuery;
+import jakarta.persistence.TypedQueryReference;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaDelete;
 import jakarta.persistence.criteria.CriteriaQuery;
@@ -1258,15 +1260,7 @@ public class EntityManagerImpl implements org.eclipse.persistence.jpa.JpaEntityM
      */
     @Override
     public Query createNamedQuery(String name) {
-        try {
-            verifyOpen();
-            EJBQueryImpl query = new EJBQueryImpl(name, this, true);
-            query.getDatabaseQueryInternal();
-            return query;
-        } catch (RuntimeException e) {
-            setRollbackOnly();
-            throw e;
-        }
+        return createNamedQueryInternal(name, null);
     }
 
     /**
@@ -1281,8 +1275,38 @@ public class EntityManagerImpl implements org.eclipse.persistence.jpa.JpaEntityM
      *      found to be invalid
      */
     @Override
-    public <T> TypedQuery<T> createNamedQuery(String name, Class<T> resultClass){
-        return (TypedQuery<T>) createNamedQuery(name);
+    public <T> TypedQuery<T> createNamedQuery(String name, Class<T> resultClass) {
+        return createNamedQueryInternal(name, null);
+    }
+
+    @Override
+    public <T> TypedQuery<T> createQuery(TypedQueryReference<T> typedQueryReference) {
+        Objects.requireNonNull(typedQueryReference, ExceptionLocalization.buildMessage("typed_query_reference_is_null"));
+        return createNamedQueryInternal(typedQueryReference.getName(), typedQueryReference.getHints());
+    }
+
+    /**
+     * Create an instance of {@link TypedQuery} for executing a named query written in the Jakarta Persistence query language
+     * or in native SQL.
+     *
+     * @param name the name of the query
+     * @param hints a {@link Map} with query hints or {@code null} to pass no hints
+     * @return the new {@link TypedQuery} instance
+     * @param <T> the query result type
+     */
+    private <T> TypedQuery<T> createNamedQueryInternal(String name, Map<String,Object> hints) {
+        try {
+            verifyOpen();
+            EJBQueryImpl<T> query = new EJBQueryImpl<>(name, this, true);
+            query.getDatabaseQueryInternal();
+            if (hints != null) {
+                hints.forEach(query::setHint);
+            }
+            return query;
+        } catch (RuntimeException e) {
+            setRollbackOnly();
+            throw e;
+        }
     }
 
     /**

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerImpl.java
@@ -3187,7 +3187,7 @@ public class EntityManagerImpl implements org.eclipse.persistence.jpa.JpaEntityM
         if (descriptor == null || descriptor.isAggregateDescriptor()){
             throw new IllegalArgumentException(ExceptionLocalization.buildMessage("unknown_bean_class", new Object[]{rootType.getName()}));
         }
-        return new EntityGraphImpl<>(new AttributeGroup(null, rootType, true), factory.getMetamodel(), descriptor);
+        return new EntityGraphImpl<>(new AttributeGroup(null, rootType, true), descriptor);
     }
 
     @Override
@@ -3197,7 +3197,7 @@ public class EntityManagerImpl implements org.eclipse.persistence.jpa.JpaEntityM
             return null;
         }
         ClassDescriptor descriptor = this.getAbstractSession().getDescriptor(group.getType());
-        return new EntityGraphImpl<>(group.clone(), factory.getMetamodel(), descriptor);
+        return new EntityGraphImpl<>(group.clone(), descriptor);
     }
 
     @Override
@@ -3206,7 +3206,7 @@ public class EntityManagerImpl implements org.eclipse.persistence.jpa.JpaEntityM
         if (group == null){
             throw new IllegalArgumentException(ExceptionLocalization.buildMessage("no_entity_graph_of_name", new Object[]{graphName}));
         }
-        return new EntityGraphImpl<>(group, factory.getMetamodel());
+        return new EntityGraphImpl<>(group);
     }
 
     @Override
@@ -3217,13 +3217,13 @@ public class EntityManagerImpl implements org.eclipse.persistence.jpa.JpaEntityM
         }
         List<EntityGraph<? super T>> result = new ArrayList<>();
         for (AttributeGroup group : descriptor.getAttributeGroups().values()){
-            result.add(new EntityGraphImpl<>(group, factory.getMetamodel()));
+            result.add(new EntityGraphImpl<>(group));
         }
         if (descriptor.hasInheritance()){
             while(descriptor.getInheritancePolicy().getParentDescriptor() != null){
                 descriptor = descriptor.getInheritancePolicy().getParentDescriptor();
                 for (AttributeGroup group : descriptor.getAttributeGroups().values()){
-                    result.add(new EntityGraphImpl<>(group, factory.getMetamodel()));
+                    result.add(new EntityGraphImpl<>(group));
                 }
             }
         }

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerImpl.java
@@ -3163,26 +3163,26 @@ public class EntityManagerImpl implements org.eclipse.persistence.jpa.JpaEntityM
         if (descriptor == null || descriptor.isAggregateDescriptor()){
             throw new IllegalArgumentException(ExceptionLocalization.buildMessage("unknown_bean_class", new Object[]{rootType.getName()}));
         }
-        return new EntityGraphImpl<>(new AttributeGroup(null, rootType, true), descriptor);
+        return new EntityGraphImpl<>(new AttributeGroup(null, rootType, true), factory.getMetamodel(), descriptor);
     }
 
     @Override
-    public EntityGraph createEntityGraph(String graphName) {
+    public EntityGraph<?> createEntityGraph(String graphName) {
         AttributeGroup group = this.getAbstractSession().getAttributeGroups().get(graphName);
         if (group == null){
             return null;
         }
         ClassDescriptor descriptor = this.getAbstractSession().getDescriptor(group.getType());
-        return new EntityGraphImpl(group.clone(), descriptor);
+        return new EntityGraphImpl<>(group.clone(), factory.getMetamodel(), descriptor);
     }
 
     @Override
-    public EntityGraph getEntityGraph(String graphName) {
+    public EntityGraph<?> getEntityGraph(String graphName) {
         AttributeGroup group = this.getAbstractSession().getAttributeGroups().get(graphName);
         if (group == null){
             throw new IllegalArgumentException(ExceptionLocalization.buildMessage("no_entity_graph_of_name", new Object[]{graphName}));
         }
-        return new EntityGraphImpl(group);
+        return new EntityGraphImpl<>(group, factory.getMetamodel());
     }
 
     @Override
@@ -3193,13 +3193,13 @@ public class EntityManagerImpl implements org.eclipse.persistence.jpa.JpaEntityM
         }
         List<EntityGraph<? super T>> result = new ArrayList<>();
         for (AttributeGroup group : descriptor.getAttributeGroups().values()){
-            result.add(new EntityGraphImpl<>(group));
+            result.add(new EntityGraphImpl<>(group, factory.getMetamodel()));
         }
         if (descriptor.hasInheritance()){
             while(descriptor.getInheritancePolicy().getParentDescriptor() != null){
                 descriptor = descriptor.getInheritancePolicy().getParentDescriptor();
                 for (AttributeGroup group : descriptor.getAttributeGroups().values()){
-                    result.add(new EntityGraphImpl<>(group));
+                    result.add(new EntityGraphImpl<>(group, factory.getMetamodel()));
                 }
             }
         }

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/QueryHintsHandler.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/QueryHintsHandler.java
@@ -159,6 +159,12 @@ public class QueryHintsHandler {
         Hint.verify(hintName, shouldUseDefault(hintValue), hintValue, queryName, session);
     }
 
+    // Retrieve query hints Map from DatabaseQuery
+    @SuppressWarnings("unchecked")
+    static Map<String, Object> get(DatabaseQuery query) {
+        return (Map<String, Object>) query.getProperty(QUERY_HINT_PROPERTY);
+    }
+
     /**
      * Applies the hints to the query.
      * Throws IllegalArgumentException in case the hint value is illegal.

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/TypedQueryReferenceImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/TypedQueryReferenceImpl.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 IBM Corporation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     12/21/2023: Tomas Kraus
+//       - New Jakarta Persistence 3.2 Features
+package org.eclipse.persistence.internal.jpa;
+
+import java.util.Collections;
+import java.util.Map;
+
+import jakarta.persistence.TypedQueryReference;
+
+/**
+ * EclipseLink implementation of {@link TypedQueryReference} interface.
+ * @param <R> an upper bound on the result type of the query
+ */
+class TypedQueryReferenceImpl<R> implements TypedQueryReference<R> {
+
+    private final String name;
+    private final Class<? extends R> resultType;
+    private final Map<String, Object> hints;
+
+    TypedQueryReferenceImpl(String name, Class<? extends R> resultType, Map<String, Object> hints) {
+        this.name = name;
+        this.resultType = resultType;
+        // TypedQueryReference javadoc says nothing about null, but let's be safe
+        this.hints = hints != null ? hints : Collections.emptyMap();
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Class<? extends R> getResultType() {
+        return resultType;
+    }
+
+    @Override
+    public Map<String, Object> getHints() {
+        return hints;
+    }
+
+}

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metamodel/AttributeImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metamodel/AttributeImpl.java
@@ -229,11 +229,12 @@ public abstract class AttributeImpl<X, T> implements Attribute<X, T>, Serializab
     }
 
     /**
-     *  Return the persistent attribute type for the attribute.
-     *  @return persistent attribute type
+     * Return the persistent attribute type for provided attribute mapping.
+     *
+     * @param mapping attribute database mapping
+     * @return persistent attribute type
      */
-    @Override
-    public Attribute.PersistentAttributeType getPersistentAttributeType() {
+    public static Attribute.PersistentAttributeType getPersistentAttributeType(DatabaseMapping mapping) {
         /*
          * process the following mappings by referencing the Core API Mapping.
          * MANY_TO_ONE (ONE_TO_ONE internally)
@@ -276,6 +277,15 @@ public abstract class AttributeImpl<X, T> implements Attribute<X, T>, Serializab
         }
         // Test coverage required
         return PersistentAttributeType.ELEMENT_COLLECTION;
+    }
+
+    /**
+     *  Return the persistent attribute type for the attribute.
+     *  @return persistent attribute type
+     */
+    @Override
+    public Attribute.PersistentAttributeType getPersistentAttributeType() {
+        return getPersistentAttributeType(mapping);
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
         <jersey.version>3.1.3</jersey.version>
         <jms.version>3.1.0</jms.version>
         <json.version>2.1.3</json.version>
-        <jpa.api.version>3.2.0-B02</jpa.api.version>
+        <jpa.api.version>3.2.0-M1</jpa.api.version>
         <mail-api.version>2.1.2</mail-api.version>
         <angus-mail.version>2.0.2</angus-mail.version>
         <oracle.ddlparser.version>3.0.1</oracle.ddlparser.version>


### PR DESCRIPTION
- jakartaee/persistence#454 - removeAttributeNodes(Attribute.PersistentAttributeType) in Graph
- jakartaee/persistence#512 - factory-level access to named queries and named entity graphs
- Updated jakarta.persistence version to 3.2.0-M1
