### PR TITLE
[2.7] WebLogic Server tests fix

### DIFF
--- a/jpa/eclipselink.jpa.test/antbuild.xml
+++ b/jpa/eclipselink.jpa.test/antbuild.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -526,24 +526,28 @@
         </path>
         <echo message="Configuring 'compile.server.path' to:"/>
         <echo message="   'compile.path'"/>
+        <echo message="   '${oracle.extensions.depend.dir}/${oracle.ucp.jar}'"/>
         <echo message="   '${oracle.extensions.depend.dir}/${oracle.sdoapi.jar}'"/>
         <echo message="   '../../../extension.lib.external/mongo.jar'"/>
         <echo message="  "/>
         <path id="compile.server.path">
             <path refid="compile.path"/>
             <pathelement path="${jdbc.driver.jar}"/>
+            <pathelement path="${oracle.extensions.depend.dir}/${oracle.ucp.jar}"/>
             <pathelement path="${oracle.extensions.depend.dir}/${oracle.sdoapi.jar}"/>
             <pathelement path="../../../extension.lib.external/mongo.jar"/>
         </path>
         <path id="compile.jpa21.server.path">
             <path refid="jpa21.compile.path"/>
             <pathelement path="${jdbc.driver.jar}"/>
+            <pathelement path="${oracle.extensions.depend.dir}/${oracle.ucp.jar}"/>
             <pathelement path="${oracle.extensions.depend.dir}/${oracle.sdoapi.jar}"/>
             <pathelement path="../../../extension.lib.external/mongo.jar"/>
         </path>
         <path id="compile.jpa22.server.path">
             <path refid="jpa22.compile.path"/>
             <pathelement path="${jdbc.driver.jar}"/>
+            <pathelement path="${oracle.extensions.depend.dir}/${oracle.ucp.jar}"/>
             <pathelement path="${oracle.extensions.depend.dir}/${oracle.sdoapi.jar}"/>
             <pathelement path="../../../extension.lib.external/mongo.jar"/>
         </path>

--- a/jpa/eclipselink.jpa.test/resource/weblogic/wls_composite_setup.py
+++ b/jpa/eclipselink.jpa.test/resource/weblogic/wls_composite_setup.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at
@@ -48,6 +48,7 @@ set('PasswordEncrypted','@DBPWD@')
 
 cd('/JDBCSystemResources/EclipseLinkDS/JDBCResource/EclipseLinkDS/JDBCConnectionPoolParams/EclipseLinkDS')
 cmo.setTestTableName('SQL SELECT 1 FROM DUAL')
+cmo.setWrapTypes(false)
 
 cd('/JDBCSystemResources/EclipseLinkDS/JDBCResource/EclipseLinkDS/JDBCDriverParams/EclipseLinkDS/Properties/EclipseLinkDS')
 cmo.createProperty('user')

--- a/jpa/eclipselink.jpa.test/resource/weblogic/wls_exalogic_setup.py
+++ b/jpa/eclipselink.jpa.test/resource/weblogic/wls_exalogic_setup.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at
@@ -46,6 +46,7 @@ set('PasswordEncrypted','@DBPWD@')
 
 cd('/JDBCSystemResources/EclipseLinkDS/JDBCResource/EclipseLinkDS/JDBCConnectionPoolParams/EclipseLinkDS')
 cmo.setTestTableName('SQL SELECT 1 FROM DUAL')
+cmo.setWrapTypes(false)
 
 cd('/JDBCSystemResources/EclipseLinkDS/JDBCResource/EclipseLinkDS/JDBCDriverParams/EclipseLinkDS/Properties/EclipseLinkDS')
 cmo.createProperty('user')
@@ -85,6 +86,7 @@ set('PasswordEncrypted','@DBPWD@')
 
 cd('/JDBCSystemResources/ELNonJTADS/JDBCResource/ELNonJTADS/JDBCConnectionPoolParams/ELNonJTADS')
 cmo.setTestTableName('SQL SELECT 1 FROM DUAL')
+cmo.setWrapTypes(false)
 
 cd('/JDBCSystemResources/ELNonJTADS/JDBCResource/ELNonJTADS/JDBCDriverParams/ELNonJTADS/Properties/ELNonJTADS')
 cmo.createProperty('user')

--- a/jpa/eclipselink.jpa.test/resource/weblogic/wls_setup.py
+++ b/jpa/eclipselink.jpa.test/resource/weblogic/wls_setup.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at
@@ -47,6 +47,7 @@ try:
 
     cd('/JDBCSystemResources/EclipseLinkDS/JDBCResource/EclipseLinkDS/JDBCConnectionPoolParams/EclipseLinkDS')
     cmo.setTestTableName('SQL SELECT 1 FROM DUAL')
+    cmo.setWrapTypes(false)
 
     cd('/JDBCSystemResources/EclipseLinkDS/JDBCResource/EclipseLinkDS/JDBCDriverParams/EclipseLinkDS/Properties/EclipseLinkDS')
     cmo.createProperty('user')
@@ -89,6 +90,7 @@ try:
 
     cd('/JDBCSystemResources/ELNonJTADS/JDBCResource/ELNonJTADS/JDBCConnectionPoolParams/ELNonJTADS')
     cmo.setTestTableName('SQL SELECT 1 FROM DUAL')
+    cmo.setWrapTypes(false)
 
     cd('/JDBCSystemResources/ELNonJTADS/JDBCResource/ELNonJTADS/JDBCDriverParams/ELNonJTADS/Properties/ELNonJTADS')
     cmo.createProperty('user')

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/framework/junit/JUnitTestCase.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/framework/junit/JUnitTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -44,6 +44,7 @@ import org.eclipse.persistence.internal.sessions.DatabaseSessionImpl;
 import org.eclipse.persistence.internal.jpa.EntityManagerFactoryImpl;
 import org.eclipse.persistence.logging.DefaultSessionLog;
 import org.eclipse.persistence.logging.SessionLog;
+import org.eclipse.persistence.platform.server.ServerPlatformUtils;
 import org.eclipse.persistence.sessions.Connector;
 import org.eclipse.persistence.sessions.DefaultConnector;
 import org.eclipse.persistence.sessions.JNDIConnector;
@@ -51,6 +52,7 @@ import org.eclipse.persistence.sessions.broker.SessionBroker;
 import org.eclipse.persistence.sessions.server.ServerSession;
 import org.eclipse.persistence.testing.framework.server.JEEPlatform;
 import org.eclipse.persistence.testing.framework.server.ServerPlatform;
+import org.eclipse.persistence.testing.framework.server.WebLogicPlatform;
 import org.eclipse.persistence.testing.framework.server.TestRunner;
 import org.eclipse.persistence.testing.framework.server.TestRunner1;
 import org.eclipse.persistence.testing.framework.server.TestRunner2;
@@ -298,7 +300,12 @@ public abstract class JUnitTestCase extends TestCase {
         if (serverPlatform == null) {
             String platformClass = System.getProperty("TEST_SERVER_PLATFORM");
             if (platformClass == null) {
-                serverPlatform = new JEEPlatform();
+                String detectedServerPlatform = ServerPlatformUtils.detectServerPlatform(null);
+                if (detectedServerPlatform != null && detectedServerPlatform.contains("WebLogic")) {
+                    serverPlatform = new WebLogicPlatform();
+                } else {
+                    serverPlatform = new JEEPlatform();
+                }
             } else {
                 try {
                     serverPlatform = (ServerPlatform)Class.forName(platformClass).newInstance();

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/jpaadvancedproperties/JPAAdvPropertiesJUnitTestCase.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/jpaadvancedproperties/JPAAdvPropertiesJUnitTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -363,27 +363,28 @@ public class JPAAdvPropertiesJUnitTestCase extends JUnitTestCase {
     }
 
     public void testLoginEncryptorProperty() {
-        EntityManager em = createEntityManager(persistenceUnitName);
-        try {
-            //Create new customer
-            beginTransaction(em);
-            Customer customer = ModelExamples.customerExample1();
-            em.persist(customer);
-            em.flush();
-            Integer customerId = customer.getCustomerId();
-            commitTransaction(em);
+        if (!isOnServer()) {
+            EntityManager em = createEntityManager(persistenceUnitName);
+            try {
+                //Create new customer
+                beginTransaction(em);
+                Customer customer = ModelExamples.customerExample1();
+                em.persist(customer);
+                em.flush();
+                Integer customerId = customer.getCustomerId();
+                commitTransaction(em);
 
-            customer = em.find(org.eclipse.persistence.testing.models.jpa.jpaadvancedproperties.Customer.class, customerId);
-            //Purge it
-            beginTransaction(em);
-            em.remove(customer);
-            commitTransaction(em);
+                //Purge it
+                beginTransaction(em);
+                em.remove(em.find(org.eclipse.persistence.testing.models.jpa.jpaadvancedproperties.Customer.class, customerId));
+                commitTransaction(em);
 
-            assertNotNull(customer);
-            assertTrue("CustomizedEncryptor.encryptPassword() method wasn't called.", CustomizedEncryptor.encryptPasswordCounter > 0);
-            assertTrue("CustomizedEncryptor.decryptPassword() method wasn't called.", CustomizedEncryptor.decryptPasswordCounter > 0);
-        } finally {
-            closeEntityManager(em);
+                assertNotNull(customer);
+                assertTrue("CustomizedEncryptor.encryptPassword() method wasn't called.", CustomizedEncryptor.encryptPasswordCounter > 0);
+                assertTrue("CustomizedEncryptor.decryptPassword() method wasn't called.", CustomizedEncryptor.decryptPasswordCounter > 0);
+            } finally {
+                closeEntityManager(em);
+            }
         }
     }
 }


### PR DESCRIPTION
This is fix for some JPA test errors/failurest if they are executed in WebLogic server environment 14.1.x.
- `JPAAdvPropertiesJUnitTestCase.testLoginEncryptorProperty()` excluded in JEE server tests as DB connection is provided by JEE server by data source and encryptor is not called
- `EntityManagerJUnitTestSuite.testApplicationManagedInServer()` in WebLogic is `org.eclipse.persistence.testing.framework.server.WebLogicPlatform` set instead of default `org.eclipse.persistence.testing.framework.server.JEEPlatform`
- `AdvancedJPAJunitTest.testNamedStoredProcedureQueryByIndex()` needs latest JDBC driver
- `PLSQLTestSuite.testEmpRecordInOut` fixed by setWrapTypes(false) in WLST script (Data source properties) to avoid use weblogic.jdbc.wrapper.* classes
- UCP classpath fix to reflect changes in Oracle 23c JDBC driver