### PR TITLE
Support null value for UUID (#2031)

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
@@ -1102,7 +1102,7 @@ public class DatabasePlatform extends DatasourcePlatform {
      */
     public int getJDBCType(Class<?> javaType) {
         if (javaType == null) {
-            return Types.VARCHAR;// Best guess, sometimes we cannot determine type from mapping, this may fail on some drivers, other dont care what type it is.
+            return Types.OTHER;// Best guess, sometimes we cannot determine type from mapping, this may fail on some drivers, other dont care what type it is.
         } else if (javaType == ClassConstants.STRING) {
             return Types.VARCHAR;
         } else if (javaType == ClassConstants.BIGDECIMAL) {
@@ -1157,7 +1157,7 @@ public class DatabasePlatform extends DatasourcePlatform {
         } else if (javaType == ClassConstants.CLOB) {
             return Types.CLOB;
         } else {
-            return Types.VARCHAR;// Best guess, sometimes we cannot determine type from mapping, this may fail on some drivers, other dont care what type it is.
+            return Types.OTHER;// Best guess, sometimes we cannot determine type from mapping, this may fail on some drivers, other dont care what type it is.
         }
     }
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/mappings/converters/UUIDConverter.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/mappings/converters/UUIDConverter.java
@@ -41,7 +41,10 @@ public class UUIDConverter implements Converter {
     @Override
     public Object convertObjectValueToDataValue(Object uuidValue, Session session) {
         if (uuidValue instanceof UUID) {
-            return uuidValue.toString();
+            return uuidValue;
+        }
+        if (uuidValue == null) {
+            return null;
         }
         throw new IllegalArgumentException("Source object is not an instance of java.util.UUID");
     }
@@ -55,7 +58,14 @@ public class UUIDConverter implements Converter {
      */
     @Override
     public Object convertDataValueToObjectValue(Object jdbcValue, Session session) {
-        return UUID.fromString(jdbcValue.toString());
+        if (jdbcValue == null) {
+            return (UUID) null;
+        }
+        if (jdbcValue instanceof UUID) {
+            return jdbcValue;
+        } else {
+            return UUID.fromString(jdbcValue.toString());
+        }
     }
 
     /**


### PR DESCRIPTION
- Add `null` value handling to UUIDConverter
- Change `DatabasePlatform.java#getJDBCType` fallback type from `VARCHAR` to `OTHER` -> Postgres was failing when a `null` value was tried to stored to a UUID type column hence EclipseLink was sent varchar type null.