### PR TITLE
[master] org.eclipse.persistence.internal.helper.Helper.dateFromYearMonthDate fix

### DIFF
--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/models/insurance/PolicyHolder.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/models/insurance/PolicyHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -79,7 +79,7 @@ public class PolicyHolder implements Serializable {
         holder.addChildName("Bessy-Ray");
         holder.setMale();
         holder.setSsn(1111);
-        holder.setBirthDate(Helper.dateFromString("1950/02/30"));
+        holder.setBirthDate(Helper.dateFromString("1950/02/25"));
         holder.setOccupation("Engineer");
 
         holder.setAddress(Address.example1());

--- a/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/changeflag/ALCTEmployeeSystem.java
+++ b/foundation/eclipselink.core.test/src/it/java/org/eclipse/persistence/testing/tests/unitofwork/changeflag/ALCTEmployeeSystem.java
@@ -85,8 +85,9 @@ public class ALCTEmployeeSystem extends TestSystem {
         emp.setFirstName("ALCTEmp");
         emp.setLastName("NotRequired");
         ALCTEmploymentPeriod empPeriod = new ALCTEmploymentPeriod();
-        empPeriod.setEndDate(Helper.dateFromYearMonthDate(2006, 12, 2));
-        empPeriod.setStartDate(Helper.dateFromYearMonthDate(2004, 12, 2));
+        //Valid month is 0-11
+        empPeriod.setEndDate(Helper.dateFromYearMonthDate(2006, 11, 2));
+        empPeriod.setStartDate(Helper.dateFromYearMonthDate(2004, 11, 2));
         emp.setPeriod(empPeriod);
         unitOfWork.registerObject(emp);
         unitOfWork.commit();

--- a/foundation/eclipselink.core.test/src/test/java/org/eclipse/persistence/testing/tests/junit/helper/HelperTest.java
+++ b/foundation/eclipselink.core.test/src/test/java/org/eclipse/persistence/testing/tests/junit/helper/HelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Vector;
 
+import org.eclipse.persistence.exceptions.ConversionException;
 import org.eclipse.persistence.internal.helper.Helper;
 import org.junit.Assert;
 import org.junit.Test;
@@ -313,6 +314,25 @@ public class HelperTest {
 
         } finally {
             Helper.setShouldOptimizeDates(optimizedDatesState);
+        }
+    }
+
+    @Test
+    public void dateFromYearMonthDateTest() {
+        //1950-02-20 //valid month is 0-11 0-January
+        java.sql.Date date = Helper.dateFromYearMonthDate(1950, 1, 20);
+        Assert.assertEquals("1950-02-20", date.toString());
+    }
+
+    @Test
+    public void dateFromYearMonthDateInvalidValueTest() {
+        //1950-02-30 //valid month is 0-11 0-January
+        //Invalid day value 30
+        try {
+            java.sql.Date date = Helper.dateFromYearMonthDate(1950, 1, 30);
+            Assert.assertEquals("1950-02-30", date.toString());
+        } catch (ConversionException e) {
+            Assert.assertTrue("The incorrect exception was thrown", e.getErrorCode() == ConversionException.INCORRECT_DATE_VALUE);
         }
     }
 }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/exceptions/ConversionException.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/exceptions/ConversionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2023 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -30,6 +30,7 @@ public class ConversionException extends EclipseLinkException {
     public final static int COULD_NOT_BE_CONVERTED = 3001;
     public final static int COULD_NOT_BE_CONVERTED_EXTENDED = 3002;
     public final static int INCORRECT_DATE_FORMAT = 3003;
+    public final static int INCORRECT_DATE_VALUE = 3010;
     public final static int INCORRECT_TIME_FORMAT = 3004;
     public final static int INCORRECT_TIMESTAMP_FORMAT = 3005;
     public final static int COULD_NOT_CONVERT_TO_BYTE_ARRAY = 3006;
@@ -126,6 +127,14 @@ public class ConversionException extends EclipseLinkException {
         String message = ExceptionMessageGenerator.buildMessage(ConversionException.class, INCORRECT_DATE_FORMAT, args);
         ConversionException conversionException = new ConversionException(message, dateString, java.sql.Date.class, null);
         conversionException.setErrorCode(INCORRECT_DATE_FORMAT);
+        return conversionException;
+    }
+
+    public static ConversionException incorrectDateValue(String dateString) {
+        Object[] args = { dateString };
+        String message = ExceptionMessageGenerator.buildMessage(ConversionException.class, INCORRECT_DATE_VALUE, args);
+        ConversionException conversionException = new ConversionException(message, dateString, java.sql.Date.class, null);
+        conversionException.setErrorCode(INCORRECT_DATE_VALUE);
         return conversionException;
     }
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/exceptions/i18n/ConversionExceptionResource.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/exceptions/i18n/ConversionExceptionResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2018 IBM Corporation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -36,7 +36,8 @@ public final class ConversionExceptionResource extends ListResourceBundle {
                                            { "3006", "[{0}] must be of even length to be converted to a byte array." },
                                            { "3007", "The object [{0}], of class [{1}], could not be converted to [{2}].  Ensure that the class [{2}] is on the CLASSPATH.  You may need to use alternate API passing in the appropriate class loader as required, or setting it on the default ConversionManager" },
                                            { "3008", "Incorrect date-time format: [{0}] (expected [YYYY-MM-DD''T''HH:MM:SS])" },
-                                           { "3009", "Unable to set {0} properties [{1}] into [{2}]." }
+                                           { "3009", "Unable to set {0} properties [{1}] into [{2}]." },
+                                           { "3010", "Incorrect date value [YYYY-MM-DD]: [{0}]." }
     };
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/Helper.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/Helper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2023 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -48,6 +48,8 @@ import java.math.BigInteger;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.sql.Timestamp;
+import java.time.DateTimeException;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
@@ -882,13 +884,12 @@ public class Helper extends CoreHelper implements Serializable {
      * i.e. year is from 0, month is 0-11, date is 1-31.
      */
     public static java.sql.Date dateFromYearMonthDate(int year, int month, int day) {
-        // Use a calendar to compute the correct millis for the date.
-        Calendar localCalendar = allocateCalendar();
-        localCalendar.clear();
-        localCalendar.set(year, month, day, 0, 0, 0);
-        long millis = localCalendar.getTimeInMillis();
-        java.sql.Date date = new java.sql.Date(millis);
-        releaseCalendar(localCalendar);
+        java.sql.Date date = null;
+        try {
+            date = java.sql.Date.valueOf(LocalDate.of(year, month + 1, day));
+        } catch (DateTimeException exception) {
+            throw ConversionException.incorrectDateValue(year + "-" + (month + 1) + "-" + day);
+        }
         return date;
     }
 

--- a/jpa/eclipselink.jpa.testapps/jpa.test.inherited/src/test/java/org/eclipse/persistence/testing/tests/jpa/inherited/InheritedModelJunitTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.inherited/src/test/java/org/eclipse/persistence/testing/tests/jpa/inherited/InheritedModelJunitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -546,7 +546,7 @@ public class InheritedModelJunitTest extends JUnitTestCase {
 
             Record record3 = new Record();
             record3.setDescription("Most beers consumed in a second - 5");
-            record3.setDate(Helper.dateFromYearMonthDate(2005, 12, 12));
+            record3.setDate(Helper.dateFromYearMonthDate(2005, 11, 12));
             record3.setLocation(new Location("Miami", "USA"));
             Venue venue3 = new Venue();
             venue3.setAttendance(63000);

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.inherited/src/test/java/org/eclipse/persistence/testing/tests/jpa/xml/inherited/EntityMappingsInheritedJUnitTestCase.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.inherited/src/test/java/org/eclipse/persistence/testing/tests/jpa/xml/inherited/EntityMappingsInheritedJUnitTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -347,7 +347,7 @@ public class EntityMappingsInheritedJUnitTestCase extends JUnitTestCase {
 
             Record record2 = new Record();
             record2.setDescription("Most beers consumed in a second - 5");
-            record2.setDate(Helper.dateFromYearMonthDate(2005, 12, 12));
+            record2.setDate(Helper.dateFromYearMonthDate(2005, 11, 12));
             record2.setLocation(new Location("Miami", "USA"));
             beerConsumer.getRecords().add(record2);
 

--- a/moxy/org.eclipse.persistence.moxy/pom.xml
+++ b/moxy/org.eclipse.persistence.moxy/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -236,8 +236,6 @@
                         <configuration>
                             <skipTests>${test-skip-moxy-jaxb}</skipTests>
                             <reportNameSuffix>test-moxy-jaxb</reportNameSuffix>
-                            <forkCount>1</forkCount>
-                            <reuseForks>false</reuseForks>
                             <includes>
                                 <include>org.eclipse.persistence.testing.jaxb.JAXBTestSuite</include>
                                 <include>org.eclipse.persistence.testing.jaxb.JAXBTestSuite2</include>


### PR DESCRIPTION
Fixes following issues:
- MOXy tests parallel execution
- in some special cases `Calendar` cache in `Helper` should contain `Calendar` instances with different time zone settings than current time zone. It should lead into unexpected date/time conversion results. Special case means that current time zone is changed during JVM execution see `org.eclipse.persistence.testing.oxm.XMLTestCase`
- Incorrect date values were accepted without any warning/exception and incorrect results (overflow) were produced.

I briefly checked there performance for

```
for (int i = 0; i < 10000000; i++) {
    java.sql.Date date = dateFromYearMonthDate(YEAR + i, MONTH, DAY);
}
```

and there is some improvement
Origin:		1956 ms
LocalDate:	500 ms