### PR TITLE
[master] ClassWeaver refresh

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/exceptions/StaticWeaveException.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/exceptions/StaticWeaveException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -138,13 +138,6 @@ public class StaticWeaveException  extends EclipseLinkException {
         Object[] args = { sourceJar };
 
         StaticWeaveException loadingException = new StaticWeaveException(ExceptionMessageGenerator.buildMessage(StaticWeaveException.class, EXCEPTION_WEAVING, args), cause);
-        loadingException.setResourceName(null);
-        loadingException.setErrorCode(EXCEPTION_WEAVING);
-        return loadingException;
-    }
-
-    public static StaticWeaveException exceptionPerformWeaving(String message) {
-        StaticWeaveException loadingException = new StaticWeaveException(message);
         loadingException.setResourceName(null);
         loadingException.setErrorCode(EXCEPTION_WEAVING);
         return loadingException;

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/exceptions/StaticWeaveException.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/exceptions/StaticWeaveException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -143,6 +143,12 @@ public class StaticWeaveException  extends EclipseLinkException {
         return loadingException;
     }
 
+    public static StaticWeaveException exceptionPerformWeaving(String message) {
+        StaticWeaveException loadingException = new StaticWeaveException(message);
+        loadingException.setResourceName(null);
+        loadingException.setErrorCode(EXCEPTION_WEAVING);
+        return loadingException;
+    }
 
     public String getResourceName(){
         return resourceName;

--- a/jpa/eclipselink.jpa.testapps/jpa.test.weaving/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.weaving/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -34,8 +34,19 @@
     <build>
         <resources>
             <resource>
+                <directory>src/main/resources/META-INF</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>persistence.xml</include>
+                </includes>
+                <targetPath>META-INF</targetPath>
+            </resource>
+            <resource>
                 <directory>src/main/resources</directory>
                 <filtering>false</filtering>
+                <includes>
+                    <include>*.jar</include>
+                </includes>
             </resource>
         </resources>
         <plugins>
@@ -99,6 +110,12 @@
                             </classpathDependencyExcludes>
                             <systemPropertyVariables>
                                 <eclipselink.asm.service>eclipselink</eclipselink.asm.service>
+                                <!--Following system properties must be initialized again as systemPropertyVariables reset environment.-->
+                                <db.driver>${db.driver}</db.driver>
+                                <db.url>${db.url}</db.url>
+                                <db.user>${db.user}</db.user>
+                                <db.pwd>${db.pwd}</db.pwd>
+                                <db.platform>${db.platform}</db.platform>
                             </systemPropertyVariables>
                         </configuration>
                     </execution>
@@ -110,6 +127,12 @@
                         <configuration>
                             <systemPropertyVariables>
                                 <eclipselink.asm.service>ow2</eclipselink.asm.service>
+                                <!--Following system properties must be initialized again as systemPropertyVariables reset environment.-->
+                                <db.driver>${db.driver}</db.driver>
+                                <db.url>${db.url}</db.url>
+                                <db.user>${db.user}</db.user>
+                                <db.pwd>${db.pwd}</db.pwd>
+                                <db.platform>${db.platform}</db.platform>
                             </systemPropertyVariables>
                             <classpathDependencyExcludes>
                                 <classpathDependencyExclude>org.eclipse.persistence.asm</classpathDependencyExclude>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.weaving/src/main/resources/META-INF/persistence.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.weaving/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0,
+    or the Eclipse Distribution License v. 1.0 which is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+
+    SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+-->
+
+<persistence version="1.0" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd">
+    <persistence-unit name="weaving-dir-test-pu" transaction-type="RESOURCE_LOCAL">
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+        <class>org.eclipse.persistence.testing.models.jpa.weaving.WeavingEntityInDir</class>
+        <exclude-unlisted-classes>true</exclude-unlisted-classes>
+        <properties>
+            <property name="eclipselink.ddl-generation" value="drop-and-create-tables" />
+            <property name="eclipselink.ddl-generation.output-mode" value="database" />
+            <property name="eclipselink.logging.level" value="${eclipselink.logging.level}"/>
+            <property name="eclipselink.logging.level.sql" value="${eclipselink.logging.sql.level}"/>
+            <property name="eclipselink.logging.parameters" value="${eclipselink.logging.parameters}"/>
+            <property name="eclipse.weaving" value="static"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.weaving/src/main/resources/META-INF/persistence.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.weaving/src/main/resources/META-INF/persistence.xml
@@ -13,7 +13,8 @@
 
 -->
 
-<persistence version="1.0" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd">
+<persistence version="3.0" xmlns="https://jakarta.ee/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd">
+
     <persistence-unit name="weaving-dir-test-pu" transaction-type="RESOURCE_LOCAL">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
         <class>org.eclipse.persistence.testing.models.jpa.weaving.WeavingEntityInDir</class>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.weaving/src/test/java/org/eclipse/persistence/testing/models/jpa/weaving/WeavingChangeListener.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.weaving/src/test/java/org/eclipse/persistence/testing/models/jpa/weaving/WeavingChangeListener.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.testing.models.jpa.weaving;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+public class WeavingChangeListener implements PropertyChangeListener {
+
+    private boolean listenerInvoked = false;
+
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        listenerInvoked = true;
+    }
+
+    public boolean isListenerInvoked() {
+        return listenerInvoked;
+    }
+}

--- a/jpa/eclipselink.jpa.testapps/jpa.test.weaving/src/test/java/org/eclipse/persistence/testing/models/jpa/weaving/WeavingEntityInDir.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.weaving/src/test/java/org/eclipse/persistence/testing/models/jpa/weaving/WeavingEntityInDir.java
@@ -14,9 +14,13 @@
 //     Oracle - initial API and implementation
 package org.eclipse.persistence.testing.models.jpa.weaving;
 
+import jakarta.persistence.Basic;
 import jakarta.persistence.Cacheable;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
 import org.eclipse.persistence.annotations.FetchAttribute;
 import org.eclipse.persistence.annotations.FetchGroup;
 
@@ -30,12 +34,13 @@ public class WeavingEntityInDir {
     private int id;
     private boolean booleanField;
     private byte byteField;
-    private short shortFiled;
+    private short shortField;
     private int intField;
     private long longField;
     private float floatField;
     private double doubleField;
     private String stringField;
+    private byte[] blobField;
 
     public WeavingEntityInDir() {
     }
@@ -69,12 +74,12 @@ public class WeavingEntityInDir {
         this.byteField = byteField;
     }
 
-    public short getShortFiled() {
-        return shortFiled;
+    public short getShortField() {
+        return shortField;
     }
 
-    public void setShortFiled(short shortFiled) {
-        this.shortFiled = shortFiled;
+    public void setShortField(short shortFiled) {
+        this.shortField = shortFiled;
     }
 
     public int getIntField() {
@@ -115,5 +120,16 @@ public class WeavingEntityInDir {
 
     public void setStringField(String stringField) {
         this.stringField = stringField;
+    }
+
+    @Lob
+    @Column(length=4800)
+    @Basic(fetch= FetchType.LAZY)
+    public byte[] getBlobField() {
+        return blobField;
+    }
+
+    public void setBlobField(byte[] blobField) {
+        this.blobField = blobField;
     }
 }

--- a/jpa/eclipselink.jpa.testapps/jpa.test.weaving/src/test/java/org/eclipse/persistence/testing/models/jpa/weaving/WeavingEntityInDir.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.weaving/src/test/java/org/eclipse/persistence/testing/models/jpa/weaving/WeavingEntityInDir.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.testing.models.jpa.weaving;
+
+import jakarta.persistence.Cacheable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import org.eclipse.persistence.annotations.FetchAttribute;
+import org.eclipse.persistence.annotations.FetchGroup;
+
+@Entity
+@FetchGroup(name="FloatingPointFieldsOnly",
+        attributes={
+                @FetchAttribute(name="floatField"),
+                @FetchAttribute(name="doubleField")})
+@Cacheable(false)
+public class WeavingEntityInDir {
+    private int id;
+    private boolean booleanField;
+    private byte byteField;
+    private short shortFiled;
+    private int intField;
+    private long longField;
+    private float floatField;
+    private double doubleField;
+    private String stringField;
+
+    public WeavingEntityInDir() {
+    }
+
+    public WeavingEntityInDir(int id) {
+        this.id = id;
+    }
+
+    @Id
+    public int getId() {
+        return this.id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public boolean isBooleanField() {
+        return booleanField;
+    }
+
+    public void setBooleanField(boolean booleanField) {
+        this.booleanField = booleanField;
+    }
+
+    public byte getByteField() {
+        return byteField;
+    }
+
+    public void setByteField(byte byteField) {
+        this.byteField = byteField;
+    }
+
+    public short getShortFiled() {
+        return shortFiled;
+    }
+
+    public void setShortFiled(short shortFiled) {
+        this.shortFiled = shortFiled;
+    }
+
+    public int getIntField() {
+        return intField;
+    }
+
+    public void setIntField(int intField) {
+        this.intField = intField;
+    }
+
+    public long getLongField() {
+        return longField;
+    }
+
+    public void setLongField(long longField) {
+        this.longField = longField;
+    }
+
+    public float getFloatField() {
+        return floatField;
+    }
+
+    public void setFloatField(float floatField) {
+        this.floatField = floatField;
+    }
+
+    public double getDoubleField() {
+        return doubleField;
+    }
+
+    public void setDoubleField(double doubleField) {
+        this.doubleField = doubleField;
+    }
+
+    public String getStringField() {
+        return stringField;
+    }
+
+    public void setStringField(String stringField) {
+        this.stringField = stringField;
+    }
+}

--- a/jpa/eclipselink.jpa.testapps/jpa.test.weaving/src/test/java/org/eclipse/persistence/testing/tests/jpa/weaving/WeavingTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.weaving/src/test/java/org/eclipse/persistence/testing/tests/jpa/weaving/WeavingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,23 +14,39 @@
 //     Oracle - initial API and implementation
 package org.eclipse.persistence.testing.tests.jpa.weaving;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 
+import org.eclipse.persistence.config.QueryHints;
 import org.eclipse.persistence.config.SystemProperties;
+import org.eclipse.persistence.descriptors.changetracking.ChangeTracker;
+import org.eclipse.persistence.internal.descriptors.PersistenceObject;
+import org.eclipse.persistence.queries.FetchGroupTracker;
 import org.eclipse.persistence.testing.framework.jpa.junit.JUnitTestCase;
+import org.eclipse.persistence.testing.models.jpa.weaving.WeavingChangeListener;
+import org.eclipse.persistence.testing.models.jpa.weaving.WeavingEntityInDir;
 import org.eclipse.persistence.tools.weaving.jpa.StaticWeaveProcessor;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
 
 public class WeavingTest extends JUnitTestCase {
 
+    private final String PU_NAME = "weaving-dir-test-pu";
     private final String WEAVING_ENTITY_CLASS = "org.eclipse.persistence.testing.models.jpa.weaving.WeavingEntity";
     private final String SOURCE_JAR = "source.jar";
     private final String TARGET_JAR = "target" + System.getProperty(SystemProperties.ASM_SERVICE, "") + ".jar";
+
+    private final String DIR_WEAVING_ENTITY_CLASS = "org.eclipse.persistence.testing.models.jpa.weaving.WeavingEntityInDir";
+    private final int ID = 1;
+    private final int NEW_INT_FIELD_VALUE = 100;
 
     public WeavingTest() {
         super();
@@ -40,14 +56,136 @@ public class WeavingTest extends JUnitTestCase {
         super(name);
     }
 
+    @Override
+    public String getPersistenceUnitName() {
+        return PU_NAME;
+    }
+
     public static Test suite() {
         TestSuite suite = new TestSuite();
         suite.setName("WeavingTest");
-        suite.addTest(new WeavingTest("testWeaving"));
+        suite.addTest(new WeavingTest("setup"));
+        suite.addTest(new WeavingTest("testWeavingDir"));
+        suite.addTest(new WeavingTest("testWeavingDirChangeListener"));
+        suite.addTest(new WeavingTest("testWeavingDirFetchGroup"));
+        suite.addTest(new WeavingTest("testWeavingDirInvokeGeneratedMethods"));
+        suite.addTest(new WeavingTest("testWeavingJar"));
         return suite;
     }
 
-    public void testWeaving() throws IOException, URISyntaxException, ClassNotFoundException, NoSuchMethodException {
+    public void setup() {
+        WeavingEntityInDir weavingEntityInDir = new WeavingEntityInDir(ID);
+        weavingEntityInDir.setBooleanField(true);
+        weavingEntityInDir.setByteField((byte)1);
+        weavingEntityInDir.setShortFiled((short)2);
+        weavingEntityInDir.setIntField(3);
+        weavingEntityInDir.setLongField(4);
+        weavingEntityInDir.setFloatField(1.1F);
+        weavingEntityInDir.setDoubleField(2.2);
+        weavingEntityInDir.setStringField("abcde");
+
+        EntityManager em = createEntityManager();
+        try {
+            beginTransaction(em);
+            em.persist(weavingEntityInDir);
+            commitTransaction(em);
+            em.clear();
+        } finally {
+            if (isTransactionActive(em)) {
+                rollbackTransaction(em);
+            }
+            closeEntityManager(em);
+        }
+    }
+
+    public void testWeavingDir() throws Throwable {
+        final String PU_PATH = "META-INF/persistence.xml";
+        URL source =  Thread.currentThread().getContextClassLoader().getResource(".");
+        URL target =  Thread.currentThread().getContextClassLoader().getResource(".");
+        URL puInfo =  new URL("file:" + Thread.currentThread().getContextClassLoader().getResource(PU_PATH).getFile().replace(PU_PATH, ""));
+
+        StaticWeaveProcessor staticWeaverProcessor= new StaticWeaveProcessor(source,target);
+        staticWeaverProcessor.setPersistenceInfo(puInfo.getFile());
+        staticWeaverProcessor.performWeaving();
+
+        ClassLoader classLoader = new URLClassLoader(new URL[]{target});
+        Class weavingEntityClass = classLoader.loadClass(DIR_WEAVING_ENTITY_CLASS);
+        //Check existence of various methods added to entity by weaving
+        assertNotNull(weavingEntityClass.getMethod("_persistence_post_clone"));
+        assertNotNull(weavingEntityClass.getMethod("_persistence_shallow_clone"));
+        assertNotNull(weavingEntityClass.getMethod("_persistence_getId"));
+        assertNotNull(weavingEntityClass.getMethod("_persistence_getCacheKey"));
+        assertNotNull(weavingEntityClass.getMethod("_persistence_getPropertyChangeListener"));
+        assertNotNull(weavingEntityClass.getMethod("_persistence_checkFetched", String.class));
+        assertNotNull(weavingEntityClass.getMethod("_persistence_checkFetchedForSet", String.class));
+
+    }
+
+    public void testWeavingDirChangeListener() {
+        WeavingEntityInDir weavingEntityInDir = null;
+        EntityManager em = createEntityManager();
+        try {
+            weavingEntityInDir = em.find(WeavingEntityInDir.class, ID);
+        } finally {
+            if (isTransactionActive(em)) {
+                rollbackTransaction(em);
+            }
+            closeEntityManager(em);
+        }
+
+        //Test change listener support generated by weaving
+        WeavingChangeListener weavingChangeListener = new WeavingChangeListener();
+        ((ChangeTracker)weavingEntityInDir)._persistence_setPropertyChangeListener(weavingChangeListener);
+        weavingEntityInDir.setIntField(NEW_INT_FIELD_VALUE);
+        assertTrue(weavingChangeListener.isListenerInvoked());
+    }
+
+    public void testWeavingDirFetchGroup() {
+        WeavingEntityInDir weavingEntityInDir = null;
+        EntityManager em = createEntityManager();
+        try {
+            TypedQuery query = em.createQuery("SELECT w FROM WeavingEntityInDir w WHERE w.id = ?1", WeavingEntityInDir.class);
+            query.setHint(QueryHints.FETCH_GROUP_NAME, "FloatingPointFieldsOnly");
+            query.setParameter(1, ID);
+            weavingEntityInDir = (WeavingEntityInDir)query.getSingleResult();
+            assertNotNull(((FetchGroupTracker)weavingEntityInDir)._persistence_getFetchGroup());
+            assertEquals(3, weavingEntityInDir.getIntField());
+            assertNull(((FetchGroupTracker)weavingEntityInDir)._persistence_getFetchGroup());
+        } finally {
+            if (isTransactionActive(em)) {
+                rollbackTransaction(em);
+            }
+            closeEntityManager(em);
+        }
+    }
+
+    public void testWeavingDirInvokeGeneratedMethods() throws Throwable {
+        final int NEW_INT_FIELD_VALUE = 100;
+        WeavingEntityInDir weavingEntityInDir = null;
+        EntityManager em = createEntityManager();
+        try {
+            weavingEntityInDir = em.find(WeavingEntityInDir.class, ID);
+        } finally {
+            if (isTransactionActive(em)) {
+                rollbackTransaction(em);
+            }
+            closeEntityManager(em);
+        }
+
+        //Test _persistence_set_intField method generated by weaving
+        MethodHandles.Lookup lookup = MethodHandles.lookup();
+        MethodType mt = MethodType.methodType(void.class, int.class);
+        MethodHandle mh = lookup.findVirtual(WeavingEntityInDir.class, "_persistence_set_intField", mt);
+        mh.invoke(weavingEntityInDir, NEW_INT_FIELD_VALUE);
+        assertEquals(NEW_INT_FIELD_VALUE, weavingEntityInDir.getIntField());
+        assertEquals(NEW_INT_FIELD_VALUE, ((PersistenceObject)weavingEntityInDir)._persistence_get("intField"));
+
+        //Test _persistence_shallow_clone method generated by weaving
+        Object weavingEntityInDirCloned = ((PersistenceObject)weavingEntityInDir)._persistence_shallow_clone();
+        assertNotNull(weavingEntityInDirCloned);
+    }
+
+    public void testWeavingJar() throws IOException, URISyntaxException, ClassNotFoundException, NoSuchMethodException {
         URL source =  Thread.currentThread().getContextClassLoader().getResource(SOURCE_JAR);
         URL target = new URL(source.toString().replace(SOURCE_JAR, TARGET_JAR));
 

--- a/jpa/eclipselink.jpa.testapps/jpa.test.weaving/src/test/java/org/eclipse/persistence/testing/tests/jpa/weaving/WeavingTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.weaving/src/test/java/org/eclipse/persistence/testing/tests/jpa/weaving/WeavingTest.java
@@ -77,12 +77,13 @@ public class WeavingTest extends JUnitTestCase {
         WeavingEntityInDir weavingEntityInDir = new WeavingEntityInDir(ID);
         weavingEntityInDir.setBooleanField(true);
         weavingEntityInDir.setByteField((byte)1);
-        weavingEntityInDir.setShortFiled((short)2);
+        weavingEntityInDir.setShortField((short)2);
         weavingEntityInDir.setIntField(3);
         weavingEntityInDir.setLongField(4);
         weavingEntityInDir.setFloatField(1.1F);
         weavingEntityInDir.setDoubleField(2.2);
         weavingEntityInDir.setStringField("abcde");
+        weavingEntityInDir.setBlobField(new byte[] {1, 2, 3});
 
         EntityManager em = createEntityManager();
         try {
@@ -125,7 +126,11 @@ public class WeavingTest extends JUnitTestCase {
         WeavingEntityInDir weavingEntityInDir = null;
         EntityManager em = createEntityManager();
         try {
+            beginTransaction(em);
             weavingEntityInDir = em.find(WeavingEntityInDir.class, ID);
+            // Verify _persistence_checkFetchedForSet(...) as blobField has "@Basic(fetch= FetchType.LAZY)"
+            weavingEntityInDir.setBlobField(null);
+            commitTransaction(em);
         } finally {
             if (isTransactionActive(em)) {
                 rollbackTransaction(em);

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/weaving/ClassWeaver.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/weaving/ClassWeaver.java
@@ -1136,13 +1136,17 @@ public class ClassWeaver extends ClassVisitor {
      * _persistence_fetchGroup.containsAttribute(attribute); }
      * <p>
      * public void _persistence_checkFetched(String attribute) { if
-     * (this._persistence_fetchGroup != null) {
-     * EntityManagerImpl.processUnfetchedAttribute(this, attribute); } }
+     * (!this._persistence_isAttributeFetched(var1)) {
+     * String var2 = this._persistence_getFetchGroup().onUnfetchedAttribute(this, var1);
+     * if (var2 != null) {
+     * throw new EntityNotFoundException(var2);}}}
      * <p>
      *
      * public void _persistence_checkSetFetched(String attribute) { if
-     * (this._persistence_fetchGroup != null) {
-     * EntityManagerImpl.processUnfetchedAttributeForSet(this, attribute); } }
+     * if (!this._persistence_isAttributeFetched(var1)) {
+     * String var2 = this._persistence_getFetchGroup().onUnfetchedAttributeForSet(this, var1);
+     * if (var2 != null) {
+     * throw new EntityNotFoundException(var2);}}}
      */
     public void addFetchGroupMethods(ClassDetails classDetails) {
         MethodVisitor cv_getSession = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_getSession", "()" + SESSION_SIGNATURE, null, null);
@@ -1256,7 +1260,7 @@ public class ClassWeaver extends ClassVisitor {
             // .onUnfetchedAttribute(entity, attributeName);
             cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
             cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-            cv_checkFetchedForSet.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), FETCHGROUP_SHORT_SIGNATURE, "onUnfetchedAttributeSet", "(" + FETCHGROUP_TRACKER_SIGNATURE + STRING_SIGNATURE + ")" + STRING_SIGNATURE, false);
+            cv_checkFetchedForSet.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), FETCHGROUP_SHORT_SIGNATURE, "onUnfetchedAttributeForSet", "(" + FETCHGROUP_TRACKER_SIGNATURE + STRING_SIGNATURE + ")" + STRING_SIGNATURE, false);
             cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ASTORE"), 2);
             cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 2);
             cv_checkFetchedForSet.visitJumpInsn(Opcodes.valueInt("IFNULL"), l1);

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/weaving/ClassWeaver.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/weaving/ClassWeaver.java
@@ -79,7 +79,6 @@ public class ClassWeaver extends ClassVisitor {
     public static final String FETCHGROUP_SHORT_SIGNATURE = "org/eclipse/persistence/queries/FetchGroup";
     public static final String FETCHGROUP_SIGNATURE = "Lorg/eclipse/persistence/queries/FetchGroup;";
     public static final String SESSION_SIGNATURE = "Lorg/eclipse/persistence/sessions/Session;";
-    public static final String ENTITY_MANAGER_IMPL_SHORT_SIGNATURE = "org/eclipse/persistence/internal/jpa/EntityManagerImpl";
     public static final String PBOOLEAN_SIGNATURE = "Z";
     public static final String LONG_SIGNATURE = "J";
 
@@ -598,32 +597,22 @@ public class ClassWeaver extends ClassVisitor {
             // e.g. if it is an integer: Integer.valueOf(attribute)
             // This is the first part of the wrapping
             String wrapper = ClassWeaver.wrapperFor(attributeDetails.getReferenceClassType().getSort());
-            if (wrapper != null) {
-                cv_set.visitTypeInsn(Opcodes.valueInt("NEW"), wrapper);
-                cv_set.visitInsn(Opcodes.valueInt("DUP"));
-            }
-
             // load the method argument
             cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
             cv_set.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), attribute, attributeDetails.getReferenceClassType().getDescriptor());
 
             if (wrapper != null) {
-                // invoke the constructor for wrapping
-                // e.g. Integer.valueOf(variableName)
-                cv_set.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), wrapper, "<init>", "(" + attributeDetails.getReferenceClassType().getDescriptor() + ")V", false);
-
-                // wrap the method argument
-                // e.g. Integer.valueOf(argument)
-                cv_set.visitTypeInsn(Opcodes.valueInt("NEW"), wrapper);
-                cv_set.visitInsn(Opcodes.valueInt("DUP"));
+                //convert from global field e.g. Integer.valueOf(this.intField)
+                cv_set.visitMethodInsn(Opcodes.valueInt("INVOKESTATIC"), wrapper, "valueOf", "(" + attributeDetails.getReferenceClassType().getDescriptor() + ")L" + wrapper + ";", false);
+                //convert from method argument e.g. Integer.valueOf(var1)
                 cv_set.visitVarInsn(opcode, 1);
-                cv_set.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), wrapper, "<init>", "(" + attributeDetails.getReferenceClassType().getDescriptor() + ")V", false);
+                cv_set.visitMethodInsn(Opcodes.valueInt("INVOKESTATIC"), wrapper, "valueOf", "(" + attributeDetails.getReferenceClassType().getDescriptor() + ")L" + wrapper + ";", false);
             } else {
                 // if we are not wrapping the argument, just load it
                 cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
             }
-            // _persistence_propertyChange("variableName", variableName,
-            // argument);
+            // _persistence_propertyChange("variableName", variableName, argument);
+            //e.g.  this._persistence_propertyChange("intField", Integer.valueOf(this.intField), Integer.valueOf(var1));
             cv_set.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_propertyChange", "(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V", false);
         } else {
             if (attributeDetails.weaveValueHolders()) {
@@ -881,10 +870,34 @@ public class ClassWeaver extends ClassVisitor {
         // create the _persistence_shallow_clone() method
         MethodVisitor cv_clone = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_shallow_clone", "()Ljava/lang/Object;", null, null);
 
+        Label l0 = ASMFactory.createLabel();
+        Label l1 = ASMFactory.createLabel();
+        Label l2 = ASMFactory.createLabel();
+        // try {
+        cv_clone.visitTryCatchBlock(l0, l1, l2, "java/lang/CloneNotSupportedException");
+        cv_clone.visitLabel(l0);
         // return super.clone();
         cv_clone.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
         cv_clone.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), "java/lang/Object", "clone", "()Ljava/lang/Object;", false);
-
+        // } catch (CloneNotSupportedException e) {
+        cv_clone.visitLabel(l1);
+        cv_clone.visitInsn(Opcodes.valueInt("ARETURN"));
+        cv_clone.visitLabel(l2);
+        cv_clone.visitFrame(Opcodes.valueInt("F_SAME1"), 0, null, 1, new Object[]{"java/lang/CloneNotSupportedException"});
+        cv_clone.visitVarInsn(Opcodes.valueInt("ASTORE"), 1);
+        // throw new InternalError(e);
+        Label l3 = ASMFactory.createLabel();
+        cv_clone.visitLabel(l3);
+        cv_clone.visitTypeInsn(Opcodes.valueInt("NEW"), "java/lang/InternalError");
+        cv_clone.visitInsn(Opcodes.valueInt("DUP"));
+        cv_clone.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+        cv_clone.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), "java/lang/InternalError", "<init>", "(Ljava/lang/Throwable;)V", false);
+        cv_clone.visitInsn(Opcodes.valueInt("ATHROW"));
+        Label l4 = ASMFactory.createLabel();
+        cv_clone.visitLabel(l4);
+        cv_clone.visitLocalVariable("e", "Ljava/lang/CloneNotSupportedException;", null, l3, l4, 1);
+        cv_clone.visitLocalVariable("this", "L" + classDetails.getClassName() + ";", null, l0, l4, 0);
+        // Method end - implicit return
         cv_clone.visitInsn(Opcodes.valueInt("ARETURN"));
         cv_clone.visitMaxs(0, 0);
     }
@@ -1193,33 +1206,62 @@ public class ClassWeaver extends ClassVisitor {
         cv_isAttributeFetched.visitInsn(Opcodes.valueInt("IRETURN"));
         cv_isAttributeFetched.visitMaxs(0, 0);
 
-        MethodVisitor cv_checkFetched = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_checkFetched", "(Ljava/lang/String;)V", null, null);
-        cv_checkFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_checkFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_checkFetched.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_isAttributeFetched", "(Ljava/lang/String;)Z", false);
-        gotoReturn = ASMFactory.createLabel();
-        cv_checkFetched.visitJumpInsn(Opcodes.valueInt("IFNE"), gotoReturn);
-        cv_checkFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_checkFetched.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), FETCHGROUP_TRACKER_SHORT_SIGNATURE);
-        cv_checkFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_checkFetched.visitMethodInsn(Opcodes.valueInt("INVOKESTATIC"), ENTITY_MANAGER_IMPL_SHORT_SIGNATURE, "processUnfetchedAttribute", "(" + FETCHGROUP_TRACKER_SIGNATURE + "Ljava/lang/String;)V", false);
-        cv_checkFetched.visitLabel(gotoReturn);
-        cv_checkFetched.visitInsn(Opcodes.valueInt("RETURN"));
-        cv_checkFetched.visitMaxs(0, 0);
+        MethodVisitor cv_checkFetched = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_checkFetched", "(Ljava/lang/String;)V", null, null); {
+            Label l0 = ASMFactory.createLabel();
+            cv_checkFetched.visitLabel(l0);
+            // if (!this._persistence_isAttributeFetched(attributeName)) {
+            cv_checkFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            cv_checkFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+            cv_checkFetched.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_isAttributeFetched", "(Ljava/lang/String;)Z", false);
+            Label l1 = ASMFactory.createLabel();
+            cv_checkFetched.visitJumpInsn(Opcodes.valueInt("IFNE"), l1);
+            // String errorMsg = _persistence_getFetchGroup().
+            cv_checkFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            cv_checkFetched.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_getFetchGroup", "()Lorg/eclipse/persistence/queries/FetchGroup;", false);
+            // .onUnfetchedAttribute(entity, attributeName);
+            cv_checkFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            cv_checkFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+            cv_checkFetched.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), "org/eclipse/persistence/queries/FetchGroup", "onUnfetchedAttribute", "(Lorg/eclipse/persistence/queries/FetchGroupTracker;Ljava/lang/String;)Ljava/lang/String;", false);
+            cv_checkFetched.visitVarInsn(Opcodes.valueInt("ASTORE"), 2);
+            cv_checkFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 2);
+            cv_checkFetched.visitJumpInsn(Opcodes.valueInt("IFNULL"), l1);
+            cv_checkFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 2);
+            cv_checkFetched.visitMethodInsn(Opcodes.valueInt("INVOKESTATIC"), "org/eclipse/persistence/exceptions/StaticWeaveException", "exceptionPerformWeaving", "(Ljava/lang/String;)Lorg/eclipse/persistence/exceptions/StaticWeaveException;", false);
+            cv_checkFetched.visitInsn(Opcodes.valueInt("ATHROW"));
+            cv_checkFetched.visitLabel(l1);
+            cv_checkFetched.visitFrame(Opcodes.valueInt("F_APPEND"), 1, new Object[]{"java/lang/String"}, 0, null);
+            cv_checkFetched.visitInsn(Opcodes.valueInt("RETURN"));
+            cv_checkFetched.visitMaxs(0, 0);
+        }
 
         MethodVisitor cv_checkFetchedForSet = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_checkFetchedForSet", "(Ljava/lang/String;)V", null, null);
-        cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_checkFetchedForSet.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_isAttributeFetched", "(Ljava/lang/String;)Z", false);
-        gotoReturn = ASMFactory.createLabel();
-        cv_checkFetchedForSet.visitJumpInsn(Opcodes.valueInt("IFNE"), gotoReturn);
-        cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_checkFetchedForSet.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), FETCHGROUP_TRACKER_SHORT_SIGNATURE);
-        cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_checkFetchedForSet.visitMethodInsn(Opcodes.valueInt("INVOKESTATIC"), ENTITY_MANAGER_IMPL_SHORT_SIGNATURE, "processUnfetchedAttributeForSet", "(" + FETCHGROUP_TRACKER_SIGNATURE + "Ljava/lang/String;)V", false);
-        cv_checkFetchedForSet.visitLabel(gotoReturn);
-        cv_checkFetchedForSet.visitInsn(Opcodes.valueInt("RETURN"));
-        cv_checkFetchedForSet.visitMaxs(0, 0);
+        {
+            Label l0 = ASMFactory.createLabel();
+            cv_checkFetchedForSet.visitLabel(l0);
+            // if (!this._persistence_isAttributeFetched(attributeName)) {
+            cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+            cv_checkFetchedForSet.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_isAttributeFetched", "(Ljava/lang/String;)Z", false);
+            Label l1 = ASMFactory.createLabel();
+            cv_checkFetchedForSet.visitJumpInsn(Opcodes.valueInt("IFNE"), l1);
+            // String errorMsg = _persistence_getFetchGroup().
+            cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            cv_checkFetchedForSet.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_getFetchGroup", "()Lorg/eclipse/persistence/queries/FetchGroup;", false);
+            // .onUnfetchedAttribute(entity, attributeName);
+            cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+            cv_checkFetchedForSet.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), "org/eclipse/persistence/queries/FetchGroup", "onUnfetchedAttributeSet", "(Lorg/eclipse/persistence/queries/FetchGroupTracker;Ljava/lang/String;)Ljava/lang/String;", false);
+            cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ASTORE"), 2);
+            cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 2);
+            cv_checkFetchedForSet.visitJumpInsn(Opcodes.valueInt("IFNULL"), l1);
+            cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 2);
+            cv_checkFetchedForSet.visitMethodInsn(Opcodes.valueInt("INVOKESTATIC"), "org/eclipse/persistence/exceptions/StaticWeaveException", "exceptionPerformWeaving", "(Ljava/lang/String;)Lorg/eclipse/persistence/exceptions/StaticWeaveException;", false);
+            cv_checkFetchedForSet.visitInsn(Opcodes.valueInt("ATHROW"));
+            cv_checkFetchedForSet.visitLabel(l1);
+            cv_checkFetchedForSet.visitFrame(Opcodes.valueInt("F_APPEND"), 1, new Object[]{"java/lang/String"}, 0, null);
+            cv_checkFetchedForSet.visitInsn(Opcodes.valueInt("RETURN"));
+            cv_checkFetchedForSet.visitMaxs(0, 0);
+        }
     }
 
     /**

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/weaving/ClassWeaver.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/weaving/ClassWeaver.java
@@ -96,6 +96,9 @@ public class ClassWeaver extends ClassVisitor {
     public static final String JPA_TRANSIENT_DESCRIPTION = "Ljakarta/persistence/Transient;";
     public static final String XML_TRANSIENT_DESCRIPTION = "Ljakarta/xml/bind/annotation/XmlTransient;";
 
+    // Jakarta Persistence API
+    public static final String JPA_ENTITY_NOT_FOUND_EXCEPTION_SHORT_SIGNATURE = "jakarta/persistence/EntityNotFoundException";
+
     public static final String PERSISTENCE_SET = Helper.PERSISTENCE_SET;
     public static final String PERSISTENCE_GET = Helper.PERSISTENCE_GET;
 
@@ -878,7 +881,7 @@ public class ClassWeaver extends ClassVisitor {
         cv_clone.visitLabel(l0);
         // return super.clone();
         cv_clone.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_clone.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), "java/lang/Object", "clone", "()Ljava/lang/Object;", false);
+        cv_clone.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), "java/lang/Object", "clone", "()" + OBJECT_SIGNATURE, false);
         // } catch (CloneNotSupportedException e) {
         cv_clone.visitLabel(l1);
         cv_clone.visitInsn(Opcodes.valueInt("ARETURN"));
@@ -1206,27 +1209,30 @@ public class ClassWeaver extends ClassVisitor {
         cv_isAttributeFetched.visitInsn(Opcodes.valueInt("IRETURN"));
         cv_isAttributeFetched.visitMaxs(0, 0);
 
-        MethodVisitor cv_checkFetched = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_checkFetched", "(Ljava/lang/String;)V", null, null); {
+        MethodVisitor cv_checkFetched = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_checkFetched", "(" + STRING_SIGNATURE + ")V", null, null); {
             Label l0 = ASMFactory.createLabel();
             cv_checkFetched.visitLabel(l0);
             // if (!this._persistence_isAttributeFetched(attributeName)) {
             cv_checkFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
             cv_checkFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-            cv_checkFetched.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_isAttributeFetched", "(Ljava/lang/String;)Z", false);
+            cv_checkFetched.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_isAttributeFetched", "(" + STRING_SIGNATURE + ")Z", false);
             Label l1 = ASMFactory.createLabel();
             cv_checkFetched.visitJumpInsn(Opcodes.valueInt("IFNE"), l1);
             // String errorMsg = _persistence_getFetchGroup().
             cv_checkFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_checkFetched.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_getFetchGroup", "()Lorg/eclipse/persistence/queries/FetchGroup;", false);
+            cv_checkFetched.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_getFetchGroup", "()" + FETCHGROUP_SIGNATURE, false);
             // .onUnfetchedAttribute(entity, attributeName);
             cv_checkFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
             cv_checkFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-            cv_checkFetched.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), "org/eclipse/persistence/queries/FetchGroup", "onUnfetchedAttribute", "(Lorg/eclipse/persistence/queries/FetchGroupTracker;Ljava/lang/String;)Ljava/lang/String;", false);
+            cv_checkFetched.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), FETCHGROUP_SHORT_SIGNATURE, "onUnfetchedAttribute", "(" + FETCHGROUP_TRACKER_SIGNATURE + STRING_SIGNATURE + ")" + STRING_SIGNATURE, false);
             cv_checkFetched.visitVarInsn(Opcodes.valueInt("ASTORE"), 2);
             cv_checkFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 2);
             cv_checkFetched.visitJumpInsn(Opcodes.valueInt("IFNULL"), l1);
+            // throw new EntityNotFoundException(errorMsg);
+            cv_checkFetched.visitTypeInsn(Opcodes.valueInt("NEW"), JPA_ENTITY_NOT_FOUND_EXCEPTION_SHORT_SIGNATURE);
+            cv_checkFetched.visitInsn(Opcodes.valueInt("DUP"));
             cv_checkFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 2);
-            cv_checkFetched.visitMethodInsn(Opcodes.valueInt("INVOKESTATIC"), "org/eclipse/persistence/exceptions/StaticWeaveException", "exceptionPerformWeaving", "(Ljava/lang/String;)Lorg/eclipse/persistence/exceptions/StaticWeaveException;", false);
+            cv_checkFetched.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), JPA_ENTITY_NOT_FOUND_EXCEPTION_SHORT_SIGNATURE, "<init>", "(" + STRING_SIGNATURE + ")V", false);
             cv_checkFetched.visitInsn(Opcodes.valueInt("ATHROW"));
             cv_checkFetched.visitLabel(l1);
             cv_checkFetched.visitFrame(Opcodes.valueInt("F_APPEND"), 1, new Object[]{"java/lang/String"}, 0, null);
@@ -1234,28 +1240,31 @@ public class ClassWeaver extends ClassVisitor {
             cv_checkFetched.visitMaxs(0, 0);
         }
 
-        MethodVisitor cv_checkFetchedForSet = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_checkFetchedForSet", "(Ljava/lang/String;)V", null, null);
+        MethodVisitor cv_checkFetchedForSet = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_checkFetchedForSet", "(" + STRING_SIGNATURE + ")V", null, null);
         {
             Label l0 = ASMFactory.createLabel();
             cv_checkFetchedForSet.visitLabel(l0);
             // if (!this._persistence_isAttributeFetched(attributeName)) {
             cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
             cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-            cv_checkFetchedForSet.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_isAttributeFetched", "(Ljava/lang/String;)Z", false);
+            cv_checkFetchedForSet.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_isAttributeFetched", "(" + STRING_SIGNATURE + ")Z", false);
             Label l1 = ASMFactory.createLabel();
             cv_checkFetchedForSet.visitJumpInsn(Opcodes.valueInt("IFNE"), l1);
             // String errorMsg = _persistence_getFetchGroup().
             cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_checkFetchedForSet.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_getFetchGroup", "()Lorg/eclipse/persistence/queries/FetchGroup;", false);
+            cv_checkFetchedForSet.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_getFetchGroup", "()" + FETCHGROUP_SIGNATURE, false);
             // .onUnfetchedAttribute(entity, attributeName);
             cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
             cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-            cv_checkFetchedForSet.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), "org/eclipse/persistence/queries/FetchGroup", "onUnfetchedAttributeSet", "(Lorg/eclipse/persistence/queries/FetchGroupTracker;Ljava/lang/String;)Ljava/lang/String;", false);
+            cv_checkFetchedForSet.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), FETCHGROUP_SHORT_SIGNATURE, "onUnfetchedAttributeSet", "(" + FETCHGROUP_TRACKER_SIGNATURE + STRING_SIGNATURE + ")" + STRING_SIGNATURE, false);
             cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ASTORE"), 2);
             cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 2);
             cv_checkFetchedForSet.visitJumpInsn(Opcodes.valueInt("IFNULL"), l1);
+            // throw new EntityNotFoundException(errorMsg);
+            cv_checkFetchedForSet.visitTypeInsn(Opcodes.valueInt("NEW"), JPA_ENTITY_NOT_FOUND_EXCEPTION_SHORT_SIGNATURE);
+            cv_checkFetchedForSet.visitInsn(Opcodes.valueInt("DUP"));
             cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 2);
-            cv_checkFetchedForSet.visitMethodInsn(Opcodes.valueInt("INVOKESTATIC"), "org/eclipse/persistence/exceptions/StaticWeaveException", "exceptionPerformWeaving", "(Ljava/lang/String;)Lorg/eclipse/persistence/exceptions/StaticWeaveException;", false);
+            cv_checkFetchedForSet.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), JPA_ENTITY_NOT_FOUND_EXCEPTION_SHORT_SIGNATURE, "<init>", "(" + STRING_SIGNATURE + ")V", false);
             cv_checkFetchedForSet.visitInsn(Opcodes.valueInt("ATHROW"));
             cv_checkFetchedForSet.visitLabel(l1);
             cv_checkFetchedForSet.visitFrame(Opcodes.valueInt("F_APPEND"), 1, new Object[]{"java/lang/String"}, 0, null);


### PR DESCRIPTION
Contains following main changes:
- Replacement of deprecated e.g. `new Integer(...)` by `Integer.valueOf(...)`
- Generated `_persistence_shallow_clone` content is wrapped by `try/catch`
- Remove dependency to JPA module (`org.eclipse.persistence.internal.jpa.EntityManagerImpl` class) in generated `_persistence_checkFetched` and `_persistence_checkFetchedForSet`

There are some extensions in weaving test to more deeply check methods/logic generated by ClassWeaver.
To verify generated code I'd like recommend in extension to decompiler to use some plugin which can display decompiled bytecode as ASMified code. E.g. _ASM Bytecode Viewer_ in _InteliJ_. Reason is that `Integer.valueOf(...)` is not displayed in decompiled bytecode.