### PR TITLE
[master] Allow an empty collection or null as a parameter in an "IN" expression

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabaseCall.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabaseCall.java
@@ -1131,6 +1131,12 @@ public abstract class DatabaseCall extends DatasourceCall {
                         if (parameter instanceof ParameterExpression) {
                             field = ((ParameterExpression)parameter).getField();
                             translatedValue = ((ParameterExpression)parameter).getValue(translationRow, query, session);
+                            Object type = ((ParameterExpression) parameter).getType();
+                            //handle null passed into ...IN (?) as a parameter
+                            if (translatedValue == null && type != null && type.equals(Collection.class)) {
+                                // Must re-translate IN parameters.
+                                hasParameterizedIN = true;
+                            }
                         } else {
                             field = (DatabaseField)parameter;
                             translatedValue = translationRow.get(field);

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatasourceCall.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatasourceCall.java
@@ -1387,6 +1387,10 @@ public abstract class DatasourceCall implements Call {
                                     writer.write(",");
                                 }
                             }
+                        } else if (values.isEmpty()){
+                            //Empty collection passed as parameter is translated into null
+                            parametersValues.add(null);
+                            writer.write("?");
                         } else {
                             parametersValues.addAll(values);
                             int size = values.size();
@@ -1421,6 +1425,10 @@ public abstract class DatasourceCall implements Call {
                             }
                         }
                         writer.write(")");
+                    //handle null passed into ...IN (?) as a parameter
+                    } else if (parameter instanceof DatabaseField && translationRow.get(parameter) == null){
+                        parametersValues.add(null);
+                        writer.write("(?)");
                     } else {
                         parametersValues.add(parameter);
                         writer.write("?");

--- a/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpql/advanced/JUnitJPQLComplexTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpql/advanced/JUnitJPQLComplexTest.java
@@ -76,7 +76,6 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Vector;

--- a/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpql/advanced/JUnitJPQLComplexTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpql/advanced/JUnitJPQLComplexTest.java
@@ -76,6 +76,7 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Vector;
@@ -137,9 +138,13 @@ public class JUnitJPQLComplexTest extends JUnitTestCase
         tests.add("complexInTest3");
         tests.add("complexInTest4");
         tests.add("complexInTest5");
+        tests.add("complexInTest6NullParameter");
+        tests.add("complexInTest7EmptyCollectionParameter");
         tests.add("complexLengthTest");
         tests.add("complexLikeTest");
-        tests.add("complexNotInTest");
+        tests.add("complexNotInTest1");
+        tests.add("complexNotInTest2NullParameter");
+        tests.add("complexNotInTest3EmptyCollectionParameter");
         tests.add("complexNotLikeTest");
         tests.add("complexParameterTest");
         tests.add("complexReverseAbsTest");
@@ -492,6 +497,30 @@ public class JUnitJPQLComplexTest extends JUnitTestCase
         closeEntityManager(em);
     }
 
+    public void complexInTest6NullParameter() {
+
+        EntityManager em = createEntityManager();
+        Query query = em.createQuery("SELECT e from Employee e WHERE e.lastName IN :lastName");
+
+        query.setParameter("lastName", null);
+
+        List<Employee> result = query.getResultList();
+        Assert.assertTrue(result.isEmpty());
+        closeEntityManager(em);
+    }
+
+    public void complexInTest7EmptyCollectionParameter() {
+
+        EntityManager em = createEntityManager();
+        Query query = em.createQuery("SELECT e from Employee e WHERE e.lastName IN :lastName");
+
+        query.setParameter("lastName", new ArrayList<>());
+
+        List<Employee> result = query.getResultList();
+        Assert.assertTrue(result.isEmpty());
+        closeEntityManager(em);
+    }
+
     public void complexLengthTest()
     {
         if ((getPersistenceUnitServerSession()).getPlatform().isSQLServer()) {
@@ -542,7 +571,7 @@ public class JUnitJPQLComplexTest extends JUnitTestCase
 
     }
 
-    public void complexNotInTest()
+    public void complexNotInTest1()
     {
         EntityManager em = createEntityManager();
 
@@ -576,6 +605,30 @@ public class JUnitJPQLComplexTest extends JUnitTestCase
 
         Assert.assertTrue("Complex Not IN test failed", comparer.compareObjects(result, expectedResult));
 
+    }
+
+    public void complexNotInTest2NullParameter() {
+
+        EntityManager em = createEntityManager();
+        Query query = em.createQuery("SELECT e from Employee e WHERE e.lastName NOT IN :lastName");
+
+        query.setParameter("lastName", null);
+
+        List<Employee> result = query.getResultList();
+        Assert.assertTrue(result.isEmpty());
+        closeEntityManager(em);
+    }
+
+    public void complexNotInTest3EmptyCollectionParameter() {
+
+        EntityManager em = createEntityManager();
+        Query query = em.createQuery("SELECT e from Employee e WHERE e.lastName NOT IN :lastName");
+
+        query.setParameter("lastName", List.of());
+
+        List<Employee> result = query.getResultList();
+        Assert.assertTrue(result.isEmpty());
+        closeEntityManager(em);
     }
 
     public void complexNotLikeTest()

--- a/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpql/advanced/JUnitJPQLComplexTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpql/advanced/JUnitJPQLComplexTest.java
@@ -139,6 +139,8 @@ public class JUnitJPQLComplexTest extends JUnitTestCase
         tests.add("complexInTest5");
         tests.add("complexInTest6NullParameter");
         tests.add("complexInTest7EmptyCollectionParameter");
+        tests.add("complexInTest8NullPartialParameter");
+        tests.add("complexInTest9EmptyStringPartialParameter");
         tests.add("complexLengthTest");
         tests.add("complexLikeTest");
         tests.add("complexNotInTest1");
@@ -517,6 +519,38 @@ public class JUnitJPQLComplexTest extends JUnitTestCase
 
         List<Employee> result = query.getResultList();
         Assert.assertTrue(result.isEmpty());
+        closeEntityManager(em);
+    }
+
+    public void complexInTest8NullPartialParameter() {
+
+        EntityManager em = createEntityManager();
+        Query expectedQuery = em.createQuery("SELECT e from Employee e WHERE e.lastName IN ('Jones', 'Smith') ORDER BY e.id");
+        List<Employee> expectedResult = expectedQuery.getResultList();
+
+        Query query = em.createQuery("SELECT e from Employee e WHERE e.lastName IN ('Jones', 'Smith', :lastName) ORDER BY e.id");
+        query.setParameter("lastName", null);
+        List<Employee> result = query.getResultList();
+
+        Assert.assertTrue(result.size() > 0);
+        Assert.assertTrue("Complex IN with NULL test failed", comparer.compareObjects(result, expectedResult));
+
+        closeEntityManager(em);
+    }
+
+    public void complexInTest9EmptyStringPartialParameter() {
+
+        EntityManager em = createEntityManager();
+        Query expectedQuery = em.createQuery("SELECT e from Employee e WHERE e.lastName IN ('Jones', 'Smith') ORDER BY e.id");
+        List<Employee> expectedResult = expectedQuery.getResultList();
+
+        Query query = em.createQuery("SELECT e from Employee e WHERE e.lastName IN ('Jones', 'Smith', :lastName) ORDER BY e.id");
+        query.setParameter("lastName", "");
+        List<Employee> result = query.getResultList();
+
+        Assert.assertTrue(result.size() > 0);
+        Assert.assertTrue("Complex IN with NULL test failed", comparer.compareObjects(result, expectedResult));
+
         closeEntityManager(em);
     }
 


### PR DESCRIPTION
This is bugfix for case like
```
...
Query query = em.createQuery("SELECT e from Employee e WHERE e.lastName IN :lastName");
query.setParameter("lastName", null);
...
```
or
```
...
Query query = em.createQuery("SELECT e from Employee e WHERE e.lastName IN :lastName");
query.setParameter("lastName", new ArrayList<>());
...
```
before this fix some `SQLException` was thrown due a incorrect SQL query.
After this fix booth JPQLs will be translated into something like
`SELECT * FROM employee WHERE l_name IN (NULL)`
Database will return empty `ResultSet` for this kind of query.
By default there is handling for
```
...
Query query = em.createQuery("SELECT e from Employee e WHERE e.lastName NOT IN :lastName");
query.setParameter("lastName", List.of());
...
```
which is translated into
`SELECT * FROM employee WHERE l_name NOT IN (NULL)`
Database will return empty `ResultSet` for `WHERE l_name NOT IN (NULL)`

NOTE: Currently empty collection like `List.of()` or `new ArrayList<>()` is translated into DB `NULL`.
This is implementation for https://github.com/jakartaee/persistence/issues/100
