### PR TITLE
[master] Performance tests - code refresh

### DIFF
--- a/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/beanvalidation/MOXyValidationBenchmark.java
+++ b/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/beanvalidation/MOXyValidationBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -103,7 +103,7 @@ public class MOXyValidationBenchmark {
     }
 
     private void prepareJAXB() throws Exception {
-        ctx = JAXBContextFactory.createContext(EMPLOYEES, new HashMap<Object, Object>(){{put(JAXBContextProperties
+        ctx = JAXBContextFactory.createContext(EMPLOYEES, new HashMap<>(){{put(JAXBContextProperties
                 .BEAN_VALIDATION_MODE, BeanValidationMode.CALLBACK);}});
         mar = (JAXBMarshaller) ctx.createMarshaller();
         mar.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);

--- a/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/jpa/tests/basic/JPAMetadataProcessingTests.java
+++ b/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/jpa/tests/basic/JPAMetadataProcessingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -41,7 +41,7 @@ import org.openjdk.jmh.annotations.State;
 public class JPAMetadataProcessingTests {
 
     private ServerSession session;
-    private Set<Class> entities;
+    private Set<Class<?>> entities;
 
     @Setup
     public void setup() {

--- a/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/largexml/bigpo/channel_code/ChannelCodeContentType.java
+++ b/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/largexml/bigpo/channel_code/ChannelCodeContentType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -22,7 +22,6 @@ import jakarta.xml.bind.annotation.XmlType;
  * <p>Java class for ChannelCodeContentType.
  *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
  * <pre>
  * &lt;simpleType name="ChannelCodeContentType">
  *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}normalizedString">

--- a/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/largexml/bigpo/chip_code/ChipCodeContentType.java
+++ b/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/largexml/bigpo/chip_code/ChipCodeContentType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -23,7 +23,6 @@ import jakarta.xml.bind.annotation.XmlType;
  * <p>Java class for ChipCodeContentType.
  *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
  * <pre>
  * &lt;simpleType name="ChipCodeContentType">
  *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}normalizedString">

--- a/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/largexml/bigpo/core_component_types/BinaryObjectType.java
+++ b/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/largexml/bigpo/core_component_types/BinaryObjectType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -111,7 +111,7 @@ public class BinaryObjectType {
      *     byte[]
      */
     public void setValue(byte[] value) {
-        this.value = ((byte[]) value);
+        this.value = value;
     }
 
     /**

--- a/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/largexml/bigpo/country_identification_code/CountryIdentificationCodeContentType.java
+++ b/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/largexml/bigpo/country_identification_code/CountryIdentificationCodeContentType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -22,7 +22,6 @@ import jakarta.xml.bind.annotation.XmlType;
  * <p>Java class for CountryIdentificationCodeContentType.
  *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
  * <pre>
  * &lt;simpleType name="CountryIdentificationCodeContentType">
  *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}normalizedString">

--- a/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/largexml/bigpo/currency_code/CurrencyCodeContentType.java
+++ b/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/largexml/bigpo/currency_code/CurrencyCodeContentType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -22,7 +22,6 @@ import jakarta.xml.bind.annotation.XmlType;
  * <p>Java class for CurrencyCodeContentType.
  *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
  * <pre>
  * &lt;simpleType name="CurrencyCodeContentType">
  *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}normalizedString">

--- a/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/largexml/bigpo/document_status_code/DocumentStatusCodeContentType.java
+++ b/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/largexml/bigpo/document_status_code/DocumentStatusCodeContentType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -23,7 +23,6 @@ import jakarta.xml.bind.annotation.XmlType;
  * <p>Java class for DocumentStatusCodeContentType.
  *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
  * <pre>
  * &lt;simpleType name="DocumentStatusCodeContentType">
  *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}normalizedString">

--- a/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/largexml/bigpo/latitude_direction_code/LatitudeDirectionCodeContentType.java
+++ b/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/largexml/bigpo/latitude_direction_code/LatitudeDirectionCodeContentType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -23,7 +23,6 @@ import jakarta.xml.bind.annotation.XmlType;
  * <p>Java class for LatitudeDirectionCodeContentType.
  *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
  * <pre>
  * &lt;simpleType name="LatitudeDirectionCodeContentType">
  *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}normalizedString">

--- a/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/largexml/bigpo/line_status_code/LineStatusCodeContentType.java
+++ b/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/largexml/bigpo/line_status_code/LineStatusCodeContentType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -23,7 +23,6 @@ import jakarta.xml.bind.annotation.XmlType;
  * <p>Java class for LineStatusCodeContentType.
  *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
  * <pre>
  * &lt;simpleType name="LineStatusCodeContentType">
  *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}normalizedString">

--- a/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/largexml/bigpo/longitude_direction_code/LongitudeDirectionCodeContentType.java
+++ b/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/largexml/bigpo/longitude_direction_code/LongitudeDirectionCodeContentType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -23,7 +23,6 @@ import jakarta.xml.bind.annotation.XmlType;
  * <p>Java class for LongitudeDirectionCodeContentType.
  *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
  * <pre>
  * &lt;simpleType name="LongitudeDirectionCodeContentType">
  *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}normalizedString">

--- a/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/largexml/bigpo/operator_code/OperatorCodeContentType.java
+++ b/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/largexml/bigpo/operator_code/OperatorCodeContentType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -23,7 +23,6 @@ import jakarta.xml.bind.annotation.XmlType;
  * <p>Java class for OperatorCodeContentType.
  *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
  * <pre>
  * &lt;simpleType name="OperatorCodeContentType">
  *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}normalizedString">

--- a/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/largexml/bigpo/substitution_status_code/SubstitutionStatusCodeContentType.java
+++ b/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/largexml/bigpo/substitution_status_code/SubstitutionStatusCodeContentType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -23,7 +23,6 @@ import jakarta.xml.bind.annotation.XmlType;
  * <p>Java class for SubstitutionStatusCodeContentType.
  *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
  * <pre>
  * &lt;simpleType name="SubstitutionStatusCodeContentType">
  *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}normalizedString">

--- a/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/reflection/ReflectionBenchmark.java
+++ b/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/reflection/ReflectionBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -35,7 +35,7 @@ import java.security.PrivilegedAction;
  *
  * Tests are ran in multi-threaded environment.
  *
- * @author Marcel Valovy <marcel.valovy@oracle.com>
+ * @author Marcel Valovy marcel.valovy@oracle.com
  */
 @State(Scope.Benchmark)
 public class ReflectionBenchmark {

--- a/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/reflection/ReflectionUtils.java
+++ b/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/reflection/ReflectionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -36,7 +36,7 @@ final class ReflectionUtils {
 
     /**
      * Retrieves declared fields.
-     * <p/>
+     * <p>
      * If security is enabled, makes {@linkplain java.security.AccessController#doPrivileged(PrivilegedAction)
      * privileged calls}.
      *

--- a/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/reflection/SimpleConcurrentReflectionUtils.java
+++ b/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/reflection/SimpleConcurrentReflectionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,19 +14,9 @@
 //     Marcel Valovy - 2.6 - initial API and implementation
 package org.eclipse.persistence.testing.perf.reflection;
 
-import java.lang.management.ManagementFactory;
-import java.lang.management.ThreadMXBean;
-import java.lang.ref.SoftReference;
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.ArrayList;
-import java.util.Deque;
-import java.util.Iterator;
-import java.util.List;
-import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
@@ -40,7 +30,7 @@ public class SimpleConcurrentReflectionUtils {
 
     /**
      * Retrieves declared fields.
-     * <p/>
+     * <p>
      * If security is enabled, makes {@linkplain java.security.AccessController#doPrivileged(java.security.PrivilegedAction)
      * privileged calls}.
      *


### PR DESCRIPTION
- cleanup some compilation issues on Java 21
- warnings cleanup include some Javadoc warnings
Performance tests against Derby should be executed by
`mvn clean test -pl :org.eclipse.persistence.performance.test -Ptest-performance`