### PR TITLE
[master] Startup Time Regression in EclipseLink fix - ASM Opcodes loading - backport from 4.x

### DIFF
--- a/dbws/org.eclipse.persistence.dbws/src/main/java/org/eclipse/persistence/internal/dbws/SOAPResponseClassLoader.java
+++ b/dbws/org.eclipse.persistence.dbws/src/main/java/org/eclipse/persistence/internal/dbws/SOAPResponseClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -58,12 +58,12 @@ public class SOAPResponseClassLoader extends ClassLoader {
        *   }
        */
       ClassWriter cw = new EclipseLinkASMClassWriter();
-      cw.visit(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_SUPER"), className, null, SOAP_RESPONSE_CLASSNAME_SLASHES, null);
+      cw.visit(Opcodes.ACC_PUBLIC + Opcodes.ACC_SUPER, className, null, SOAP_RESPONSE_CLASSNAME_SLASHES, null);
 
-      MethodVisitor mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "<init>", "()V", null, null);
-      mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-      mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), SOAP_RESPONSE_CLASSNAME_SLASHES, "<init>", "()V", false);
-      mv.visitInsn(Opcodes.valueInt("RETURN"));
+      MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "()V", null, null);
+      mv.visitVarInsn(Opcodes.ALOAD, 0);
+      mv.visitMethodInsn(Opcodes.INVOKESPECIAL, SOAP_RESPONSE_CLASSNAME_SLASHES, "<init>", "()V", false);
+      mv.visitInsn(Opcodes.RETURN);
       mv.visitMaxs(0, 0);
       mv.visitEnd();
 

--- a/dbws/org.eclipse.persistence.dbws/src/main/java/org/eclipse/persistence/internal/xr/XRClassWriter.java
+++ b/dbws/org.eclipse.persistence.dbws/src/main/java/org/eclipse/persistence/internal/xr/XRClassWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -67,44 +67,44 @@ public class XRClassWriter extends DynamicClassWriter {
 
         // special-case: build sub-class of XRDynamicEntityCollection
         if (className.endsWith(COLLECTION_WRAPPER_SUFFIX)) {
-            cw.visit(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_SUPER"), classNameAsSlashes, null, XR_DYNAMIC_ENTITY_COLLECTION_CLASSNAME_SLASHES, null);
-            mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), INIT, "()V", null, null);
-            mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), XR_DYNAMIC_ENTITY_COLLECTION_CLASSNAME_SLASHES, INIT, "()V", false);
-            mv.visitInsn(Opcodes.valueInt("RETURN"));
+            cw.visit(Opcodes.ACC_PUBLIC + Opcodes.ACC_SUPER, classNameAsSlashes, null, XR_DYNAMIC_ENTITY_COLLECTION_CLASSNAME_SLASHES, null);
+            mv = cw.visitMethod(Opcodes.ACC_PUBLIC, INIT, "()V", null, null);
+            mv.visitVarInsn(Opcodes.ALOAD, 0);
+            mv.visitMethodInsn(Opcodes.INVOKESPECIAL, XR_DYNAMIC_ENTITY_COLLECTION_CLASSNAME_SLASHES, INIT, "()V", false);
+            mv.visitInsn(Opcodes.RETURN);
             mv.visitMaxs(0, 0);
             mv.visitEnd();
         } else {
             // public class Foo extends XRDynamicEntity {
-            cw.visit(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_SUPER"), classNameAsSlashes, null, XR_DYNAMIC_ENTITY_CLASSNAME_SLASHES, null);
+            cw.visit(Opcodes.ACC_PUBLIC + Opcodes.ACC_SUPER, classNameAsSlashes, null, XR_DYNAMIC_ENTITY_CLASSNAME_SLASHES, null);
 
             // public static XRDynamicPropertiesManager DPM = new
             // XRDynamicPropertiesManager();
-            cw.visitField(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_STATIC"), PROPERTIES_MANAGER_FIELD, "L" + XR_DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES + ";", null, null);
+            cw.visitField(Opcodes.ACC_PUBLIC + Opcodes.ACC_STATIC, PROPERTIES_MANAGER_FIELD, "L" + XR_DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES + ";", null, null);
 
-            mv = cw.visitMethod(Opcodes.valueInt("ACC_STATIC"), CLINIT, "()V", null, null);
-            mv.visitTypeInsn(Opcodes.valueInt("NEW"), XR_DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES);
-            mv.visitInsn(Opcodes.valueInt("DUP"));
-            mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), XR_DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES, INIT, "()V", false);
-            mv.visitFieldInsn(Opcodes.valueInt("PUTSTATIC"), classNameAsSlashes, PROPERTIES_MANAGER_FIELD, "L" + XR_DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES + ";");
-            mv.visitInsn(Opcodes.valueInt("RETURN"));
+            mv = cw.visitMethod(Opcodes.ACC_STATIC, CLINIT, "()V", null, null);
+            mv.visitTypeInsn(Opcodes.NEW, XR_DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES);
+            mv.visitInsn(Opcodes.DUP);
+            mv.visitMethodInsn(Opcodes.INVOKESPECIAL, XR_DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES, INIT, "()V", false);
+            mv.visitFieldInsn(Opcodes.PUTSTATIC, classNameAsSlashes, PROPERTIES_MANAGER_FIELD, "L" + XR_DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES + ";");
+            mv.visitInsn(Opcodes.RETURN);
             mv.visitMaxs(0, 0);
             mv.visitEnd();
 
             // public Foo() {
             // super();
             // }
-            mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), INIT, "()V", null, null);
-            mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), XR_DYNAMIC_ENTITY_CLASSNAME_SLASHES, INIT, "()V", false);
-            mv.visitInsn(Opcodes.valueInt("RETURN"));
+            mv = cw.visitMethod(Opcodes.ACC_PUBLIC, INIT, "()V", null, null);
+            mv.visitVarInsn(Opcodes.ALOAD, 0);
+            mv.visitMethodInsn(Opcodes.INVOKESPECIAL, XR_DYNAMIC_ENTITY_CLASSNAME_SLASHES, INIT, "()V", false);
+            mv.visitInsn(Opcodes.RETURN);
             mv.visitMaxs(0, 0);
             mv.visitEnd();
 
             // public XRDynamicPropertiesManager fetchPropertiesManager() {
-            mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "fetchPropertiesManager", "()L" + XR_DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES + ";", null, null);
-            mv.visitFieldInsn(Opcodes.valueInt("GETSTATIC"), classNameAsSlashes, PROPERTIES_MANAGER_FIELD, "L" + XR_DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES + ";");
-            mv.visitInsn(Opcodes.valueInt("ARETURN"));
+            mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "fetchPropertiesManager", "()L" + XR_DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES + ";", null, null);
+            mv.visitFieldInsn(Opcodes.GETSTATIC, classNameAsSlashes, PROPERTIES_MANAGER_FIELD, "L" + XR_DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES + ";");
+            mv.visitInsn(Opcodes.ARETURN);
             mv.visitMaxs(0, 0);
             mv.visitEnd();
         }

--- a/foundation/eclipselink.core.test/src/test/java/org/eclipse/persistence/testing/tests/junit/asm/ASMFactoryTest.java
+++ b/foundation/eclipselink.core.test/src/test/java/org/eclipse/persistence/testing/tests/junit/asm/ASMFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,6 +16,7 @@ package org.eclipse.persistence.testing.tests.junit.asm;
 
 import org.eclipse.persistence.asm.ASMFactory;
 import org.eclipse.persistence.asm.ClassVisitor;
+import org.eclipse.persistence.asm.Opcodes;
 import org.eclipse.persistence.config.SystemProperties;
 import org.junit.Test;
 
@@ -40,7 +41,7 @@ public class ASMFactoryTest {
     @Test
     public void createClassVisitorTest() {
         String asmServiceSysProperty = System.getProperty(SystemProperties.ASM_SERVICE, "");
-        ClassVisitor classVisitor = ASMFactory.createClassVisitor(ASMFactory.ASM_API_SELECTED);
+        ClassVisitor classVisitor = ASMFactory.createClassVisitor(Opcodes.ASM_API_SELECTED);
         switch (asmServiceSysProperty) {
             case ASMFactory.ASM_SERVICE_OW2:
                 assertEquals(org.eclipse.persistence.asm.internal.platform.ow2.ClassVisitorImpl.class, classVisitor.getClass());

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/asm/ASMFactory.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/asm/ASMFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,6 +14,7 @@
 //     Oracle - initial API and implementation
 package org.eclipse.persistence.asm;
 
+import org.eclipse.persistence.asm.internal.Util;
 import org.eclipse.persistence.config.SystemProperties;
 import org.eclipse.persistence.exceptions.ValidationException;
 import org.eclipse.persistence.internal.security.PrivilegedAccessHelper;
@@ -26,6 +27,7 @@ import java.lang.reflect.Field;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -33,16 +35,15 @@ import java.util.regex.Pattern;
 
 public class ASMFactory {
 
-    private final static SessionLog LOG = AbstractSessionLog.getLog();
-
+    // This block must be first - begin
     public final static String ASM_SERVICE_ECLIPSELINK = "eclipselink";
     public final static String ASM_SERVICE_OW2 = "ow2";
     private final static String ASM_OW2_CLASS_VISITOR = "org.objectweb.asm.ClassVisitor";
     private final static String ASM_ECLIPSELINK_CLASS_VISITOR = "org.eclipse.persistence.internal.libraries.asm.ClassVisitor";
+    private final static SessionLog LOG = AbstractSessionLog.getLog();
+    // This block must be first - end
 
-    //Should be changed in case of ASM upgrade
-    public final static int ASM_API_SELECTED = Opcodes.valueInt("ASM9");
-    public final static int JAVA_CLASS_VERSION = Opcodes.valueInt("V1_8");
+    // Should be changed in case of ASM upgrade
     public final static int JAVA_CLASS_LATEST_VERSION = ASMFactory.getLatestOPCodeVersion();
 
     public static AnnotationVisitor createAnnotationVisitor(final int api) {

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/asm/ClassReader.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/asm/ClassReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -21,6 +21,7 @@ import java.util.Map;
 
 public abstract class ClassReader {
 
+    //This block must be first - begin
     private final static String ASM_CLASSREADER_ECLIPSELINK = "org.eclipse.persistence.internal.libraries.asm.ClassReader";
     private final static String ASM_CLASSREADER_OW2 = "org.objectweb.asm.ClassReader";
 
@@ -30,8 +31,13 @@ public abstract class ClassReader {
         ASM_CLASSREADER_MAP.put(ASMFactory.ASM_SERVICE_OW2, ASM_CLASSREADER_OW2);
         ASM_CLASSREADER_MAP.put(ASMFactory.ASM_SERVICE_ECLIPSELINK, ASM_CLASSREADER_ECLIPSELINK);
     }
+    //This block must be first - end
 
-    public static int valueInt(String fieldName) {
+    public static final int SKIP_CODE = valueInt("SKIP_CODE");
+    public static final int SKIP_DEBUG = valueInt("SKIP_DEBUG");
+    public static final int SKIP_FRAMES = valueInt("SKIP_FRAMES");
+
+    private static int valueInt(String fieldName) {
         return ((int) Util.getFieldValue(ASM_CLASSREADER_MAP, fieldName, Integer.TYPE));
     }
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/asm/ClassWriter.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/asm/ClassWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -21,6 +21,7 @@ import java.util.Map;
 
 public abstract class ClassWriter extends ClassVisitor {
 
+    //This block must be first - begin
     private final static String ASM_CLASSWRITER_ECLIPSELINK = "org.eclipse.persistence.internal.libraries.asm.ClassWriter";
     private final static String ASM_CLASSWRITER_OW2 = "org.objectweb.asm.ClassWriter";
 
@@ -30,7 +31,9 @@ public abstract class ClassWriter extends ClassVisitor {
         ASM_CLASSWRITER_MAP.put(ASMFactory.ASM_SERVICE_OW2, ASM_CLASSWRITER_OW2);
         ASM_CLASSWRITER_MAP.put(ASMFactory.ASM_SERVICE_ECLIPSELINK, ASM_CLASSWRITER_ECLIPSELINK);
     }
+    //This block must be first - end
 
+    public static final int COMPUTE_FRAMES = valueInt("COMPUTE_FRAMES");
     private ClassWriter cw;
     protected ClassWriter customClassWriter;
 
@@ -42,7 +45,7 @@ public abstract class ClassWriter extends ClassVisitor {
     }
 
     public ClassWriter(final ClassReader classReader, final int flags) {
-        super(ASMFactory.ASM_API_SELECTED);
+        super(Opcodes.ASM_API_SELECTED);
         cw = ASMFactory.createClassWriter(flags);
     }
 
@@ -58,7 +61,7 @@ public abstract class ClassWriter extends ClassVisitor {
         return cw;
     }
 
-    public static int valueInt(String fieldName) {
+    private static int valueInt(String fieldName) {
         return ((int) Util.getFieldValue(ASM_CLASSWRITER_MAP, fieldName, Integer.TYPE));
     }
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/asm/EclipseLinkASMClassWriter.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/asm/EclipseLinkASMClassWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -23,7 +23,7 @@ public class EclipseLinkASMClassWriter extends ClassWriter {
     private ClassWriter classWriter;
 
     public EclipseLinkASMClassWriter() {
-        this(ClassWriter.valueInt("COMPUTE_FRAMES"));
+        this(ClassWriter.COMPUTE_FRAMES);
     }
 
     public EclipseLinkASMClassWriter(final int flags) {

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/asm/EclipseLinkAnnotationVisitor.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/asm/EclipseLinkAnnotationVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -19,11 +19,11 @@ public abstract class EclipseLinkAnnotationVisitor extends AnnotationVisitor {
     private AnnotationVisitor annotationVisitor;
 
     public EclipseLinkAnnotationVisitor() {
-        this.annotationVisitor = ASMFactory.createAnnotationVisitor(ASMFactory.ASM_API_SELECTED);
+        this.annotationVisitor = ASMFactory.createAnnotationVisitor(Opcodes.ASM_API_SELECTED);
     }
 
     public EclipseLinkAnnotationVisitor(AnnotationVisitor annotationVisitor) {
-        this.annotationVisitor = ASMFactory.createAnnotationVisitor(ASMFactory.ASM_API_SELECTED, annotationVisitor);
+        this.annotationVisitor = ASMFactory.createAnnotationVisitor(Opcodes.ASM_API_SELECTED, annotationVisitor);
     }
 
     @Override

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/asm/EclipseLinkClassVisitor.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/asm/EclipseLinkClassVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -17,11 +17,11 @@ package org.eclipse.persistence.asm;
 public abstract class EclipseLinkClassVisitor extends ClassVisitor {
 
     public EclipseLinkClassVisitor() {
-        super(ASMFactory.ASM_API_SELECTED);
+        super(Opcodes.ASM_API_SELECTED);
     }
 
     public EclipseLinkClassVisitor(ClassVisitor classVisitor) {
-        super(ASMFactory.ASM_API_SELECTED, classVisitor);
+        super(Opcodes.ASM_API_SELECTED, classVisitor);
     }
 
     public void visit(
@@ -30,7 +30,7 @@ public abstract class EclipseLinkClassVisitor extends ClassVisitor {
             final String signature,
             final String superName,
             final String[] interfaces) {
-        visit(ASMFactory.ASM_API_SELECTED, access, name, signature, superName, interfaces);
+        visit(Opcodes.ASM_API_SELECTED, access, name, signature, superName, interfaces);
     }
 
     public abstract AnnotationVisitor visitAnnotation(String desc, boolean visible);

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/asm/EclipseLinkFieldVisitor.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/asm/EclipseLinkFieldVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -19,11 +19,11 @@ public class EclipseLinkFieldVisitor extends FieldVisitor {
     private FieldVisitor fieldVisitor;
 
     public EclipseLinkFieldVisitor() {
-        this.fieldVisitor = ASMFactory.createFieldVisitor(ASMFactory.ASM_API_SELECTED);
+        this.fieldVisitor = ASMFactory.createFieldVisitor(Opcodes.ASM_API_SELECTED);
     }
 
     public EclipseLinkFieldVisitor(FieldVisitor fieldVisitor) {
-        this.fieldVisitor = ASMFactory.createFieldVisitor(ASMFactory.ASM_API_SELECTED, fieldVisitor);
+        this.fieldVisitor = ASMFactory.createFieldVisitor(Opcodes.ASM_API_SELECTED, fieldVisitor);
     }
 
     @Override

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/asm/EclipseLinkMethodVisitor.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/asm/EclipseLinkMethodVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -19,11 +19,11 @@ public class EclipseLinkMethodVisitor extends MethodVisitor {
     protected MethodVisitor methodVisitor;
 
     public EclipseLinkMethodVisitor() {
-        this.methodVisitor = ASMFactory.createMethodVisitor(ASMFactory.ASM_API_SELECTED);
+        this.methodVisitor = ASMFactory.createMethodVisitor(Opcodes.ASM_API_SELECTED);
     }
 
     public EclipseLinkMethodVisitor(MethodVisitor methodVisitor) {
-        this.methodVisitor = ASMFactory.createMethodVisitor(ASMFactory.ASM_API_SELECTED, methodVisitor);
+        this.methodVisitor = ASMFactory.createMethodVisitor(Opcodes.ASM_API_SELECTED, methodVisitor);
     }
 
     @Override

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/asm/Opcodes.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/asm/Opcodes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -22,22 +22,81 @@ import java.util.Map;
 
 public class Opcodes {
 
+    //This block must be first - begin
     private final static String ASM_OPCCODES_ECLIPSELINK = "org.eclipse.persistence.internal.libraries.asm.Opcodes";
     private final static String ASM_OPCCODES_OW2 = "org.objectweb.asm.Opcodes";
-
     private final static Map<String, String> ASM_OPCCODES_MAP = new HashMap<>();
 
     static {
         ASM_OPCCODES_MAP.put(ASMFactory.ASM_SERVICE_OW2, ASM_OPCCODES_OW2);
         ASM_OPCCODES_MAP.put(ASMFactory.ASM_SERVICE_ECLIPSELINK, ASM_OPCCODES_ECLIPSELINK);
     }
+    //This block must be first - end
 
-    public static int valueInt(String fieldName) {
+    public static final int AASTORE = valueInt("AASTORE");
+    public static final int ACC_ENUM = valueInt("ACC_ENUM");
+    public static final int ACC_FINAL = valueInt("ACC_FINAL");
+    public static final int ACC_INTERFACE = valueInt("ACC_INTERFACE");
+    public static final int ACC_PRIVATE = valueInt("ACC_PRIVATE");
+    public static final int ACC_PROTECTED = valueInt("ACC_PROTECTED");
+    public static final int ACC_PUBLIC = valueInt("ACC_PUBLIC");
+    public static final int ACC_STATIC = valueInt("ACC_STATIC");
+    public static final int ACC_SUPER = valueInt("ACC_SUPER");
+    public static final int ACC_SYNTHETIC = valueInt("ACC_SYNTHETIC");
+    public static final int ACC_TRANSIENT = valueInt("ACC_TRANSIENT");
+    public static final int ACONST_NULL = valueInt("ACONST_NULL");
+    public static final int ALOAD = valueInt("ALOAD");
+    public static final int ANEWARRAY = valueInt("ANEWARRAY");
+    public static final int ARETURN = valueInt("ARETURN");
+    public static final int ASM9 = valueInt("ASM9");
+    public static final int ASTORE = valueInt("ASTORE");
+    public static final int ATHROW = valueInt("ATHROW");
+    public static final int BIPUSH = valueInt("BIPUSH");
+    public static final int CHECKCAST = valueInt("CHECKCAST");
+    public static final int DUP = valueInt("DUP");
+    public static final int F_APPEND = valueInt("F_APPEND");
+    public static final int F_SAME = valueInt("F_SAME");
+    public static final int F_SAME1 = valueInt("F_SAME1");
+    public static final int GETFIELD = valueInt("GETFIELD");
+    public static final int GETSTATIC = valueInt("GETSTATIC");
+    public static final int GOTO = valueInt("GOTO");
+    public static final int ICONST_0 = valueInt("ICONST_0");
+    public static final int ICONST_1 = valueInt("ICONST_1");
+    public static final int ICONST_2 = valueInt("ICONST_2");
+    public static final int ICONST_3 = valueInt("ICONST_3");
+    public static final int ICONST_4 = valueInt("ICONST_4");
+    public static final int ICONST_5 = valueInt("ICONST_5");
+    public static final int IF_ACMPEQ = valueInt("IF_ACMPEQ");
+    public static final int IF_ACMPNE = valueInt("IF_ACMPNE");
+    public static final int IFEQ = valueInt("IFEQ");
+    public static final int IFNE = valueInt("IFNE");
+    public static final int IFNONNULL = valueInt("IFNONNULL");
+    public static final int IFNULL = valueInt("IFNULL");
+    public static final int ILOAD = valueInt("ILOAD");
+    public static final int INVOKEINTERFACE = valueInt("INVOKEINTERFACE");
+    public static final int INVOKESPECIAL = valueInt("INVOKESPECIAL");
+    public static final int INVOKESTATIC = valueInt("INVOKESTATIC");
+    public static final int INVOKEVIRTUAL = valueInt("INVOKEVIRTUAL");
+    public static final int IRETURN = valueInt("IRETURN");
+    public static final int NEW = valueInt("NEW");
+    public static final int POP = valueInt("POP");
+    public static final int PUTFIELD = valueInt("PUTFIELD");
+    public static final int PUTSTATIC = valueInt("PUTSTATIC");
+    public static final int RETURN = valueInt("RETURN");
+    public static final int SIPUSH = valueInt("SIPUSH");
+    public static final int V1_8 = valueInt("V1_8");
+    public static final int ACC_BRIDGE = valueInt("ACC_BRIDGE");
+    public static final int ISTORE = valueInt("ISTORE");
+    public static final int DLOAD = valueInt("DLOAD");
+    public static final int LLOAD = valueInt("LLOAD");
+    public static final int ASM5 = valueInt("ASM5");
+
+    // Should be changed in case of ASM upgrade
+    public final static int ASM_API_SELECTED = ASM9;
+    public final static int JAVA_CLASS_VERSION = V1_8;
+
+    private static int valueInt(String fieldName) {
         return ((int) Util.getFieldValue(ASM_OPCCODES_MAP, fieldName, Integer.TYPE));
-    }
-
-    public static Integer valueInteger(String fieldName) {
-        return ((Integer) Util.getFieldValue(ASM_OPCCODES_MAP, fieldName, Integer.class));
     }
 
     public static Class getOpcodesClass() {

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/asm/internal/platform/eclipselink/ClassWriterImpl.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/asm/internal/platform/eclipselink/ClassWriterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -18,6 +18,7 @@ import org.eclipse.persistence.asm.ASMFactory;
 import org.eclipse.persistence.asm.AnnotationVisitor;
 import org.eclipse.persistence.asm.FieldVisitor;
 import org.eclipse.persistence.asm.MethodVisitor;
+import org.eclipse.persistence.asm.Opcodes;
 import org.eclipse.persistence.internal.libraries.asm.ClassReader;
 import org.eclipse.persistence.internal.libraries.asm.ClassWriter;
 
@@ -94,7 +95,7 @@ public class ClassWriterImpl extends org.eclipse.persistence.asm.ClassWriter {
 
     @Override
     public void visit(final int access, final String name, final String signature, final String superName, final String[] interfaces) {
-        this.visit(ASMFactory.JAVA_CLASS_VERSION, access, name, signature, superName, interfaces);
+        this.visit(Opcodes.JAVA_CLASS_VERSION, access, name, signature, superName, interfaces);
     }
 
     @Override

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/asm/internal/platform/eclipselink/SerialVersionUIDAdderImpl.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/asm/internal/platform/eclipselink/SerialVersionUIDAdderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,6 +15,7 @@
 package org.eclipse.persistence.asm.internal.platform.eclipselink;
 
 import org.eclipse.persistence.asm.ASMFactory;
+import org.eclipse.persistence.asm.Opcodes;
 import org.eclipse.persistence.internal.libraries.asm.ClassVisitor;
 import org.eclipse.persistence.internal.libraries.asm.commons.SerialVersionUIDAdder;
 
@@ -23,7 +24,7 @@ public class SerialVersionUIDAdderImpl extends org.eclipse.persistence.asm.Seria
     private class ElSerialVersionUIDAdder extends SerialVersionUIDAdder {
 
         public ElSerialVersionUIDAdder(final ClassVisitor classVisitor) {
-            super(ASMFactory.ASM_API_SELECTED, classVisitor);
+            super(Opcodes.ASM_API_SELECTED, classVisitor);
         }
     }
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/asm/internal/platform/ow2/ClassWriterImpl.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/asm/internal/platform/ow2/ClassWriterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -18,6 +18,7 @@ import org.eclipse.persistence.asm.ASMFactory;
 import org.eclipse.persistence.asm.AnnotationVisitor;
 import org.eclipse.persistence.asm.FieldVisitor;
 import org.eclipse.persistence.asm.MethodVisitor;
+import org.eclipse.persistence.asm.Opcodes;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
 
@@ -94,7 +95,7 @@ public class ClassWriterImpl extends org.eclipse.persistence.asm.ClassWriter {
 
     @Override
     public void visit(final int access, final String name, final String signature, final String superName, final String[] interfaces) {
-        this.visit(ASMFactory.JAVA_CLASS_VERSION, access, name, signature, superName, interfaces);
+        this.visit(Opcodes.JAVA_CLASS_VERSION, access, name, signature, superName, interfaces);
     }
 
     @Override

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/asm/internal/platform/ow2/SerialVersionUIDAdderImpl.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/asm/internal/platform/ow2/SerialVersionUIDAdderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,6 +15,7 @@
 package org.eclipse.persistence.asm.internal.platform.ow2;
 
 import org.eclipse.persistence.asm.ASMFactory;
+import org.eclipse.persistence.asm.Opcodes;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.commons.SerialVersionUIDAdder;
 
@@ -23,7 +24,7 @@ public class SerialVersionUIDAdderImpl extends org.eclipse.persistence.asm.Seria
     private class OW2SerialVersionUIDAdder extends SerialVersionUIDAdder {
 
         public OW2SerialVersionUIDAdder(final ClassVisitor classVisitor) {
-            super(ASMFactory.ASM_API_SELECTED, classVisitor);
+            super(Opcodes.ASM_API_SELECTED, classVisitor);
         }
     }
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/dynamic/DynamicClassWriter.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/dynamic/DynamicClassWriter.java
@@ -158,31 +158,31 @@ public class DynamicClassWriter implements EclipseLinkClassWriter {
         ClassWriter cw = new EclipseLinkASMClassWriter();
 
         // public class Foo extends DynamicEntityImpl {
-        cw.visit(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_SUPER"), classNameAsSlashes, null, parentClassNameAsSlashes, interfaces != null ? interfaces.toArray(new String[0]) : null);
+        cw.visit(Opcodes.ACC_PUBLIC + Opcodes.ACC_SUPER, classNameAsSlashes, null, parentClassNameAsSlashes, interfaces != null ? interfaces.toArray(new String[interfaces.size()]) : null);
 
         // public static DynamicPropertiesManager DPM = new
         // DynamicPropertiesManager();
-        cw.visitField(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_STATIC"), PROPERTIES_MANAGER_FIELD, "L" + DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES + ";", null, null);
-        MethodVisitor mv = cw.visitMethod(Opcodes.valueInt("ACC_STATIC"), CLINIT, "()V", null, null);
-        mv.visitTypeInsn(Opcodes.valueInt("NEW"), DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES);
-        mv.visitInsn(Opcodes.valueInt("DUP"));
-        mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES, INIT, "()V", false);
-        mv.visitFieldInsn(Opcodes.valueInt("PUTSTATIC"), classNameAsSlashes, PROPERTIES_MANAGER_FIELD, "L" + DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES + ";");
-        mv.visitInsn(Opcodes.valueInt("RETURN"));
+        cw.visitField(Opcodes.ACC_PUBLIC + Opcodes.ACC_STATIC, PROPERTIES_MANAGER_FIELD, "L" + DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES + ";", null, null);
+        MethodVisitor mv = cw.visitMethod(Opcodes.ACC_STATIC, CLINIT, "()V", null, null);
+        mv.visitTypeInsn(Opcodes.NEW, DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES);
+        mv.visitInsn(Opcodes.DUP);
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES, INIT, "()V", false);
+        mv.visitFieldInsn(Opcodes.PUTSTATIC, classNameAsSlashes, PROPERTIES_MANAGER_FIELD, "L" + DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES + ";");
+        mv.visitInsn(Opcodes.RETURN);
         mv.visitMaxs(0, 0);
 
         // public Foo() {
         // super();
         // }
-        mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), INIT, "()V", null, null);
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), parentClassNameAsSlashes, INIT, "()V", false);
-        mv.visitInsn(Opcodes.valueInt("RETURN"));
+        mv = cw.visitMethod(Opcodes.ACC_PUBLIC, INIT, "()V", null, null);
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, parentClassNameAsSlashes, INIT, "()V", false);
+        mv.visitInsn(Opcodes.RETURN);
         mv.visitMaxs(0, 0);
 
-        mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "fetchPropertiesManager", "()L" + DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES + ";", null, null);
-        mv.visitFieldInsn(Opcodes.valueInt("GETSTATIC"), classNameAsSlashes, PROPERTIES_MANAGER_FIELD, "L" + DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES + ";");
-        mv.visitInsn(Opcodes.valueInt("ARETURN"));
+        mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "fetchPropertiesManager", "()L" + DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES + ";", null, null);
+        mv.visitFieldInsn(Opcodes.GETSTATIC, classNameAsSlashes, PROPERTIES_MANAGER_FIELD, "L" + DYNAMIC_PROPERTIES_MANAGER_CLASSNAME_SLASHES + ";");
+        mv.visitInsn(Opcodes.ARETURN);
         mv.visitMaxs(0, 0);
 
         addFields(cw, parentClassNameAsSlashes);
@@ -219,7 +219,7 @@ public class DynamicClassWriter implements EclipseLinkClassWriter {
     protected void addMethods(ClassWriter cw, String parentClassType) {
     }
 
-    public static int[] ICONST = new int[] { Opcodes.valueInt("ICONST_0"), Opcodes.valueInt("ICONST_1"), Opcodes.valueInt("ICONST_2"), Opcodes.valueInt("ICONST_3"), Opcodes.valueInt("ICONST_4"), Opcodes.valueInt("ICONST_5") };
+    public static int[] ICONST = new int[] { Opcodes.ICONST_0, Opcodes.ICONST_1, Opcodes.ICONST_2, Opcodes.ICONST_3, Opcodes.ICONST_4, Opcodes.ICONST_5 };
 
     protected byte[] createEnum(EnumInfo enumInfo) {
 
@@ -229,88 +229,88 @@ public class DynamicClassWriter implements EclipseLinkClassWriter {
         String internalClassName = className.replace('.', '/');
 
         ClassWriter cw = new EclipseLinkASMClassWriter();
-        cw.visit(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_FINAL") + Opcodes.valueInt("ACC_SUPER") + Opcodes.valueInt("ACC_ENUM"), internalClassName, null, "java/lang/Enum", null);
+        cw.visit(Opcodes.ACC_PUBLIC + Opcodes.ACC_FINAL + Opcodes.ACC_SUPER + Opcodes.ACC_ENUM, internalClassName, null, "java/lang/Enum", null);
 
         // Add the individual enum values
         for (String enumValue : enumValues) {
-            cw.visitField(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_FINAL") + Opcodes.valueInt("ACC_STATIC") + Opcodes.valueInt("ACC_ENUM"), enumValue, "L" + internalClassName + ";", null, null);
+            cw.visitField(Opcodes.ACC_PUBLIC + Opcodes.ACC_FINAL + Opcodes.ACC_STATIC + Opcodes.ACC_ENUM, enumValue, "L" + internalClassName + ";", null, null);
         }
 
         // add the synthetic "$VALUES" field
-        cw.visitField(Opcodes.valueInt("ACC_PRIVATE") + Opcodes.valueInt("ACC_FINAL") + Opcodes.valueInt("ACC_STATIC") + Opcodes.valueInt("ACC_SYNTHETIC"), "$VALUES", "[L" + internalClassName + ";", null, null);
+        cw.visitField(Opcodes.ACC_PRIVATE + Opcodes.ACC_FINAL + Opcodes.ACC_STATIC + Opcodes.ACC_SYNTHETIC, "$VALUES", "[L" + internalClassName + ";", null, null);
 
         // Add the "values()" method
-        MethodVisitor mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_STATIC"), "values", "()[L" + internalClassName + ";", null, null);
-        mv.visitFieldInsn(Opcodes.valueInt("GETSTATIC"), internalClassName, "$VALUES", "[L" + internalClassName + ";");
-        mv.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), "[L" + internalClassName + ";", "clone", "()Ljava/lang/Object;", false);
-        mv.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), "[L" + internalClassName + ";");
-        mv.visitInsn(Opcodes.valueInt("ARETURN"));
+        MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC + Opcodes.ACC_STATIC, "values", "()[L" + internalClassName + ";", null, null);
+        mv.visitFieldInsn(Opcodes.GETSTATIC, internalClassName, "$VALUES", "[L" + internalClassName + ";");
+        mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "[L" + internalClassName + ";", "clone", "()Ljava/lang/Object;", false);
+        mv.visitTypeInsn(Opcodes.CHECKCAST, "[L" + internalClassName + ";");
+        mv.visitInsn(Opcodes.ARETURN);
         mv.visitMaxs(1, 0);
 
         // Add the "valueOf()" method
-        mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_STATIC"), "valueOf", "(Ljava/lang/String;)L" + internalClassName + ";", null, null);
+        mv = cw.visitMethod(Opcodes.ACC_PUBLIC + Opcodes.ACC_STATIC, "valueOf", "(Ljava/lang/String;)L" + internalClassName + ";", null, null);
         mv.visitLdcInsn(Type.getType("L" + internalClassName + ";").unwrap());
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitMethodInsn(Opcodes.valueInt("INVOKESTATIC"), "java/lang/Enum", "valueOf", "(Ljava/lang/Class;Ljava/lang/String;)Ljava/lang/Enum;", false);
-        mv.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), internalClassName);
-        mv.visitInsn(Opcodes.valueInt("ARETURN"));
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Enum", "valueOf", "(Ljava/lang/Class;Ljava/lang/String;)Ljava/lang/Enum;", false);
+        mv.visitTypeInsn(Opcodes.CHECKCAST, internalClassName);
+        mv.visitInsn(Opcodes.ARETURN);
         mv.visitMaxs(2, 1);
 
         // Add constructors
         // SignatureAttribute methodAttrs1 = new SignatureAttribute("()V");
-        mv = cw.visitMethod(Opcodes.valueInt("ACC_PRIVATE"), "<init>", "(Ljava/lang/String;I)V", null, null);
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        mv.visitVarInsn(Opcodes.valueInt("ILOAD"), 2);
-        mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), "java/lang/Enum", "<init>", "(Ljava/lang/String;I)V", false);
-        mv.visitInsn(Opcodes.valueInt("RETURN"));
+        mv = cw.visitMethod(Opcodes.ACC_PRIVATE, "<init>", "(Ljava/lang/String;I)V", null, null);
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitVarInsn(Opcodes.ALOAD, 1);
+        mv.visitVarInsn(Opcodes.ILOAD, 2);
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/Enum", "<init>", "(Ljava/lang/String;I)V", false);
+        mv.visitInsn(Opcodes.RETURN);
         mv.visitMaxs(3, 3);
 
         // Add enum constants
-        mv = cw.visitMethod(Opcodes.valueInt("ACC_STATIC"), "<clinit>", "()V", null, null);
+        mv = cw.visitMethod(Opcodes.ACC_STATIC, "<clinit>", "()V", null, null);
 
         int lastCount = 0;
         for (int i = 0; i < enumValues.length; i++) {
             String enumValue = enumValues[i];
-            mv.visitTypeInsn(Opcodes.valueInt("NEW"), internalClassName);
-            mv.visitInsn(Opcodes.valueInt("DUP"));
+            mv.visitTypeInsn(Opcodes.NEW, internalClassName);
+            mv.visitInsn(Opcodes.DUP);
             mv.visitLdcInsn(enumValue);
             if (i <= 5) {
                 mv.visitInsn(ICONST[i]);
             } else if (i <= 127) {
-                mv.visitIntInsn(Opcodes.valueInt("BIPUSH"), i);
+                mv.visitIntInsn(Opcodes.BIPUSH, i);
             } else {
-                mv.visitIntInsn(Opcodes.valueInt("SIPUSH"), i);
+                mv.visitIntInsn(Opcodes.SIPUSH, i);
             }
-            mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), internalClassName, "<init>", "(Ljava/lang/String;I)V", false);
-            mv.visitFieldInsn(Opcodes.valueInt("PUTSTATIC"), internalClassName, enumValue, "L" + internalClassName + ";");
+            mv.visitMethodInsn(Opcodes.INVOKESPECIAL, internalClassName, "<init>", "(Ljava/lang/String;I)V", false);
+            mv.visitFieldInsn(Opcodes.PUTSTATIC, internalClassName, enumValue, "L" + internalClassName + ";");
             lastCount = i;
         }
 
         if (lastCount < 5) {
             mv.visitInsn(ICONST[lastCount + 1]);
         } else if (lastCount < 127) {
-            mv.visitIntInsn(Opcodes.valueInt("BIPUSH"), lastCount + 1);
+            mv.visitIntInsn(Opcodes.BIPUSH, lastCount + 1);
         } else {
-            mv.visitIntInsn(Opcodes.valueInt("SIPUSH"), lastCount + 1);
+            mv.visitIntInsn(Opcodes.SIPUSH, lastCount + 1);
         }
-        mv.visitTypeInsn(Opcodes.valueInt("ANEWARRAY"), internalClassName);
+        mv.visitTypeInsn(Opcodes.ANEWARRAY, internalClassName);
 
         for (int i = 0; i < enumValues.length; i++) {
             String enumValue = enumValues[i];
-            mv.visitInsn(Opcodes.valueInt("DUP"));
+            mv.visitInsn(Opcodes.DUP);
             if (i <= 5) {
                 mv.visitInsn(ICONST[i]);
             } else if (i <= 127) {
-                mv.visitIntInsn(Opcodes.valueInt("BIPUSH"), i);
+                mv.visitIntInsn(Opcodes.BIPUSH, i);
             } else {
-                mv.visitIntInsn(Opcodes.valueInt("SIPUSH"), i);
+                mv.visitIntInsn(Opcodes.SIPUSH, i);
             }
-            mv.visitFieldInsn(Opcodes.valueInt("GETSTATIC"), internalClassName, enumValue, "L" + internalClassName + ";");
-            mv.visitInsn(Opcodes.valueInt("AASTORE"));
+            mv.visitFieldInsn(Opcodes.GETSTATIC, internalClassName, enumValue, "L" + internalClassName + ";");
+            mv.visitInsn(Opcodes.AASTORE);
         }
-        mv.visitFieldInsn(Opcodes.valueInt("PUTSTATIC"), internalClassName, "$VALUES", "[L" + internalClassName + ";");
-        mv.visitInsn(Opcodes.valueInt("RETURN"));
+        mv.visitFieldInsn(Opcodes.PUTSTATIC, internalClassName, "$VALUES", "[L" + internalClassName + ";");
+        mv.visitInsn(Opcodes.RETURN);
         mv.visitMaxs(4, 0);
 
         cw.visitEnd();

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/MetadataDynamicClassWriter.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/MetadataDynamicClassWriter.java
@@ -64,25 +64,25 @@ public class MetadataDynamicClassWriter extends DynamicClassWriter {
             Type returnType = getAsmType(accessor);
 
             // Add getter
-            MethodVisitor mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), GET + propertyName, "()" + returnType.getDescriptor(), null, new String[] { DYNAMIC_EXCEPTION });
+            MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, GET + propertyName, "()" + returnType.getDescriptor(), null, new String[] { DYNAMIC_EXCEPTION });
             mv.visitCode();
-            mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            mv.visitVarInsn(Opcodes.ALOAD, 0);
             mv.visitLdcInsn(accessor.getAttributeName());
-            mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), parentClassType, "get", "(" + LJAVA_LANG_STRING + ")" + LJAVA_LANG_OBJECT, false);
-            mv.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), returnType.getInternalName());
-            mv.visitInsn(Opcodes.valueInt("ARETURN"));
+            mv.visitMethodInsn(Opcodes.INVOKESPECIAL, parentClassType, "get", "(" + LJAVA_LANG_STRING + ")" + LJAVA_LANG_OBJECT, false);
+            mv.visitTypeInsn(Opcodes.CHECKCAST, returnType.getInternalName());
+            mv.visitInsn(Opcodes.ARETURN);
             mv.visitMaxs(2, 1);
             mv.visitEnd();
 
             // Add setter
-            mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), SET + propertyName, "(" + returnType.getDescriptor() + ")V", null, new String[] { DYNAMIC_EXCEPTION });
+            mv = cw.visitMethod(Opcodes.ACC_PUBLIC, SET + propertyName, "(" + returnType.getDescriptor() + ")V", null, new String[] { DYNAMIC_EXCEPTION });
             mv.visitCode();
-            mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            mv.visitVarInsn(Opcodes.ALOAD, 0);
             mv.visitLdcInsn("id");
-            mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-            mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), parentClassType, SET, "(" + LJAVA_LANG_STRING + LJAVA_LANG_OBJECT + ")" + LDYNAMIC_ENTITY, false);
-            mv.visitInsn(Opcodes.valueInt("POP"));
-            mv.visitInsn(Opcodes.valueInt("RETURN"));
+            mv.visitVarInsn(Opcodes.ALOAD, 1);
+            mv.visitMethodInsn(Opcodes.INVOKESPECIAL, parentClassType, SET, "(" + LJAVA_LANG_STRING + LJAVA_LANG_OBJECT + ")" + LDYNAMIC_ENTITY, false);
+            mv.visitInsn(Opcodes.POP);
+            mv.visitInsn(Opcodes.RETURN);
             mv.visitMaxs(3, 2);
             mv.visitEnd();
         }

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/accessors/objects/MetadataAsmFactory.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/accessors/objects/MetadataAsmFactory.java
@@ -100,7 +100,7 @@ public class MetadataAsmFactory extends MetadataFactory {
 
             ClassReader reader = ASMFactory.createClassReader(stream);
             Attribute[] attributes = new Attribute[0];
-            reader.accept(visitor, attributes, ClassReader.valueInt("SKIP_CODE") | ClassReader.valueInt("SKIP_DEBUG") | ClassReader.valueInt("SKIP_FRAMES"));
+            reader.accept(visitor, attributes, ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
         } catch (IllegalArgumentException iae) {
             // class was probably compiled with some newer than officially
             // supported and tested JDK
@@ -131,7 +131,7 @@ public class MetadataAsmFactory extends MetadataFactory {
                     //as checkClassVersion is not visible by public constructor
                     ClassReader reader = ASMFactory.createClassReader(stream, false);
                     Attribute[] attributes = new Attribute[0];
-                    reader.accept(visitor, attributes, ClassReader.valueInt("SKIP_CODE") | ClassReader.valueInt("SKIP_DEBUG") | ClassReader.valueInt("SKIP_FRAMES"));
+                    reader.accept(visitor, attributes, ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
                 } catch (Exception e) {
                     SessionLog log = getLogger().getSession() != null
                             ? getLogger().getSession().getSessionLog() : AbstractSessionLog.getLog();

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/accessors/objects/MetadataClass.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/accessors/objects/MetadataClass.java
@@ -487,7 +487,7 @@ public class MetadataClass extends MetadataAnnotatedElement {
      * Return if this is an interface (super is null).
      */
     public boolean isInterface() {
-        return (Opcodes.valueInt("ACC_INTERFACE") & m_modifiers) != 0;
+        return (Opcodes.ACC_INTERFACE & m_modifiers) != 0;
     }
 
     /**

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/weaving/ClassWeaver.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/weaving/ClassWeaver.java
@@ -163,28 +163,28 @@ public class ClassWeaver extends ClassVisitor {
         String wrapper = wrapperFor(attribute.getReferenceClassType().getSort());
         int sort = attribute.getReferenceClassType().getSort();
         if (sort == Type.BOOLEAN) {
-            visitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), wrapper, "booleanValue", "()Z", false);
+            visitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, wrapper, "booleanValue", "()Z", false);
             return;
         } else if (sort == Type.BYTE) {
-            visitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), wrapper, "byteValue", "()B", false);
+            visitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, wrapper, "byteValue", "()B", false);
             return;
         } else if (sort == Type.CHAR) {
-            visitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), wrapper, "charValue", "()C", false);
+            visitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, wrapper, "charValue", "()C", false);
             return;
         } else if (sort == Type.SHORT) {
-            visitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), wrapper, "shortValue", "()S", false);
+            visitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, wrapper, "shortValue", "()S", false);
             return;
         } else if (sort == Type.INT) {
-            visitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), wrapper, "intValue", "()I", false);
+            visitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, wrapper, "intValue", "()I", false);
             return;
         } else if (sort == Type.FLOAT) {
-            visitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), wrapper, "floatValue", "()F", false);
+            visitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, wrapper, "floatValue", "()F", false);
             return;
         } else if (sort == Type.LONG) {
-            visitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), wrapper, "longValue", "()J", false);
+            visitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, wrapper, "longValue", "()J", false);
             return;
         } else if (sort == Type.DOUBLE) {
-            visitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), wrapper, "doubleValue", "()D", false);
+            visitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, wrapper, "doubleValue", "()D", false);
             return;
         }
     }
@@ -220,7 +220,7 @@ public class ClassWeaver extends ClassVisitor {
     }
 
     public ClassWeaver(ClassVisitor classWriter, ClassDetails classDetails) {
-        super(ASMFactory.ASM_API_SELECTED, classWriter);
+        super(Opcodes.ASM_API_SELECTED, classWriter);
         super.setCustomClassVisitor(this);
         this.cw = classWriter;
         this.classDetails = classDetails;
@@ -230,17 +230,17 @@ public class ClassWeaver extends ClassVisitor {
      * Add a variable of type ValueHolderInterface to the class. When this
      * method has been run, the class will contain a variable declaration
      * similar to the following:
-     * <p>
+     *
      * private ValueHolderInterface _persistence_variableName_vh;
      */
     public void addValueHolder(AttributeDetails attributeDetails) {
         String attribute = attributeDetails.getAttributeName();
-        FieldVisitor fv = cv.visitField(Opcodes.valueInt("ACC_PROTECTED"), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE, null, null);
+        FieldVisitor fv = cv.visitField(Opcodes.ACC_PROTECTED, PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE, null, null);
 
         // only mark @Transient if this is property access. Otherwise, the
         // @Transient annotation could mistakenly
         // cause the class to use attribute access.
-        if (attributeDetails.getGetterMethodName() == null || attributeDetails.getGetterMethodName().isEmpty() || attributeDetails.weaveTransientFieldValueHolders()) {
+        if (attributeDetails.getGetterMethodName() == null || attributeDetails.getGetterMethodName().equals("") || attributeDetails.weaveTransientFieldValueHolders()) {
             fv.visitAnnotation(JPA_TRANSIENT_DESCRIPTION, true).visitEnd();
             if (isJAXBOnPath()) {
                 fv.visitAnnotation(XML_TRANSIENT_DESCRIPTION, true).visitEnd();
@@ -253,48 +253,48 @@ public class ClassWeaver extends ClassVisitor {
      * Add a variable of type PropertyChangeListener to the class. When this
      * method has been run, the class will contain a variable declaration
      * similar to the following
-     * <p>
+     *
      * private transient _persistence_listener;
      */
     public void addPropertyChangeListener(boolean attributeAccess) {
-        cv.visitField(Opcodes.valueInt("ACC_PROTECTED") + Opcodes.valueInt("ACC_TRANSIENT"), "_persistence_listener", PCL_SIGNATURE, null, null);
+        cv.visitField(Opcodes.ACC_PROTECTED + Opcodes.ACC_TRANSIENT, "_persistence_listener", PCL_SIGNATURE, null, null);
     }
 
     /**
      * Add the implementation of the changeTracker_getPropertyChangeListener
      * method to the class. The result is a method that looks as follows:
-     * <p>
+     *
      * public PropertyChangeListener _persistence_getPropertyChangeListener() {
      * return _persistence_listener; }
      */
     public void addGetPropertyChangeListener(ClassDetails classDetails) {
-        MethodVisitor cv_getPCL = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_getPropertyChangeListener", "()" + PCL_SIGNATURE, null, null);
-        cv_getPCL.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_getPCL.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), "_persistence_listener", PCL_SIGNATURE);
-        cv_getPCL.visitInsn(Opcodes.valueInt("ARETURN"));
+        MethodVisitor cv_getPCL = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_getPropertyChangeListener", "()" + PCL_SIGNATURE, null, null);
+        cv_getPCL.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_getPCL.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), "_persistence_listener", PCL_SIGNATURE);
+        cv_getPCL.visitInsn(Opcodes.ARETURN);
         cv_getPCL.visitMaxs(0, 0);
     }
 
     /**
      * Add the implementation of the changeTracker_setPropertyChangeListener
      * method to the class. The result is a method that looks as follows:
-     * <p>
+     *
      * public void _persistence_setPropertyChangeListener(PropertyChangeListener
      * propertychangelistener){ _persistence_listener = propertychangelistener;
      * }
      */
     public void addSetPropertyChangeListener(ClassDetails classDetails) {
-        MethodVisitor cv_setPCL = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_setPropertyChangeListener", "(" + PCL_SIGNATURE + ")V", null, null);
-        cv_setPCL.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_setPCL.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_setPCL.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), "_persistence_listener", PCL_SIGNATURE);
-        cv_setPCL.visitInsn(Opcodes.valueInt("RETURN"));
+        MethodVisitor cv_setPCL = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_setPropertyChangeListener", "(" + PCL_SIGNATURE + ")V", null, null);
+        cv_setPCL.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_setPCL.visitVarInsn(Opcodes.ALOAD, 1);
+        cv_setPCL.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), "_persistence_listener", PCL_SIGNATURE);
+        cv_setPCL.visitInsn(Opcodes.RETURN);
         cv_setPCL.visitMaxs(0, 0);
     }
 
     /**
      * Add a method to track property changes. The method will look as follows:
-     * <p>
+     *
      * public void _toplink_propertyChange(String s, Object obj, Object obj1){
      * if(_persistence_listener != null {@literal &&} obj != obj1){
      * _persistence_listener.propertyChange(new PropertyChangeEvent(this, s,
@@ -302,37 +302,37 @@ public class ClassWeaver extends ClassVisitor {
      */
     public void addPropertyChange(ClassDetails classDetails) {
         // create the _toplink_propertyChange() method
-        MethodVisitor cv_addPC = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_propertyChange", "(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V", null, null);
+        MethodVisitor cv_addPC = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_propertyChange", "(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V", null, null);
 
         // if (_toplink_Listener != null)
-        cv_addPC.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_addPC.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), "_persistence_listener", PCL_SIGNATURE);
+        cv_addPC.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_addPC.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), "_persistence_listener", PCL_SIGNATURE);
         Label l0 = ASMFactory.createLabel();
-        cv_addPC.visitJumpInsn(Opcodes.valueInt("IFNULL"), l0);
+        cv_addPC.visitJumpInsn(Opcodes.IFNULL, l0);
 
         // if (obj != obj1)
-        cv_addPC.visitVarInsn(Opcodes.valueInt("ALOAD"), 2);
-        cv_addPC.visitVarInsn(Opcodes.valueInt("ALOAD"), 3);
-        cv_addPC.visitJumpInsn(Opcodes.valueInt("IF_ACMPEQ"), l0);
+        cv_addPC.visitVarInsn(Opcodes.ALOAD, 2);
+        cv_addPC.visitVarInsn(Opcodes.ALOAD, 3);
+        cv_addPC.visitJumpInsn(Opcodes.IF_ACMPEQ, l0);
 
         // _toplink_listener.propertyChange(...);
-        cv_addPC.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_addPC.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), "_persistence_listener", PCL_SIGNATURE);
-        cv_addPC.visitTypeInsn(Opcodes.valueInt("NEW"), PCE_SHORT_SIGNATURE);
-        cv_addPC.visitInsn(Opcodes.valueInt("DUP"));
+        cv_addPC.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_addPC.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), "_persistence_listener", PCL_SIGNATURE);
+        cv_addPC.visitTypeInsn(Opcodes.NEW, PCE_SHORT_SIGNATURE);
+        cv_addPC.visitInsn(Opcodes.DUP);
 
         // new PropertyChangeEvent(this, s, obj, obj1)
-        cv_addPC.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_addPC.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_addPC.visitVarInsn(Opcodes.valueInt("ALOAD"), 2);
-        cv_addPC.visitVarInsn(Opcodes.valueInt("ALOAD"), 3);
-        cv_addPC.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), PCE_SHORT_SIGNATURE, "<init>", "(Ljava/lang/Object;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V", false);
-        cv_addPC.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), PCL_SHORT_SIGNATURE, "propertyChange", "(" + PCE_SIGNATURE + ")V", true);
+        cv_addPC.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_addPC.visitVarInsn(Opcodes.ALOAD, 1);
+        cv_addPC.visitVarInsn(Opcodes.ALOAD, 2);
+        cv_addPC.visitVarInsn(Opcodes.ALOAD, 3);
+        cv_addPC.visitMethodInsn(Opcodes.INVOKESPECIAL, PCE_SHORT_SIGNATURE, "<init>", "(Ljava/lang/Object;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V", false);
+        cv_addPC.visitMethodInsn(Opcodes.INVOKEINTERFACE, PCL_SHORT_SIGNATURE, "propertyChange", "(" + PCE_SIGNATURE + ")V", true);
 
         // }
         cv_addPC.visitLabel(l0);
 
-        cv_addPC.visitInsn(Opcodes.valueInt("RETURN"));
+        cv_addPC.visitInsn(Opcodes.RETURN);
         cv_addPC.visitMaxs(0, 0);
     }
 
@@ -352,37 +352,37 @@ public class ClassWeaver extends ClassVisitor {
 
         // Create a getter method for the new valueholder
         // protected void _persistence_initialize_attribute_vh(){
-        MethodVisitor cv_init_VH = cv.visitMethod(Opcodes.valueInt("ACC_PROTECTED"), "_persistence_initialize_" + attribute + PERSISTENCE_FIELDNAME_POSTFIX, "()V", null, null);
+        MethodVisitor cv_init_VH = cv.visitMethod(Opcodes.ACC_PROTECTED, "_persistence_initialize_" + attribute + PERSISTENCE_FIELDNAME_POSTFIX, "()V", null, null);
 
         // if(_persistence_attribute_vh == null){
-        cv_init_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_init_VH.visitFieldInsn(Opcodes.valueInt("GETFIELD"), className, PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
+        cv_init_VH.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_init_VH.visitFieldInsn(Opcodes.GETFIELD, className, PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
         Label l0 = ASMFactory.createLabel();
-        cv_init_VH.visitJumpInsn(Opcodes.valueInt("IFNONNULL"), l0);
+        cv_init_VH.visitJumpInsn(Opcodes.IFNONNULL, l0);
 
         // _persistence_attribute_vh = new ValueHolder(this.attribute);
-        cv_init_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_init_VH.visitTypeInsn(Opcodes.valueInt("NEW"), VH_SHORT_SIGNATURE);
-        cv_init_VH.visitInsn(Opcodes.valueInt("DUP"));
+        cv_init_VH.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_init_VH.visitTypeInsn(Opcodes.NEW, VH_SHORT_SIGNATURE);
+        cv_init_VH.visitInsn(Opcodes.DUP);
         if (attributeDetails.hasField()) {
-            cv_init_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_init_VH.visitFieldInsn(Opcodes.valueInt("GETFIELD"), className, attribute, attributeDetails.getReferenceClassType().getDescriptor());
-            cv_init_VH.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), VH_SHORT_SIGNATURE, "<init>", "(Ljava/lang/Object;)V", false);
+            cv_init_VH.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_init_VH.visitFieldInsn(Opcodes.GETFIELD, className, attribute, attributeDetails.getReferenceClassType().getDescriptor());
+            cv_init_VH.visitMethodInsn(Opcodes.INVOKESPECIAL, VH_SHORT_SIGNATURE, "<init>", "(Ljava/lang/Object;)V", false);
         } else {
-            cv_init_VH.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), VH_SHORT_SIGNATURE, "<init>", "()V", false);
+            cv_init_VH.visitMethodInsn(Opcodes.INVOKESPECIAL, VH_SHORT_SIGNATURE, "<init>", "()V", false);
         }
-        cv_init_VH.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), className, PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
+        cv_init_VH.visitFieldInsn(Opcodes.PUTFIELD, className, PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
 
         // _persistence_attribute_vh.setIsNewlyWeavedValueHolder(true);
-        cv_init_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_init_VH.visitFieldInsn(Opcodes.valueInt("GETFIELD"), className, PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
-        cv_init_VH.visitInsn(Opcodes.valueInt("ICONST_1"));
-        cv_init_VH.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), VHI_SHORT_SIGNATURE, "setIsNewlyWeavedValueHolder", "(Z)V", true);
+        cv_init_VH.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_init_VH.visitFieldInsn(Opcodes.GETFIELD, className, PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
+        cv_init_VH.visitInsn(Opcodes.ICONST_1);
+        cv_init_VH.visitMethodInsn(Opcodes.INVOKEINTERFACE, VHI_SHORT_SIGNATURE, "setIsNewlyWeavedValueHolder", "(Z)V", true);
 
         // }
         cv_init_VH.visitLabel(l0);
 
-        cv_init_VH.visitInsn(Opcodes.valueInt("RETURN"));
+        cv_init_VH.visitInsn(Opcodes.RETURN);
         cv_init_VH.visitMaxs(0, 0);
     }
 
@@ -401,59 +401,59 @@ public class ClassWeaver extends ClassVisitor {
         String attribute = attributeDetails.getAttributeName();
         String className = classDetails.getClassName();
         // Create a getter method for the new valueholder
-        MethodVisitor cv_get_VH = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_GET + attribute + PERSISTENCE_FIELDNAME_POSTFIX, "()" + VHI_SIGNATURE, null, null);
+        MethodVisitor cv_get_VH = cv.visitMethod(Opcodes.ACC_PUBLIC, PERSISTENCE_GET + attribute + PERSISTENCE_FIELDNAME_POSTFIX, "()" + VHI_SIGNATURE, null, null);
 
         // _persistence_initialize_attributeName_vh();
-        cv_get_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_get_VH.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_initialize_" + attributeDetails.getAttributeName() + PERSISTENCE_FIELDNAME_POSTFIX, "()V", false);
+        cv_get_VH.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_get_VH.visitMethodInsn(Opcodes.INVOKEVIRTUAL, classDetails.getClassName(), "_persistence_initialize_" + attributeDetails.getAttributeName() + PERSISTENCE_FIELDNAME_POSTFIX, "()V", false);
 
         // if (_toplink_foo_vh.isCoordinatedWithProperty() ||
         // _toplink_foo_vh.isNewlyWeavedValueHolder()){
-        cv_get_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_get_VH.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
-        cv_get_VH.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), VHI_SHORT_SIGNATURE, "isCoordinatedWithProperty", "()Z", true);
+        cv_get_VH.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_get_VH.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
+        cv_get_VH.visitMethodInsn(Opcodes.INVOKEINTERFACE, VHI_SHORT_SIGNATURE, "isCoordinatedWithProperty", "()Z", true);
         Label l0 = ASMFactory.createLabel();
-        cv_get_VH.visitJumpInsn(Opcodes.valueInt("IFNE"), l0);
-        cv_get_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_get_VH.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
-        cv_get_VH.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), VHI_SHORT_SIGNATURE, "isNewlyWeavedValueHolder", "()Z", true);
+        cv_get_VH.visitJumpInsn(Opcodes.IFNE, l0);
+        cv_get_VH.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_get_VH.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
+        cv_get_VH.visitMethodInsn(Opcodes.INVOKEINTERFACE, VHI_SHORT_SIGNATURE, "isNewlyWeavedValueHolder", "()Z", true);
         Label l1 = ASMFactory.createLabel();
-        cv_get_VH.visitJumpInsn(Opcodes.valueInt("IFEQ"), l1);
+        cv_get_VH.visitJumpInsn(Opcodes.IFEQ, l1);
         cv_get_VH.visitLabel(l0);
-        cv_get_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_get_VH.visitVarInsn(Opcodes.ALOAD, 0);
 
         // EntityC object = (EntityC)getFoo();
         if (attributeDetails.getGetterMethodName() != null) {
-            cv_get_VH.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), attributeDetails.getGetterMethodName(), "()L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";", false);
-            cv_get_VH.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), attributeDetails.getReferenceClassName().replace('.', '/'));
+            cv_get_VH.visitMethodInsn(Opcodes.INVOKEVIRTUAL, classDetails.getClassName(), attributeDetails.getGetterMethodName(), "()L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";", false);
+            cv_get_VH.visitTypeInsn(Opcodes.CHECKCAST, attributeDetails.getReferenceClassName().replace('.', '/'));
         } else {
-            cv_get_VH.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), PERSISTENCE_GET + attributeDetails.attributeName, "()L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";", false);
+            cv_get_VH.visitMethodInsn(Opcodes.INVOKEVIRTUAL, classDetails.getClassName(), PERSISTENCE_GET + attributeDetails.attributeName, "()L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";", false);
         }
-        cv_get_VH.visitVarInsn(Opcodes.valueInt("ASTORE"), 1);
+        cv_get_VH.visitVarInsn(Opcodes.ASTORE, 1);
 
         // if (object != _toplink_foo_vh.getValue()){
-        cv_get_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_get_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_get_VH.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
-        cv_get_VH.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), VHI_SHORT_SIGNATURE, "getValue", "()Ljava/lang/Object;", true);
-        cv_get_VH.visitJumpInsn(Opcodes.valueInt("IF_ACMPEQ"), l1);
+        cv_get_VH.visitVarInsn(Opcodes.ALOAD, 1);
+        cv_get_VH.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_get_VH.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
+        cv_get_VH.visitMethodInsn(Opcodes.INVOKEINTERFACE, VHI_SHORT_SIGNATURE, "getValue", "()Ljava/lang/Object;", true);
+        cv_get_VH.visitJumpInsn(Opcodes.IF_ACMPEQ, l1);
 
         // setFoo(object);
-        cv_get_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_get_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+        cv_get_VH.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_get_VH.visitVarInsn(Opcodes.ALOAD, 1);
         if (attributeDetails.getSetterMethodName() != null) {
-            cv_get_VH.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), attributeDetails.getSetterMethodName(), "(L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";)V", false);
+            cv_get_VH.visitMethodInsn(Opcodes.INVOKEVIRTUAL, classDetails.getClassName(), attributeDetails.getSetterMethodName(), "(L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";)V", false);
         } else {
-            cv_get_VH.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), PERSISTENCE_SET + attributeDetails.getAttributeName(), "(L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";)V", false);
+            cv_get_VH.visitMethodInsn(Opcodes.INVOKEVIRTUAL, classDetails.getClassName(), PERSISTENCE_SET + attributeDetails.getAttributeName(), "(L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";)V", false);
         }
 
         // }
         cv_get_VH.visitLabel(l1);
 
         // return _toplink_foo_vh;
-        cv_get_VH.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_get_VH.visitFieldInsn(Opcodes.valueInt("GETFIELD"), className, PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
-        cv_get_VH.visitInsn(Opcodes.valueInt("ARETURN"));
+        cv_get_VH.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_get_VH.visitFieldInsn(Opcodes.GETFIELD, className, PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
+        cv_get_VH.visitInsn(Opcodes.ARETURN);
 
         cv_get_VH.visitMaxs(0, 0);
     }
@@ -472,72 +472,72 @@ public class ClassWeaver extends ClassVisitor {
         String attribute = attributeDetails.getAttributeName();
         String className = classDetails.getClassName();
         // create a setter method for the new valueholder
-        MethodVisitor cv_set_value = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_SET + attribute + PERSISTENCE_FIELDNAME_POSTFIX, "(" + VHI_SIGNATURE + ")V", null, null);
+        MethodVisitor cv_set_value = cv.visitMethod(Opcodes.ACC_PUBLIC, PERSISTENCE_SET + attribute + PERSISTENCE_FIELDNAME_POSTFIX, "(" + VHI_SIGNATURE + ")V", null, null);
 
         // _toplink_foo_vh = valueholderinterface;
-        cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_set_value.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), className, PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
+        cv_set_value.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_set_value.visitVarInsn(Opcodes.ALOAD, 1);
+        cv_set_value.visitFieldInsn(Opcodes.PUTFIELD, className, PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, VHI_SIGNATURE);
 
         // if (valueholderinterface.isInstantiated()){
-        cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_set_value.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), VHI_SHORT_SIGNATURE, "isInstantiated", "()Z", true);
+        cv_set_value.visitVarInsn(Opcodes.ALOAD, 1);
+        cv_set_value.visitMethodInsn(Opcodes.INVOKEINTERFACE, VHI_SHORT_SIGNATURE, "isInstantiated", "()Z", true);
         Label l0 = ASMFactory.createLabel();
-        cv_set_value.visitJumpInsn(Opcodes.valueInt("IFEQ"), l0);
+        cv_set_value.visitJumpInsn(Opcodes.IFEQ, l0);
 
         // Object object = getFoo();
-        cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_set_value.visitVarInsn(Opcodes.ALOAD, 0);
         if (attributeDetails.getGetterMethodName() != null) {
-            cv_set_value.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), className, attributeDetails.getGetterMethodName(), "()L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";", false);
+            cv_set_value.visitMethodInsn(Opcodes.INVOKEVIRTUAL, className, attributeDetails.getGetterMethodName(), "()L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";", false);
         } else {
-            cv_set_value.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), className, PERSISTENCE_GET + attributeDetails.attributeName, "()L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";", false);
+            cv_set_value.visitMethodInsn(Opcodes.INVOKEVIRTUAL, className, PERSISTENCE_GET + attributeDetails.attributeName, "()L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";", false);
         }
-        cv_set_value.visitVarInsn(Opcodes.valueInt("ASTORE"), 2);
+        cv_set_value.visitVarInsn(Opcodes.ASTORE, 2);
 
         // Object value = valueholderinterface.getValue();
-        cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_set_value.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), VHI_SHORT_SIGNATURE, "getValue", "()Ljava/lang/Object;", true);
-        cv_set_value.visitVarInsn(Opcodes.valueInt("ASTORE"), 3);
+        cv_set_value.visitVarInsn(Opcodes.ALOAD, 1);
+        cv_set_value.visitMethodInsn(Opcodes.INVOKEINTERFACE, VHI_SHORT_SIGNATURE, "getValue", "()Ljava/lang/Object;", true);
+        cv_set_value.visitVarInsn(Opcodes.ASTORE, 3);
 
         // if (object != value){
-        cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 2);
-        cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 3);
+        cv_set_value.visitVarInsn(Opcodes.ALOAD, 2);
+        cv_set_value.visitVarInsn(Opcodes.ALOAD, 3);
         if (attributeDetails.getSetterMethodName() != null) {
-            cv_set_value.visitJumpInsn(Opcodes.valueInt("IF_ACMPEQ"), l0);
+            cv_set_value.visitJumpInsn(Opcodes.IF_ACMPEQ, l0);
             // setFoo((EntityC)value);
-            cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 3);
-            cv_set_value.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), attributeDetails.getReferenceClassName().replace('.', '/'));
-            cv_set_value.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), className, attributeDetails.getSetterMethodName(), "(L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";)V", false);
+            cv_set_value.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_set_value.visitVarInsn(Opcodes.ALOAD, 3);
+            cv_set_value.visitTypeInsn(Opcodes.CHECKCAST, attributeDetails.getReferenceClassName().replace('.', '/'));
+            cv_set_value.visitMethodInsn(Opcodes.INVOKEVIRTUAL, className, attributeDetails.getSetterMethodName(), "(L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";)V", false);
             //}
             cv_set_value.visitLabel(l0);
         } else {
             Label l1 = ASMFactory.createLabel();
-            cv_set_value.visitJumpInsn(Opcodes.valueInt("IF_ACMPEQ"), l1);
+            cv_set_value.visitJumpInsn(Opcodes.IF_ACMPEQ, l1);
             // _persistence_setFoo((EntityC)value);
-            cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 3);
-            cv_set_value.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), attributeDetails.getReferenceClassName().replace('.', '/'));
-            cv_set_value.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), className, PERSISTENCE_SET + attributeDetails.getAttributeName(), "(L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";)V", false);
+            cv_set_value.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_set_value.visitVarInsn(Opcodes.ALOAD, 3);
+            cv_set_value.visitTypeInsn(Opcodes.CHECKCAST, attributeDetails.getReferenceClassName().replace('.', '/'));
+            cv_set_value.visitMethodInsn(Opcodes.INVOKEVIRTUAL, className, PERSISTENCE_SET + attributeDetails.getAttributeName(), "(L" + attributeDetails.getReferenceClassName().replace('.', '/') + ";)V", false);
             // }
             cv_set_value.visitLabel(l1);
-            cv_set_value.visitFrame(Opcodes.valueInt("F_SAME"), 0, null, 0, null);
+            cv_set_value.visitFrame(Opcodes.F_SAME, 0, null, 0, null);
             Label l2 = ASMFactory.createLabel();
-            cv_set_value.visitJumpInsn(Opcodes.valueInt("GOTO"), l2);
+            cv_set_value.visitJumpInsn(Opcodes.GOTO, l2);
             // }
             cv_set_value.visitLabel(l0);
             // else {
-            cv_set_value.visitFrame(Opcodes.valueInt("F_SAME"), 0, null, 0, null);
+            cv_set_value.visitFrame(Opcodes.F_SAME, 0, null, 0, null);
             // foo = null;
-            cv_set_value.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_set_value.visitInsn(Opcodes.valueInt("ACONST_NULL"));
-            cv_set_value.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), className, attributeDetails.attributeName, attributeDetails.getReferenceClassType().getDescriptor());
+            cv_set_value.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_set_value.visitInsn(Opcodes.ACONST_NULL);
+            cv_set_value.visitFieldInsn(Opcodes.PUTFIELD, className, attributeDetails.attributeName, attributeDetails.getReferenceClassType().getDescriptor());
             //}
             cv_set_value.visitLabel(l2);
-            cv_set_value.visitFrame(Opcodes.valueInt("F_SAME"), 0, null, 0, null);
+            cv_set_value.visitFrame(Opcodes.F_SAME, 0, null, 0, null);
         }
 
-        cv_set_value.visitInsn(Opcodes.valueInt("RETURN"));
+        cv_set_value.visitInsn(Opcodes.RETURN);
         cv_set_value.visitMaxs(0, 0);
     }
 
@@ -557,43 +557,43 @@ public class ClassWeaver extends ClassVisitor {
         String attribute = attributeDetails.getAttributeName();
 
         // create _persistence_set_variableName
-        MethodVisitor cv_set = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_SET + attribute, "(" + attributeDetails.getReferenceClassType().getDescriptor() + ")V", null, null);
+        MethodVisitor cv_set = cv.visitMethod(Opcodes.ACC_PUBLIC, PERSISTENCE_SET + attribute, "(" + attributeDetails.getReferenceClassType().getDescriptor() + ")V", null, null);
 
         // Get the opcode for the load instruction. This may be different
         // depending on the type
-        int opcode = attributeDetails.getReferenceClassType().getOpcode(Opcodes.valueInt("ILOAD"));
+        int opcode = attributeDetails.getReferenceClassType().getOpcode(Opcodes.ILOAD);
 
         if (classDetails.shouldWeaveFetchGroups()) {
-            cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            cv_set.visitVarInsn(Opcodes.ALOAD, 0);
             cv_set.visitLdcInsn(attribute);
             // _persistence_checkFetchedForSet("variableName");
-            cv_set.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_checkFetchedForSet", "(Ljava/lang/String;)V", false);
+            cv_set.visitMethodInsn(Opcodes.INVOKEVIRTUAL, classDetails.getClassName(), "_persistence_checkFetchedForSet", "(Ljava/lang/String;)V", false);
         }
 
         if (classDetails.shouldWeaveChangeTracking()) {
             if (attributeDetails.weaveValueHolders()) {
                 // _persistence_initialize_variableName_vh();
-                cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                cv_set.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_initialize_" + attributeDetails.getAttributeName() + PERSISTENCE_FIELDNAME_POSTFIX, "()V", false);
+                cv_set.visitVarInsn(Opcodes.ALOAD, 0);
+                cv_set.visitMethodInsn(Opcodes.INVOKEVIRTUAL, classDetails.getClassName(), "_persistence_initialize_" + attributeDetails.getAttributeName() + PERSISTENCE_FIELDNAME_POSTFIX, "()V", false);
 
                 // _persistenc_variableName_vh.getValue();
-                cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                cv_set.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
-                cv_set.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), ClassWeaver.VHI_SHORT_SIGNATURE, "getValue", "()Ljava/lang/Object;", true);
+                cv_set.visitVarInsn(Opcodes.ALOAD, 0);
+                cv_set.visitVarInsn(Opcodes.ALOAD, 0);
+                cv_set.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
+                cv_set.visitMethodInsn(Opcodes.INVOKEINTERFACE, ClassWeaver.VHI_SHORT_SIGNATURE, "getValue", "()Ljava/lang/Object;", true);
 
                 // Add the cast:
                 // (<VariableClass>)_persistenc_variableName_vh.getValue()
-                cv_set.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), attributeDetails.getReferenceClassName().replace('.', '/'));
+                cv_set.visitTypeInsn(Opcodes.CHECKCAST, attributeDetails.getReferenceClassName().replace('.', '/'));
 
                 // add the assignment: this.variableName =
                 // (<VariableClass>)_persistenc_variableName_vh.getValue();
-                cv_set.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), attribute, attributeDetails.getReferenceClassType().getDescriptor());
+                cv_set.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), attribute, attributeDetails.getReferenceClassType().getDescriptor());
             }
 
             // load the string attribute name as the first argument of the
             // property change call
-            cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            cv_set.visitVarInsn(Opcodes.ALOAD, 0);
             cv_set.visitLdcInsn(attribute);
 
             // if the attribute is a primitive, wrap it
@@ -601,60 +601,60 @@ public class ClassWeaver extends ClassVisitor {
             // This is the first part of the wrapping
             String wrapper = ClassWeaver.wrapperFor(attributeDetails.getReferenceClassType().getSort());
             // load the method argument
-            cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_set.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), attribute, attributeDetails.getReferenceClassType().getDescriptor());
+            cv_set.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_set.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), attribute, attributeDetails.getReferenceClassType().getDescriptor());
 
             if (wrapper != null) {
                 //convert from global field e.g. Integer.valueOf(this.intField)
-                cv_set.visitMethodInsn(Opcodes.valueInt("INVOKESTATIC"), wrapper, "valueOf", "(" + attributeDetails.getReferenceClassType().getDescriptor() + ")L" + wrapper + ";", false);
+                cv_set.visitMethodInsn(Opcodes.INVOKESTATIC, wrapper, "valueOf", "(" + attributeDetails.getReferenceClassType().getDescriptor() + ")L" + wrapper + ";", false);
                 //convert from method argument e.g. Integer.valueOf(var1)
                 cv_set.visitVarInsn(opcode, 1);
-                cv_set.visitMethodInsn(Opcodes.valueInt("INVOKESTATIC"), wrapper, "valueOf", "(" + attributeDetails.getReferenceClassType().getDescriptor() + ")L" + wrapper + ";", false);
+                cv_set.visitMethodInsn(Opcodes.INVOKESTATIC, wrapper, "valueOf", "(" + attributeDetails.getReferenceClassType().getDescriptor() + ")L" + wrapper + ";", false);
             } else {
                 // if we are not wrapping the argument, just load it
-                cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+                cv_set.visitVarInsn(Opcodes.ALOAD, 1);
             }
             // _persistence_propertyChange("variableName", variableName, argument);
             //e.g.  this._persistence_propertyChange("intField", Integer.valueOf(this.intField), Integer.valueOf(var1));
-            cv_set.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_propertyChange", "(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V", false);
+            cv_set.visitMethodInsn(Opcodes.INVOKEVIRTUAL, classDetails.getClassName(), "_persistence_propertyChange", "(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V", false);
         } else {
             if (attributeDetails.weaveValueHolders()) {
                 // _persistence_initialize_variableName_vh();
-                cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                cv_set.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_initialize_" + attributeDetails.getAttributeName() + PERSISTENCE_FIELDNAME_POSTFIX, "()V", false);
+                cv_set.visitVarInsn(Opcodes.ALOAD, 0);
+                cv_set.visitMethodInsn(Opcodes.INVOKEVIRTUAL, classDetails.getClassName(), "_persistence_initialize_" + attributeDetails.getAttributeName() + PERSISTENCE_FIELDNAME_POSTFIX, "()V", false);
 
                 // _persistenc_variableName_vh.getValue();
-                cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                cv_set.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
-                cv_set.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), ClassWeaver.VHI_SHORT_SIGNATURE, "getValue", "()Ljava/lang/Object;", true);
+                cv_set.visitVarInsn(Opcodes.ALOAD, 0);
+                cv_set.visitVarInsn(Opcodes.ALOAD, 0);
+                cv_set.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
+                cv_set.visitMethodInsn(Opcodes.INVOKEINTERFACE, ClassWeaver.VHI_SHORT_SIGNATURE, "getValue", "()Ljava/lang/Object;", true);
 
                 // Add the cast:
                 // (<VariableClass>)_persistenc_variableName_vh.getValue()
-                cv_set.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), attributeDetails.getReferenceClassName().replace('.', '/'));
+                cv_set.visitTypeInsn(Opcodes.CHECKCAST, attributeDetails.getReferenceClassName().replace('.', '/'));
 
                 // add the assignment: this.variableName =
                 // (<VariableClass>)_persistenc_variableName_vh.getValue();
-                cv_set.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), attribute, attributeDetails.getReferenceClassType().getDescriptor());
+                cv_set.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), attribute, attributeDetails.getReferenceClassType().getDescriptor());
             }
         }
 
         // Must set variable after raising change event, so event has old and
         // new value.
         // variableName = argument
-        cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_set.visitVarInsn(Opcodes.ALOAD, 0);
         cv_set.visitVarInsn(opcode, 1);
-        cv_set.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), attribute, attributeDetails.getReferenceClassType().getDescriptor());
+        cv_set.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), attribute, attributeDetails.getReferenceClassType().getDescriptor());
 
         if (attributeDetails.weaveValueHolders()) {
             // _persistence_variableName_vh.setValue(argument);
-            cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_set.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
-            cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-            cv_set.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), ClassWeaver.VHI_SHORT_SIGNATURE, "setValue", "(Ljava/lang/Object;)V", true);
+            cv_set.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_set.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
+            cv_set.visitVarInsn(Opcodes.ALOAD, 1);
+            cv_set.visitMethodInsn(Opcodes.INVOKEINTERFACE, ClassWeaver.VHI_SHORT_SIGNATURE, "setValue", "(Ljava/lang/Object;)V", true);
         }
 
-        cv_set.visitInsn(Opcodes.valueInt("RETURN"));
+        cv_set.visitInsn(Opcodes.RETURN);
         cv_set.visitMaxs(0, 0);
     }
 
@@ -672,41 +672,41 @@ public class ClassWeaver extends ClassVisitor {
         String attribute = attributeDetails.getAttributeName();
 
         // create the _persistenc_getvariableName method
-        MethodVisitor cv_get = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_GET + attribute, "()" + attributeDetails.getReferenceClassType().getDescriptor(), null, null);
+        MethodVisitor cv_get = cv.visitMethod(Opcodes.ACC_PUBLIC, PERSISTENCE_GET + attribute, "()" + attributeDetails.getReferenceClassType().getDescriptor(), null, null);
 
         if (classDetails.shouldWeaveFetchGroups()) {
-            cv_get.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+            cv_get.visitVarInsn(Opcodes.ALOAD, 0);
             cv_get.visitLdcInsn(attribute);
             // _persistence_checkFetched("variableName");
-            cv_get.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_checkFetched", "(Ljava/lang/String;)V", false);
+            cv_get.visitMethodInsn(Opcodes.INVOKEVIRTUAL, classDetails.getClassName(), "_persistence_checkFetched", "(Ljava/lang/String;)V", false);
         }
 
         if (attributeDetails.weaveValueHolders()) {
             // _persistence_initialize_variableName_vh();
-            cv_get.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_get.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_initialize_" + attributeDetails.getAttributeName() + PERSISTENCE_FIELDNAME_POSTFIX, "()V", false);
+            cv_get.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_get.visitMethodInsn(Opcodes.INVOKEVIRTUAL, classDetails.getClassName(), "_persistence_initialize_" + attributeDetails.getAttributeName() + PERSISTENCE_FIELDNAME_POSTFIX, "()V", false);
 
             // _persistenc_variableName_vh.getValue();
-            cv_get.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_get.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_get.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
-            cv_get.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), ClassWeaver.VHI_SHORT_SIGNATURE, "getValue", "()Ljava/lang/Object;", true);
+            cv_get.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_get.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_get.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attribute + PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
+            cv_get.visitMethodInsn(Opcodes.INVOKEINTERFACE, ClassWeaver.VHI_SHORT_SIGNATURE, "getValue", "()Ljava/lang/Object;", true);
 
             // Add the cast:
             // (<VariableClass>)_persistenc_variableName_vh.getValue()
-            cv_get.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), attributeDetails.getReferenceClassName().replace('.', '/'));
+            cv_get.visitTypeInsn(Opcodes.CHECKCAST, attributeDetails.getReferenceClassName().replace('.', '/'));
 
             // add the assignment: this.variableName =
             // (<VariableClass>)_persistenc_variableName_vh.getValue();
-            cv_get.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), attribute, attributeDetails.getReferenceClassType().getDescriptor());
+            cv_get.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), attribute, attributeDetails.getReferenceClassType().getDescriptor());
         }
 
         // return this.variableName;
-        cv_get.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_get.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), attribute, attributeDetails.getReferenceClassType().getDescriptor());
+        cv_get.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_get.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), attribute, attributeDetails.getReferenceClassType().getDescriptor());
         // Get the opcode for the return insturction. This may be different
         // depending on the type.
-        int opcode = attributeDetails.getReferenceClassType().getOpcode(Opcodes.valueInt("IRETURN"));
+        int opcode = attributeDetails.getReferenceClassType().getOpcode(Opcodes.IRETURN);
         cv_get.visitInsn(opcode);
         cv_get.visitMaxs(0, 0);
     }
@@ -719,8 +719,8 @@ public class ClassWeaver extends ClassVisitor {
      * private Object _persistence_primaryKey;
      */
     public void addPersistenceEntityVariables() {
-        cv.visitField(Opcodes.valueInt("ACC_PROTECTED") + Opcodes.valueInt("ACC_TRANSIENT"), "_persistence_primaryKey", OBJECT_SIGNATURE, null, null);
-        cv.visitField(Opcodes.valueInt("ACC_PROTECTED") + Opcodes.valueInt("ACC_TRANSIENT"), "_persistence_cacheKey", CACHEKEY_SIGNATURE, null, null);
+        cv.visitField(Opcodes.ACC_PROTECTED + Opcodes.ACC_TRANSIENT, "_persistence_primaryKey", OBJECT_SIGNATURE, null, null);
+        cv.visitField(Opcodes.ACC_PROTECTED + Opcodes.ACC_TRANSIENT, "_persistence_cacheKey", CACHEKEY_SIGNATURE, null, null);
     }
 
     /**
@@ -733,14 +733,14 @@ public class ClassWeaver extends ClassVisitor {
      */
     public void addPersistencePostClone(ClassDetails classDetails) {
         // create the _persistence_post_clone() method
-        MethodVisitor cv_clone = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_post_clone", "()Ljava/lang/Object;", null, null);
+        MethodVisitor cv_clone = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_post_clone", "()Ljava/lang/Object;", null, null);
 
         // if there is a weaved superclass, it will implement
         // _persistence_post_clone. Call that method
         // super._persistence_post_clone()
         if (classDetails.getSuperClassDetails() != null && classDetails.getSuperClassDetails().shouldWeaveInternal()) {
-            cv_clone.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_clone.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), classDetails.getSuperClassName(), "_persistence_post_clone", "()Ljava/lang/Object;", false);
+            cv_clone.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_clone.visitMethodInsn(Opcodes.INVOKESPECIAL, classDetails.getSuperClassName(), "_persistence_post_clone", "()Ljava/lang/Object;", false);
         }
 
         if (classDetails.shouldWeaveValueHolders()) {
@@ -750,47 +750,47 @@ public class ClassWeaver extends ClassVisitor {
                                                             // !attributeDetails.isAttributeOnSuperClass())
                                                             // {
                     // clone._attribute_vh = this._attribute_vh.clone();
-                    cv_clone.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                    cv_clone.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attributeDetails.getAttributeName() + PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
+                    cv_clone.visitVarInsn(Opcodes.ALOAD, 0);
+                    cv_clone.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attributeDetails.getAttributeName() + PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
                     Label label = ASMFactory.createLabel();
-                    cv_clone.visitJumpInsn(Opcodes.valueInt("IFNULL"), label);
-                    cv_clone.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                    cv_clone.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                    cv_clone.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attributeDetails.getAttributeName() + PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
-                    cv_clone.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), ClassWeaver.VHI_SHORT_SIGNATURE, "clone", "()Ljava/lang/Object;", true);
-                    cv_clone.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), ClassWeaver.VHI_SHORT_SIGNATURE);
-                    cv_clone.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attributeDetails.getAttributeName() + PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
+                    cv_clone.visitJumpInsn(Opcodes.IFNULL, label);
+                    cv_clone.visitVarInsn(Opcodes.ALOAD, 0);
+                    cv_clone.visitVarInsn(Opcodes.ALOAD, 0);
+                    cv_clone.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attributeDetails.getAttributeName() + PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
+                    cv_clone.visitMethodInsn(Opcodes.INVOKEINTERFACE, ClassWeaver.VHI_SHORT_SIGNATURE, "clone", "()Ljava/lang/Object;", true);
+                    cv_clone.visitTypeInsn(Opcodes.CHECKCAST, ClassWeaver.VHI_SHORT_SIGNATURE);
+                    cv_clone.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + attributeDetails.getAttributeName() + PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
                     cv_clone.visitLabel(label);
                 }
             }
         }
         if (classDetails.shouldWeaveChangeTracking()) {
             // clone._persistence_listener = null;
-            cv_clone.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_clone.visitInsn(Opcodes.valueInt("ACONST_NULL"));
-            cv_clone.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), "_persistence_listener", PCL_SIGNATURE);
+            cv_clone.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_clone.visitInsn(Opcodes.ACONST_NULL);
+            cv_clone.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), "_persistence_listener", PCL_SIGNATURE);
         }
         if (classDetails.shouldWeaveFetchGroups()) {
             // clone._persistence_fetchGroup = null;
             // clone._persistence_session = null;
-            cv_clone.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_clone.visitInsn(Opcodes.valueInt("ACONST_NULL"));
-            cv_clone.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), "_persistence_fetchGroup", FETCHGROUP_SIGNATURE);
-            cv_clone.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_clone.visitInsn(Opcodes.valueInt("ACONST_NULL"));
-            cv_clone.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), "_persistence_session", SESSION_SIGNATURE);
+            cv_clone.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_clone.visitInsn(Opcodes.ACONST_NULL);
+            cv_clone.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), "_persistence_fetchGroup", FETCHGROUP_SIGNATURE);
+            cv_clone.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_clone.visitInsn(Opcodes.ACONST_NULL);
+            cv_clone.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), "_persistence_session", SESSION_SIGNATURE);
         }
 
         if (!classDetails.isEmbedable()) {
             // clone._persistence_primaryKey = null;
-            cv_clone.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_clone.visitInsn(Opcodes.valueInt("ACONST_NULL"));
-            cv_clone.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), "_persistence_primaryKey", OBJECT_SIGNATURE);
+            cv_clone.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_clone.visitInsn(Opcodes.ACONST_NULL);
+            cv_clone.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), "_persistence_primaryKey", OBJECT_SIGNATURE);
         }
 
         // return clone;
-        cv_clone.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_clone.visitInsn(Opcodes.valueInt("ARETURN"));
+        cv_clone.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_clone.visitInsn(Opcodes.ARETURN);
         cv_clone.visitMaxs(0, 0);
     }
 
@@ -798,69 +798,69 @@ public class ClassWeaver extends ClassVisitor {
         // public List<RelationshipInfo> _persistence_getRelationships() {
         //   return this._persistence_relationshipInfo;
         // }
-        MethodVisitor cv_getPKVector = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_FIELDNAME_PREFIX + "getRelationships", "()" + LIST_RELATIONSHIP_INFO_SIGNATURE, "()" + LIST_RELATIONSHIP_INFO_GENERIC_SIGNATURE, null);
-        cv_getPKVector.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_getPKVector.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), "_persistence_relationshipInfo", LIST_RELATIONSHIP_INFO_SIGNATURE);
-        cv_getPKVector.visitInsn(Opcodes.valueInt("ARETURN"));
+        MethodVisitor cv_getPKVector = cv.visitMethod(Opcodes.ACC_PUBLIC, PERSISTENCE_FIELDNAME_PREFIX + "getRelationships", "()" + LIST_RELATIONSHIP_INFO_SIGNATURE, "()" + LIST_RELATIONSHIP_INFO_GENERIC_SIGNATURE, null);
+        cv_getPKVector.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_getPKVector.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), "_persistence_relationshipInfo", LIST_RELATIONSHIP_INFO_SIGNATURE);
+        cv_getPKVector.visitInsn(Opcodes.ARETURN);
         cv_getPKVector.visitMaxs(0, 0);
 
         // public void _persistence_setRelationships(List<RelationshipInfo> paramList) {
         //   this._persistence_relationshipInfo = paramList;
         // }
-        MethodVisitor cv_setPKVector = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_FIELDNAME_PREFIX + "setRelationships", "(" + LIST_RELATIONSHIP_INFO_SIGNATURE + ")V", "(" + LIST_RELATIONSHIP_INFO_GENERIC_SIGNATURE + ")V", null);
-        cv_setPKVector.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_setPKVector.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_setPKVector.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + "relationshipInfo", LIST_RELATIONSHIP_INFO_SIGNATURE);
-        cv_setPKVector.visitInsn(Opcodes.valueInt("RETURN"));
+        MethodVisitor cv_setPKVector = cv.visitMethod(Opcodes.ACC_PUBLIC, PERSISTENCE_FIELDNAME_PREFIX + "setRelationships", "(" + LIST_RELATIONSHIP_INFO_SIGNATURE + ")V", "(" + LIST_RELATIONSHIP_INFO_GENERIC_SIGNATURE + ")V", null);
+        cv_setPKVector.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_setPKVector.visitVarInsn(Opcodes.ALOAD, 1);
+        cv_setPKVector.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + "relationshipInfo", LIST_RELATIONSHIP_INFO_SIGNATURE);
+        cv_setPKVector.visitInsn(Opcodes.RETURN);
         cv_setPKVector.visitMaxs(0, 0);
 
         // public Link _persistence_getHref() {
         //   return this._persistence_href;
         // }
-        MethodVisitor cv_getHref = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_FIELDNAME_PREFIX + "getHref", "()" + LINK_SIGNATURE, null, null);
-        cv_getHref.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_getHref.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + "href", LINK_SIGNATURE);
-        cv_getHref.visitInsn(Opcodes.valueInt("ARETURN"));
+        MethodVisitor cv_getHref = cv.visitMethod(Opcodes.ACC_PUBLIC, PERSISTENCE_FIELDNAME_PREFIX + "getHref", "()" + LINK_SIGNATURE, null, null);
+        cv_getHref.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_getHref.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + "href", LINK_SIGNATURE);
+        cv_getHref.visitInsn(Opcodes.ARETURN);
         cv_getHref.visitMaxs(0, 0);
 
         // public void _persistence_setHref(Link paramLink)
         //   this._persistence_href = paramLink;
         // }
-        MethodVisitor cv_setHref = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_FIELDNAME_PREFIX + "setHref", "(" + LINK_SIGNATURE + ")V", null, null);
-        cv_setHref.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_setHref.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_setHref.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + "href", LINK_SIGNATURE);
-        cv_setHref.visitInsn(Opcodes.valueInt("RETURN"));
+        MethodVisitor cv_setHref = cv.visitMethod(Opcodes.ACC_PUBLIC, PERSISTENCE_FIELDNAME_PREFIX + "setHref", "(" + LINK_SIGNATURE + ")V", null, null);
+        cv_setHref.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_setHref.visitVarInsn(Opcodes.ALOAD, 1);
+        cv_setHref.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + "href", LINK_SIGNATURE);
+        cv_setHref.visitInsn(Opcodes.RETURN);
         cv_setHref.visitMaxs(0, 0);
 
         // public ItemLinks _persistence_getLinks() {
         //   return this._persistence_links;
         // }
-        MethodVisitor cv_getLinks = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_FIELDNAME_PREFIX + "getLinks", "()" + ITEM_LINKS_SIGNATURE, null, null);
-        cv_getLinks.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_getLinks.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + "links", ITEM_LINKS_SIGNATURE);
-        cv_getLinks.visitInsn(Opcodes.valueInt("ARETURN"));
+        MethodVisitor cv_getLinks = cv.visitMethod(Opcodes.ACC_PUBLIC, PERSISTENCE_FIELDNAME_PREFIX + "getLinks", "()" + ITEM_LINKS_SIGNATURE, null, null);
+        cv_getLinks.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_getLinks.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + "links", ITEM_LINKS_SIGNATURE);
+        cv_getLinks.visitInsn(Opcodes.ARETURN);
         cv_getLinks.visitMaxs(0, 0);
 
         // public void _persistence_setLinks(ItemLinks paramItemLinks) {
         //   this._persistence_links = paramItemLinks;
         // }
-        MethodVisitor cv_setLinks = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_FIELDNAME_PREFIX + "setLinks", "(" + ITEM_LINKS_SIGNATURE + ")V", null, null);
-        cv_setLinks.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_setLinks.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_setLinks.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + "links", ITEM_LINKS_SIGNATURE);
-        cv_setLinks.visitInsn(Opcodes.valueInt("RETURN"));
+        MethodVisitor cv_setLinks = cv.visitMethod(Opcodes.ACC_PUBLIC, PERSISTENCE_FIELDNAME_PREFIX + "setLinks", "(" + ITEM_LINKS_SIGNATURE + ")V", null, null);
+        cv_setLinks.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_setLinks.visitVarInsn(Opcodes.ALOAD, 1);
+        cv_setLinks.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), PERSISTENCE_FIELDNAME_PREFIX + "links", ITEM_LINKS_SIGNATURE);
+        cv_setLinks.visitInsn(Opcodes.RETURN);
         cv_setLinks.visitMaxs(0, 0);
 
     }
 
     public void addPersistenceRestVariables() {
         // protected transient List<RelationshipInfo> _persistence_relationshipInfo;
-        cv.visitField(Opcodes.valueInt("ACC_PROTECTED") | Opcodes.valueInt("ACC_TRANSIENT"), PERSISTENCE_FIELDNAME_PREFIX + "relationshipInfo", LIST_RELATIONSHIP_INFO_SIGNATURE, LIST_RELATIONSHIP_INFO_GENERIC_SIGNATURE, null);
+        cv.visitField(Opcodes.ACC_PROTECTED | Opcodes.ACC_TRANSIENT, PERSISTENCE_FIELDNAME_PREFIX + "relationshipInfo", LIST_RELATIONSHIP_INFO_SIGNATURE, LIST_RELATIONSHIP_INFO_GENERIC_SIGNATURE, null);
         // protected transient Link _persistence_href;
-        cv.visitField(Opcodes.valueInt("ACC_PROTECTED") | Opcodes.valueInt("ACC_TRANSIENT"), PERSISTENCE_FIELDNAME_PREFIX + "href", LINK_SIGNATURE, null, null);
+        cv.visitField(Opcodes.ACC_PROTECTED | Opcodes.ACC_TRANSIENT, PERSISTENCE_FIELDNAME_PREFIX + "href", LINK_SIGNATURE, null, null);
         // protected transient ItemLinks _persistence_links;
-        cv.visitField(Opcodes.valueInt("ACC_PROTECTED") | Opcodes.valueInt("ACC_TRANSIENT"), PERSISTENCE_FIELDNAME_PREFIX + "links", ITEM_LINKS_SIGNATURE, null, null);
+        cv.visitField(Opcodes.ACC_PROTECTED | Opcodes.ACC_TRANSIENT, PERSISTENCE_FIELDNAME_PREFIX + "links", ITEM_LINKS_SIGNATURE, null, null);
     }
 
     /**
@@ -871,7 +871,7 @@ public class ClassWeaver extends ClassVisitor {
      */
     public void addShallowClone(ClassDetails classDetails) {
         // create the _persistence_shallow_clone() method
-        MethodVisitor cv_clone = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_shallow_clone", "()Ljava/lang/Object;", null, null);
+        MethodVisitor cv_clone = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_shallow_clone", "()Ljava/lang/Object;", null, null);
 
         Label l0 = ASMFactory.createLabel();
         Label l1 = ASMFactory.createLabel();
@@ -880,28 +880,28 @@ public class ClassWeaver extends ClassVisitor {
         cv_clone.visitTryCatchBlock(l0, l1, l2, "java/lang/CloneNotSupportedException");
         cv_clone.visitLabel(l0);
         // return super.clone();
-        cv_clone.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_clone.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), "java/lang/Object", "clone", "()" + OBJECT_SIGNATURE, false);
+        cv_clone.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_clone.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/Object", "clone", "()" + OBJECT_SIGNATURE, false);
         // } catch (CloneNotSupportedException e) {
         cv_clone.visitLabel(l1);
-        cv_clone.visitInsn(Opcodes.valueInt("ARETURN"));
+        cv_clone.visitInsn(Opcodes.ARETURN);
         cv_clone.visitLabel(l2);
-        cv_clone.visitFrame(Opcodes.valueInt("F_SAME1"), 0, null, 1, new Object[]{"java/lang/CloneNotSupportedException"});
-        cv_clone.visitVarInsn(Opcodes.valueInt("ASTORE"), 1);
+        cv_clone.visitFrame(Opcodes.F_SAME1, 0, null, 1, new Object[]{"java/lang/CloneNotSupportedException"});
+        cv_clone.visitVarInsn(Opcodes.ASTORE, 1);
         // throw new InternalError(e);
         Label l3 = ASMFactory.createLabel();
         cv_clone.visitLabel(l3);
-        cv_clone.visitTypeInsn(Opcodes.valueInt("NEW"), "java/lang/InternalError");
-        cv_clone.visitInsn(Opcodes.valueInt("DUP"));
-        cv_clone.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_clone.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), "java/lang/InternalError", "<init>", "(Ljava/lang/Throwable;)V", false);
-        cv_clone.visitInsn(Opcodes.valueInt("ATHROW"));
+        cv_clone.visitTypeInsn(Opcodes.NEW, "java/lang/InternalError");
+        cv_clone.visitInsn(Opcodes.DUP);
+        cv_clone.visitVarInsn(Opcodes.ALOAD, 1);
+        cv_clone.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/InternalError", "<init>", "(Ljava/lang/Throwable;)V", false);
+        cv_clone.visitInsn(Opcodes.ATHROW);
         Label l4 = ASMFactory.createLabel();
         cv_clone.visitLabel(l4);
         cv_clone.visitLocalVariable("e", "Ljava/lang/CloneNotSupportedException;", null, l3, l4, 1);
         cv_clone.visitLocalVariable("this", "L" + classDetails.getClassName() + ";", null, l0, l4, 0);
         // Method end - implicit return
-        cv_clone.visitInsn(Opcodes.valueInt("ARETURN"));
+        cv_clone.visitInsn(Opcodes.ARETURN);
         cv_clone.visitMaxs(0, 0);
     }
 
@@ -916,36 +916,37 @@ public class ClassWeaver extends ClassVisitor {
      */
     public void addPersistenceNew(ClassDetails classDetails) {
         // create the _persistence_new() method
-        MethodVisitor cv_new = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_new", "(" + PERSISTENCE_OBJECT_SIGNATURE + ")Ljava/lang/Object;", null, null);
+        MethodVisitor cv_new = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_new", "(" + PERSISTENCE_OBJECT_SIGNATURE + ")Ljava/lang/Object;", null, null);
 
         // return new ClassType(factory);
-        cv_new.visitTypeInsn(Opcodes.valueInt("NEW"), classDetails.getClassName());
-        cv_new.visitInsn(Opcodes.valueInt("DUP"));
+        cv_new.visitTypeInsn(Opcodes.NEW, classDetails.getClassName());
+        cv_new.visitInsn(Opcodes.DUP);
         if (!classDetails.canWeaveConstructorOptimization()) {
-            cv_new.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), classDetails.getClassName(), "<init>", "()V", false);
-            cv_new.visitInsn(Opcodes.valueInt("ARETURN"));
+            cv_new.visitMethodInsn(Opcodes.INVOKESPECIAL, classDetails.getClassName(), "<init>", "()V", false);
+            cv_new.visitInsn(Opcodes.ARETURN);
             cv_new.visitMaxs(0, 0);
             return;
         } else {
-            cv_new.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-            cv_new.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), classDetails.getClassName(), "<init>", "(" + PERSISTENCE_OBJECT_SIGNATURE + ")V", false);
+            cv_new.visitVarInsn(Opcodes.ALOAD, 1);
+            cv_new.visitMethodInsn(Opcodes.INVOKESPECIAL, classDetails.getClassName(), "<init>", "(" + PERSISTENCE_OBJECT_SIGNATURE + ")V", false);
         }
-        cv_new.visitInsn(Opcodes.valueInt("ARETURN"));
+        cv_new.visitInsn(Opcodes.ARETURN);
         cv_new.visitMaxs(0, 0);
 
         // create the ClassType() method
-        MethodVisitor cv_constructor = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "<init>", "(" + PERSISTENCE_OBJECT_SIGNATURE + ")V", null, null);
+        MethodVisitor cv_constructor = cv.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "(" + PERSISTENCE_OBJECT_SIGNATURE + ")V", null, null);
 
-        cv_constructor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+        cv_constructor.visitVarInsn(Opcodes.ALOAD, 0);
+
         if (classDetails.getSuperClassDetails() == null) {
             // super();
-            cv_constructor.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), classDetails.getSuperClassName(), "<init>", "()V", false);
+            cv_constructor.visitMethodInsn(Opcodes.INVOKESPECIAL, classDetails.getSuperClassName(), "<init>", "()V", false);
         } else {
             // super(factory);
-            cv_constructor.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-            cv_constructor.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), classDetails.getSuperClassName(), "<init>", "(" + PERSISTENCE_OBJECT_SIGNATURE + ")V", false);
+            cv_constructor.visitVarInsn(Opcodes.ALOAD, 1);
+            cv_constructor.visitMethodInsn(Opcodes.INVOKESPECIAL, classDetails.getSuperClassName(), "<init>", "(" + PERSISTENCE_OBJECT_SIGNATURE + ")V", false);
         }
-        cv_constructor.visitInsn(Opcodes.valueInt("RETURN"));
+        cv_constructor.visitInsn(Opcodes.RETURN);
         cv_constructor.visitMaxs(0, 0);
     }
 
@@ -963,7 +964,7 @@ public class ClassWeaver extends ClassVisitor {
      */
     public void addPersistenceGetSet(ClassDetails classDetails) {
         // create the _persistence_get() method
-        MethodVisitor cv_get = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_get", "(Ljava/lang/String;)Ljava/lang/Object;", null, null);
+        MethodVisitor cv_get = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_get", "(Ljava/lang/String;)Ljava/lang/Object;", null, null);
 
         Label label = null;
         for (AttributeDetails attributeDetails : classDetails.getAttributesMap().values()) {
@@ -972,22 +973,22 @@ public class ClassWeaver extends ClassVisitor {
                     cv_get.visitLabel(label);
                 }
                 // else if (attribute == "address")
-                cv_get.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+                cv_get.visitVarInsn(Opcodes.ALOAD, 1);
                 cv_get.visitLdcInsn(attributeDetails.getAttributeName().intern());
                 label = ASMFactory.createLabel();
-                cv_get.visitJumpInsn(Opcodes.valueInt("IF_ACMPNE"), label);
+                cv_get.visitJumpInsn(Opcodes.IF_ACMPNE, label);
                 // return this.address
-                cv_get.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                cv_get.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), attributeDetails.getAttributeName(), attributeDetails.getReferenceClassType().getDescriptor());
+                cv_get.visitVarInsn(Opcodes.ALOAD, 0);
+                cv_get.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), attributeDetails.getAttributeName(), attributeDetails.getReferenceClassType().getDescriptor());
                 // if this is a primitive, get the wrapper class
                 String wrapper = ClassWeaver.wrapperFor(attributeDetails.getReferenceClassType().getSort());
                 if (wrapper != null) {
                     // Call valueOf on the wrapper (more optimal than
                     // constructor).
-                    cv_get.visitMethodInsn(Opcodes.valueInt("INVOKESTATIC"), wrapper, "valueOf", "(" + attributeDetails.getReferenceClassType().getDescriptor() + ")L" + wrapper + ";", false);
+                    cv_get.visitMethodInsn(Opcodes.INVOKESTATIC, wrapper, "valueOf", "(" + attributeDetails.getReferenceClassType().getDescriptor() + ")L" + wrapper + ";", false);
                 }
 
-                cv_get.visitInsn(Opcodes.valueInt("ARETURN"));
+                cv_get.visitInsn(Opcodes.ARETURN);
             }
         }
         if (label != null) {
@@ -996,18 +997,18 @@ public class ClassWeaver extends ClassVisitor {
         // call super, or return null
         if (classDetails.getSuperClassDetails() == null) {
             // return null;
-            cv_get.visitInsn(Opcodes.valueInt("ACONST_NULL"));
+            cv_get.visitInsn(Opcodes.ACONST_NULL);
         } else {
-            cv_get.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_get.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-            cv_get.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), classDetails.getSuperClassName(), "_persistence_get", "(Ljava/lang/String;)Ljava/lang/Object;", false);
+            cv_get.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_get.visitVarInsn(Opcodes.ALOAD, 1);
+            cv_get.visitMethodInsn(Opcodes.INVOKESPECIAL, classDetails.getSuperClassName(), "_persistence_get", "(Ljava/lang/String;)Ljava/lang/Object;", false);
         }
 
-        cv_get.visitInsn(Opcodes.valueInt("ARETURN"));
+        cv_get.visitInsn(Opcodes.ARETURN);
         cv_get.visitMaxs(0, 0);
 
         // create the _persistence_set() method
-        MethodVisitor cv_set = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_set", "(Ljava/lang/String;Ljava/lang/Object;)V", null, null);
+        MethodVisitor cv_set = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_set", "(Ljava/lang/String;Ljava/lang/Object;)V", null, null);
 
         label = null;
         for (AttributeDetails attribute : classDetails.getAttributesMap().values()) {
@@ -1016,23 +1017,23 @@ public class ClassWeaver extends ClassVisitor {
                     cv_set.visitLabel(label);
                 }
                 // else if (attribute == "address")
-                cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+                cv_set.visitVarInsn(Opcodes.ALOAD, 1);
                 cv_set.visitLdcInsn(attribute.getAttributeName().intern());
                 label = ASMFactory.createLabel();
-                cv_set.visitJumpInsn(Opcodes.valueInt("IF_ACMPNE"), label);
+                cv_set.visitJumpInsn(Opcodes.IF_ACMPNE, label);
                 // this.address = (String)value;
-                cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 2);
+                cv_set.visitVarInsn(Opcodes.ALOAD, 0);
+                cv_set.visitVarInsn(Opcodes.ALOAD, 2);
                 String wrapper = wrapperFor(attribute.getReferenceClassType().getSort());
                 if (wrapper == null) {
                     wrapper = attribute.getReferenceClassName().replace('.', '/');
                 }
-                cv_set.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), wrapper);
+                cv_set.visitTypeInsn(Opcodes.CHECKCAST, wrapper);
                 // Unwrap any primitive wrapper to its value.
                 unwrapPrimitive(attribute, cv_set);
-                cv_set.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), attribute.getAttributeName(), attribute.getReferenceClassType().getDescriptor());
+                cv_set.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), attribute.getAttributeName(), attribute.getReferenceClassType().getDescriptor());
                 // return;
-                cv_set.visitInsn(Opcodes.valueInt("RETURN"));
+                cv_set.visitInsn(Opcodes.RETURN);
             }
         }
         if (label != null) {
@@ -1040,13 +1041,13 @@ public class ClassWeaver extends ClassVisitor {
         }
         // call super, or return null
         if (classDetails.getSuperClassDetails() != null) {
-            cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-            cv_set.visitVarInsn(Opcodes.valueInt("ALOAD"), 2);
-            cv_set.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), classDetails.getSuperClassName(), "_persistence_set", "(Ljava/lang/String;Ljava/lang/Object;)V", false);
+            cv_set.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_set.visitVarInsn(Opcodes.ALOAD, 1);
+            cv_set.visitVarInsn(Opcodes.ALOAD, 2);
+            cv_set.visitMethodInsn(Opcodes.INVOKESPECIAL, classDetails.getSuperClassName(), "_persistence_set", "(Ljava/lang/String;Ljava/lang/Object;)V", false);
         }
 
-        cv_set.visitInsn(Opcodes.valueInt("RETURN"));
+        cv_set.visitInsn(Opcodes.RETURN);
         cv_set.visitMaxs(0, 0);
     }
 
@@ -1059,30 +1060,30 @@ public class ClassWeaver extends ClassVisitor {
      * this._persistence_primaryKey = primaryKey; }
      */
     public void addPersistenceEntityMethods(ClassDetails classDetails) {
-        MethodVisitor cv_getPKVector = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_getId", "()" + OBJECT_SIGNATURE, null, null);
-        cv_getPKVector.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_getPKVector.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), "_persistence_primaryKey", OBJECT_SIGNATURE);
-        cv_getPKVector.visitInsn(Opcodes.valueInt("ARETURN"));
+        MethodVisitor cv_getPKVector = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_getId", "()" + OBJECT_SIGNATURE, null, null);
+        cv_getPKVector.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_getPKVector.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), "_persistence_primaryKey", OBJECT_SIGNATURE);
+        cv_getPKVector.visitInsn(Opcodes.ARETURN);
         cv_getPKVector.visitMaxs(0, 0);
 
-        MethodVisitor cv_setPKVector = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_setId", "(" + OBJECT_SIGNATURE + ")V", null, null);
-        cv_setPKVector.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_setPKVector.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_setPKVector.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), "_persistence_primaryKey", OBJECT_SIGNATURE);
-        cv_setPKVector.visitInsn(Opcodes.valueInt("RETURN"));
+        MethodVisitor cv_setPKVector = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_setId", "(" + OBJECT_SIGNATURE + ")V", null, null);
+        cv_setPKVector.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_setPKVector.visitVarInsn(Opcodes.ALOAD, 1);
+        cv_setPKVector.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), "_persistence_primaryKey", OBJECT_SIGNATURE);
+        cv_setPKVector.visitInsn(Opcodes.RETURN);
         cv_setPKVector.visitMaxs(0, 0);
 
-        MethodVisitor cv_getCacheKey = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_getCacheKey", "()" + CACHEKEY_SIGNATURE, null, null);
-        cv_getCacheKey.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_getCacheKey.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), "_persistence_cacheKey", CACHEKEY_SIGNATURE);
-        cv_getCacheKey.visitInsn(Opcodes.valueInt("ARETURN"));
+        MethodVisitor cv_getCacheKey = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_getCacheKey", "()" + CACHEKEY_SIGNATURE, null, null);
+        cv_getCacheKey.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_getCacheKey.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), "_persistence_cacheKey", CACHEKEY_SIGNATURE);
+        cv_getCacheKey.visitInsn(Opcodes.ARETURN);
         cv_getCacheKey.visitMaxs(0, 0);
 
-        MethodVisitor cv_setCacheKey = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_setCacheKey", "(" + CACHEKEY_SIGNATURE + ")V", null, null);
-        cv_setCacheKey.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_setCacheKey.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_setCacheKey.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), "_persistence_cacheKey", CACHEKEY_SIGNATURE);
-        cv_setCacheKey.visitInsn(Opcodes.valueInt("RETURN"));
+        MethodVisitor cv_setCacheKey = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_setCacheKey", "(" + CACHEKEY_SIGNATURE + ")V", null, null);
+        cv_setCacheKey.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_setCacheKey.visitVarInsn(Opcodes.ALOAD, 1);
+        cv_setCacheKey.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), "_persistence_cacheKey", CACHEKEY_SIGNATURE);
+        cv_setCacheKey.visitInsn(Opcodes.RETURN);
         cv_setCacheKey.visitMaxs(0, 0);
     }
 
@@ -1096,7 +1097,7 @@ public class ClassWeaver extends ClassVisitor {
      * _persistence_session;
      */
     public void addFetchGroupVariables() {
-        FieldVisitor fv = cv.visitField(Opcodes.valueInt("ACC_PROTECTED"), "_persistence_fetchGroup", FETCHGROUP_SIGNATURE, null, null);
+        FieldVisitor fv = cv.visitField(Opcodes.ACC_PROTECTED, "_persistence_fetchGroup", FETCHGROUP_SIGNATURE, null, null);
         // Only add jakarta.persistence.Transient annotation if attribute access
         // is being used
         if (classDetails.usesAttributeAccess()) {
@@ -1107,8 +1108,8 @@ public class ClassWeaver extends ClassVisitor {
         }
         fv.visitEnd();
 
-        cv.visitField(Opcodes.valueInt("ACC_PROTECTED") + Opcodes.valueInt("ACC_TRANSIENT"), "_persistence_shouldRefreshFetchGroup", PBOOLEAN_SIGNATURE, null, null).visitEnd();
-        cv.visitField(Opcodes.valueInt("ACC_PROTECTED") + Opcodes.valueInt("ACC_TRANSIENT"), "_persistence_session", SESSION_SIGNATURE, null, null).visitEnd();
+        cv.visitField(Opcodes.ACC_PROTECTED + Opcodes.ACC_TRANSIENT, "_persistence_shouldRefreshFetchGroup", PBOOLEAN_SIGNATURE, null, null).visitEnd();
+        cv.visitField(Opcodes.ACC_PROTECTED + Opcodes.ACC_TRANSIENT, "_persistence_session", SESSION_SIGNATURE, null, null).visitEnd();
     }
 
     /**
@@ -1149,130 +1150,130 @@ public class ClassWeaver extends ClassVisitor {
      * throw new EntityNotFoundException(var2);}}}
      */
     public void addFetchGroupMethods(ClassDetails classDetails) {
-        MethodVisitor cv_getSession = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_getSession", "()" + SESSION_SIGNATURE, null, null);
-        cv_getSession.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_getSession.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), "_persistence_session", SESSION_SIGNATURE);
-        cv_getSession.visitInsn(Opcodes.valueInt("ARETURN"));
+        MethodVisitor cv_getSession = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_getSession", "()" + SESSION_SIGNATURE, null, null);
+        cv_getSession.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_getSession.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), "_persistence_session", SESSION_SIGNATURE);
+        cv_getSession.visitInsn(Opcodes.ARETURN);
         cv_getSession.visitMaxs(0, 0);
 
-        MethodVisitor cv_setSession = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_setSession", "(" + SESSION_SIGNATURE + ")V", null, null);
-        cv_setSession.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_setSession.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_setSession.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), "_persistence_session", SESSION_SIGNATURE);
-        cv_setSession.visitInsn(Opcodes.valueInt("RETURN"));
+        MethodVisitor cv_setSession = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_setSession", "(" + SESSION_SIGNATURE + ")V", null, null);
+        cv_setSession.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_setSession.visitVarInsn(Opcodes.ALOAD, 1);
+        cv_setSession.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), "_persistence_session", SESSION_SIGNATURE);
+        cv_setSession.visitInsn(Opcodes.RETURN);
         cv_setSession.visitMaxs(0, 0);
 
-        MethodVisitor cv_getFetchGroup = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_getFetchGroup", "()" + FETCHGROUP_SIGNATURE, null, null);
-        cv_getFetchGroup.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_getFetchGroup.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), "_persistence_fetchGroup", FETCHGROUP_SIGNATURE);
-        cv_getFetchGroup.visitInsn(Opcodes.valueInt("ARETURN"));
+        MethodVisitor cv_getFetchGroup = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_getFetchGroup", "()" + FETCHGROUP_SIGNATURE, null, null);
+        cv_getFetchGroup.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_getFetchGroup.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), "_persistence_fetchGroup", FETCHGROUP_SIGNATURE);
+        cv_getFetchGroup.visitInsn(Opcodes.ARETURN);
         cv_getFetchGroup.visitMaxs(0, 0);
 
-        MethodVisitor cv_setFetchGroup = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_setFetchGroup", "(" + FETCHGROUP_SIGNATURE + ")V", null, null);
-        cv_setFetchGroup.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_setFetchGroup.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_setFetchGroup.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), "_persistence_fetchGroup", FETCHGROUP_SIGNATURE);
-        cv_setFetchGroup.visitInsn(Opcodes.valueInt("RETURN"));
+        MethodVisitor cv_setFetchGroup = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_setFetchGroup", "(" + FETCHGROUP_SIGNATURE + ")V", null, null);
+        cv_setFetchGroup.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_setFetchGroup.visitVarInsn(Opcodes.ALOAD, 1);
+        cv_setFetchGroup.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), "_persistence_fetchGroup", FETCHGROUP_SIGNATURE);
+        cv_setFetchGroup.visitInsn(Opcodes.RETURN);
         cv_setFetchGroup.visitMaxs(0, 0);
 
-        MethodVisitor cv_shouldRefreshFetchGroup = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_shouldRefreshFetchGroup", "()" + PBOOLEAN_SIGNATURE, null, null);
-        cv_shouldRefreshFetchGroup.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_shouldRefreshFetchGroup.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), "_persistence_shouldRefreshFetchGroup", PBOOLEAN_SIGNATURE);
-        cv_shouldRefreshFetchGroup.visitInsn(Opcodes.valueInt("IRETURN"));
+        MethodVisitor cv_shouldRefreshFetchGroup = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_shouldRefreshFetchGroup", "()" + PBOOLEAN_SIGNATURE, null, null);
+        cv_shouldRefreshFetchGroup.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_shouldRefreshFetchGroup.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), "_persistence_shouldRefreshFetchGroup", PBOOLEAN_SIGNATURE);
+        cv_shouldRefreshFetchGroup.visitInsn(Opcodes.IRETURN);
         cv_shouldRefreshFetchGroup.visitMaxs(0, 0);
 
-        MethodVisitor cv_setShouldRefreshFetchGroup = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_setShouldRefreshFetchGroup", "(" + PBOOLEAN_SIGNATURE + ")V", null, null);
-        cv_setShouldRefreshFetchGroup.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_setShouldRefreshFetchGroup.visitVarInsn(Opcodes.valueInt("ILOAD"), 1);
-        cv_setShouldRefreshFetchGroup.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classDetails.getClassName(), "_persistence_shouldRefreshFetchGroup", PBOOLEAN_SIGNATURE);
-        cv_setShouldRefreshFetchGroup.visitInsn(Opcodes.valueInt("RETURN"));
+        MethodVisitor cv_setShouldRefreshFetchGroup = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_setShouldRefreshFetchGroup", "(" + PBOOLEAN_SIGNATURE + ")V", null, null);
+        cv_setShouldRefreshFetchGroup.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_setShouldRefreshFetchGroup.visitVarInsn(Opcodes.ILOAD, 1);
+        cv_setShouldRefreshFetchGroup.visitFieldInsn(Opcodes.PUTFIELD, classDetails.getClassName(), "_persistence_shouldRefreshFetchGroup", PBOOLEAN_SIGNATURE);
+        cv_setShouldRefreshFetchGroup.visitInsn(Opcodes.RETURN);
         cv_setShouldRefreshFetchGroup.visitMaxs(0, 0);
 
-        MethodVisitor cv_resetFetchGroup = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_resetFetchGroup", "()V", null, null);
-        cv_resetFetchGroup.visitInsn(Opcodes.valueInt("RETURN"));
+        MethodVisitor cv_resetFetchGroup = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_resetFetchGroup", "()V", null, null);
+        cv_resetFetchGroup.visitInsn(Opcodes.RETURN);
         cv_resetFetchGroup.visitMaxs(0, 0);
 
-        MethodVisitor cv_isAttributeFetched = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_isAttributeFetched", "(Ljava/lang/String;)Z", null, null);
-        cv_isAttributeFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_isAttributeFetched.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), "_persistence_fetchGroup", FETCHGROUP_SIGNATURE);
+        MethodVisitor cv_isAttributeFetched = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_isAttributeFetched", "(Ljava/lang/String;)Z", null, null);
+        cv_isAttributeFetched.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_isAttributeFetched.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), "_persistence_fetchGroup", FETCHGROUP_SIGNATURE);
         Label gotoTrue = ASMFactory.createLabel();
-        cv_isAttributeFetched.visitJumpInsn(Opcodes.valueInt("IFNULL"), gotoTrue);
-        cv_isAttributeFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        cv_isAttributeFetched.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classDetails.getClassName(), "_persistence_fetchGroup", FETCHGROUP_SIGNATURE);
-        cv_isAttributeFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        cv_isAttributeFetched.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), FETCHGROUP_SHORT_SIGNATURE, "containsAttributeInternal", "(Ljava/lang/String;)Z", false);
+        cv_isAttributeFetched.visitJumpInsn(Opcodes.IFNULL, gotoTrue);
+        cv_isAttributeFetched.visitVarInsn(Opcodes.ALOAD, 0);
+        cv_isAttributeFetched.visitFieldInsn(Opcodes.GETFIELD, classDetails.getClassName(), "_persistence_fetchGroup", FETCHGROUP_SIGNATURE);
+        cv_isAttributeFetched.visitVarInsn(Opcodes.ALOAD, 1);
+        cv_isAttributeFetched.visitMethodInsn(Opcodes.INVOKEVIRTUAL, FETCHGROUP_SHORT_SIGNATURE, "containsAttributeInternal", "(Ljava/lang/String;)Z", false);
         Label gotoFalse = ASMFactory.createLabel();
-        cv_isAttributeFetched.visitJumpInsn(Opcodes.valueInt("IFEQ"), gotoFalse);
+        cv_isAttributeFetched.visitJumpInsn(Opcodes.IFEQ, gotoFalse);
         cv_isAttributeFetched.visitLabel(gotoTrue);
-        cv_isAttributeFetched.visitInsn(Opcodes.valueInt("ICONST_1"));
+        cv_isAttributeFetched.visitInsn(Opcodes.ICONST_1);
         Label gotoReturn = ASMFactory.createLabel();
-        cv_isAttributeFetched.visitJumpInsn(Opcodes.valueInt("GOTO"), gotoReturn);
+        cv_isAttributeFetched.visitJumpInsn(Opcodes.GOTO, gotoReturn);
         cv_isAttributeFetched.visitLabel(gotoFalse);
-        cv_isAttributeFetched.visitInsn(Opcodes.valueInt("ICONST_0"));
+        cv_isAttributeFetched.visitInsn(Opcodes.ICONST_0);
         cv_isAttributeFetched.visitLabel(gotoReturn);
-        cv_isAttributeFetched.visitInsn(Opcodes.valueInt("IRETURN"));
+        cv_isAttributeFetched.visitInsn(Opcodes.IRETURN);
         cv_isAttributeFetched.visitMaxs(0, 0);
 
-        MethodVisitor cv_checkFetched = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_checkFetched", "(" + STRING_SIGNATURE + ")V", null, null); {
+        MethodVisitor cv_checkFetched = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_checkFetched", "(" + STRING_SIGNATURE + ")V", null, null); {
             Label l0 = ASMFactory.createLabel();
             cv_checkFetched.visitLabel(l0);
             // if (!this._persistence_isAttributeFetched(attributeName)) {
-            cv_checkFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_checkFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-            cv_checkFetched.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_isAttributeFetched", "(" + STRING_SIGNATURE + ")Z", false);
+            cv_checkFetched.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_checkFetched.visitVarInsn(Opcodes.ALOAD, 1);
+            cv_checkFetched.visitMethodInsn(Opcodes.INVOKEVIRTUAL, classDetails.getClassName(), "_persistence_isAttributeFetched", "(" + STRING_SIGNATURE + ")Z", false);
             Label l1 = ASMFactory.createLabel();
-            cv_checkFetched.visitJumpInsn(Opcodes.valueInt("IFNE"), l1);
+            cv_checkFetched.visitJumpInsn(Opcodes.IFNE, l1);
             // String errorMsg = _persistence_getFetchGroup().
-            cv_checkFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_checkFetched.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_getFetchGroup", "()" + FETCHGROUP_SIGNATURE, false);
+            cv_checkFetched.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_checkFetched.visitMethodInsn(Opcodes.INVOKEVIRTUAL, classDetails.getClassName(), "_persistence_getFetchGroup", "()" + FETCHGROUP_SIGNATURE, false);
             // .onUnfetchedAttribute(entity, attributeName);
-            cv_checkFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_checkFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-            cv_checkFetched.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), FETCHGROUP_SHORT_SIGNATURE, "onUnfetchedAttribute", "(" + FETCHGROUP_TRACKER_SIGNATURE + STRING_SIGNATURE + ")" + STRING_SIGNATURE, false);
-            cv_checkFetched.visitVarInsn(Opcodes.valueInt("ASTORE"), 2);
-            cv_checkFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 2);
-            cv_checkFetched.visitJumpInsn(Opcodes.valueInt("IFNULL"), l1);
+            cv_checkFetched.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_checkFetched.visitVarInsn(Opcodes.ALOAD, 1);
+            cv_checkFetched.visitMethodInsn(Opcodes.INVOKEVIRTUAL, FETCHGROUP_SHORT_SIGNATURE, "onUnfetchedAttribute", "(" + FETCHGROUP_TRACKER_SIGNATURE + STRING_SIGNATURE + ")" + STRING_SIGNATURE, false);
+            cv_checkFetched.visitVarInsn(Opcodes.ASTORE, 2);
+            cv_checkFetched.visitVarInsn(Opcodes.ALOAD, 2);
+            cv_checkFetched.visitJumpInsn(Opcodes.IFNULL, l1);
             // throw new EntityNotFoundException(errorMsg);
-            cv_checkFetched.visitTypeInsn(Opcodes.valueInt("NEW"), JPA_ENTITY_NOT_FOUND_EXCEPTION_SHORT_SIGNATURE);
-            cv_checkFetched.visitInsn(Opcodes.valueInt("DUP"));
-            cv_checkFetched.visitVarInsn(Opcodes.valueInt("ALOAD"), 2);
-            cv_checkFetched.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), JPA_ENTITY_NOT_FOUND_EXCEPTION_SHORT_SIGNATURE, "<init>", "(" + STRING_SIGNATURE + ")V", false);
-            cv_checkFetched.visitInsn(Opcodes.valueInt("ATHROW"));
+            cv_checkFetched.visitTypeInsn(Opcodes.NEW, JPA_ENTITY_NOT_FOUND_EXCEPTION_SHORT_SIGNATURE);
+            cv_checkFetched.visitInsn(Opcodes.DUP);
+            cv_checkFetched.visitVarInsn(Opcodes.ALOAD, 2);
+            cv_checkFetched.visitMethodInsn(Opcodes.INVOKESPECIAL, JPA_ENTITY_NOT_FOUND_EXCEPTION_SHORT_SIGNATURE, "<init>", "(" + STRING_SIGNATURE + ")V", false);
+            cv_checkFetched.visitInsn(Opcodes.ATHROW);
             cv_checkFetched.visitLabel(l1);
-            cv_checkFetched.visitFrame(Opcodes.valueInt("F_APPEND"), 1, new Object[]{"java/lang/String"}, 0, null);
-            cv_checkFetched.visitInsn(Opcodes.valueInt("RETURN"));
+            cv_checkFetched.visitFrame(Opcodes.F_APPEND, 1, new Object[]{"java/lang/String"}, 0, null);
+            cv_checkFetched.visitInsn(Opcodes.RETURN);
             cv_checkFetched.visitMaxs(0, 0);
         }
 
-        MethodVisitor cv_checkFetchedForSet = cv.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "_persistence_checkFetchedForSet", "(" + STRING_SIGNATURE + ")V", null, null);
+        MethodVisitor cv_checkFetchedForSet = cv.visitMethod(Opcodes.ACC_PUBLIC, "_persistence_checkFetchedForSet", "(" + STRING_SIGNATURE + ")V", null, null);
         {
             Label l0 = ASMFactory.createLabel();
             cv_checkFetchedForSet.visitLabel(l0);
             // if (!this._persistence_isAttributeFetched(attributeName)) {
-            cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-            cv_checkFetchedForSet.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_isAttributeFetched", "(" + STRING_SIGNATURE + ")Z", false);
+            cv_checkFetchedForSet.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_checkFetchedForSet.visitVarInsn(Opcodes.ALOAD, 1);
+            cv_checkFetchedForSet.visitMethodInsn(Opcodes.INVOKEVIRTUAL, classDetails.getClassName(), "_persistence_isAttributeFetched", "(" + STRING_SIGNATURE + ")Z", false);
             Label l1 = ASMFactory.createLabel();
-            cv_checkFetchedForSet.visitJumpInsn(Opcodes.valueInt("IFNE"), l1);
+            cv_checkFetchedForSet.visitJumpInsn(Opcodes.IFNE, l1);
             // String errorMsg = _persistence_getFetchGroup().
-            cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_checkFetchedForSet.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), classDetails.getClassName(), "_persistence_getFetchGroup", "()" + FETCHGROUP_SIGNATURE, false);
+            cv_checkFetchedForSet.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_checkFetchedForSet.visitMethodInsn(Opcodes.INVOKEVIRTUAL, classDetails.getClassName(), "_persistence_getFetchGroup", "()" + FETCHGROUP_SIGNATURE, false);
             // .onUnfetchedAttribute(entity, attributeName);
-            cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-            cv_checkFetchedForSet.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), FETCHGROUP_SHORT_SIGNATURE, "onUnfetchedAttributeForSet", "(" + FETCHGROUP_TRACKER_SIGNATURE + STRING_SIGNATURE + ")" + STRING_SIGNATURE, false);
-            cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ASTORE"), 2);
-            cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 2);
-            cv_checkFetchedForSet.visitJumpInsn(Opcodes.valueInt("IFNULL"), l1);
+            cv_checkFetchedForSet.visitVarInsn(Opcodes.ALOAD, 0);
+            cv_checkFetchedForSet.visitVarInsn(Opcodes.ALOAD, 1);
+            cv_checkFetchedForSet.visitMethodInsn(Opcodes.INVOKEVIRTUAL, FETCHGROUP_SHORT_SIGNATURE, "onUnfetchedAttributeForSet", "(" + FETCHGROUP_TRACKER_SIGNATURE + STRING_SIGNATURE + ")" + STRING_SIGNATURE, false);
+            cv_checkFetchedForSet.visitVarInsn(Opcodes.ASTORE, 2);
+            cv_checkFetchedForSet.visitVarInsn(Opcodes.ALOAD, 2);
+            cv_checkFetchedForSet.visitJumpInsn(Opcodes.IFNULL, l1);
             // throw new EntityNotFoundException(errorMsg);
-            cv_checkFetchedForSet.visitTypeInsn(Opcodes.valueInt("NEW"), JPA_ENTITY_NOT_FOUND_EXCEPTION_SHORT_SIGNATURE);
-            cv_checkFetchedForSet.visitInsn(Opcodes.valueInt("DUP"));
-            cv_checkFetchedForSet.visitVarInsn(Opcodes.valueInt("ALOAD"), 2);
-            cv_checkFetchedForSet.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), JPA_ENTITY_NOT_FOUND_EXCEPTION_SHORT_SIGNATURE, "<init>", "(" + STRING_SIGNATURE + ")V", false);
-            cv_checkFetchedForSet.visitInsn(Opcodes.valueInt("ATHROW"));
+            cv_checkFetchedForSet.visitTypeInsn(Opcodes.NEW, JPA_ENTITY_NOT_FOUND_EXCEPTION_SHORT_SIGNATURE);
+            cv_checkFetchedForSet.visitInsn(Opcodes.DUP);
+            cv_checkFetchedForSet.visitVarInsn(Opcodes.ALOAD, 2);
+            cv_checkFetchedForSet.visitMethodInsn(Opcodes.INVOKESPECIAL, JPA_ENTITY_NOT_FOUND_EXCEPTION_SHORT_SIGNATURE, "<init>", "(" + STRING_SIGNATURE + ")V", false);
+            cv_checkFetchedForSet.visitInsn(Opcodes.ATHROW);
             cv_checkFetchedForSet.visitLabel(l1);
-            cv_checkFetchedForSet.visitFrame(Opcodes.valueInt("F_APPEND"), 1, new Object[]{"java/lang/String"}, 0, null);
-            cv_checkFetchedForSet.visitInsn(Opcodes.valueInt("RETURN"));
+            cv_checkFetchedForSet.visitFrame(Opcodes.F_APPEND, 1, new Object[]{"java/lang/String"}, 0, null);
+            cv_checkFetchedForSet.visitInsn(Opcodes.RETURN);
             cv_checkFetchedForSet.visitMaxs(0, 0);
         }
     }

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/weaving/ComputeClassWriter.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/weaving/ComputeClassWriter.java
@@ -64,14 +64,14 @@ class ComputeClassWriter extends ClassWriter {
         try {
             ClassReader info1 = typeInfo(type1);
             ClassReader info2 = typeInfo(type2);
-            if ((info1.getAccess() & Opcodes.valueInt("ACC_INTERFACE")) != 0) {
+            if ((info1.getAccess() & Opcodes.ACC_INTERFACE) != 0) {
                 if (typeImplements(type2, info2, type1)) {
                     return type1;
                 } else {
                     return "java/lang/Object";
                 }
             }
-            if ((info2.getAccess() & Opcodes.valueInt("ACC_INTERFACE")) != 0) {
+            if ((info2.getAccess() & Opcodes.ACC_INTERFACE) != 0) {
                 if (typeImplements(type1, info1, type2)) {
                     return type2;
                 } else {

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/weaving/MethodWeaver.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/weaving/MethodWeaver.java
@@ -58,7 +58,7 @@ public class MethodWeaver extends EclipseLinkMethodVisitor {
     @Override
     public void visitInsn (final int opcode) {
         weaveBeginningOfMethodIfRequired();
-        if (opcode == Opcodes.valueInt("RETURN")) {
+        if (opcode == Opcodes.RETURN) {
             weaveEndOfMethodIfRequired();
         }
         super.visitInsnSuper(opcode);
@@ -104,8 +104,8 @@ public class MethodWeaver extends EclipseLinkMethodVisitor {
                 this.tcw.classDetails.isInSuperclassHierarchy(owner) && this.tcw.classDetails.isInMetadataHierarchy(descClassName) &&
                 (this.tcw.classDetails.getNameOfSuperclassImplementingCloneMethod() == null)) {
             super.visitMethodInsnSuper(opcode, owner, name, desc, intf);
-            super.visitTypeInsnSuper(Opcodes.valueInt("CHECKCAST"), this.tcw.classDetails.getClassName());
-            super.visitMethodInsnSuper(Opcodes.valueInt("INVOKEVIRTUAL"), this.tcw.classDetails.getClassName(), "_persistence_post_clone", "()Ljava/lang/Object;", false);
+            super.visitTypeInsnSuper(Opcodes.CHECKCAST, this.tcw.classDetails.getClassName());
+            super.visitMethodInsnSuper(Opcodes.INVOKEVIRTUAL, this.tcw.classDetails.getClassName(), "_persistence_post_clone", "()Ljava/lang/Object;", false);
         } else {
             super.visitMethodInsnSuper(opcode, owner, name, desc, intf);
         }
@@ -210,15 +210,15 @@ public class MethodWeaver extends EclipseLinkMethodVisitor {
             super.visitFieldInsnSuper(opcode, owner, name, desc);
             return;
         }
-        if (opcode == Opcodes.valueInt("GETFIELD")) {
+        if (opcode == Opcodes.GETFIELD) {
             if (attributeDetails.weaveValueHolders() || tcw.classDetails.shouldWeaveFetchGroups()) {
-                methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), ClassWeaver.PERSISTENCE_GET + name, "()" + attributeDetails.getReferenceClassType().getDescriptor(), false);
+                methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, tcw.classDetails.getClassName(), ClassWeaver.PERSISTENCE_GET + name, "()" + attributeDetails.getReferenceClassType().getDescriptor(), false);
             } else {
                 super.visitFieldInsnSuper(opcode, owner, name, desc);
             }
-        } else if (opcode == Opcodes.valueInt("PUTFIELD")) {
+        } else if (opcode == Opcodes.PUTFIELD) {
             if ((attributeDetails.weaveValueHolders()) || (tcw.classDetails.shouldWeaveChangeTracking()) || (tcw.classDetails.shouldWeaveFetchGroups())) {
-                methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), ClassWeaver.PERSISTENCE_SET + name, "(" + attributeDetails.getReferenceClassType().getDescriptor() + ")V", false);
+                methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, tcw.classDetails.getClassName(), ClassWeaver.PERSISTENCE_SET + name, "(" + attributeDetails.getReferenceClassType().getDescriptor() + ")V", false);
             } else {
                 super.visitFieldInsnSuper(opcode, owner, name, desc);
             }
@@ -332,51 +332,51 @@ public class MethodWeaver extends EclipseLinkMethodVisitor {
         }
         if (isVirtual || (isGetMethod && !attributeDetails.hasField())) {
             if (tcw.classDetails.shouldWeaveFetchGroups()) {
-                methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
                 if (isVirtual){
-                    methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+                    methodVisitor.visitVarInsn(Opcodes.ALOAD, 1);
                 } else {
                     methodVisitor.visitLdcInsn(attributeName);
                 }
                 // _persistence_checkFetched("attributeName");
-                methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), "_persistence_checkFetched", "(Ljava/lang/String;)V", false);
+                methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, tcw.classDetails.getClassName(), "_persistence_checkFetched", "(Ljava/lang/String;)V", false);
             }
             if (!isVirtual && attributeDetails.weaveValueHolders()) {
                 // _persistence_initialize_attributeName_vh();
-                methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), "_persistence_initialize_" + attributeName + ClassWeaver.PERSISTENCE_FIELDNAME_POSTFIX, "()V", false);
+                methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+                methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, tcw.classDetails.getClassName(), "_persistence_initialize_" + attributeName + ClassWeaver.PERSISTENCE_FIELDNAME_POSTFIX, "()V", false);
 
                 // if (!_persistence_attributeName_vh.isInstantiated()) {
-                methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                methodVisitor.visitFieldInsn(Opcodes.valueInt("GETFIELD"), tcw.classDetails.getClassName(), ClassWeaver.PERSISTENCE_FIELDNAME_PREFIX + attributeName + ClassWeaver.PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
-                methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), ClassWeaver.VHI_SHORT_SIGNATURE, "isInstantiated", "()Z", true);
+                methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+                methodVisitor.visitFieldInsn(Opcodes.GETFIELD, tcw.classDetails.getClassName(), ClassWeaver.PERSISTENCE_FIELDNAME_PREFIX + attributeName + ClassWeaver.PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
+                methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, ClassWeaver.VHI_SHORT_SIGNATURE, "isInstantiated", "()Z", true);
                 Label l0 = ASMFactory.createLabel();
-                methodVisitor.visitJumpInsn(Opcodes.valueInt("IFNE"), l0);
+                methodVisitor.visitJumpInsn(Opcodes.IFNE, l0);
 
                 // Need to disable change tracking when the set method is called to avoid thinking the attribute changed.
                 if (tcw.classDetails.shouldWeaveChangeTracking()) {
                     // PropertyChangeListener temp_persistence_listener = _persistence_listener;
-                    methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                    methodVisitor.visitFieldInsn(Opcodes.valueInt("GETFIELD"), tcw.classDetails.getClassName(), "_persistence_listener", ClassWeaver.PCL_SIGNATURE);
-                    methodVisitor.visitVarInsn(Opcodes.valueInt("ASTORE"), 4);
+                    methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+                    methodVisitor.visitFieldInsn(Opcodes.GETFIELD, tcw.classDetails.getClassName(), "_persistence_listener", ClassWeaver.PCL_SIGNATURE);
+                    methodVisitor.visitVarInsn(Opcodes.ASTORE, 4);
                     // _persistence_listener = null;
-                    methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                    methodVisitor.visitInsn(Opcodes.valueInt("ACONST_NULL"));
-                    methodVisitor.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), tcw.classDetails.getClassName(), "_persistence_listener", ClassWeaver.PCL_SIGNATURE);
+                    methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+                    methodVisitor.visitInsn(Opcodes.ACONST_NULL);
+                    methodVisitor.visitFieldInsn(Opcodes.PUTFIELD, tcw.classDetails.getClassName(), "_persistence_listener", ClassWeaver.PCL_SIGNATURE);
                 }
                 // setAttributeName((AttributeType)_persistence_attributeName_vh.getValue());
-                methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                methodVisitor.visitFieldInsn(Opcodes.valueInt("GETFIELD"), tcw.classDetails.getClassName(), ClassWeaver.PERSISTENCE_FIELDNAME_PREFIX + attributeName + ClassWeaver.PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
-                methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), ClassWeaver.VHI_SHORT_SIGNATURE, "getValue", "()Ljava/lang/Object;", true);
-                methodVisitor.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), referenceClassName.replace('.','/'));
-                methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), setterMethodName, "(" + referenceClassType.getDescriptor() + ")V", false);
+                methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+                methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+                methodVisitor.visitFieldInsn(Opcodes.GETFIELD, tcw.classDetails.getClassName(), ClassWeaver.PERSISTENCE_FIELDNAME_PREFIX + attributeName + ClassWeaver.PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
+                methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, ClassWeaver.VHI_SHORT_SIGNATURE, "getValue", "()Ljava/lang/Object;", true);
+                methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, referenceClassName.replace('.','/'));
+                methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, tcw.classDetails.getClassName(), setterMethodName, "(" + referenceClassType.getDescriptor() + ")V", false);
 
                 if (tcw.classDetails.shouldWeaveChangeTracking()) {
                     // _persistence_listener = temp_persistence_listener;
-                    methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                    methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 4);
-                    methodVisitor.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), tcw.classDetails.getClassName(), "_persistence_listener", ClassWeaver.PCL_SIGNATURE);
+                    methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+                    methodVisitor.visitVarInsn(Opcodes.ALOAD, 4);
+                    methodVisitor.visitFieldInsn(Opcodes.PUTFIELD, tcw.classDetails.getClassName(), "_persistence_listener", ClassWeaver.PCL_SIGNATURE);
                 }
                 // }
                 methodVisitor.visitLabel(l0);
@@ -412,16 +412,16 @@ public class MethodWeaver extends EclipseLinkMethodVisitor {
                         // if this is a primitive, get the wrapper class
                         String wrapper = ClassWeaver.wrapperFor(referenceClassType.getSort());
 
-                        methodVisitor.visitInsn(Opcodes.valueInt("ACONST_NULL"));
+                        methodVisitor.visitInsn(Opcodes.ACONST_NULL);
                         if (wrapper != null){
-                            methodVisitor.visitVarInsn(Opcodes.valueInt("ASTORE"), valueStorageLocation + 1);
+                            methodVisitor.visitVarInsn(Opcodes.ASTORE, valueStorageLocation + 1);
                         } else {
-                            methodVisitor.visitVarInsn(Opcodes.valueInt("ASTORE"), valueStorageLocation);
+                            methodVisitor.visitVarInsn(Opcodes.ASTORE, valueStorageLocation);
                         }
-                        methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                        methodVisitor.visitFieldInsn(Opcodes.valueInt("GETFIELD"), tcw.classDetails.getClassName(), "_persistence_listener", "Ljava/beans/PropertyChangeListener;");
+                        methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+                        methodVisitor.visitFieldInsn(Opcodes.GETFIELD, tcw.classDetails.getClassName(), "_persistence_listener", "Ljava/beans/PropertyChangeListener;");
                         Label l0 = ASMFactory.createLabel();
-                        methodVisitor.visitJumpInsn(Opcodes.valueInt("IFNULL"), l0);
+                        methodVisitor.visitJumpInsn(Opcodes.IFNULL, l0);
 
                         /*
                          * The code below constructs the following code
@@ -432,65 +432,65 @@ public class MethodWeaver extends EclipseLinkMethodVisitor {
                          */
                         // 1st part of invoking constructor for primitives to wrap them
                         if (wrapper != null) {
-                            methodVisitor.visitTypeInsn(Opcodes.valueInt("NEW"), wrapper);
-                            methodVisitor.visitInsn(Opcodes.valueInt("DUP"));
+                            methodVisitor.visitTypeInsn(Opcodes.NEW, wrapper);
+                            methodVisitor.visitInsn(Opcodes.DUP);
                         }
 
                         // Call the getter
                         // getAttribute()
-                        methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                        methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
                         String getterArgument = "";
                         String getterReturn = referenceClassType.getDescriptor();
                         if (isVirtual){
                             getterArgument = ClassWeaver.STRING_SIGNATURE;
                             getterReturn = ClassWeaver.OBJECT_SIGNATURE;
-                            methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+                            methodVisitor.visitVarInsn(Opcodes.ALOAD, 1);
                         }
-                        methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), getterMethodName, "(" + getterArgument + ")" + getterReturn, false);
+                        methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, tcw.classDetails.getClassName(), getterMethodName, "(" + getterArgument + ")" + getterReturn, false);
                         if (wrapper != null){
                             // 2nd part of using constructor.
-                            methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), wrapper, "<init>", "(" + referenceClassType.getDescriptor() + ")V", false);
-                            methodVisitor.visitVarInsn(Opcodes.valueInt("ASTORE"),  valueStorageLocation + 1);
+                            methodVisitor.visitMethodInsn(Opcodes.INVOKESPECIAL, wrapper, "<init>", "(" + referenceClassType.getDescriptor() + ")V", false);
+                            methodVisitor.visitVarInsn(Opcodes.ASTORE,  valueStorageLocation + 1);
                         } else {
                             // store the result
-                            methodVisitor.visitVarInsn(Opcodes.valueInt("ASTORE"), valueStorageLocation);
+                            methodVisitor.visitVarInsn(Opcodes.ASTORE, valueStorageLocation);
                         }
 
                         Label l1 = ASMFactory.createLabel();
-                        methodVisitor.visitJumpInsn(Opcodes.valueInt("GOTO"), l1);
+                        methodVisitor.visitJumpInsn(Opcodes.GOTO, l1);
                         methodVisitor.visitLabel(l0);
-                        methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                        methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
 
                         if (isVirtual){
-                            methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+                            methodVisitor.visitVarInsn(Opcodes.ALOAD, 1);
                         } else {
                             methodVisitor.visitLdcInsn(attributeName);
                         }
-                        methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), "_persistence_checkFetchedForSet", "(Ljava/lang/String;)V", false);
+                        methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, tcw.classDetails.getClassName(), "_persistence_checkFetchedForSet", "(Ljava/lang/String;)V", false);
                         methodVisitor.visitLabel(l1);
 
-                        methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                        methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
 
                         if (isVirtual){
-                            methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+                            methodVisitor.visitVarInsn(Opcodes.ALOAD, 1);
                         } else {
                             methodVisitor.visitLdcInsn(attributeName);
                         }
 
                         if (wrapper != null) {
-                            methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), valueStorageLocation + 1);
-                            methodVisitor.visitTypeInsn(Opcodes.valueInt("NEW"), wrapper);
-                            methodVisitor.visitInsn(Opcodes.valueInt("DUP"));
+                            methodVisitor.visitVarInsn(Opcodes.ALOAD, valueStorageLocation + 1);
+                            methodVisitor.visitTypeInsn(Opcodes.NEW, wrapper);
+                            methodVisitor.visitInsn(Opcodes.DUP);
                         } else {
-                            methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), valueStorageLocation);
+                            methodVisitor.visitVarInsn(Opcodes.ALOAD, valueStorageLocation);
                         }
                         // get an appropriate load opcode for the type
-                        int opcode = referenceClassType.getOpcode(Opcodes.valueInt("ILOAD"));
+                        int opcode = referenceClassType.getOpcode(Opcodes.ILOAD);
                         methodVisitor.visitVarInsn(opcode, valueHoldingLocation);
                         if (wrapper != null){
-                            methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), wrapper, "<init>", "(" + referenceClassType.getDescriptor() + ")V", false);
+                            methodVisitor.visitMethodInsn(Opcodes.INVOKESPECIAL, wrapper, "<init>", "(" + referenceClassType.getDescriptor() + ")V", false);
                         }
-                        methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), "_persistence_propertyChange", "(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V", false);
+                        methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, tcw.classDetails.getClassName(), "_persistence_propertyChange", "(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V", false);
                     } else {
                         // tcw.classDetails.shouldWeaveFetchGroups()
                         /*
@@ -505,63 +505,62 @@ public class MethodWeaver extends EclipseLinkMethodVisitor {
 
                         // 1st part of invoking constructor for primitives to wrap them
                         if (wrapper != null) {
-                            methodVisitor.visitTypeInsn(Opcodes.valueInt("NEW"), wrapper);
-                            methodVisitor.visitInsn(Opcodes.valueInt("DUP"));
-                        }
+                            methodVisitor.visitTypeInsn(Opcodes.NEW, wrapper);
+                            methodVisitor.visitInsn(Opcodes.DUP); }
 
                         // Call the getter
                         // getAttribute()
-                        methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                        methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
                         String getterArgument = "";
                         String getterReturn = referenceClassType.getDescriptor();
                         if (isVirtual){
                             getterArgument = ClassWeaver.STRING_SIGNATURE;
                             getterReturn = ClassWeaver.OBJECT_SIGNATURE;
-                            methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+                            methodVisitor.visitVarInsn(Opcodes.ALOAD, 1);
                         }
-                        methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), getterMethodName, "(" + getterArgument + ")" + getterReturn, false);
+                        methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, tcw.classDetails.getClassName(), getterMethodName, "(" + getterArgument + ")" + getterReturn, false);
                         if (wrapper != null){
                             // 2nd part of using constructor.
-                            methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), wrapper, "<init>", "(" + attributeDetails.getReferenceClassType().getDescriptor() + ")V", false);
-                            methodVisitor.visitVarInsn(Opcodes.valueInt("ASTORE"), valueStorageLocation + 1);
+                            methodVisitor.visitMethodInsn(Opcodes.INVOKESPECIAL, wrapper, "<init>", "(" + attributeDetails.getReferenceClassType().getDescriptor() + ")V", false);
+                            methodVisitor.visitVarInsn(Opcodes.ASTORE, valueStorageLocation + 1);
                         } else {
                             // store the result
-                            methodVisitor.visitVarInsn(Opcodes.valueInt("ASTORE"), valueStorageLocation);
+                            methodVisitor.visitVarInsn(Opcodes.ASTORE, valueStorageLocation);
                         }
 
                         // makes use of the value stored in weaveBeginningOfMethodIfRequired to call property change method
                         // _persistence_propertyChange("attributeName", oldAttribute, argument);
-                        methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                        methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
                         if (isVirtual){
-                            methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+                            methodVisitor.visitVarInsn(Opcodes.ALOAD, 1);
                         } else {
                             methodVisitor.visitLdcInsn(attributeName);
                         }
                         if (wrapper != null) {
-                            methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), valueStorageLocation + 1);
-                            methodVisitor.visitTypeInsn(Opcodes.valueInt("NEW"), wrapper);
-                            methodVisitor.visitInsn(Opcodes.valueInt("DUP"));
+                            methodVisitor.visitVarInsn(Opcodes.ALOAD, valueStorageLocation + 1);
+                            methodVisitor.visitTypeInsn(Opcodes.NEW, wrapper);
+                            methodVisitor.visitInsn(Opcodes.DUP);
                         } else {
-                            methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), valueStorageLocation);
+                            methodVisitor.visitVarInsn(Opcodes.ALOAD, valueStorageLocation);
                         }
-                        int opcode = referenceClassType.getOpcode(Opcodes.valueInt("ILOAD"));
+                        int opcode = referenceClassType.getOpcode(Opcodes.ILOAD);
                         methodVisitor.visitVarInsn(opcode, valueHoldingLocation);
                         if (wrapper != null) {
-                            methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), wrapper, "<init>", "(" + referenceClassType.getDescriptor() + ")V", false);
+                            methodVisitor.visitMethodInsn(Opcodes.INVOKESPECIAL, wrapper, "<init>", "(" + referenceClassType.getDescriptor() + ")V", false);
                         }
-                        methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), "_persistence_propertyChange", "(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V", false);
+                        methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, tcw.classDetails.getClassName(), "_persistence_propertyChange", "(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V", false);
                     }
                 } else {
                     // !tcw.classDetails.shouldWeaveChangeTracking()
                     if(tcw.classDetails.shouldWeaveFetchGroups()) {
-                        methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
+                        methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
                         if (isVirtual){
-                            methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+                            methodVisitor.visitVarInsn(Opcodes.ALOAD, 1);
                         } else {
                             methodVisitor.visitLdcInsn(attributeName);
                         }
                         // _persistence_checkFetchedForSet("variableName");
-                        methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), "_persistence_checkFetchedForSet", "(Ljava/lang/String;)V", false);
+                        methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, tcw.classDetails.getClassName(), "_persistence_checkFetchedForSet", "(Ljava/lang/String;)V", false);
                     }
                 }
             }
@@ -588,20 +587,20 @@ public class MethodWeaver extends EclipseLinkMethodVisitor {
         boolean isSetMethod = (attributeDetails != null) && this.methodDescriptor.equals(attributeDetails.getSetterMethodSignature());
         if (isSetMethod  && !attributeDetails.hasField()) {
             if (attributeDetails.weaveValueHolders()) {
-                methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), tcw.classDetails.getClassName(), "_persistence_initialize_" + attributeDetails.getAttributeName() + ClassWeaver.PERSISTENCE_FIELDNAME_POSTFIX, "()V", false);
+                methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+                methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, tcw.classDetails.getClassName(), "_persistence_initialize_" + attributeDetails.getAttributeName() + ClassWeaver.PERSISTENCE_FIELDNAME_POSTFIX, "()V", false);
 
                 //_persistence_attributeName_vh.setValue(argument);
-                methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                methodVisitor.visitFieldInsn(Opcodes.valueInt("GETFIELD"), tcw.classDetails.getClassName(), ClassWeaver.PERSISTENCE_FIELDNAME_PREFIX + attributeDetails.getAttributeName() + ClassWeaver.PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
-                methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-                methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), ClassWeaver.VHI_SHORT_SIGNATURE, "setValue", "(Ljava/lang/Object;)V", true);
+                methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+                methodVisitor.visitFieldInsn(Opcodes.GETFIELD, tcw.classDetails.getClassName(), ClassWeaver.PERSISTENCE_FIELDNAME_PREFIX + attributeDetails.getAttributeName() + ClassWeaver.PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
+                methodVisitor.visitVarInsn(Opcodes.ALOAD, 1);
+                methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, ClassWeaver.VHI_SHORT_SIGNATURE, "setValue", "(Ljava/lang/Object;)V", true);
 
                 //  _persistence_attributeName_vh.setIsCoordinatedWithProperty(true);
-                methodVisitor.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-                methodVisitor.visitFieldInsn(Opcodes.valueInt("GETFIELD"), tcw.classDetails.getClassName(), ClassWeaver.PERSISTENCE_FIELDNAME_PREFIX + attributeDetails.getAttributeName() + ClassWeaver.PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
-                methodVisitor.visitInsn(Opcodes.valueInt("ICONST_1"));
-                methodVisitor.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), ClassWeaver.VHI_SHORT_SIGNATURE, "setIsCoordinatedWithProperty", "(Z)V", true);
+                methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+                methodVisitor.visitFieldInsn(Opcodes.GETFIELD, tcw.classDetails.getClassName(), ClassWeaver.PERSISTENCE_FIELDNAME_PREFIX + attributeDetails.getAttributeName() + ClassWeaver.PERSISTENCE_FIELDNAME_POSTFIX, ClassWeaver.VHI_SIGNATURE);
+                methodVisitor.visitInsn(Opcodes.ICONST_1);
+                methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, ClassWeaver.VHI_SHORT_SIGNATURE, "setIsCoordinatedWithProperty", "(Z)V", true);
             }
         }
     }

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/weaving/PersistenceWeaver.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/weaving/PersistenceWeaver.java
@@ -124,9 +124,9 @@ public class PersistenceWeaver implements ClassTransformer {
                         PrivilegedAccessHelper.getSystemProperty(SystemProperties.WEAVING_REFLECTIVE_INTROSPECTION);
                 ClassWriter classWriter = null;
                 if (reflectiveIntrospectionProperty != null) {
-                    classWriter = ASMFactory.createClassWriter(ClassWriter.valueInt("COMPUTE_FRAMES"));
+                    classWriter = ASMFactory.createClassWriter(ClassWriter.COMPUTE_FRAMES);
                 } else {
-                    classWriter = new ComputeClassWriter(loader, ClassWriter.valueInt("COMPUTE_FRAMES"));
+                    classWriter = new ComputeClassWriter(loader,ClassWriter.COMPUTE_FRAMES);
                     classWriter.setCustomClassWriterInImpl(classWriter);
                 }
                 final ClassWeaver classWeaver = new ClassWeaver(classWriter, classDetails);

--- a/jpa/org.eclipse.persistence.jpars.server/src/main/java/org/eclipse/persistence/internal/jpa/rs/weaving/CollectionProxyClassWriter.java
+++ b/jpa/org.eclipse.persistence.jpars.server/src/main/java/org/eclipse/persistence/internal/jpa/rs/weaving/CollectionProxyClassWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -106,10 +106,10 @@ public class CollectionProxyClassWriter implements EclipseLinkClassWriter {
         MethodVisitor mv;
 
         // public class Proxy extends SuperType implements CollectionProxy
-        cw.visit(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_SUPER"), getASMClassName(), null, getASMParentClassName(), new String[]{INTERFACE});
+        cw.visit(Opcodes.ACC_PUBLIC + Opcodes.ACC_SUPER, getASMClassName(), null, getASMParentClassName(), new String[]{INTERFACE});
 
         // private List<LinkV2> links;
-        final FieldVisitor fv = cw.visitField(Opcodes.valueInt("ACC_PRIVATE"), "links", "Ljava/util/List;", "Ljava/util/List<Lorg/eclipse/persistence/internal/jpa/rs/metadata/model/LinkV2;>;", null);
+        final FieldVisitor fv = cw.visitField(Opcodes.ACC_PRIVATE, "links", "Ljava/util/List;", "Ljava/util/List<Lorg/eclipse/persistence/internal/jpa/rs/metadata/model/LinkV2;>;", null);
         fv.visitEnd();
 
         // public CollectionProxy(Collection c) {
@@ -117,24 +117,24 @@ public class CollectionProxyClassWriter implements EclipseLinkClassWriter {
         //     this.addAll(c);
         // }
         {
-            mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "<init>", "(Ljava/util/Collection;)V", null, null);
+            mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "(Ljava/util/Collection;)V", null, null);
             mv.visitCode();
             Label l0 = ASMFactory.createLabel();
             mv.visitLabel(l0);
             mv.visitLineNumber(15, l0);
-            mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), getASMParentClassName(), "<init>", "()V", false);
+            mv.visitVarInsn(Opcodes.ALOAD, 0);
+            mv.visitMethodInsn(Opcodes.INVOKESPECIAL, getASMParentClassName(), "<init>", "()V", false);
             Label l1 = ASMFactory.createLabel();
             mv.visitLabel(l1);
             mv.visitLineNumber(16, l1);
-            mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-            mv.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), getASMClassName(), "addAll", "(Ljava/util/Collection;)Z", false);
-            mv.visitInsn(Opcodes.valueInt("POP"));
+            mv.visitVarInsn(Opcodes.ALOAD, 0);
+            mv.visitVarInsn(Opcodes.ALOAD, 1);
+            mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, getASMClassName(), "addAll", "(Ljava/util/Collection;)Z", false);
+            mv.visitInsn(Opcodes.POP);
             Label l2 = ASMFactory.createLabel();
             mv.visitLabel(l2);
             mv.visitLineNumber(17, l2);
-            mv.visitInsn(Opcodes.valueInt("RETURN"));
+            mv.visitInsn(Opcodes.RETURN);
             Label l3 = ASMFactory.createLabel();
             mv.visitLabel(l3);
             mv.visitLocalVariable("this", "L" + getASMClassName() + ";", null, l0, l3, 0);
@@ -148,14 +148,14 @@ public class CollectionProxyClassWriter implements EclipseLinkClassWriter {
         //    return links;
         // }
         {
-            mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "getLinks", "()Ljava/util/List;", "()Ljava/util/List<Lorg/eclipse/persistence/internal/jpa/rs/metadata/model/LinkV2;>;", null);
+            mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "getLinks", "()Ljava/util/List;", "()Ljava/util/List<Lorg/eclipse/persistence/internal/jpa/rs/metadata/model/LinkV2;>;", null);
             mv.visitCode();
             Label l0 = ASMFactory.createLabel();
             mv.visitLabel(l0);
             mv.visitLineNumber(21, l0);
-            mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            mv.visitFieldInsn(Opcodes.valueInt("GETFIELD"), getASMClassName(), "links", "Ljava/util/List;");
-            mv.visitInsn(Opcodes.valueInt("ARETURN"));
+            mv.visitVarInsn(Opcodes.ALOAD, 0);
+            mv.visitFieldInsn(Opcodes.GETFIELD, getASMClassName(), "links", "Ljava/util/List;");
+            mv.visitInsn(Opcodes.ARETURN);
             Label l1 = ASMFactory.createLabel();
             mv.visitLabel(l1);
             mv.visitLocalVariable("this", "L" + getASMClassName() + ";", null, l0, l1, 0);
@@ -168,18 +168,18 @@ public class CollectionProxyClassWriter implements EclipseLinkClassWriter {
         //    this.links = links;
         // }
         {
-            mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "setLinks", "(Ljava/util/List;)V", "(Ljava/util/List<Lorg/eclipse/persistence/internal/jpa/rs/metadata/model/LinkV2;>;)V", null);
+            mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "setLinks", "(Ljava/util/List;)V", "(Ljava/util/List<Lorg/eclipse/persistence/internal/jpa/rs/metadata/model/LinkV2;>;)V", null);
             mv.visitCode();
             Label l0 = ASMFactory.createLabel();
             mv.visitLabel(l0);
             mv.visitLineNumber(26, l0);
-            mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-            mv.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), getASMClassName(), "links", "Ljava/util/List;");
+            mv.visitVarInsn(Opcodes.ALOAD, 0);
+            mv.visitVarInsn(Opcodes.ALOAD, 1);
+            mv.visitFieldInsn(Opcodes.PUTFIELD, getASMClassName(), "links", "Ljava/util/List;");
             Label l1 = ASMFactory.createLabel();
             mv.visitLabel(l1);
             mv.visitLineNumber(27, l1);
-            mv.visitInsn(Opcodes.valueInt("RETURN"));
+            mv.visitInsn(Opcodes.RETURN);
             Label l2 = ASMFactory.createLabel();
             mv.visitLabel(l2);
             mv.visitLocalVariable("this", "L" + getASMClassName()+ ";", null, l0, l2, 0);

--- a/jpa/org.eclipse.persistence.jpars.server/src/main/java/org/eclipse/persistence/internal/jpa/rs/weaving/RestAdapterClassWriter.java
+++ b/jpa/org.eclipse.persistence.jpars.server/src/main/java/org/eclipse/persistence/internal/jpa/rs/weaving/RestAdapterClassWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -63,23 +63,23 @@ public class RestAdapterClassWriter implements EclipseLinkClassWriter {
 
         ClassWriter cw = new EclipseLinkASMClassWriter(0);
 
-        cw.visit(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_SUPER"), getASMClassName(), "L" + REFERENCE_ADAPTER_SHORT_SIGNATURE + "<L" + getASMParentClassName() + ";>;", REFERENCE_ADAPTER_SHORT_SIGNATURE, null);
+        cw.visit(Opcodes.ACC_PUBLIC + Opcodes.ACC_SUPER, getASMClassName(), "L" + REFERENCE_ADAPTER_SHORT_SIGNATURE + "<L" + getASMParentClassName() + ";>;", REFERENCE_ADAPTER_SHORT_SIGNATURE, null);
 
-        MethodVisitor mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "<init>", "()V", null, null);
+        MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "()V", null, null);
         mv.visitCode();
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), REFERENCE_ADAPTER_SHORT_SIGNATURE, "<init>", "()V", false);
-        mv.visitInsn(Opcodes.valueInt("RETURN"));
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, REFERENCE_ADAPTER_SHORT_SIGNATURE, "<init>", "()V", false);
+        mv.visitInsn(Opcodes.RETURN);
         mv.visitMaxs(1, 1);
         mv.visitEnd();
 
-        mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "<init>", "(Ljava/lang/String;Lorg/eclipse/persistence/jpa/rs/PersistenceContext;)V", null, null);
+        mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "(Ljava/lang/String;Lorg/eclipse/persistence/jpa/rs/PersistenceContext;)V", null, null);
         mv.visitCode();
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 2);
-        mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), REFERENCE_ADAPTER_SHORT_SIGNATURE, "<init>", "(Ljava/lang/String;Lorg/eclipse/persistence/jpa/rs/PersistenceContext;)V", false);
-        mv.visitInsn(Opcodes.valueInt("RETURN"));
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitVarInsn(Opcodes.ALOAD, 1);
+        mv.visitVarInsn(Opcodes.ALOAD, 2);
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, REFERENCE_ADAPTER_SHORT_SIGNATURE, "<init>", "(Ljava/lang/String;Lorg/eclipse/persistence/jpa/rs/PersistenceContext;)V", false);
+        mv.visitInsn(Opcodes.RETURN);
         mv.visitMaxs(3, 3);
         mv.visitEnd();
 

--- a/jpa/org.eclipse.persistence.jpars.server/src/main/java/org/eclipse/persistence/internal/jpa/rs/weaving/RestCollectionAdapterClassWriter.java
+++ b/jpa/org.eclipse.persistence.jpars.server/src/main/java/org/eclipse/persistence/internal/jpa/rs/weaving/RestCollectionAdapterClassWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -84,24 +84,24 @@ public class RestCollectionAdapterClassWriter implements EclipseLinkClassWriter 
 
         // Class signature
         final ClassWriter cw = new EclipseLinkASMClassWriter(0);
-        cw.visit(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_SUPER"), getASMClassName(), "L" + REFERENCE_ADAPTER_SHORT_SIGNATURE + "<L" + getASMParentClassName() + ";>;", REFERENCE_ADAPTER_SHORT_SIGNATURE, null);
+        cw.visit(Opcodes.ACC_PUBLIC + Opcodes.ACC_SUPER, getASMClassName(), "L" + REFERENCE_ADAPTER_SHORT_SIGNATURE + "<L" + getASMParentClassName() + ";>;", REFERENCE_ADAPTER_SHORT_SIGNATURE, null);
 
         // Default constructor
-        MethodVisitor mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "<init>", "()V", null, null);
+        MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "()V", null, null);
         mv.visitCode();
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), REFERENCE_ADAPTER_SHORT_SIGNATURE, "<init>", "()V", false);
-        mv.visitInsn(Opcodes.valueInt("RETURN"));
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, REFERENCE_ADAPTER_SHORT_SIGNATURE, "<init>", "()V", false);
+        mv.visitInsn(Opcodes.RETURN);
         mv.visitMaxs(1, 1);
         mv.visitEnd();
 
         // Another constructor
-        mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "<init>", "(Lorg/eclipse/persistence/jpa/rs/PersistenceContext;)V", null, null);
+        mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "(Lorg/eclipse/persistence/jpa/rs/PersistenceContext;)V", null, null);
         mv.visitCode();
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), REFERENCE_ADAPTER_SHORT_SIGNATURE, "<init>", "(Lorg/eclipse/persistence/jpa/rs/PersistenceContext;)V", false);
-        mv.visitInsn(Opcodes.valueInt("RETURN"));
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitVarInsn(Opcodes.ALOAD, 1);
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, REFERENCE_ADAPTER_SHORT_SIGNATURE, "<init>", "(Lorg/eclipse/persistence/jpa/rs/PersistenceContext;)V", false);
+        mv.visitInsn(Opcodes.RETURN);
         mv.visitMaxs(2, 2);
         mv.visitEnd();
 

--- a/jpa/org.eclipse.persistence.jpars.server/src/main/java/org/eclipse/persistence/internal/jpa/rs/weaving/RestDynamicClassWriter.java
+++ b/jpa/org.eclipse.persistence.jpars.server/src/main/java/org/eclipse/persistence/internal/jpa/rs/weaving/RestDynamicClassWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -43,13 +43,13 @@ public class RestDynamicClassWriter extends MetadataDynamicClassWriter {
     protected void addFields(ClassWriter cw, String parentClassType) {
         super.addFields(cw, parentClassType);
         // protected transient List<RelationshipInfo> _persistence_relationshipInfo;
-        FieldVisitor fv = cw.visitField(Opcodes.valueInt("ACC_PROTECTED") | Opcodes.valueInt("ACC_TRANSIENT"), PERSISTENCE_FIELDNAME_PREFIX + "relationshipInfo", LIST_RELATIONSHIP_INFO_SIGNATURE, LIST_RELATIONSHIP_INFO_GENERIC_SIGNATURE, null);
+        FieldVisitor fv = cw.visitField(Opcodes.ACC_PROTECTED | Opcodes.ACC_TRANSIENT, PERSISTENCE_FIELDNAME_PREFIX + "relationshipInfo", LIST_RELATIONSHIP_INFO_SIGNATURE, LIST_RELATIONSHIP_INFO_GENERIC_SIGNATURE, null);
         fv.visitEnd();
         // protected transient Link _persistence_href;
-        fv = cw.visitField(Opcodes.valueInt("ACC_PROTECTED") | Opcodes.valueInt("ACC_TRANSIENT"), PERSISTENCE_FIELDNAME_PREFIX + "href", LINK_SIGNATURE, null, null);
+        fv = cw.visitField(Opcodes.ACC_PROTECTED | Opcodes.ACC_TRANSIENT, PERSISTENCE_FIELDNAME_PREFIX + "href", LINK_SIGNATURE, null, null);
         fv.visitEnd();
         // protected transient ItemLinks _persistence_links;
-        fv = cw.visitField(Opcodes.valueInt("ACC_PROTECTED") | Opcodes.valueInt("ACC_TRANSIENT"), PERSISTENCE_FIELDNAME_PREFIX + "links", ITEM_LINKS_SIGNATURE, null, null);
+        fv = cw.visitField(Opcodes.ACC_PROTECTED | Opcodes.ACC_TRANSIENT, PERSISTENCE_FIELDNAME_PREFIX + "links", ITEM_LINKS_SIGNATURE, null, null);
         fv.visitEnd();
     }
 
@@ -61,63 +61,63 @@ public class RestDynamicClassWriter extends MetadataDynamicClassWriter {
         // public List<RelationshipInfo> _persistence_getRelationships() {
         //   return this._persistence_relationshipInfo;
         // }
-        MethodVisitor mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_FIELDNAME_PREFIX + "getRelationships", "()" + LIST_RELATIONSHIP_INFO_SIGNATURE, "()" + LIST_RELATIONSHIP_INFO_GENERIC_SIGNATURE, null);
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitFieldInsn(Opcodes.valueInt("GETFIELD"), clsName, PERSISTENCE_FIELDNAME_PREFIX + "relationshipInfo", LIST_RELATIONSHIP_INFO_SIGNATURE);
-        mv.visitInsn(Opcodes.valueInt("ARETURN"));
+        MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, PERSISTENCE_FIELDNAME_PREFIX + "getRelationships", "()" + LIST_RELATIONSHIP_INFO_SIGNATURE, "()" + LIST_RELATIONSHIP_INFO_GENERIC_SIGNATURE, null);
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitFieldInsn(Opcodes.GETFIELD, clsName, PERSISTENCE_FIELDNAME_PREFIX + "relationshipInfo", LIST_RELATIONSHIP_INFO_SIGNATURE);
+        mv.visitInsn(Opcodes.ARETURN);
         mv.visitMaxs(1, 1);
         mv.visitEnd();
 
         // public void _persistence_setRelationships(List<RelationshipInfo> paramList) {
         //   this._persistence_relationshipInfo = paramList;
         // }
-        mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_FIELDNAME_PREFIX + "setRelationships", "(" + LIST_RELATIONSHIP_INFO_SIGNATURE + ")V", "(" + LIST_RELATIONSHIP_INFO_GENERIC_SIGNATURE + ")V", null);
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        mv.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), clsName, PERSISTENCE_FIELDNAME_PREFIX + "relationshipInfo", LIST_RELATIONSHIP_INFO_SIGNATURE);
-        mv.visitInsn(Opcodes.valueInt("RETURN"));
+        mv = cw.visitMethod(Opcodes.ACC_PUBLIC, PERSISTENCE_FIELDNAME_PREFIX + "setRelationships", "(" + LIST_RELATIONSHIP_INFO_SIGNATURE + ")V", "(" + LIST_RELATIONSHIP_INFO_GENERIC_SIGNATURE + ")V", null);
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitVarInsn(Opcodes.ALOAD, 1);
+        mv.visitFieldInsn(Opcodes.PUTFIELD, clsName, PERSISTENCE_FIELDNAME_PREFIX + "relationshipInfo", LIST_RELATIONSHIP_INFO_SIGNATURE);
+        mv.visitInsn(Opcodes.RETURN);
         mv.visitMaxs(2, 2);
         mv.visitEnd();
 
         // public Link _persistence_getHref() {
         //   return this._persistence_href;
         // }
-        mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_FIELDNAME_PREFIX + "getHref", "()" + LINK_SIGNATURE, null, null);
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitFieldInsn(Opcodes.valueInt("GETFIELD"), clsName, PERSISTENCE_FIELDNAME_PREFIX + "href", LINK_SIGNATURE);
-        mv.visitInsn(Opcodes.valueInt("ARETURN"));
+        mv = cw.visitMethod(Opcodes.ACC_PUBLIC, PERSISTENCE_FIELDNAME_PREFIX + "getHref", "()" + LINK_SIGNATURE, null, null);
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitFieldInsn(Opcodes.GETFIELD, clsName, PERSISTENCE_FIELDNAME_PREFIX + "href", LINK_SIGNATURE);
+        mv.visitInsn(Opcodes.ARETURN);
         mv.visitMaxs(1, 1);
         mv.visitEnd();
 
         // public void _persistence_setHref(Link paramLink)
         //   this._persistence_href = paramLink;
         // }
-        mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_FIELDNAME_PREFIX + "setHref", "(" + LINK_SIGNATURE + ")V", null, null);
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        mv.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), clsName, PERSISTENCE_FIELDNAME_PREFIX + "href", LINK_SIGNATURE);
-        mv.visitInsn(Opcodes.valueInt("RETURN"));
+        mv = cw.visitMethod(Opcodes.ACC_PUBLIC, PERSISTENCE_FIELDNAME_PREFIX + "setHref", "(" + LINK_SIGNATURE + ")V", null, null);
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitVarInsn(Opcodes.ALOAD, 1);
+        mv.visitFieldInsn(Opcodes.PUTFIELD, clsName, PERSISTENCE_FIELDNAME_PREFIX + "href", LINK_SIGNATURE);
+        mv.visitInsn(Opcodes.RETURN);
         mv.visitMaxs(2, 2);
         mv.visitEnd();
 
         // public ItemLinks _persistence_getLinks() {
         //   return this._persistence_links;
         // }
-        mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_FIELDNAME_PREFIX + "getLinks", "()" + ITEM_LINKS_SIGNATURE, null, null);
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitFieldInsn(Opcodes.valueInt("GETFIELD"), clsName, PERSISTENCE_FIELDNAME_PREFIX + "links", ITEM_LINKS_SIGNATURE);
-        mv.visitInsn(Opcodes.valueInt("ARETURN"));
+        mv = cw.visitMethod(Opcodes.ACC_PUBLIC, PERSISTENCE_FIELDNAME_PREFIX + "getLinks", "()" + ITEM_LINKS_SIGNATURE, null, null);
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitFieldInsn(Opcodes.GETFIELD, clsName, PERSISTENCE_FIELDNAME_PREFIX + "links", ITEM_LINKS_SIGNATURE);
+        mv.visitInsn(Opcodes.ARETURN);
         mv.visitMaxs(1, 1);
         mv.visitEnd();
 
         // public void _persistence_setLinks(ItemLinks paramItemLinks) {
         //   this._persistence_links = paramItemLinks;
         // }
-        mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), PERSISTENCE_FIELDNAME_PREFIX + "setLinks", "(" + ITEM_LINKS_SIGNATURE + ")V", null, null);
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        mv.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), clsName, PERSISTENCE_FIELDNAME_PREFIX + "links", ITEM_LINKS_SIGNATURE);
-        mv.visitInsn(Opcodes.valueInt("RETURN"));
+        mv = cw.visitMethod(Opcodes.ACC_PUBLIC, PERSISTENCE_FIELDNAME_PREFIX + "setLinks", "(" + ITEM_LINKS_SIGNATURE + ")V", null, null);
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitVarInsn(Opcodes.ALOAD, 1);
+        mv.visitFieldInsn(Opcodes.PUTFIELD, clsName, PERSISTENCE_FIELDNAME_PREFIX + "links", ITEM_LINKS_SIGNATURE);
+        mv.visitInsn(Opcodes.RETURN);
         mv.visitMaxs(2, 2);
         mv.visitEnd();
     }

--- a/jpa/org.eclipse.persistence.jpars.server/src/main/java/org/eclipse/persistence/internal/jpa/rs/weaving/RestReferenceAdapterV2ClassWriter.java
+++ b/jpa/org.eclipse.persistence.jpars.server/src/main/java/org/eclipse/persistence/internal/jpa/rs/weaving/RestReferenceAdapterV2ClassWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -82,24 +82,24 @@ public class RestReferenceAdapterV2ClassWriter implements EclipseLinkClassWriter
             throws ClassNotFoundException {
 
         final ClassWriter cw = new EclipseLinkASMClassWriter(0);
-        cw.visit(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_SUPER"), getASMClassName(), "L" + REFERENCE_ADAPTER_SHORT_SIGNATURE + "<L" + getASMParentClassName() + ";>;", REFERENCE_ADAPTER_SHORT_SIGNATURE, null);
+        cw.visit(Opcodes.ACC_PUBLIC+ Opcodes.ACC_SUPER, getASMClassName(), "L" + REFERENCE_ADAPTER_SHORT_SIGNATURE + "<L" + getASMParentClassName() + ";>;", REFERENCE_ADAPTER_SHORT_SIGNATURE, null);
 
         // Default constructor
-        MethodVisitor mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "<init>", "()V", null, null);
+        MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "()V", null, null);
         mv.visitCode();
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), REFERENCE_ADAPTER_SHORT_SIGNATURE, "<init>", "()V", false);
-        mv.visitInsn(Opcodes.valueInt("RETURN"));
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, REFERENCE_ADAPTER_SHORT_SIGNATURE, "<init>", "()V", false);
+        mv.visitInsn(Opcodes.RETURN);
         mv.visitMaxs(1, 1);
         mv.visitEnd();
 
         // Another constructor
-        mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "<init>", "(Lorg/eclipse/persistence/jpa/rs/PersistenceContext;)V", null, null);
+        mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "(Lorg/eclipse/persistence/jpa/rs/PersistenceContext;)V", null, null);
         mv.visitCode();
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), REFERENCE_ADAPTER_SHORT_SIGNATURE, "<init>", "(Lorg/eclipse/persistence/jpa/rs/PersistenceContext;)V", false);
-        mv.visitInsn(Opcodes.valueInt("RETURN"));
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitVarInsn(Opcodes.ALOAD, 1);
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, REFERENCE_ADAPTER_SHORT_SIGNATURE, "<init>", "(Lorg/eclipse/persistence/jpa/rs/PersistenceContext;)V", false);
+        mv.visitInsn(Opcodes.RETURN);
         mv.visitMaxs(2, 2);
         mv.visitEnd();
 

--- a/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/compiler/AnnotationsProcessor.java
+++ b/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/compiler/AnnotationsProcessor.java
@@ -4212,11 +4212,11 @@ public final class AnnotationsProcessor {
         ClassWriter cw = new EclipseLinkASMClassWriter();
 
         String sig = "Lorg/eclipse/persistence/internal/jaxb/many/MapValue<L" + mapType.getInternalName() + "<L" + internalKeyName + ";L" + internalValueName + ";>;>;";
-        cw.visit(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_SUPER"), qualifiedInternalClassName, sig, "org/eclipse/persistence/internal/jaxb/many/MapValue", null);
+        cw.visit(Opcodes.ACC_PUBLIC + Opcodes.ACC_SUPER, qualifiedInternalClassName, sig, "org/eclipse/persistence/internal/jaxb/many/MapValue", null);
 
         // Write Field: @... public Map entry
         String fieldSig = L + mapType.getInternalName() + "<L" + internalKeyName + ";L" + internalValueName + ";>;";
-        FieldVisitor fv = cw.visitField(Opcodes.valueInt("ACC_PUBLIC"), "entry", L + mapType.getInternalName() + SEMI_COLON, fieldSig, null);
+        FieldVisitor fv = cw.visitField(Opcodes.ACC_PUBLIC, "entry", L + mapType.getInternalName() + SEMI_COLON, fieldSig, null);
         fv.visitAnnotation(Type.getDescriptor(XmlElement.class), true);
         if (typeMappingInfo != null) {
             Annotation[] annotations = typeMappingInfo.getAnnotations();
@@ -4246,25 +4246,25 @@ public final class AnnotationsProcessor {
         }
         fv.visitEnd();
 
-        MethodVisitor mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "<init>", "()V", null, null);
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), "org/eclipse/persistence/internal/jaxb/many/MapValue", "<init>", "()V", false);
-        mv.visitInsn(Opcodes.valueInt("RETURN"));
+        MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "()V", null, null);
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, "org/eclipse/persistence/internal/jaxb/many/MapValue", "<init>", "()V", false);
+        mv.visitInsn(Opcodes.RETURN);
         mv.visitMaxs(1, 1);
         mv.visitEnd();
 
         // Write: @XmlTransient public void setItem(???)
         String methodSig = "(L" + mapType.getInternalName() + "<L" + internalKeyName + ";L" + internalValueName + ";>;)V";
-        mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "setItem", "(L" + mapType.getInternalName() + ";)V", methodSig, null);
+        mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "setItem", "(L" + mapType.getInternalName() + ";)V", methodSig, null);
         // TODO: Verify that we really want to put @XmlTranient on setItem
         // method
         mv.visitAnnotation("Ljakarta/xml/bind/annotation/XmlTransient;", true);
         Label l0 = ASMFactory.createLabel();
         mv.visitLabel(l0);
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        mv.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), qualifiedInternalClassName, "entry", L + mapType.getInternalName() + SEMI_COLON);
-        mv.visitInsn(Opcodes.valueInt("RETURN"));
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitVarInsn(Opcodes.ALOAD, 1);
+        mv.visitFieldInsn(Opcodes.PUTFIELD, qualifiedInternalClassName, "entry", L + mapType.getInternalName() + SEMI_COLON);
+        mv.visitInsn(Opcodes.RETURN);
         Label l1 = ASMFactory.createLabel();
         mv.visitLabel(l1);
 
@@ -4277,27 +4277,27 @@ public final class AnnotationsProcessor {
 
         // Write @XmlTransient public ??? getItem()
         methodSig = "()L" + mapType.getInternalName() + "<L" + internalKeyName + ";L" + internalValueName + ";>;";
-        mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "getItem", "()L" + mapType.getInternalName() + SEMI_COLON, methodSig, null);
+        mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "getItem", "()L" + mapType.getInternalName() + SEMI_COLON, methodSig, null);
         mv.visitAnnotation("Ljakarta/xml/bind/annotation/XmlTransient;", true);
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitFieldInsn(Opcodes.valueInt("GETFIELD"), qualifiedInternalClassName, "entry", L + mapType.getInternalName() + SEMI_COLON);
-        mv.visitInsn(Opcodes.valueInt("ARETURN"));
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitFieldInsn(Opcodes.GETFIELD, qualifiedInternalClassName, "entry", L + mapType.getInternalName() + SEMI_COLON);
+        mv.visitInsn(Opcodes.ARETURN);
         mv.visitMaxs(1, 1);
         mv.visitEnd();
 
-        mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_BRIDGE") + Opcodes.valueInt("ACC_SYNTHETIC"), "getItem", "()Ljava/lang/Object;", null, null);
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), qualifiedInternalClassName, "getItem", "()L" + mapType.getInternalName() + SEMI_COLON, false);
-        mv.visitInsn(Opcodes.valueInt("ARETURN"));
+        mv = cw.visitMethod(Opcodes.ACC_PUBLIC + Opcodes.ACC_BRIDGE + Opcodes.ACC_SYNTHETIC, "getItem", "()Ljava/lang/Object;", null, null);
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, qualifiedInternalClassName, "getItem", "()L" + mapType.getInternalName() + SEMI_COLON, false);
+        mv.visitInsn(Opcodes.ARETURN);
         mv.visitMaxs(1, 1);
         mv.visitEnd();
 
-        mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_BRIDGE") + Opcodes.valueInt("ACC_SYNTHETIC"), "setItem", "(Ljava/lang/Object;)V", null, null);
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        mv.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), mapType.getInternalName());
-        mv.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), qualifiedInternalClassName, "setItem", "(L" + mapType.getInternalName() + ";)V", false);
-        mv.visitInsn(Opcodes.valueInt("RETURN"));
+        mv = cw.visitMethod(Opcodes.ACC_PUBLIC + Opcodes.ACC_BRIDGE + Opcodes.ACC_SYNTHETIC, "setItem", "(Ljava/lang/Object;)V", null, null);
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitVarInsn(Opcodes.ALOAD, 1);
+        mv.visitTypeInsn(Opcodes.CHECKCAST, mapType.getInternalName());
+        mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, qualifiedInternalClassName, "setItem", "(L" + mapType.getInternalName() + ";)V", false);
+        mv.visitInsn(Opcodes.RETURN);
         mv.visitMaxs(2, 2);
         mv.visitEnd();
 
@@ -4523,9 +4523,9 @@ public final class AnnotationsProcessor {
         String componentClassNameSeparatedBySlash = getObjectType(componentType).getQualifiedName().replace(DOT_CHR, SLASH_CHR);
         String containerClassNameSeperatedBySlash = containerType.getQualifiedName().replace(DOT_CHR, SLASH_CHR);
         if("[B".equals(componentClassNameSeparatedBySlash)) {
-            cw.visit(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_SUPER"), classNameSeparatedBySlash, "L" + Type.getInternalName(superType) + "<" + componentClassNameSeparatedBySlash + ">;", Type.getInternalName(superType), null);
+            cw.visit(Opcodes.ACC_PUBLIC + Opcodes.ACC_SUPER, classNameSeparatedBySlash, "L" + Type.getInternalName(superType) + "<" + componentClassNameSeparatedBySlash + ">;", Type.getInternalName(superType), null);
         } else {
-            cw.visit(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_SUPER"), classNameSeparatedBySlash, "L" + Type.getInternalName(superType) + "<L" + componentClassNameSeparatedBySlash + ";>;", Type.getInternalName(superType), null);
+            cw.visit(Opcodes.ACC_PUBLIC + Opcodes.ACC_SUPER, classNameSeparatedBySlash, "L" + Type.getInternalName(superType) + "<L" + componentClassNameSeparatedBySlash + ";>;", Type.getInternalName(superType), null);
         }
 
         // Write @XmlType(namespace)
@@ -4539,11 +4539,11 @@ public final class AnnotationsProcessor {
         av.visitEnd();
 
         // Public No-Arg Constructor
-        MethodVisitor mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "<init>", "()V", null, null);
+        MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "()V", null, null);
         mv.visitCode();
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), Type.getInternalName(superType), "<init>", "()V", false);
-        mv.visitInsn(Opcodes.valueInt("RETURN"));
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, Type.getInternalName(superType), "<init>", "()V", false);
+        mv.visitInsn(Opcodes.RETURN);
         mv.visitMaxs(1, 1);
         mv.visitEnd();
 
@@ -4559,31 +4559,31 @@ public final class AnnotationsProcessor {
             //    adaptedValue.toArray(array);
             //    return array;
             // }
-            mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "getItem", "()Ljava/lang/Object;", null, null);
+            mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "getItem", "()Ljava/lang/Object;", null, null);
             mv.visitCode();
-            mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            mv.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classNameSeparatedBySlash, "adaptedValue", "Ljava/util/Collection;");
+            mv.visitVarInsn(Opcodes.ALOAD, 0);
+            mv.visitFieldInsn(Opcodes.GETFIELD, classNameSeparatedBySlash, "adaptedValue", "Ljava/util/Collection;");
             Label l0 = ASMFactory.createLabel();;
-            mv.visitJumpInsn(Opcodes.valueInt("IFNONNULL"), l0);
-            mv.visitInsn(Opcodes.valueInt("ACONST_NULL"));
-            mv.visitInsn(Opcodes.valueInt("ARETURN"));
+            mv.visitJumpInsn(Opcodes.IFNONNULL, l0);
+            mv.visitInsn(Opcodes.ACONST_NULL);
+            mv.visitInsn(Opcodes.ARETURN);
             mv.visitLabel(l0);
-            mv.visitFrame(Opcodes.valueInt("F_SAME"), 0, null, 0, null);
-            mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            mv.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classNameSeparatedBySlash, "adaptedValue", "Ljava/util/Collection;");
-            mv.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), "java/util/Collection", "size", "()I", true);
-            mv.visitVarInsn(Opcodes.valueInt("ISTORE"), 1);
-            mv.visitVarInsn(Opcodes.valueInt("ILOAD"), 1);
-            mv.visitTypeInsn(Opcodes.valueInt("ANEWARRAY"), componentClassNameSeparatedBySlash);
-            mv.visitVarInsn(Opcodes.valueInt("ASTORE"), 2);
-            mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            mv.visitFieldInsn(Opcodes.valueInt("GETFIELD"), classNameSeparatedBySlash, "adaptedValue", "Ljava/util/Collection;");
-            mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 2);
-            mv.visitMethodInsn(Opcodes.valueInt("INVOKEINTERFACE"), "java/util/Collection", "toArray", "([Ljava/lang/Object;)[Ljava/lang/Object;", true);
-            mv.visitInsn(Opcodes.valueInt("POP"));
+            mv.visitFrame(Opcodes.F_SAME, 0, null, 0, null);
+            mv.visitVarInsn(Opcodes.ALOAD, 0);
+            mv.visitFieldInsn(Opcodes.GETFIELD, classNameSeparatedBySlash, "adaptedValue", "Ljava/util/Collection;");
+            mv.visitMethodInsn(Opcodes.INVOKEINTERFACE, "java/util/Collection", "size", "()I", true);
+            mv.visitVarInsn(Opcodes.ISTORE, 1);
+            mv.visitVarInsn(Opcodes.ILOAD, 1);
+            mv.visitTypeInsn(Opcodes.ANEWARRAY, componentClassNameSeparatedBySlash);
+            mv.visitVarInsn(Opcodes.ASTORE, 2);
+            mv.visitVarInsn(Opcodes.ALOAD, 0);
+            mv.visitFieldInsn(Opcodes.GETFIELD, classNameSeparatedBySlash, "adaptedValue", "Ljava/util/Collection;");
+            mv.visitVarInsn(Opcodes.ALOAD, 2);
+            mv.visitMethodInsn(Opcodes.INVOKEINTERFACE, "java/util/Collection", "toArray", "([Ljava/lang/Object;)[Ljava/lang/Object;", true);
+            mv.visitInsn(Opcodes.POP);
 
-            mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 2);
-            mv.visitInsn(Opcodes.valueInt("ARETURN"));
+            mv.visitVarInsn(Opcodes.ALOAD, 2);
+            mv.visitInsn(Opcodes.ARETURN);
             mv.visitMaxs(2, 3);
             mv.visitEnd();
 
@@ -4593,16 +4593,16 @@ public final class AnnotationsProcessor {
             //    Float[] floatArray = (Float[])array;
             //    adaptedValue =   (Collection<T>) Arrays.asList(floatArray);
             //}
-            mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "setItem", "(Ljava/lang/Object;)V", null, null);
+            mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "setItem", "(Ljava/lang/Object;)V", null, null);
             mv.visitCode();
-            mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-            mv.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), "[L"+componentClassNameSeparatedBySlash+";");
-            mv.visitVarInsn(Opcodes.valueInt("ASTORE"), 2);
-            mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 2);
-            mv.visitMethodInsn(Opcodes.valueInt("INVOKESTATIC"), "java/util/Arrays", "asList", "([Ljava/lang/Object;)Ljava/util/List;", false);
-            mv.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), classNameSeparatedBySlash, "adaptedValue", "Ljava/util/Collection;");
-            mv.visitInsn(Opcodes.valueInt("RETURN"));
+            mv.visitVarInsn(Opcodes.ALOAD, 1);
+            mv.visitTypeInsn(Opcodes.CHECKCAST, "[L"+componentClassNameSeparatedBySlash+";");
+            mv.visitVarInsn(Opcodes.ASTORE, 2);
+            mv.visitVarInsn(Opcodes.ALOAD, 0);
+            mv.visitVarInsn(Opcodes.ALOAD, 2);
+            mv.visitMethodInsn(Opcodes.INVOKESTATIC, "java/util/Arrays", "asList", "([Ljava/lang/Object;)Ljava/util/List;", false);
+            mv.visitFieldInsn(Opcodes.PUTFIELD, classNameSeparatedBySlash, "adaptedValue", "Ljava/util/Collection;");
+            mv.visitInsn(Opcodes.RETURN);
             mv.visitMaxs(2, 3);
             mv.visitEnd();
         }
@@ -4618,9 +4618,9 @@ public final class AnnotationsProcessor {
         //    return super.getAdaptedValue();
         // }
         if("[B".equals(componentClassNameSeparatedBySlash)) {
-            mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "getAdaptedValue", "()Ljava/util/Collection;", "()Ljava/util/Collection<" + componentClassNameSeparatedBySlash + ">;", null);
+            mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "getAdaptedValue", "()Ljava/util/Collection;", "()Ljava/util/Collection<" + componentClassNameSeparatedBySlash + ">;", null);
         } else {
-            mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "getAdaptedValue", "()Ljava/util/Collection;", "()Ljava/util/Collection<L" + componentClassNameSeparatedBySlash + ";>;", null);
+            mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "getAdaptedValue", "()Ljava/util/Collection;", "()Ljava/util/Collection<L" + componentClassNameSeparatedBySlash + ";>;", null);
         }
         // Copy annotations
         boolean hasXmlList = false;
@@ -4662,31 +4662,31 @@ public final class AnnotationsProcessor {
         }
 
         mv.visitCode();
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), Type.getInternalName(superType), "getAdaptedValue", "()Ljava/util/Collection;", false);
-        mv.visitInsn(Opcodes.valueInt("ARETURN"));
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, Type.getInternalName(superType), "getAdaptedValue", "()Ljava/util/Collection;", false);
+        mv.visitInsn(Opcodes.ARETURN);
         mv.visitMaxs(1, 1);
         mv.visitEnd();
 
         // public void setAdaptedValue(Collection<COMPONENT_TYPE> adaptedValue) {
         //     super.setAdaptedValue(adaptedValue);
         // }
-        mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "setAdaptedValue", "(Ljava/util/Collection;)V", "(Ljava/util/Collection<L" + componentClassNameSeparatedBySlash + ";>;)V", null);
+        mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "setAdaptedValue", "(Ljava/util/Collection;)V", "(Ljava/util/Collection<L" + componentClassNameSeparatedBySlash + ";>;)V", null);
         mv.visitCode();
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), Type.getInternalName(superType), "setAdaptedValue", "(Ljava/util/Collection;)V", false);
-        mv.visitInsn(Opcodes.valueInt("RETURN"));
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitVarInsn(Opcodes.ALOAD, 1);
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, Type.getInternalName(superType), "setAdaptedValue", "(Ljava/util/Collection;)V", false);
+        mv.visitInsn(Opcodes.RETURN);
         mv.visitMaxs(2, 2);
         mv.visitEnd();
 
         // public Class<?> containerClass() {
         //     return CONTAINER_TYPE.class;
         // }
-        mv = cw.visitMethod(Opcodes.valueInt("ACC_PROTECTED"), "containerClass", "()Ljava/lang/Class;", "()Ljava/lang/Class<*>;", null);
+        mv = cw.visitMethod(Opcodes.ACC_PROTECTED, "containerClass", "()Ljava/lang/Class;", "()Ljava/lang/Class<*>;", null);
         mv.visitCode();
         if(componentType.isPrimitive()) {
-            mv.visitFieldInsn(Opcodes.valueInt("GETSTATIC"), getObjectType(componentType).getQualifiedName().replace(DOT_CHR, SLASH_CHR), "TYPE", "Ljava/lang/Class;");
+            mv.visitFieldInsn(Opcodes.GETSTATIC, getObjectType(componentType).getQualifiedName().replace(DOT_CHR, SLASH_CHR), "TYPE", "Ljava/lang/Class;");
         } else {
             if(containerClassNameSeperatedBySlash.contains(";")) {
                 mv.visitLdcInsn(Type.getType(containerClassNameSeperatedBySlash).unwrap());
@@ -4694,7 +4694,7 @@ public final class AnnotationsProcessor {
                 mv.visitLdcInsn(Type.getType("L" + containerClassNameSeperatedBySlash + ";").unwrap());
             }
         }
-        mv.visitInsn(Opcodes.valueInt("ARETURN"));
+        mv.visitInsn(Opcodes.ARETURN);
         mv.visitMaxs(1, 1);
         mv.visitEnd();
     }
@@ -4712,10 +4712,10 @@ public final class AnnotationsProcessor {
         //    return COMPONENT_TYPE.class;
         // }
         String componentClassNameSeparatedBySlash = componentType.getQualifiedName().replace(DOT_CHR, SLASH_CHR);
-        MethodVisitor mv = cw.visitMethod(Opcodes.valueInt("ACC_PROTECTED"), "componentClass", "()Ljava/lang/Class;", "()Ljava/lang/Class<L" + componentClassNameSeparatedBySlash + ";>;", null);
+        MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PROTECTED, "componentClass", "()Ljava/lang/Class;", "()Ljava/lang/Class<L" + componentClassNameSeparatedBySlash + ";>;", null);
         mv.visitCode();
         mv.visitLdcInsn(Type.getType("L" + componentClassNameSeparatedBySlash + ";").unwrap());
-        mv.visitInsn(Opcodes.valueInt("ARETURN"));
+        mv.visitInsn(Opcodes.ARETURN);
         mv.visitMaxs(1, 1);
         mv.visitEnd();
     }

--- a/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/compiler/MappingsGenerator.java
+++ b/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/compiler/MappingsGenerator.java
@@ -1982,86 +1982,86 @@ public class MappingsGenerator {
         }
 
         String sig = "Ljava/lang/Object;Lorg/eclipse/persistence/internal/jaxb/many/MapEntry<L"+qualifiedInternalKeyClassName+";" + valuePrefix + qualifiedInternalValueClassName+";>;";
-        cw.visit(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_SUPER"), qualifiedInternalClassName, sig, "java/lang/Object", new String[] { "org/eclipse/persistence/internal/jaxb/many/MapEntry" });
+        cw.visit(Opcodes.ACC_PUBLIC + Opcodes.ACC_SUPER, qualifiedInternalClassName, sig, "java/lang/Object", new String[] { "org/eclipse/persistence/internal/jaxb/many/MapEntry" });
 
-        cw.visitField(Opcodes.valueInt("ACC_PRIVATE"), "key", "L"+qualifiedInternalKeyClassName+";", null, null);
+        cw.visitField(Opcodes.ACC_PRIVATE, "key", "L"+qualifiedInternalKeyClassName+";", null, null);
 
-        cw.visitField(Opcodes.valueInt("ACC_PRIVATE"), "value", valuePrefix + qualifiedInternalValueClassName+";", null, null);
+        cw.visitField(Opcodes.ACC_PRIVATE, "value", valuePrefix + qualifiedInternalValueClassName+";", null, null);
 
-        MethodVisitor mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "<init>", "()V", null, null);
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), "java/lang/Object", "<init>", "()V", false);
-        mv.visitInsn(Opcodes.valueInt("RETURN"));
+        MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "()V", null, null);
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+        mv.visitInsn(Opcodes.RETURN);
         mv.visitMaxs(1, 1);
         mv.visitEnd();
 
-        mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "getKey", "()L"+qualifiedInternalKeyClassName+";", null, null);
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitFieldInsn(Opcodes.valueInt("GETFIELD"), qualifiedInternalClassName, "key", "L"+qualifiedInternalKeyClassName+";");
-        mv.visitInsn(Opcodes.valueInt("ARETURN"));
+        mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "getKey", "()L"+qualifiedInternalKeyClassName+";", null, null);
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitFieldInsn(Opcodes.GETFIELD, qualifiedInternalClassName, "key", "L"+qualifiedInternalKeyClassName+";");
+        mv.visitInsn(Opcodes.ARETURN);
         mv.visitMaxs(1, 1);
         mv.visitEnd();
 
-        mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "setKey", "(L"+qualifiedInternalKeyClassName+";)V", null, null);
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        mv.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), qualifiedInternalClassName, "key", "L"+qualifiedInternalKeyClassName+";");
-        mv.visitInsn(Opcodes.valueInt("RETURN"));
+        mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "setKey", "(L"+qualifiedInternalKeyClassName+";)V", null, null);
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitVarInsn(Opcodes.ALOAD, 1);
+        mv.visitFieldInsn(Opcodes.PUTFIELD, qualifiedInternalClassName, "key", "L"+qualifiedInternalKeyClassName+";");
+        mv.visitInsn(Opcodes.RETURN);
         mv.visitMaxs(2, 2);
         mv.visitEnd();
 
-        mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "getValue", "()" + valuePrefix + qualifiedInternalValueClassName+";", null, null);
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitFieldInsn(Opcodes.valueInt("GETFIELD"), qualifiedInternalClassName, "value", valuePrefix + qualifiedInternalValueClassName+";");
-        mv.visitInsn(Opcodes.valueInt("ARETURN"));
+        mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "getValue", "()" + valuePrefix + qualifiedInternalValueClassName+";", null, null);
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitFieldInsn(Opcodes.GETFIELD, qualifiedInternalClassName, "value", valuePrefix + qualifiedInternalValueClassName+";");
+        mv.visitInsn(Opcodes.ARETURN);
         mv.visitMaxs(1, 1);
         mv.visitEnd();
 
-        mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "setValue", "(" + valuePrefix + qualifiedInternalValueClassName+";)V", null, null);
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-        mv.visitFieldInsn(Opcodes.valueInt("PUTFIELD"), qualifiedInternalClassName, "value", valuePrefix + qualifiedInternalValueClassName+";");
-        mv.visitInsn(Opcodes.valueInt("RETURN"));
+        mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "setValue", "(" + valuePrefix + qualifiedInternalValueClassName+";)V", null, null);
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitVarInsn(Opcodes.ALOAD, 1);
+        mv.visitFieldInsn(Opcodes.PUTFIELD, qualifiedInternalClassName, "value", valuePrefix + qualifiedInternalValueClassName+";");
+        mv.visitInsn(Opcodes.RETURN);
         mv.visitMaxs(2, 2);
         mv.visitEnd();
 
         if(!qualifiedInternalValueClassName.equals("java/lang/Object")){
-            mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_BRIDGE") + Opcodes.valueInt("ACC_SYNTHETIC"), "getValue", "()Ljava/lang/Object;", null, null);
-            mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            mv.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), qualifiedInternalClassName, "getValue", "()" + valuePrefix + qualifiedInternalValueClassName+";", false);
-            mv.visitInsn(Opcodes.valueInt("ARETURN"));
+            mv = cw.visitMethod(Opcodes.ACC_PUBLIC + Opcodes.ACC_BRIDGE + Opcodes.ACC_SYNTHETIC, "getValue", "()Ljava/lang/Object;", null, null);
+            mv.visitVarInsn(Opcodes.ALOAD, 0);
+            mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, qualifiedInternalClassName, "getValue", "()" + valuePrefix + qualifiedInternalValueClassName+";", false);
+            mv.visitInsn(Opcodes.ARETURN);
             mv.visitMaxs(1, 1);
             mv.visitEnd();
 
-            mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_BRIDGE") + Opcodes.valueInt("ACC_SYNTHETIC"), "setValue", "(Ljava/lang/Object;)V", null, null);
-            mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
+            mv = cw.visitMethod(Opcodes.ACC_PUBLIC + Opcodes.ACC_BRIDGE + Opcodes.ACC_SYNTHETIC, "setValue", "(Ljava/lang/Object;)V", null, null);
+            mv.visitVarInsn(Opcodes.ALOAD, 0);
+            mv.visitVarInsn(Opcodes.ALOAD, 1);
             // CHECKCAST is slightly different for array types
             if (valuePrefix.equals("[L")) {
-                mv.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), valuePrefix + qualifiedInternalValueClassName + ";");
+                mv.visitTypeInsn(Opcodes.CHECKCAST, valuePrefix + qualifiedInternalValueClassName + ";");
             } else {
-                mv.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), qualifiedInternalValueClassName);
+                mv.visitTypeInsn(Opcodes.CHECKCAST, qualifiedInternalValueClassName);
             }
-            mv.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), qualifiedInternalClassName, "setValue", "(" + valuePrefix + qualifiedInternalValueClassName+";)V", false);
-            mv.visitInsn(Opcodes.valueInt("RETURN"));
+            mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, qualifiedInternalClassName, "setValue", "(" + valuePrefix + qualifiedInternalValueClassName+";)V", false);
+            mv.visitInsn(Opcodes.RETURN);
             mv.visitMaxs(2, 2);
             mv.visitEnd();
         }
 
         if(!qualifiedInternalKeyClassName.equals("java/lang/Object")){
-            mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_BRIDGE") + Opcodes.valueInt("ACC_SYNTHETIC"), "getKey", "()Ljava/lang/Object;", null, null);
-            mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            mv.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"),qualifiedInternalClassName, "getKey", "()L"+qualifiedInternalKeyClassName+";", false);
-            mv.visitInsn(Opcodes.valueInt("ARETURN"));
+            mv = cw.visitMethod(Opcodes.ACC_PUBLIC + Opcodes.ACC_BRIDGE + Opcodes.ACC_SYNTHETIC, "getKey", "()Ljava/lang/Object;", null, null);
+            mv.visitVarInsn(Opcodes.ALOAD, 0);
+            mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL,qualifiedInternalClassName, "getKey", "()L"+qualifiedInternalKeyClassName+";", false);
+            mv.visitInsn(Opcodes.ARETURN);
             mv.visitMaxs(1, 1);
             mv.visitEnd();
 
-            mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_BRIDGE") + Opcodes.valueInt("ACC_SYNTHETIC"), "setKey", "(Ljava/lang/Object;)V", null, null);
-            mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 1);
-            mv.visitTypeInsn(Opcodes.valueInt("CHECKCAST"), qualifiedInternalKeyClassName);
-            mv.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), qualifiedInternalClassName, "setKey", "(L"+qualifiedInternalKeyClassName+";)V", false);
-            mv.visitInsn(Opcodes.valueInt("RETURN"));
+            mv = cw.visitMethod(Opcodes.ACC_PUBLIC + Opcodes.ACC_BRIDGE + Opcodes.ACC_SYNTHETIC, "setKey", "(Ljava/lang/Object;)V", null, null);
+            mv.visitVarInsn(Opcodes.ALOAD, 0);
+            mv.visitVarInsn(Opcodes.ALOAD, 1);
+            mv.visitTypeInsn(Opcodes.CHECKCAST, qualifiedInternalKeyClassName);
+            mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, qualifiedInternalClassName, "setKey", "(L"+qualifiedInternalKeyClassName+";)V", false);
+            mv.visitInsn(Opcodes.RETURN);
             mv.visitMaxs(2, 2);
             mv.visitEnd();
         }
@@ -3250,7 +3250,7 @@ public class MappingsGenerator {
         ClassWriter cw = new EclipseLinkASMClassWriter();
 
         String sig = null;
-        cw.visit(Opcodes.valueInt("ACC_PUBLIC"), className.replace(".", "/"), sig, Type.getType(WrappedValue.class).getInternalName(), null);
+        cw.visit(Opcodes.ACC_PUBLIC, className.replace(".", "/"), sig, Type.getType(WrappedValue.class).getInternalName(), null);
 
         String fieldType = null;
         if(isList){
@@ -3266,19 +3266,19 @@ public class MappingsGenerator {
                 theQName = RESERVED_QNAME;
             }
 
-            MethodVisitor mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "<init>", "()V", null, null);
+            MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "()V", null, null);
 
-            mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-            mv.visitTypeInsn(Opcodes.valueInt("NEW"), "javax/xml/namespace/QName");
-            mv.visitInsn(Opcodes.valueInt("DUP"));
+            mv.visitVarInsn(Opcodes.ALOAD, 0);
+            mv.visitTypeInsn(Opcodes.NEW, "javax/xml/namespace/QName");
+            mv.visitInsn(Opcodes.DUP);
             mv.visitLdcInsn(theQName.getNamespaceURI());
             mv.visitLdcInsn(theQName.getLocalPart());
-            mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), "javax/xml/namespace/QName", "<init>", "(Ljava/lang/String;Ljava/lang/String;)V", false);
+            mv.visitMethodInsn(Opcodes.INVOKESPECIAL, "javax/xml/namespace/QName", "<init>", "(Ljava/lang/String;Ljava/lang/String;)V", false);
             mv.visitLdcInsn(Type.getType(fieldType).unwrap());
-            mv.visitInsn(Opcodes.valueInt("ACONST_NULL"));
+            mv.visitInsn(Opcodes.ACONST_NULL);
 
-            mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), "org/eclipse/persistence/internal/jaxb/WrappedValue", "<init>", "(Ljavax/xml/namespace/QName;Ljava/lang/Class;Ljava/lang/Object;)V", false);
-            mv.visitInsn(Opcodes.valueInt("RETURN"));
+            mv.visitMethodInsn(Opcodes.INVOKESPECIAL, "org/eclipse/persistence/internal/jaxb/WrappedValue", "<init>", "(Ljavax/xml/namespace/QName;Ljava/lang/Class;Ljava/lang/Object;)V", false);
+            mv.visitInsn(Opcodes.RETURN);
             mv.visitMaxs(5, 1);
             mv.visitEnd();
 

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/events/ClassLoaderTestCases.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/events/ClassLoaderTestCases.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -45,16 +45,16 @@ public class ClassLoaderTestCases extends TestCase {
     protected void setUp() throws Exception {
 
         ClassWriter cw = new EclipseLinkASMClassWriter();
-        cw.visit(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_SUPER"), CLASS_NAME, null, ClassLoaderRoot.class.getName().replace('.', '/'), null);
+        cw.visit(Opcodes.ACC_PUBLIC + Opcodes.ACC_SUPER, CLASS_NAME, null, ClassLoaderRoot.class.getName().replace('.', '/'), null);
         AnnotationVisitor xmlTypeAV = cw.visitAnnotation("Ljakarta/xml/bind/annotation/XmlRootElement;", true);
         xmlTypeAV.visit("name", "root");
         xmlTypeAV.visitEnd();
 
         // Write Constructor:
-        MethodVisitor mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "<init>", "()V", null, null);
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), ClassLoaderRoot.class.getName().replace('.', '/'), "<init>", "()V", false);
-        mv.visitInsn(Opcodes.valueInt("RETURN"));
+        MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "()V", null, null);
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, ClassLoaderRoot.class.getName().replace('.', '/'), "<init>", "()V", false);
+        mv.visitInsn(Opcodes.RETURN);
         mv.visitMaxs(1, 1);
         mv.visitEnd();
 

--- a/sdo/org.eclipse.persistence.sdo/src/main/java/org/eclipse/persistence/sdo/helper/DynamicClassWriter.java
+++ b/sdo/org.eclipse.persistence.sdo/src/main/java/org/eclipse/persistence/sdo/helper/DynamicClassWriter.java
@@ -107,11 +107,11 @@ public class DynamicClassWriter {
         ClassWriter cw = ASMFactory.createClassWriter();
 
         if (null == type.getInstanceClass()) {
-            cw.visit(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_SUPER"), typeImplClassDescriptor, null, Type.getType(parentClass).getInternalName(), null);
+            cw.visit(Opcodes.ACC_PUBLIC + Opcodes.ACC_SUPER, typeImplClassDescriptor, null, Type.getType(parentClass).getInternalName(), null);
         } else {
             String[] interfaces = new String[1];
             interfaces[0] = type.getInstanceClassName().replace('.', '/');
-            cw.visit(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_SUPER"), typeImplClassDescriptor, null, Type.getType(parentClass).getInternalName(), interfaces);
+            cw.visit(Opcodes.ACC_PUBLIC + Opcodes.ACC_SUPER, typeImplClassDescriptor, null, Type.getType(parentClass).getInternalName(), interfaces);
             addPropertyIndices(cw);
             for (Object object : type.getDeclaredProperties()) {
                 SDOProperty sdoProperty = (SDOProperty) object;
@@ -128,7 +128,7 @@ public class DynamicClassWriter {
     }
 
     private void addPropertyIndices(ClassWriter cw) {
-        cw.visitField(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_FINAL") + Opcodes.valueInt("ACC_STATIC"), START_PROPERTY_INDEX, "I", null, startPropertyIndex).visitEnd();
+        cw.visitField(Opcodes.ACC_PUBLIC + Opcodes.ACC_FINAL+ Opcodes.ACC_STATIC, START_PROPERTY_INDEX, "I", null, startPropertyIndex).visitEnd();
         int declaredPropsSize = type.getDeclaredProperties().size();
 
         Integer endPropertyIndex;
@@ -137,14 +137,14 @@ public class DynamicClassWriter {
         } else {
             endPropertyIndex = startPropertyIndex - 1;
         }
-        cw.visitField(Opcodes.valueInt("ACC_PUBLIC") + Opcodes.valueInt("ACC_FINAL") + Opcodes.valueInt("ACC_STATIC"), END_PROPERTY_INDEX, "I", null, endPropertyIndex).visitEnd();
+        cw.visitField(Opcodes.ACC_PUBLIC + Opcodes.ACC_FINAL+ Opcodes.ACC_STATIC, END_PROPERTY_INDEX, "I", null, endPropertyIndex).visitEnd();
     }
 
     private void addConstructors(ClassWriter cw) {
-        MethodVisitor mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), "<init>", Type.getMethodDescriptor(Type.VOID_TYPE), null, new String[] { Type.getInternalName(Serializable.class) });
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), Type.getType(parentClass).getInternalName(), "<init>", Type.getMethodDescriptor(Type.VOID_TYPE), false);
-        mv.visitInsn(Opcodes.valueInt("RETURN"));
+        MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "<init>", Type.getMethodDescriptor(Type.VOID_TYPE), null, new String[] { Type.getInternalName(Serializable.class) });
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, Type.getType(parentClass).getInternalName(), "<init>", Type.getMethodDescriptor(Type.VOID_TYPE), false);
+        mv.visitInsn(Opcodes.RETURN);
         mv.visitMaxs(1, 1);
         mv.visitEnd();
     }
@@ -169,24 +169,24 @@ public class DynamicClassWriter {
         } else {
             propertyInstanceClassDescriptor = "L" + returnType.replace('.', '/') + ";";
         }
-        MethodVisitor mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), outerGetMethodName, "()" + propertyInstanceClassDescriptor, null, null);
+        MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, outerGetMethodName, "()" + propertyInstanceClassDescriptor, null, null);
 
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitIntInsn(Opcodes.valueInt("BIPUSH"), startPropertyIndex + property.getIndexInType());
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitIntInsn(Opcodes.BIPUSH, startPropertyIndex + property.getIndexInType());
 
         String builtIn = SDOUtil.getBuiltInType(returnType);
         if (null != builtIn) {
             if (property.getType().isDataType() && !builtIn.equals(LIST)) {
-                mv.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), typeImplClassDescriptor, GET + builtIn, "(I)" + propertyInstanceClassDescriptor, false);
-                int iReturnOpcode = Type.getType(property.getType().getInstanceClass()).getOpcode(Opcodes.valueInt("IRETURN"));
+                mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, typeImplClassDescriptor, GET + builtIn, "(I)" + propertyInstanceClassDescriptor, false);
+                int iReturnOpcode = Type.getType(property.getType().getInstanceClass()).getOpcode(Opcodes.IRETURN);
                 mv.visitInsn(iReturnOpcode);
             } else {
-                mv.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), typeImplClassDescriptor, GET, "(I)Ljava/lang/Object;", false);
-                mv.visitInsn(Opcodes.valueInt("ARETURN"));
+                mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, typeImplClassDescriptor, GET, "(I)Ljava/lang/Object;", false);
+                mv.visitInsn(Opcodes.ARETURN);
             }
         } else {
-            mv.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), typeImplClassDescriptor, GET, "(I)Ljava/lang/Object;", false);
-            mv.visitInsn(Opcodes.valueInt("ARETURN"));
+            mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, typeImplClassDescriptor, GET, "(I)Ljava/lang/Object;", false);
+            mv.visitInsn(Opcodes.ARETURN);
         }
         mv.visitMaxs(2, 1);
         mv.visitEnd();
@@ -205,29 +205,29 @@ public class DynamicClassWriter {
         } else {
             propertyInstanceClassDescriptor = "L" + returnType.replace('.', '/') + ";";
         }
-        MethodVisitor mv = cw.visitMethod(Opcodes.valueInt("ACC_PUBLIC"), outerSetMethodName, "(" + propertyInstanceClassDescriptor + ")V", null, null);
+        MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, outerSetMethodName, "(" + propertyInstanceClassDescriptor + ")V", null, null);
 
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitIntInsn(Opcodes.valueInt("BIPUSH"), startPropertyIndex + property.getIndexInType());
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitIntInsn(Opcodes.BIPUSH, startPropertyIndex + property.getIndexInType());
 
         String builtIn = SDOUtil.getBuiltInType(returnType);
-        int iLoadOpcode = Opcodes.valueInt("ALOAD");
+        int iLoadOpcode = Opcodes.ALOAD;
         if (null != builtIn) {
             if (property.getType().isDataType() && !builtIn.equals(LIST)) {
-                iLoadOpcode = Type.getType(property.getType().getInstanceClass()).getOpcode(Opcodes.valueInt("ILOAD"));
+                iLoadOpcode = Type.getType(property.getType().getInstanceClass()).getOpcode(Opcodes.ILOAD);
                 mv.visitVarInsn(iLoadOpcode, 1);
-                mv.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), typeImplClassDescriptor, SET + builtIn, "(I" + propertyInstanceClassDescriptor + ")V", false);
+                mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, typeImplClassDescriptor, SET + builtIn, "(I" + propertyInstanceClassDescriptor + ")V", false);
             } else {
                 mv.visitVarInsn(iLoadOpcode, 1);
-                mv.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), typeImplClassDescriptor, SET, "(ILjava/lang/Object;)V", false);
+                mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, typeImplClassDescriptor, SET, "(ILjava/lang/Object;)V", false);
             }
         } else {
             mv.visitVarInsn(iLoadOpcode, 1);
-            mv.visitMethodInsn(Opcodes.valueInt("INVOKEVIRTUAL"), typeImplClassDescriptor, SET, "(ILjava/lang/Object;)V", false);
+            mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, typeImplClassDescriptor, SET, "(ILjava/lang/Object;)V", false);
         }
 
-        mv.visitInsn(Opcodes.valueInt("RETURN"));
-        if (iLoadOpcode == Opcodes.valueInt("DLOAD") || iLoadOpcode == Opcodes.valueInt("LLOAD")) {
+        mv.visitInsn(Opcodes.RETURN);
+        if (iLoadOpcode == Opcodes.DLOAD || iLoadOpcode == Opcodes.LLOAD) {
             mv.visitMaxs(4, 3);
         } else {
             mv.visitMaxs(3, 2);
@@ -243,11 +243,11 @@ public class DynamicClassWriter {
             return;
         }
 
-        MethodVisitor mv = cw.visitMethod(Opcodes.valueInt("ACC_PROTECTED"), method.getName(), Type.getMethodDescriptor(method), null, new String[] { Type.getInternalName(ObjectStreamException.class) });
+        MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PROTECTED, method.getName(), Type.getMethodDescriptor(method), null, new String[] { Type.getInternalName(ObjectStreamException.class) });
 
-        mv.visitVarInsn(Opcodes.valueInt("ALOAD"), 0);
-        mv.visitMethodInsn(Opcodes.valueInt("INVOKESPECIAL"), Type.getInternalName(parentClass), method.getName(), Type.getMethodDescriptor(method), false);
-        mv.visitInsn(Opcodes.valueInt("ARETURN"));
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, Type.getInternalName(parentClass), method.getName(), Type.getMethodDescriptor(method), false);
+        mv.visitInsn(Opcodes.ARETURN);
         mv.visitMaxs(1, 1);
         mv.visitEnd();
     }

--- a/utils/eclipselink.utils.sigcompare/src/main/java/eclipselink/utils/sigcompare/SignatureImporter.java
+++ b/utils/eclipselink.utils.sigcompare/src/main/java/eclipselink/utils/sigcompare/SignatureImporter.java
@@ -42,7 +42,7 @@ public class SignatureImporter {
             if (entry.getName().endsWith(".class")) {
                 InputStream in = zipFile.getInputStream(entry);
                 ClassReader reader = ASMFactory.createClassReader(in);
-                reader.accept(visitor, ClassReader.valueInt("SKIP_CODE") + ClassReader.valueInt("SKIP_DEBUG"));
+                reader.accept(visitor, ClassReader.SKIP_CODE + ClassReader.SKIP_DEBUG);
                 in.close();
             }
         }
@@ -63,19 +63,19 @@ public class SignatureImporter {
         protected ClassSignature sig = null;
 
         SignatureClassVisitor() {
-            super(Opcodes.valueInt("ASM5"));
+            super(Opcodes.ASM5);
         }
 
         @Override
         public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
-            if ((access & Opcodes.valueInt("ACC_PUBLIC")) > 0) {
+            if ((access & Opcodes.ACC_PUBLIC) > 0) {
                 this.sig = new ClassSignature(name, superName, interfaces);
             } // TODO: Handle inheritance
         }
 
         @Override
         public FieldVisitor visitField(int access, String name, String desc, String signature, Object value) {
-            if (this.sig != null && (access & Opcodes.valueInt("ACC_PUBLIC")) > 0) {
+            if (this.sig != null && (access & Opcodes.ACC_PUBLIC) > 0) {
                 this.sig.addField(name, desc);
             }
             return null;
@@ -83,7 +83,7 @@ public class SignatureImporter {
 
         @Override
         public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
-            if (this.sig != null && (access & Opcodes.valueInt("ACC_PUBLIC")) > 0) {
+            if (this.sig != null && (access & Opcodes.ACC_PUBLIC) > 0) {
                 this.sig.addMethod(name, desc);
             }
             return null;


### PR DESCRIPTION
This is performance fix to avoid unnecessary loading of Opcodes constants from selected ASM provider. There was 4-6% Startup Time Regression in EclipseLink. Fixes #2048