### PR TITLE
[master] Jakarta Persistence 3.2: java.time.Instant and java.time.Year support as a basic types

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
@@ -565,11 +565,13 @@ public class DatabasePlatform extends DatasourcePlatform {
         fieldTypeMapping.put(java.util.Date.class, new FieldTypeDefinition("TIMESTAMP"));
         fieldTypeMapping.put(java.lang.Number.class, new FieldTypeDefinition("NUMBER", 10));
 
+        fieldTypeMapping.put(java.time.Instant.class, new FieldTypeDefinition("TIMESTAMP"));
         fieldTypeMapping.put(java.time.LocalDate.class, new FieldTypeDefinition("DATE"));
         fieldTypeMapping.put(java.time.LocalDateTime.class, new FieldTypeDefinition("TIMESTAMP"));
         fieldTypeMapping.put(java.time.LocalTime.class, new FieldTypeDefinition("TIME"));
         fieldTypeMapping.put(java.time.OffsetDateTime.class, new FieldTypeDefinition("TIMESTAMP"));
         fieldTypeMapping.put(java.time.OffsetTime.class, new FieldTypeDefinition("TIME"));
+        fieldTypeMapping.put(java.time.Year.class, new FieldTypeDefinition("NUMBER", 10));
         // Mapping for JSON type.
         getJsonPlatform().updateFieldTypes(fieldTypeMapping);
 
@@ -1127,6 +1129,8 @@ public class DatabasePlatform extends DatasourcePlatform {
             return Types.TIMESTAMP;
         } else if (javaType == ClassConstants.UTILDATE ) {//bug 5237080, return TIMESTAMP for java.util.Date as well
             return Types.TIMESTAMP;
+        } else if (javaType == ClassConstants.TIME_INSTANT ) {
+            return Types.TIMESTAMP;
         } else if (javaType == ClassConstants.TIME ||
             javaType == ClassConstants.TIME_LTIME) { //bug 546312
             return Types.TIME;
@@ -1140,6 +1144,8 @@ public class DatabasePlatform extends DatasourcePlatform {
             return Types.TIME_WITH_TIMEZONE;
         } else if(javaType == ClassConstants.TIME_ODATETIME) { //bug 546312
             return Types.TIMESTAMP_WITH_TIMEZONE;
+        } else if (javaType == ClassConstants.TIME_YEAR ) {
+            return Types.INTEGER;
         }else if (javaType == ClassConstants.ABYTE) {
             return Types.LONGVARBINARY;
         } else if (javaType == ClassConstants.APBYTE) {
@@ -2417,10 +2423,14 @@ public class DatabasePlatform extends DatasourcePlatform {
             statement.setDate(index, java.sql.Date.valueOf((java.time.LocalDate) parameter));
         } else if (parameter instanceof java.sql.Timestamp){
             statement.setTimestamp(index,(java.sql.Timestamp)parameter);
+        } else if (parameter instanceof java.time.Instant){
+            statement.setTimestamp(index, java.sql.Timestamp.from((java.time.Instant)parameter));
         } else if (parameter instanceof java.time.LocalDateTime){
             statement.setTimestamp(index, java.sql.Timestamp.valueOf((java.time.LocalDateTime) parameter));
         } else if (parameter instanceof java.time.OffsetDateTime) {
             statement.setTimestamp(index, java.sql.Timestamp.from(((java.time.OffsetDateTime) parameter).toInstant()));
+        } else if (parameter instanceof java.time.Year) {
+            statement.setInt(index, ((java.time.Year)parameter).getValue());
         } else if (parameter instanceof java.sql.Time){
             statement.setTime(index,(java.sql.Time)parameter);
         } else if (parameter instanceof java.time.LocalTime lt){
@@ -2521,6 +2531,8 @@ public class DatabasePlatform extends DatasourcePlatform {
             statement.setDate(name,(java.sql.Date)parameter);
         }  else if (parameter instanceof java.time.LocalDate){
             statement.setDate(name, java.sql.Date.valueOf((java.time.LocalDate) parameter));
+        } else if (parameter instanceof java.time.Instant){
+            statement.setTimestamp(name, java.sql.Timestamp.from((java.time.Instant)parameter));
         } else if (parameter instanceof java.sql.Timestamp){
             statement.setTimestamp(name,(java.sql.Timestamp)parameter);
         } else if (parameter instanceof java.time.LocalDateTime){
@@ -2535,6 +2547,8 @@ public class DatabasePlatform extends DatasourcePlatform {
         } else if (parameter instanceof java.time.OffsetTime ot) {
             java.sql.Timestamp ts = java.sql.Timestamp.valueOf(java.time.LocalDateTime.of(java.time.LocalDate.ofEpochDay(0), ot.toLocalTime()));
             statement.setTimestamp(name, ts);
+        } else if (parameter instanceof java.time.Year) {
+            statement.setInt(name, ((java.time.Year)parameter).getValue());
         } else if (parameter instanceof Boolean) {
             statement.setBoolean(name, (Boolean) parameter);
         } else if (parameter == null) {
@@ -2655,6 +2669,8 @@ public class DatabasePlatform extends DatasourcePlatform {
                 appendTime((java.sql.Time)dbValue, writer);
             } else if (dbValue instanceof java.sql.Timestamp) {
                 appendTimestamp((java.sql.Timestamp)dbValue, writer);
+            } else if (dbValue instanceof java.time.Instant){
+                appendTimestamp(java.sql.Timestamp.from((java.time.Instant) dbValue), writer);
             } else if (dbValue instanceof java.time.LocalDate){
                 appendDate(java.sql.Date.valueOf((java.time.LocalDate) dbValue), writer);
             } else if (dbValue instanceof java.time.LocalDateTime){
@@ -2667,6 +2683,8 @@ public class DatabasePlatform extends DatasourcePlatform {
             } else if (dbValue instanceof java.time.OffsetTime ot) {
                 java.sql.Timestamp ts = java.sql.Timestamp.valueOf(java.time.LocalDateTime.of(java.time.LocalDate.ofEpochDay(0), ot.toLocalTime()));
                 appendTimestamp(ts, writer);
+            } else if (dbValue instanceof java.time.Year){
+                appendNumber((Number)dbValue, writer);
             } else if (dbValue instanceof java.sql.Date) {
                 appendDate((java.sql.Date)dbValue, writer);
             } else if (dbValue == null) {

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ClassConstants.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ClassConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -61,11 +61,13 @@ import java.sql.Clob;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
+import java.time.Year;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Hashtable;
@@ -145,11 +147,13 @@ public final class ClassConstants extends CoreClassConstants {
     // Moved from ConversionManager
     public static final Class<?> AOBJECT = Object[].class;
     public static final Class<?> ACHAR = Character[].class;
+    public static final Class<Instant> TIME_INSTANT = Instant.class;
     public static final Class<LocalDate> TIME_LDATE = LocalDate.class;
     public static final Class<LocalTime> TIME_LTIME = LocalTime.class;
     public static final Class<LocalDateTime> TIME_LDATETIME = LocalDateTime.class;
     public static final Class<OffsetDateTime> TIME_ODATETIME = OffsetDateTime.class;
     public static final Class<OffsetTime> TIME_OTIME = OffsetTime.class;
+    public static final Class<Year> TIME_YEAR = Year.class;
 
     //LOB support types
     public static final Class<Blob> BLOB = Blob.class;

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/conversion/TestJavaTimeTypeConverter.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/conversion/TestJavaTimeTypeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -20,17 +20,21 @@ package org.eclipse.persistence.jpa.test.conversion;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.Month;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
+import java.time.Year;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoField;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
 import org.eclipse.persistence.exceptions.ConversionException;
 import org.eclipse.persistence.internal.helper.ClassConstants;
@@ -487,5 +491,152 @@ public class TestJavaTimeTypeConverter {
             // Expected
         }
     }
-    
+
+    @Test
+    public void timeConvertStringToInstant() {
+        String dateTime = "2024-02-27T10:15:30.00Z";
+
+        Instant instant = cm.convertObject(dateTime, ClassConstants.TIME_INSTANT);
+
+        Assert.assertNotNull(instant);
+        Assert.assertEquals(1709028930, instant.getEpochSecond());
+    }
+
+    @Test
+    public void timeConvertSqlDateToInstant() {
+        java.sql.Date sqlDate = java.sql.Date.valueOf("2024-02-27");
+
+        Instant instant = cm.convertObject(sqlDate, ClassConstants.TIME_INSTANT);
+
+        Assert.assertNotNull(instant);
+        Assert.assertEquals(1708988400, instant.getEpochSecond());
+    }
+
+    @Test
+    public void timeConvertSqlTimestampToInstant() {
+        java.sql.Timestamp sqlTimestamp = java.sql.Timestamp.from(Instant.ofEpochSecond(1709028930));
+
+        Instant instant = cm.convertObject(sqlTimestamp, ClassConstants.TIME_INSTANT);
+
+        Assert.assertNotNull(instant);
+        Assert.assertEquals(1709028930, instant.getEpochSecond());
+    }
+
+    @Test
+    public void timeConvertUtilDateToInstant() {
+        java.util.Date utilDate = java.util.Date.from(Instant.ofEpochSecond(1709028930));
+
+        Instant instant = cm.convertObject(utilDate, ClassConstants.TIME_INSTANT);
+
+        Assert.assertNotNull(instant);
+        Assert.assertEquals(1709028930, instant.getEpochSecond());
+    }
+
+    @Test
+    public void timeConvertUtilCalendarToInstant() {
+        TimeZone tz = TimeZone.getTimeZone("Europe/London");
+        java.util.Calendar utilCalendar = java.util.Calendar.getInstance(tz);
+        utilCalendar.setTimeInMillis(1709028930000L);
+
+        Instant instant = cm.convertObject(utilCalendar, ClassConstants.TIME_INSTANT);
+
+        Assert.assertNotNull(instant);
+        Assert.assertEquals(1709028930, instant.getEpochSecond());
+    }
+
+    @Test
+    public void timeConvertLocalDateTimeToInstant() {
+        LocalDateTime localDateTime = LocalDateTime.ofInstant(Instant.ofEpochSecond(1709028930), ZoneId.of("UTC"));
+
+        Instant instant = cm.convertObject(localDateTime, ClassConstants.TIME_INSTANT);
+
+        Assert.assertNotNull(instant);
+        Assert.assertEquals(1709028930, instant.getEpochSecond());
+    }
+
+    @Test
+    public void timeConvertLongToInstant() {
+        Long longValue = 1709028930L;
+
+        Instant instant = cm.convertObject(longValue, ClassConstants.TIME_INSTANT);
+
+        Assert.assertNotNull(instant);
+        Assert.assertEquals(1709028930, instant.getEpochSecond());
+    }
+
+    @Test
+    public void timeConvertInstantToException() {
+        String date = "Bogus";
+
+        try {
+            Instant instant = cm.convertObject(date, ClassConstants.TIME_INSTANT);
+            Assert.fail("Expected Exception was not thrown.");
+        } catch (ConversionException ce) {
+            // Expected
+        }
+    }
+
+    @Test
+    public void timeConvertStringToYear() {
+        String inputYear = "2024";
+
+        Year year = cm.convertObject(inputYear, ClassConstants.TIME_YEAR);
+
+        Assert.assertNotNull(year);
+        Assert.assertEquals(2024, year.get(ChronoField.YEAR));
+    }
+
+    @Test
+    public void timeConvertUtilDateToYear() {
+        java.util.Date utilDate = java.util.Date.from(Instant.ofEpochSecond(1709028930));
+
+        Year year = cm.convertObject(utilDate, ClassConstants.TIME_YEAR);
+
+        Assert.assertNotNull(year);
+        Assert.assertEquals(2024, year.get(ChronoField.YEAR));
+    }
+
+    @Test
+    public void timeConvertUtilCalendarToYear() {
+        TimeZone tz = TimeZone.getTimeZone("Europe/London");
+        java.util.Calendar utilCalendar = java.util.Calendar.getInstance(tz);
+        utilCalendar.setTimeInMillis(1709028930000L);
+
+        Year year = cm.convertObject(utilCalendar, ClassConstants.TIME_YEAR);
+
+        Assert.assertNotNull(year);
+        Assert.assertEquals(2024, year.get(ChronoField.YEAR));
+    }
+
+    @Test
+    public void timeConvertIntegerToYear() {
+        Integer intValue = 2024;
+
+        Year year = cm.convertObject(intValue, ClassConstants.TIME_YEAR);
+
+        Assert.assertNotNull(year);
+        Assert.assertEquals(2024, year.get(ChronoField.YEAR));
+    }
+
+    @Test
+    public void timeConvertLongToYear() {
+        Long longValue = 2024L;
+
+        Year year = cm.convertObject(longValue, ClassConstants.TIME_YEAR);
+
+        Assert.assertNotNull(year);
+        Assert.assertEquals(2024, year.get(ChronoField.YEAR));
+    }
+
+    @Test
+    public void timeConvertYearToException() {
+        String date = "Bogus";
+
+        try {
+            Year year = cm.convertObject(date, ClassConstants.TIME_YEAR);
+            Assert.fail("Expected Exception was not thrown.");
+        } catch (ConversionException ce) {
+            // Expected
+        }
+    }
 }

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/conversion/TestJavaTimeTypeConverter.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/conversion/TestJavaTimeTypeConverter.java
@@ -504,7 +504,7 @@ public class TestJavaTimeTypeConverter {
 
     @Test
     public void timeConvertSqlDateToInstant() {
-        java.sql.Date sqlDate = java.sql.Date.valueOf("2024-02-27");
+        java.sql.Date sqlDate = new java.sql.Date(1708988400000L);
 
         Instant instant = cm.convertObject(sqlDate, ClassConstants.TIME_INSTANT);
 

--- a/jpa/eclipselink.jpa.testapps/jpa.test.datetime/src/main/java/org/eclipse/persistence/testing/models/jpa/datetime/DateTime.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.datetime/src/main/java/org/eclipse/persistence/testing/models/jpa/datetime/DateTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2022 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -31,12 +31,14 @@ import jakarta.persistence.TemporalType;
 import java.io.Serializable;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZoneOffset;
+import java.time.Year;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
@@ -50,11 +52,13 @@ public class DateTime implements Serializable {
 
     private Integer id;
     private java.sql.Date date;
+    private Instant instant;
     private LocalDate localDate;
     private LocalTime localTime;
     private LocalDateTime localDateTime;
     private OffsetTime offsetTime;
     private OffsetDateTime offsetDateTime;
+    private Year year;
     private Time time;
     private Timestamp timestamp;
     private Date utilDate;
@@ -67,11 +71,13 @@ public class DateTime implements Serializable {
         LocalDateTime localDateTime = LocalDateTime.ofEpochSecond(0, 0, ZoneOffset.UTC);
 
         this.date = new java.sql.Date(0);
+        this.instant = Instant.ofEpochSecond(0);
         this.localDate = LocalDate.ofEpochDay(0);
         this.localTime = localTime;
         this.localDateTime = localDateTime;
         this.offsetTime = OffsetTime.of(localTime, ZoneOffset.UTC);
         this.offsetDateTime = OffsetDateTime.of(localDateTime, ZoneOffset.UTC);
+        this.year = Year.of(0);
         this.time = new Time(0);
         this.timestamp = new Timestamp(0);
         this.utilDate = new Date(0);
@@ -100,6 +106,15 @@ public class DateTime implements Serializable {
 
     public void setDate(java.sql.Date date) {
         this.date = date;
+    }
+
+    @Column(name = "TIME_INSTANT")
+    public Instant getInstant() {
+        return instant;
+    }
+
+    public void setInstant(Instant instant) {
+        this.instant = instant;
     }
 
     @Column(name = "LOCAL_DATE")
@@ -145,6 +160,15 @@ public class DateTime implements Serializable {
 
     public void setLocalDateTime(LocalDateTime localDateTime) {
         this.localDateTime = localDateTime;
+    }
+
+    @Column(name = "TIME_YEAR")
+    public Year getYear() {
+        return year;
+    }
+
+    public void setYear(Year year) {
+        this.year = year;
     }
 
     @Column(name = "SQL_TIME")

--- a/jpa/eclipselink.jpa.testapps/jpa.test.datetime/src/main/java/org/eclipse/persistence/testing/models/jpa/datetime/DateTimePopulator.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.datetime/src/main/java/org/eclipse/persistence/testing/models/jpa/datetime/DateTimePopulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -23,6 +23,7 @@ import java.lang.reflect.Method;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.OffsetTime;
+import java.time.Year;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Calendar;
@@ -121,11 +122,13 @@ public class DateTimePopulator {
         dateTime.setTimestamp(new Timestamp(time));
         dateTime.setUtilDate(new Date(time));
         dateTime.setCalendar(cal);
+        dateTime.setInstant(cal.getTime().toInstant());
         dateTime.setLocalDate(cal.getTime().toInstant().atZone(ZoneId.systemDefault()).toLocalDate());
         dateTime.setLocalTime(cal.getTime().toInstant().atZone(ZoneId.systemDefault()).toLocalTime());
         dateTime.setLocalDateTime(dateTime.getLocalDate().atTime(dateTime.getLocalTime()));
         dateTime.setOffsetTime(OffsetTime.of(dateTime.getLocalTime(), ZoneOffset.UTC));
         dateTime.setOffsetDateTime(dateTime.getOffsetTime().atDate(dateTime.getLocalDate()));
+        dateTime.setYear(Year.of(cal.get(Calendar.YEAR)));
 
         return dateTime;
     }

--- a/jpa/eclipselink.jpa.testapps/jpa.test.datetime/src/main/java/org/eclipse/persistence/testing/models/jpa/datetime/DateTimeTableCreator.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.datetime/src/main/java/org/eclipse/persistence/testing/models/jpa/datetime/DateTimeTableCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -73,6 +73,16 @@ public class DateTimeTableCreator extends TogglingFastTableCreator {
         fieldPROVINCE.setShouldAllowNull(true);
         table.addField(fieldPROVINCE);
 
+        FieldDefinition fieldINSTANT = new FieldDefinition();
+        fieldINSTANT.setName("TIME_INSTANT");
+        fieldINSTANT.setTypeName("TIMESTAMP");
+        fieldINSTANT.setSize(6);
+        fieldINSTANT.setIsPrimaryKey(false);
+        fieldINSTANT.setIsIdentity(false);
+        fieldINSTANT.setUnique(false);
+        fieldINSTANT.setShouldAllowNull(true);
+        table.addField(fieldINSTANT);
+
         FieldDefinition fieldPOSTALCODE = new FieldDefinition();
         fieldPOSTALCODE.setName("UTIL_DATE");
         fieldPOSTALCODE.setTypeName("TIMESTAMP");
@@ -142,6 +152,16 @@ public class DateTimeTableCreator extends TogglingFastTableCreator {
         fieldCalToCal.setUnique(false);
         fieldCalToCal.setShouldAllowNull(true);
         table.addField(fieldCalToCal);
+
+        FieldDefinition fieldYear = new FieldDefinition();
+        fieldYear.setName("TIME_YEAR");
+        fieldYear.setTypeName("NUMERIC");
+        fieldYear.setSize(9);
+        fieldYear.setIsPrimaryKey(false);
+        fieldYear.setIsIdentity(false);
+        fieldYear.setUnique(false);
+        fieldYear.setShouldAllowNull(true);
+        table.addField(fieldYear);
 
         return table;
     }

--- a/jpa/eclipselink.jpa.testapps/jpa.test.datetime/src/test/java/org/eclipse/persistence/testing/tests/jpa/datetime/NullBindingTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.datetime/src/test/java/org/eclipse/persistence/testing/tests/jpa/datetime/NullBindingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2022 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -133,6 +133,28 @@ public class NullBindingTest extends JUnitTestCase {
         }
     }
 
+    public void testNullifyInstant() {
+        EntityManager em = createEntityManager();
+        Query q;
+        DateTime dt, dt2;
+
+        try {
+            beginTransaction(em);
+            dt = em.find(DateTime.class, datetimeId);
+            dt.setInstant(null);
+            commitTransaction(em);
+            q = em.createQuery("SELECT dt FROM DateTime dt WHERE dt.id = " + datetimeId);
+            dt2 = (DateTime) q.getSingleResult();
+            assertNull("Error setting java.time.LocalDateTime field to null", dt2.getInstant());
+        } catch (RuntimeException e) {
+            if (isTransactionActive(em)) {
+                rollbackTransaction(em);
+            }
+            closeEntityManager(em);
+            throw e;
+        }
+    }
+
     public void testNullifyLocalDate() {
         EntityManager em = createEntityManager();
         Query q;
@@ -234,6 +256,28 @@ public class NullBindingTest extends JUnitTestCase {
             q = em.createQuery("SELECT dt FROM DateTime dt WHERE dt.id = " + datetimeId);
             dt2 = (DateTime) q.getSingleResult();
             assertNull("Error setting java.time.LocalDateTime field to null", dt2.getOffsetDateTime());
+        } catch (RuntimeException e) {
+            if (isTransactionActive(em)) {
+                rollbackTransaction(em);
+            }
+            closeEntityManager(em);
+            throw e;
+        }
+    }
+
+    public void testNullifyYear() {
+        EntityManager em = createEntityManager();
+        Query q;
+        DateTime dt, dt2;
+
+        try {
+            beginTransaction(em);
+            dt = em.find(DateTime.class, datetimeId);
+            dt.setYear(null);
+            commitTransaction(em);
+            q = em.createQuery("SELECT dt FROM DateTime dt WHERE dt.id = " + datetimeId);
+            dt2 = (DateTime) q.getSingleResult();
+            assertNull("Error setting java.time.LocalDateTime field to null", dt2.getYear());
         } catch (RuntimeException e) {
             if (isTransactionActive(em)) {
                 rollbackTransaction(em);

--- a/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpql/datetime/JUnitJPQLDateTimeTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpql/datetime/JUnitJPQLDateTimeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -21,6 +21,8 @@ import org.eclipse.persistence.testing.framework.jpa.junit.JUnitTestCase;
 import org.eclipse.persistence.testing.models.jpa.datetime.DateTimePopulator;
 import org.eclipse.persistence.testing.models.jpa.datetime.DateTimeTableCreator;
 
+import java.time.Instant;
+import java.time.Year;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.List;
@@ -58,6 +60,8 @@ public class JUnitJPQLDateTimeTest extends JUnitTestCase {
         suite.addTest(new JUnitJPQLDateTimeTest("testTimeWithCal"));
         suite.addTest(new JUnitJPQLDateTimeTest("testTimestampWithCal"));
         suite.addTest(new JUnitJPQLDateTimeTest("testCalendar"));
+        suite.addTest(new JUnitJPQLDateTimeTest("testInstant"));
+        suite.addTest(new JUnitJPQLDateTimeTest("testYear"));
         suite.addTest(new JUnitJPQLDateTimeTest("testTimestampGreaterThan"));
         suite.addTest(new JUnitJPQLDateTimeTest("testTimestampLessThan"));
         suite.addTest(new JUnitJPQLDateTimeTest("testTimestampIn"));
@@ -240,6 +244,29 @@ public class JUnitJPQLDateTimeTest extends JUnitTestCase {
         List<?> result = createEntityManager().createQuery("SELECT OBJECT(o) FROM DateTime o WHERE o.calendar = :calendar").
             setParameter("calendar", cal, TemporalType.TIMESTAMP).
             getResultList();
+
+        assertEquals("There should be one result", 1, result.size());
+    }
+
+    public void testInstant() {
+        GregorianCalendar cal = new GregorianCalendar();
+        cal.set(1901, 11, 31, 23, 59, 59);
+        cal.set(Calendar.MILLISECOND, 999);
+        Instant instant = cal.toInstant();
+
+        List<?> result = createEntityManager().createQuery("SELECT OBJECT(o) FROM DateTime o WHERE o.instant = :instant").
+                setParameter("instant", instant).
+                getResultList();
+
+        assertEquals("There should be one result", 1, result.size());
+    }
+
+    public void testYear() {
+        Year year = Year.of(1901);
+
+        List<?> result = createEntityManager().createQuery("SELECT OBJECT(o) FROM DateTime o WHERE o.year = :year").
+                setParameter("year", year).
+                getResultList();
 
         assertEquals("There should be one result", 1, result.size());
     }

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/accessors/mappings/MappingAccessor.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/accessors/mappings/MappingAccessor.java
@@ -1370,11 +1370,13 @@ public abstract class MappingAccessor extends MetadataAccessor {
     }
 
     protected boolean isTimeClass(MetadataClass cls) {
-        return cls.extendsClass(java.time.LocalDateTime.class) ||
+        return cls.extendsClass(java.time.Instant.class) ||
+            cls.extendsClass(java.time.LocalDateTime.class) ||
             cls.extendsClass(java.time.LocalDate.class) ||
             cls.extendsClass(java.time.LocalTime.class) ||
             cls.extendsClass(java.time.OffsetDateTime.class) ||
-            cls.extendsClass(java.time.OffsetTime.class);
+            cls.extendsClass(java.time.OffsetTime.class) ||
+            cls.extendsClass(java.time.Year.class);
     }
 
     /**


### PR DESCRIPTION
This change adds support for java.time.Instant and java.time.Year classes according spec 
2.6. Basic Types, 11.1.6. Basic Annotation
https://jakartaee.github.io/persistence/latest-nightly/nightly.html#a486 https://jakartaee.github.io/persistence/latest-nightly/nightly.html#a14205 or see Specification appendix A.1. Jakarta Persistence 3.2 https://jakartaee.github.io/persistence/latest-nightly/nightly.html#jakarta-persistence-3-2