### PR TITLE
[master] JPQL generate missing Entity alias in simple SELECT queries

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/jpa/jpql/HermesParser.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/jpa/jpql/HermesParser.java
@@ -41,6 +41,7 @@ import org.eclipse.persistence.jpa.jpql.parser.JPQLGrammar2_2;
 import org.eclipse.persistence.jpa.jpql.parser.JPQLGrammar3_0;
 import org.eclipse.persistence.jpa.jpql.parser.JPQLGrammar3_1;
 import org.eclipse.persistence.jpa.jpql.parser.JPQLGrammar3_2;
+import org.eclipse.persistence.jpa.jpql.parser.JPQLStatementBNF;
 import org.eclipse.persistence.jpa.jpql.parser.SelectStatement;
 import org.eclipse.persistence.jpa.jpql.parser.UpdateStatement;
 import org.eclipse.persistence.queries.DatabaseQuery;
@@ -260,7 +261,9 @@ public final class HermesParser implements JPAQueryBuilder {
             JPQLExpression jpqlExpression = new JPQLExpression(
                 jpqlQuery,
                 DefaultEclipseLinkJPQLGrammar.instance(),
-                isTolerant()
+                JPQLStatementBNF.ID,
+                isTolerant(),
+                this.validationLevel
             );
 
             // Create a context that caches the information contained in the JPQL query

--- a/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/main/resources/META-INF/persistence.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/main/resources/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -321,6 +321,18 @@
             <property name="eclipselink.logging.level" value="${eclipselink.logging.level}"/>
             <property name="eclipselink.logging.level.sql" value="${eclipselink.logging.sql.level}"/>
             <property name="eclipselink.logging.parameters" value="${eclipselink.logging.parameters}"/>
+        </properties>
+    </persistence-unit>
+    <persistence-unit name="advanced-noalias" transaction-type="RESOURCE_LOCAL">
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+        <class>org.eclipse.persistence.testing.models.jpa.datatypes.WrapperTypes</class>
+        <exclude-unlisted-classes>true</exclude-unlisted-classes>
+        <properties>
+            <property name="eclipselink.logging.level" value="${eclipselink.logging.level}"/>
+            <property name="eclipselink.logging.level.sql" value="${eclipselink.logging.sql.level}"/>
+            <property name="eclipselink.logging.parameters" value="${eclipselink.logging.parameters}"/>
+            <!--Used as flag for Entity aliases generation-->
+            <property name="eclipselink.jpql.validation" value="None"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpql/advanced/JUnitJPQLNoAliasTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpql/advanced/JUnitJPQLNoAliasTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation from Oracle TopLink
+package org.eclipse.persistence.testing.tests.jpa.jpql.advanced;
+
+import jakarta.persistence.EntityManager;
+import junit.framework.Test;
+import junit.framework.TestSuite;
+import org.eclipse.persistence.queries.ReadObjectQuery;
+import org.eclipse.persistence.testing.framework.jpa.junit.JUnitTestCase;
+import org.eclipse.persistence.testing.models.jpa.advanced.EmployeePopulator;
+import org.eclipse.persistence.testing.models.jpa.datatypes.DataTypesTableCreator;
+import org.eclipse.persistence.testing.models.jpa.datatypes.WrapperTypes;
+import org.eclipse.persistence.testing.tests.jpa.jpql.JUnitDomainObjectComparer;
+import org.junit.Assert;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+/**
+ * <p>
+ * <b>Purpose</b>: Test Entity alias generation EJBQL functionality.
+ * <p>
+ * <b>Description</b>: This class creates a test suite, initializes the database
+ * and adds tests to the suite.
+ * <p>
+ * <b>Responsibilities</b>:
+ * <ul>
+ * <li> Run tests for alias generation EJBQL functionality
+ * </ul>
+ * @see EmployeePopulator
+ * @see JUnitDomainObjectComparer
+ */
+public class JUnitJPQLNoAliasTest extends JUnitTestCase {
+    private static int wrapperId;
+
+    static JUnitDomainObjectComparer comparer;        //the global comparer object used in all tests
+
+    public JUnitJPQLNoAliasTest() {
+        super();
+    }
+
+    public JUnitJPQLNoAliasTest(String name) {
+        super(name);
+        setPuName(getPersistenceUnitName());
+    }
+
+    @Override
+    public String getPersistenceUnitName() {
+        return "advanced-noalias";
+    }
+
+    //This method is run at the end of EVERY test case method
+    @Override
+    public void tearDown() {
+        clearCache();
+    }
+
+    //This suite contains all tests contained in this class
+    public static Test suite() {
+        TestSuite suite = new TestSuite();
+        suite.setName("JUnitJPQLInheritanceTest");
+        suite.addTest(new JUnitJPQLNoAliasTest("testSetup"));
+        suite.addTest(new JUnitJPQLNoAliasTest("testNoAlias"));
+        suite.addTest(new JUnitJPQLNoAliasTest("testNoAliasOBJECT"));
+        suite.addTest(new JUnitJPQLNoAliasTest("testNoAliasCOUNT"));
+        suite.addTest(new JUnitJPQLNoAliasTest("testNoAliasCASTCOUNT"));
+        return suite;
+    }
+
+    /**
+     * The setup is done as a test, both to record its failure, and to allow execution in the server.
+     */
+    public void testSetup() {
+        //initialize the global comparer object
+        comparer = new JUnitDomainObjectComparer();
+        //set the session for the comparer to use
+        comparer.setSession(getPersistenceUnitServerSession());
+
+        new DataTypesTableCreator().replaceTables(getPersistenceUnitServerSession());
+        clearCache();
+        EntityManager em = createEntityManager();
+        WrapperTypes wt;
+
+        beginTransaction(em);
+        wt = new WrapperTypes(BigDecimal.ZERO, BigInteger.ZERO, Boolean.FALSE,
+                Byte.valueOf("0"), 'A', Short.valueOf("0"),
+                0, 0L, 0.0f, 0.0, "A String");
+        em.persist(wt);
+        wrapperId = wt.getId();
+        commitTransaction(em);
+        closeEntityManager(em);
+    }
+
+    public void testNoAlias() {
+        EntityManager em = createEntityManager();
+
+        WrapperTypes wrapperTypes = (WrapperTypes)em.createQuery("SELECT wt FROM WrapperTypes").getResultList().get(0);
+        clearCache();
+        ReadObjectQuery tlQuery = new ReadObjectQuery(WrapperTypes.class);
+        tlQuery.setSelectionCriteria(tlQuery.getExpressionBuilder().get("id").equal(wrapperId));
+
+        WrapperTypes tlWrapperTypes = (WrapperTypes)getPersistenceUnitServerSession().executeQuery(tlQuery);
+        Assert.assertTrue("NoAlias Test Failed", comparer.compareObjects(wrapperTypes, tlWrapperTypes));
+    }
+
+    public void testNoAliasOBJECT() {
+        EntityManager em = createEntityManager();
+
+        WrapperTypes wrapperTypes = (WrapperTypes)em.createQuery("SELECT OBJECT(wt) FROM WrapperTypes").getResultList().get(0);
+        clearCache();
+        ReadObjectQuery tlQuery = new ReadObjectQuery(WrapperTypes.class);
+        tlQuery.setSelectionCriteria(tlQuery.getExpressionBuilder().get("id").equal(wrapperId));
+
+        WrapperTypes tlWrapperTypes = (WrapperTypes)getPersistenceUnitServerSession().executeQuery(tlQuery);
+        Assert.assertTrue("NoAliasOBJECT Test Failed", comparer.compareObjects(wrapperTypes, tlWrapperTypes));
+    }
+
+    public void testNoAliasCOUNT() {
+        EntityManager em = createEntityManager();
+
+        long result = em.createQuery("SELECT COUNT(wt) FROM WrapperTypes", Long.class).getSingleResult();
+        Assert.assertTrue("NoAliasCOUNT Test Failed", result > 0L);
+    }
+
+    public void testNoAliasCASTCOUNT() {
+        EntityManager em = createEntityManager();
+
+        String result = em.createQuery("SELECT CAST(COUNT(wt) AS CHAR) FROM WrapperTypes", String.class).getSingleResult();
+        Assert.assertTrue("NoAliasCOUNT Test Failed", result.length() > 0);
+    }
+}

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/IdentificationVariable.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/IdentificationVariable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -94,6 +94,7 @@ public final class IdentificationVariable extends AbstractExpression {
      */
     public IdentificationVariable(AbstractExpression parent, String identificationVariable) {
         super(parent, identificationVariable);
+        setFirstFoundAlias(identificationVariable);
     }
 
     /**
@@ -106,7 +107,18 @@ public final class IdentificationVariable extends AbstractExpression {
      */
     public IdentificationVariable(AbstractExpression parent, String identificationVariable, boolean virtual) {
         super(parent, identificationVariable);
+        setFirstFoundAlias(identificationVariable);
         this.virtual = virtual;
+    }
+
+    private void setFirstFoundAlias(String identificationVariable) {
+        try {
+            if (this.getRoot().getFoundAlias() == null && JPQLExpression.None.equals(this.getRoot().getValidationLevel())) {
+                this.getRoot().setFoundAlias(identificationVariable);
+            }
+        } catch (ClassCastException e) {
+            //Do nothing, root is not JPQLExpression. It should happen in case of org.eclipse.persistence.annotations.AdditionalCriteria
+        }
     }
 
     @Override

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/RangeVariableDeclaration.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/RangeVariableDeclaration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -280,6 +280,9 @@ public final class RangeVariableDeclaration extends AbstractExpression {
         if (!wordParser.startsWithIdentifier(SET)) {
             if (tolerant) {
                 identificationVariable = parse(wordParser, IdentificationVariableBNF.ID, tolerant);
+                if (identificationVariable == null && JPQLExpression.None.equals(this.getRoot().getValidationLevel())) {
+                    addMissingAlias(this.getRoot().getFoundAlias());
+                }
             }
             else {
                 identificationVariable = new IdentificationVariable(this, wordParser.word());
@@ -353,6 +356,19 @@ public final class RangeVariableDeclaration extends AbstractExpression {
         // Identification variable
         if ((identificationVariable != null) && !virtualIdentificationVariable) {
             identificationVariable.toParsedText(writer, actual);
+        }
+    }
+
+    /**
+     * Add missing Entity alias into current {@link FromClause}. Limited on SELECT queries.
+     *
+     * @param aliasName Entity alias.
+     */
+    private void addMissingAlias(String aliasName) {
+        if (this.getParent() instanceof IdentificationVariableDeclaration identificationVariableDeclaration &&
+                identificationVariableDeclaration.getParent() instanceof FromClause &&
+                this.getIdentificationVariable() instanceof NullExpression) {
+            this.setVirtualIdentificationVariable(aliasName);
         }
     }
 }

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/org/eclipse/persistence/jpa/tests/jpql/parser/AllJPQLParserTests.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/org/eclipse/persistence/jpa/tests/jpql/parser/AllJPQLParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -35,7 +35,8 @@ import org.junit.runners.Suite.SuiteClasses;
     AllEclipseLinkJPQLParserTests2_1.class,
     AllEclipseLinkJPQLParserTests2_4.class,
     AllEclipseLinkJPQLParserTests2_5.class,
-    AllJPQLParserConcurrentTests.class
+    AllJPQLParserConcurrentTests.class,
+    JPQLExpressionTestJakartaData.class
 })
 @RunWith(JPQLTestRunner.class)
 public final class AllJPQLParserTests {

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/org/eclipse/persistence/jpa/tests/jpql/parser/JPQLExpressionTestJakartaData.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/org/eclipse/persistence/jpa/tests/jpql/parser/JPQLExpressionTestJakartaData.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+//
+package org.eclipse.persistence.jpa.tests.jpql.parser;
+
+import org.eclipse.persistence.jpa.jpql.parser.FromClause;
+import org.eclipse.persistence.jpa.jpql.parser.IdentificationVariableDeclaration;
+import org.eclipse.persistence.jpa.jpql.parser.IdentificationVariable;
+import org.eclipse.persistence.jpa.jpql.parser.JPQLExpression;
+import org.eclipse.persistence.jpa.jpql.parser.JPQLGrammar3_2;
+import org.eclipse.persistence.jpa.jpql.parser.JPQLStatementBNF;
+import org.eclipse.persistence.jpa.jpql.parser.RangeVariableDeclaration;
+import org.eclipse.persistence.jpa.jpql.parser.SelectStatement;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public final class JPQLExpressionTestJakartaData extends JPQLParserTest {
+
+    @Test
+    public void testNoAlias() {
+        testQuery("SELECT o FROM NoAliasEntity", "o");
+    }
+
+    @Test
+    public void testNoAliasOBJECT() {
+        testQuery("SELECT OBJECT(o) FROM NoAliasEntity", "o");
+    }
+
+    @Test
+    public void testNoAliasCOUNT() {
+        testQuery("SELECT COUNT(o) FROM NoAliasEntity", "o");
+    }
+
+    @Test
+    public void testNoAliasCASTCOUNT() {
+        testQuery("SELECT CAST(COUNT(o) AS SMALLINT) FROM NoAliasEntity", "o");
+    }
+
+    @Test
+    public void testNoAliasCASTCASTCOUNT() {
+        testQuery("SELECT CAST(CAST(COUNT(o) AS SMALLINT) AS BIGINT) FROM NoAliasEntity", "o");
+    }
+
+    private void testQuery(String actualQuery, String expectedAlias) {
+        JPQLExpression jpqlExpression = JPQLQueryBuilder.buildQuery(actualQuery, JPQLGrammar3_2.instance(), JPQLStatementBNF.ID, true, "None");
+        SelectStatement selectStatement = (SelectStatement)jpqlExpression.getQueryStatement();
+        FromClause fromClause = (FromClause)selectStatement.getFromClause();
+        IdentificationVariableDeclaration identificationVariableDeclaration = (IdentificationVariableDeclaration)fromClause.getDeclaration();
+        RangeVariableDeclaration rangeVariableDeclaration = (RangeVariableDeclaration)identificationVariableDeclaration.getRangeVariableDeclaration();
+        IdentificationVariable identificationVariable = (IdentificationVariable)rangeVariableDeclaration.getIdentificationVariable();
+        String alias = identificationVariable.getText();
+
+        assertEquals(expectedAlias, alias);
+    }
+}

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/org/eclipse/persistence/jpa/tests/jpql/parser/JPQLQueryBuilder.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/org/eclipse/persistence/jpa/tests/jpql/parser/JPQLQueryBuilder.java
@@ -135,6 +135,56 @@ public final class JPQLQueryBuilder {
     }
 
     /**
+     * Parses the given JPQL query and tests its generated string with the given query, which will be
+     * formatted first. Both the parsed and actual generated strings will be tested.
+     *
+     * @param jpqlQuery The JPQL query to parse into a parsed tree
+     * @param jpqlGrammar The JPQL grammar that defines how to parse the given JPQL query
+     * @param jpqlQueryBNFId The unique identifier of the {@link JPQLQueryBNF JPQLQueryBNF}
+     * @param tolerant Determines if the parsing system should be tolerant, meaning if it should try
+     * to parse invalid or incomplete queries
+     * @param validationLevel It matches some of the constants from org.eclipse.persistence.config.ParserValidationType. Should be null.
+     * Used to control to generate missing Entity alias for SELECT queries like "SELECT e FROM Entity",
+     * in case of org.eclipse.persistence.config.ParserValidationType#None.
+     * @return The parsed tree representation of the given JPQL query
+     */
+    public static JPQLExpression buildQuery(String jpqlQuery,
+                                            JPQLGrammar jpqlGrammar,
+                                            String jpqlQueryBNFId,
+                                            boolean tolerant,
+                                            String validationLevel) {
+
+        JPQLQueryStringFormatter formatter = JPQLQueryStringFormatter.DEFAULT;
+
+        // Format the JPQL query to reflect how the parsed tree outputs the query back as a string
+        String parsedJPQLQuery = toParsedText(jpqlQuery, jpqlGrammar);
+        String actualJPQLQuery = toActualText(jpqlQuery, jpqlGrammar);
+
+        // Format the JPQL query with this formatter so the invoker can tweak the default formatting
+        parsedJPQLQuery = formatter.format(parsedJPQLQuery);
+        actualJPQLQuery = formatter.format(actualJPQLQuery);
+
+        // Parse the JPQL query
+        JPQLExpression jpqlExpression = new JPQLExpression(jpqlQuery, jpqlGrammar, jpqlQueryBNFId, tolerant, validationLevel);
+
+        // Make sure the JPQL query was correctly parsed and the
+        // generated string matches the original JPQL query
+        assertEquals(parsedJPQLQuery, jpqlExpression.toParsedText());
+        assertEquals(actualJPQLQuery, jpqlExpression.toActualText());
+
+        // If the JPQL query is parsed with tolerance turned off, then the query should
+        // be completely parsed and there should not be any unknown ending statement
+        if (!tolerant && (jpqlQueryBNFId == JPQLStatementBNF.ID)) {
+            assertFalse(
+                    "A valid JPQL query cannot have an unknown ending fragment:" + jpqlQueryBNFId,
+                    jpqlExpression.hasUnknownEndingStatement()
+            );
+        }
+
+        return jpqlExpression;
+    }
+
+    /**
      * Formats the given JPQL query by converting it to what
      * {@link Expression#toActualText() Expression.toActualText()} would return.
      * <p>


### PR DESCRIPTION
This improvement ensure, that JPQL SELECT queries like `SELECT e FROM Entity` where entity alias is not specified in the `FROM` part will be automatically evaluated from the `SELECT` part (first available).
This happen only if `<property name="eclipselink.jpql.validation" value="None"/>` persistence property with value `None` is specified.