### PR TITLE
EntityManagerFactory.getName() fix

### DIFF
--- a/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/test/java/org/eclipse/persistence/testing/tests/jpa/persistence32/EntityManagerFactoryTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/test/java/org/eclipse/persistence/testing/tests/jpa/persistence32/EntityManagerFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -69,7 +69,8 @@ public class EntityManagerFactoryTest extends AbstractPokemon {
                 new EntityManagerFactoryTest("testGetNamedPokemonQueries"),
                 new EntityManagerFactoryTest("testGetNamedAllQueries"),
                 new EntityManagerFactoryTest("testGetNamedPokemonEntityGraphs"),
-                new EntityManagerFactoryTest("testGetNamedAllEntityGraphs")
+                new EntityManagerFactoryTest("testGetNamedAllEntityGraphs"),
+                new EntityManagerFactoryTest("testGetName")
         );
     }
 
@@ -441,6 +442,10 @@ public class EntityManagerFactoryTest extends AbstractPokemon {
                 fail(String.format("Unknown EntityGraph %s found", entityGraph.getName()));
             }
         }
+    }
+
+    public void testGetName() {
+        assertEquals(this.getPersistenceUnitName(), emf.getName());
     }
 
     private static PersistenceConfiguration createPersistenceConfiguration(JpaEntityManagerFactory emf, String puName) {

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerFactoryDelegate.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerFactoryDelegate.java
@@ -769,7 +769,7 @@ public class EntityManagerFactoryDelegate implements EntityManagerFactory, Persi
 
     @Override
     public String getName() {
-        return setupImpl.getPersistenceUnitUniqueName();
+        return setupImpl.getPersistenceUnitInfo().getPersistenceUnitName();
     }
 
     @Override


### PR DESCRIPTION
According specification to get Persistence unit name `//persistence-unit/@name` like `test_pu1` from `<persistence-unit name="test_pu1" transaction-type="RESOURCE_LOCAL">` instead of current fully qualified name.