### PR TITLE
[master] Jakarta Persistence 3.2 new feature - JPQL functions ID(), VERSION()

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/jpa/jpql/ExpressionBuilderVisitor.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/jpa/jpql/ExpressionBuilderVisitor.java
@@ -178,7 +178,7 @@ import java.util.Set;
  * @author John Bracken
  */
 @SuppressWarnings("nls")
-final class ExpressionBuilderVisitor implements EclipseLinkExpressionVisitor {
+final class ExpressionBuilderVisitor extends JPQLFunctionsAbstractBuilder implements EclipseLinkExpressionVisitor {
 
     /**
      * This visitor creates a list by retrieving either the single child or the children of the
@@ -196,11 +196,6 @@ final class ExpressionBuilderVisitor implements EclipseLinkExpressionVisitor {
      * type that takes precedence.
      */
     private Comparator<Class<?>> numericTypeComparator;
-
-    /**
-     * The context used to query information about the application metadata.
-     */
-    private final JPQLQueryContext queryContext;
 
     /**
      * The EclipseLink {@link Expression} that represents a visited parsed
@@ -226,9 +221,8 @@ final class ExpressionBuilderVisitor implements EclipseLinkExpressionVisitor {
      * cached information
      */
     ExpressionBuilderVisitor(JPQLQueryContext queryContext) {
-        super();
+        super(queryContext);
         this.type = new Class<?>[1];
-        this.queryContext = queryContext;
     }
 
     private void appendJoinVariables(org.eclipse.persistence.jpa.jpql.parser.Expression expression,

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/jpa/jpql/JPQLFunctionsAbstractBuilder.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/jpa/jpql/JPQLFunctionsAbstractBuilder.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+//
+package org.eclipse.persistence.internal.jpa.jpql;
+
+import org.eclipse.persistence.descriptors.ClassDescriptor;
+import org.eclipse.persistence.descriptors.VersionLockingPolicy;
+import org.eclipse.persistence.internal.helper.DatabaseField;
+import org.eclipse.persistence.jpa.jpql.parser.EclipseLinkAnonymousExpressionVisitor;
+import org.eclipse.persistence.jpa.jpql.parser.IdExpression;
+import org.eclipse.persistence.jpa.jpql.parser.IdentificationVariable;
+import org.eclipse.persistence.jpa.jpql.parser.StateFieldPathExpression;
+import org.eclipse.persistence.jpa.jpql.parser.VersionExpression;
+import org.eclipse.persistence.mappings.DatabaseMapping;
+
+import java.util.List;
+
+/**
+ * JPQL exclusive ID(), VERSION() functions/expressions are transformed there to StateFieldPathExpression.
+ * It should be used in the future for another JPQL functions/expressions which are not available at the DB level.
+ * E.g. For Entity e with idAttr as a primary key: <code>SELECT ID(e) FROM Entity e -> SELECT e.idAttr FROM Entity e</code>
+ * For Entity e with versionAttr as a version attribute: <code>SELECT VERSION(e) FROM Entity e -> SELECT e.versionAttr FROM Entity e</code>
+ *
+ * @author Radek Felcman
+ * @since 5.0
+ */
+public abstract class JPQLFunctionsAbstractBuilder extends EclipseLinkAnonymousExpressionVisitor {
+
+    /**
+     * The {@link JPQLQueryContext} is used to query information about the application metadata and
+     * cached information.
+     */
+    final JPQLQueryContext queryContext;
+
+    protected JPQLFunctionsAbstractBuilder(JPQLQueryContext queryContext) {
+        this.queryContext = queryContext;
+    }
+
+    /**
+     * For Entity e with idAttr as a primary key: <code>SELECT ID(e) FROM Entity e -> SELECT e.idAttr FROM Entity e</code>
+     *
+     * @param expression The {@link IdExpression} to visit
+     */
+    @Override
+    public void visit(IdExpression expression) {
+        //Fetch identification variable info
+        IdentificationVariable identificationVariable = (IdentificationVariable) expression.getExpression();
+        String variableText = identificationVariable.getText();
+        String variableName = identificationVariable.getVariableName();
+
+        //Get id attribute name
+        ClassDescriptor descriptor = this.queryContext.getDeclaration(variableName).getDescriptor();
+        List<DatabaseField> primaryKeyFields = descriptor.getPrimaryKeyFields();
+        String idAttributeName = getIdAttributeNameByField(descriptor.getMappings(), primaryKeyFields.get(0));
+        StateFieldPathExpression stateFieldPathExpression = new StateFieldPathExpression(expression.getParent(), variableText + "." + idAttributeName);
+        expression.setStateFieldPathExpression(stateFieldPathExpression);
+
+        //Continue with created StateFieldPathExpression
+        //It handle by ObjectBuilder booth @Id/primary key types (simple/composite)
+        expression.getStateFieldPathExpression().accept(this);
+    }
+
+    /**
+     * For Entity e with versionAttr as a version attribute: <code>SELECT VERSION(e) FROM Entity e -> SELECT e.versionAttr FROM Entity e</code>
+     *
+     * @param expression The {@link VersionExpression} to visit
+     */
+    @Override
+    public void visit(VersionExpression expression) {
+        //Fetch identification variable info
+        IdentificationVariable identificationVariable = (IdentificationVariable) expression.getExpression();
+        String variableText = identificationVariable.getText();
+        String variableName = identificationVariable.getVariableName();
+
+        //Get version attribute name
+        ClassDescriptor descriptor = this.queryContext.getDeclaration(variableName).getDescriptor();
+        String versionAttributeName = ((VersionLockingPolicy) descriptor.getOptimisticLockingPolicy()).getVersionMapping().getAttributeName();
+        StateFieldPathExpression stateFieldPathExpression = new StateFieldPathExpression(expression.getParent(), variableText + "." + versionAttributeName);
+        expression.setStateFieldPathExpression(stateFieldPathExpression);
+
+        //Continue with created StateFieldPathExpression
+        expression.getStateFieldPathExpression().accept(this);
+    }
+
+    private String getIdAttributeNameByField(List<DatabaseMapping> databaseMappings, DatabaseField field) {
+        for (DatabaseMapping mapping : databaseMappings) {
+            if (field.equals(mapping.getField()) || mapping.isPrimaryKeyMapping()) {
+                return mapping.getAttributeName();
+            }
+        }
+        return null;
+    }
+}

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/jpa/jpql/ReadAllQueryBuilder.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/jpa/jpql/ReadAllQueryBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,7 +16,6 @@
 package org.eclipse.persistence.internal.jpa.jpql;
 
 import org.eclipse.persistence.jpa.jpql.parser.CollectionExpression;
-import org.eclipse.persistence.jpa.jpql.parser.EclipseLinkAnonymousExpressionVisitor;
 import org.eclipse.persistence.jpa.jpql.parser.Expression;
 import org.eclipse.persistence.jpa.jpql.parser.IdentificationVariable;
 import org.eclipse.persistence.jpa.jpql.parser.NullExpression;
@@ -36,18 +35,12 @@ import org.eclipse.persistence.queries.ReportQuery;
  * @author Pascal Filion
  * @author John Bracken
  */
-final class ReadAllQueryBuilder extends EclipseLinkAnonymousExpressionVisitor {
+final class ReadAllQueryBuilder extends JPQLFunctionsAbstractBuilder {
 
     /**
      * The query that was created based on the type of select clause.
      */
     ReadAllQuery query;
-
-    /**
-     * The {@link JPQLQueryContext} is used to query information about the application metadata and
-     * cached information.
-     */
-    private final JPQLQueryContext queryContext;
 
     /**
      * The {@link Expression} being visited.
@@ -61,8 +54,7 @@ final class ReadAllQueryBuilder extends EclipseLinkAnonymousExpressionVisitor {
      * cached information
      */
     ReadAllQueryBuilder(JPQLQueryContext queryContext) {
-        super();
-        this.queryContext = queryContext;
+        super(queryContext);
     }
 
     private void initializeReadAllQuery() {

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/jpa/jpql/ReportItemBuilder.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/jpa/jpql/ReportItemBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -94,7 +94,7 @@ import static org.eclipse.persistence.jpa.jpql.LiteralType.PATH_EXPRESSION_LAST_
  * @author John Bracken
  */
 @SuppressWarnings("nls")
-final class ReportItemBuilder extends EclipseLinkAnonymousExpressionVisitor {
+final class ReportItemBuilder extends JPQLFunctionsAbstractBuilder {
 
     /**
      * The visitor responsible to visit the constructor items.
@@ -110,12 +110,6 @@ final class ReportItemBuilder extends EclipseLinkAnonymousExpressionVisitor {
      * The {@link ReportQuery} to add the select expressions.
      */
     private ReportQuery query;
-
-    /**
-     * The {@link JPQLQueryContext} is used to query information about the application metadata and
-     * cached information.
-     */
-    private final JPQLQueryContext queryContext;
 
     /**
      * If the select expression is aliased with a result variable, then temporarily cache it so it
@@ -138,10 +132,9 @@ final class ReportItemBuilder extends EclipseLinkAnonymousExpressionVisitor {
      * tree representation of the JPQL query
      */
     ReportItemBuilder(JPQLQueryContext queryContext, ReportQuery query) {
-        super();
+        super(queryContext);
         this.query        = query;
         this.type         = new Class<?>[1];
-        this.queryContext = queryContext;
     }
 
     private void addAttribute(String generateName, Expression queryExpression) {

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/jpa/jpql/TypeResolver.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/jpa/jpql/TypeResolver.java
@@ -162,7 +162,7 @@ import java.util.Map;
  * @author Pascal Filion
  */
 @SuppressWarnings("nls")
-final class TypeResolver implements EclipseLinkExpressionVisitor {
+final class TypeResolver extends JPQLFunctionsAbstractBuilder implements EclipseLinkExpressionVisitor {
 
     /**
      * This visitor is responsible to retrieve the {@link CollectionExpression} if it is visited.
@@ -178,11 +178,6 @@ final class TypeResolver implements EclipseLinkExpressionVisitor {
      * This visitor resolves a path expression by retrieving the mapping and descriptor of the last segment.
      */
     private PathResolver pathResolver;
-
-    /**
-     * The context used to query information about the application metadata and cached information.
-     */
-    private final JPQLQueryContext queryContext;
 
     /**
      * The well defined type, which does not have to be calculated.
@@ -201,8 +196,7 @@ final class TypeResolver implements EclipseLinkExpressionVisitor {
      * cached information
      */
     TypeResolver(JPQLQueryContext queryContext) {
-        super();
-        this.queryContext = queryContext;
+        super(queryContext);
     }
 
     /**

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/version/TestVersioning.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/version/TestVersioning.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018 IBM and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -43,13 +43,13 @@ public class TestVersioning {
                            value = "UseNationalCharacterVaryingTypeForString=true")})
     private EntityManagerFactory emf;
 	
-	private final static String qStr1 = "UPDATE TemporalVersionedEntity e " +
-			"SET e.updatetimestamp = ?3 " +
-			"WHERE e.id = ?1 AND e.updatetimestamp = ?2";
+	private final static String qStr1 = "UPDATE TemporalVersionedEntity " +
+			"SET updatetimestamp = ?3 " +
+			"WHERE id = ?1 AND updatetimestamp = ?2";
 	
-	private final static String qStr2 = "UPDATE TemporalVersionedEntity2 e " +
-			"SET e.version = ?3 " +
-			"WHERE e.id = ?1 AND e.version = ?2";
+	private final static String qStr2 = "UPDATE TemporalVersionedEntity2 " +
+			"SET version = ?3 " +
+			"WHERE id = ?1 AND version = ?2";
 			
 	@Test
     public void testTemporalVersionField1() throws Exception {
@@ -272,7 +272,7 @@ public class TestVersioning {
         	Assert.assertEquals(newEntity.getTheVersion(), findEntity1.getTheVersion());
         	
         	try {
-            	em.createQuery("UPDATE IntegerVersionedEntity e SET e.data = 'Lore' WHERE e.id = 2").executeUpdate();
+            	em.createQuery("UPDATE IntegerVersionedEntity SET data = 'Lore' WHERE id = 2").executeUpdate();
             	
             	findEntity1.setData("Information");
             	
@@ -313,7 +313,7 @@ public class TestVersioning {
         	em.clear();
         	
         	em.getTransaction().begin();
-        	int updates = em.createQuery("UPDATE IntegerVersionedEntity e SET e.theVersion = 10 WHERE e.id = 3 AND e.theVersion = 1").executeUpdate();
+        	int updates = em.createQuery("UPDATE IntegerVersionedEntity SET theVersion = 10 WHERE id = 3 AND theVersion = 1").executeUpdate();
         	Assert.assertEquals(1,  updates);
         	
         	em.getTransaction().commit();

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/version/TestVersioning.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/version/TestVersioning.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018 IBM and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -43,13 +43,13 @@ public class TestVersioning {
                            value = "UseNationalCharacterVaryingTypeForString=true")})
     private EntityManagerFactory emf;
 	
-	private final static String qStr1 = "UPDATE TemporalVersionedEntity " + 
-			"SET updatetimestamp = ?3 " +
-			"WHERE id = ?1 AND updatetimestamp = ?2";
+	private final static String qStr1 = "UPDATE TemporalVersionedEntity e " +
+			"SET e.updatetimestamp = ?3 " +
+			"WHERE e.id = ?1 AND e.updatetimestamp = ?2";
 	
-	private final static String qStr2 = "UPDATE TemporalVersionedEntity2 " + 
-			"SET version = ?3 " +
-			"WHERE id = ?1 AND version = ?2";
+	private final static String qStr2 = "UPDATE TemporalVersionedEntity2 e " +
+			"SET e.version = ?3 " +
+			"WHERE e.id = ?1 AND e.version = ?2";
 			
 	@Test
     public void testTemporalVersionField1() throws Exception {
@@ -272,7 +272,7 @@ public class TestVersioning {
         	Assert.assertEquals(newEntity.getTheVersion(), findEntity1.getTheVersion());
         	
         	try {
-            	em.createQuery("UPDATE IntegerVersionedEntity SET data = 'Lore' WHERE id = 2").executeUpdate();
+            	em.createQuery("UPDATE IntegerVersionedEntity e SET e.data = 'Lore' WHERE e.id = 2").executeUpdate();
             	
             	findEntity1.setData("Information");
             	
@@ -313,7 +313,7 @@ public class TestVersioning {
         	em.clear();
         	
         	em.getTransaction().begin();
-        	int updates = em.createQuery("UPDATE IntegerVersionedEntity SET theVersion = 10 WHERE id = 3 AND theVersion = 1").executeUpdate();
+        	int updates = em.createQuery("UPDATE IntegerVersionedEntity e SET e.theVersion = 10 WHERE e.id = 3 AND e.theVersion = 1").executeUpdate();
         	Assert.assertEquals(1,  updates);
         	
         	em.getTransaction().commit();

--- a/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/main/resources/META-INF/persistence.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/main/resources/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -40,6 +40,7 @@
         <class>org.eclipse.persistence.testing.models.jpa.advanced.Room</class>
         <class>org.eclipse.persistence.testing.models.jpa.advanced.SmallProject</class>
         <class>org.eclipse.persistence.testing.models.jpa.advanced.SimpleRoom</class>
+        <class>org.eclipse.persistence.testing.models.jpa.advanced.Vegetable</class>
         <class>org.eclipse.persistence.testing.models.jpa.advanced.Woman</class>
         <class>org.eclipse.persistence.testing.models.jpa.advanced.WorldRank</class>
         <class>org.eclipse.persistence.testing.models.jpa.advanced.entities.EntyA</class>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpql/advanced/JUnitJPQLFunctionsTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpql/advanced/JUnitJPQLFunctionsTest.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation from Oracle TopLink
+package org.eclipse.persistence.testing.tests.jpa.jpql.advanced;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import junit.framework.Test;
+import junit.framework.TestSuite;
+import org.eclipse.persistence.internal.sessions.AbstractSession;
+import org.eclipse.persistence.sessions.DatabaseSession;
+import org.eclipse.persistence.testing.framework.jpa.junit.JUnitTestCase;
+import org.eclipse.persistence.testing.models.jpa.advanced.AdvancedTableCreator;
+import org.eclipse.persistence.testing.models.jpa.advanced.Employee;
+import org.eclipse.persistence.testing.models.jpa.advanced.EmployeePopulator;
+import org.eclipse.persistence.testing.models.jpa.advanced.Vegetable;
+import org.eclipse.persistence.testing.models.jpa.advanced.VegetablePK;
+import org.eclipse.persistence.testing.tests.jpa.jpql.JUnitDomainObjectComparer;
+
+/**
+ * <p>
+ * <b>Purpose</b>: Test additional JPQL functions.
+ * <p>
+ * <b>Description</b>: This class creates a test suite, initializes the database
+ * and adds tests to the suite.
+ * <p>
+ * <b>Responsibilities</b>:
+ * <ul>
+ * <li> Run tests for additional JPQL functions
+ * </ul>
+ * @see EmployeePopulator
+ * @see JUnitDomainObjectComparer
+ */
+public class JUnitJPQLFunctionsTest extends JUnitTestCase {
+
+    static JUnitDomainObjectComparer comparer; //the global comparer object used in all tests
+
+    //create a new EmployeePopulator
+    EmployeePopulator employeePopulator = new EmployeePopulator(supportsStoredProcedures());
+
+    private final VegetablePK VEGETABLE_ID = new VegetablePK("abcde", "xyz");
+    private final double VEGETABLE_COST = 99999.99;
+
+    public JUnitJPQLFunctionsTest() {
+        super();
+    }
+
+    public JUnitJPQLFunctionsTest(String name) {
+        super(name);
+        setPuName(getPersistenceUnitName());
+    }
+
+    @Override
+    public String getPersistenceUnitName() {
+        return "advanced";
+    }
+
+    //This method is run at the end of EVERY test case method
+
+   @Override
+    public void tearDown() {
+        clearCache();
+    }
+
+    //This suite contains all tests contained in this class
+
+    public static Test suite() {
+        TestSuite suite = new TestSuite();
+        suite.setName("JUnitJPQLFunctionsTest");
+        suite.addTest(new JUnitJPQLFunctionsTest("testSetup"));
+
+        suite.addTest(new JUnitJPQLFunctionsTest("queryID01Test"));
+        suite.addTest(new JUnitJPQLFunctionsTest("queryID02Test"));
+        suite.addTest(new JUnitJPQLFunctionsTest("queryID03WHERETest"));
+        suite.addTest(new JUnitJPQLFunctionsTest("queryID04Test"));
+        suite.addTest(new JUnitJPQLFunctionsTest("queryID05CompositePKTest"));
+        suite.addTest(new JUnitJPQLFunctionsTest("queryID06CompositePKTest"));
+        suite.addTest(new JUnitJPQLFunctionsTest("queryVERSION1Test"));
+        suite.addTest(new JUnitJPQLFunctionsTest("queryVERSION2Test"));
+        suite.addTest(new JUnitJPQLFunctionsTest("queryVERSION3Test"));
+        suite.addTest(new JUnitJPQLFunctionsTest("queryVERSION4Test"));
+        suite.addTest(new JUnitJPQLFunctionsTest("queryVERSION5Test"));
+
+        return suite;
+    }
+
+    /**
+     * The setup is done as a test, both to record its failure, and to allow execution in the server.
+     */
+    public void testSetup() {
+        clearCache();
+        //get session to start setup
+        DatabaseSession session = getPersistenceUnitServerSession();
+
+        new AdvancedTableCreator().replaceTables(session);
+
+        //initialize the global comparer object
+        comparer = new JUnitDomainObjectComparer();
+
+        //set the session for the comparer to use
+        comparer.setSession((AbstractSession)session.getActiveSession());
+
+        //Populate the tables
+        employeePopulator.buildExamples();
+
+        //Persist the examples in the database
+        employeePopulator.persistExample(session);
+
+        EntityManager em = createEntityManager();
+        try {
+            beginTransaction(em);
+            Vegetable vegetable = new Vegetable();
+            vegetable.setId(VEGETABLE_ID);
+            vegetable.setCost(VEGETABLE_COST);
+            em.persist(vegetable);
+            commitTransaction(em);
+
+        } catch (Exception e) {
+            fail("An exception was caught: [" + e.getMessage() + "]");
+        } finally {
+            if (em.getTransaction().isActive()) {
+                rollbackTransaction(em);
+            }
+            closeEntityManager(em);
+        }
+    }
+
+    public void queryID01Test(){
+        final Employee EMPLOYEE_EXPECTED = employeePopulator.employeeExample1();
+
+        EntityManager em = createEntityManager();
+        Query query = em.createQuery("SELECT ID(e) FROM Employee e WHERE e.id = :idParam");
+        query.setParameter("idParam", EMPLOYEE_EXPECTED.getId());
+        Integer result  = (Integer)query.getSingleResult();
+        assertNotNull(result);
+        assertEquals(EMPLOYEE_EXPECTED.getId(), result);
+    }
+
+    public void queryID02Test(){
+        final Employee EMPLOYEE_EXPECTED = employeePopulator.employeeExample1();
+
+        EntityManager em = createEntityManager();
+        Query query = em.createQuery("SELECT e.id, e.lastName, ID(e) FROM Employee e WHERE e.id = :idParam");
+        query.setParameter("idParam", EMPLOYEE_EXPECTED.getId());
+        Object[] result  = (Object[])query.getSingleResult();
+        assertNotNull(result);
+        assertEquals(EMPLOYEE_EXPECTED.getId(), result[0]);
+        assertEquals(EMPLOYEE_EXPECTED.getLastName(), result[1]);
+        assertEquals(EMPLOYEE_EXPECTED.getId(), result[2]);
+    }
+
+    public void queryID03WHERETest(){
+        final Employee EMPLOYEE_EXPECTED = employeePopulator.employeeExample1();
+
+        EntityManager em = createEntityManager();
+        Query query = em.createQuery("SELECT ID(e) FROM Employee e WHERE ID(e) = :idParam");
+        query.setParameter("idParam", EMPLOYEE_EXPECTED.getId());
+        Integer result  = (Integer)query.getSingleResult();
+        assertNotNull(result);
+        assertEquals(EMPLOYEE_EXPECTED.getId(), result);
+    }
+
+    public void queryID04Test(){
+        final Employee EMPLOYEE_EXPECTED = employeePopulator.employeeExample1();
+
+        EntityManager em = createEntityManager();
+        Query query = em.createQuery("SELECT e.id, e.lastName, ID(e) FROM Employee e WHERE ID(e) = :idParam");
+        query.setParameter("idParam", EMPLOYEE_EXPECTED.getId());
+        Object[] result  = (Object[])query.getSingleResult();
+        assertNotNull(result);
+        assertEquals(EMPLOYEE_EXPECTED.getId(), result[0]);
+        assertEquals(EMPLOYEE_EXPECTED.getLastName(), result[1]);
+        assertEquals(EMPLOYEE_EXPECTED.getId(), result[2]);
+    }
+
+    public void queryID05CompositePKTest(){
+        EntityManager em = createEntityManager();
+        Query query = em.createQuery("SELECT ID(v) FROM Vegetable v WHERE v.id = :idParam");
+        query.setParameter("idParam", VEGETABLE_ID);
+        VegetablePK result  = (VegetablePK) query.getSingleResult();
+        assertNotNull(result);
+        assertEquals(VEGETABLE_ID, result);
+    }
+
+    public void queryID06CompositePKTest(){
+        EntityManager em = createEntityManager();
+        Query query = em.createQuery("SELECT v.id, v.cost, ID(v) FROM Vegetable v WHERE v.id = :idParam");
+        query.setParameter("idParam", VEGETABLE_ID);
+        Object[] result  = (Object[])query.getSingleResult();
+        assertNotNull(result);
+        assertEquals(VEGETABLE_ID, result[0]);
+        assertEquals(VEGETABLE_COST, result[1]);
+        assertEquals(VEGETABLE_ID, result[2]);
+    }
+
+    public void queryVERSION1Test(){
+        final Employee EMPLOYEE_EXPECTED = employeePopulator.employeeExample1();
+
+        EntityManager em = createEntityManager();
+        Query query = em.createQuery("SELECT VERSION(e) FROM Employee e WHERE ID(e) = :idParam");
+        query.setParameter("idParam", EMPLOYEE_EXPECTED.getId());
+        Integer result  = (Integer)query.getSingleResult();
+        assertNotNull(result);
+        assertEquals(EMPLOYEE_EXPECTED.getVersion(), result);
+    }
+
+    public void queryVERSION2Test(){
+        final Employee EMPLOYEE_EXPECTED = employeePopulator.employeeExample1();
+
+        EntityManager em = createEntityManager();
+        Query query = em.createQuery("SELECT e.id, e.lastName, VERSION(e) FROM Employee e WHERE ID(e) = :idParam");
+        query.setParameter("idParam", EMPLOYEE_EXPECTED.getId());
+        Object[] result  = (Object[])query.getSingleResult();
+        assertNotNull(result);
+        assertEquals(EMPLOYEE_EXPECTED.getId(), result[0]);
+        assertEquals(EMPLOYEE_EXPECTED.getLastName(), result[1]);
+        assertEquals(EMPLOYEE_EXPECTED.getVersion(), result[2]);
+    }
+
+    public void queryVERSION3Test(){
+        final Employee EMPLOYEE_EXPECTED = employeePopulator.employeeExample1();
+
+        EntityManager em = createEntityManager();
+        Query query = em.createQuery("SELECT e.id FROM Employee e WHERE VERSION(e) = :versionParam AND ID(e) = :idParam");
+        query.setParameter("idParam", EMPLOYEE_EXPECTED.getId());
+        query.setParameter("versionParam", EMPLOYEE_EXPECTED.getVersion());
+        Integer result  = (Integer)query.getSingleResult();
+        assertNotNull(result);
+        assertEquals(EMPLOYEE_EXPECTED.getId(), result);
+    }
+
+    public void queryVERSION4Test(){
+        final Employee EMPLOYEE_EXPECTED = employeePopulator.employeeExample1();
+
+        EntityManager em = createEntityManager();
+        Query query = em.createQuery("SELECT VERSION(e) FROM Employee e WHERE VERSION(e) = :versionParam AND ID(e) = :idParam");
+        query.setParameter("idParam", EMPLOYEE_EXPECTED.getId());
+        query.setParameter("versionParam", EMPLOYEE_EXPECTED.getVersion());
+        Integer result  = (Integer)query.getSingleResult();
+        assertNotNull(result);
+        assertEquals(EMPLOYEE_EXPECTED.getVersion(), result);
+    }
+
+    public void queryVERSION5Test(){
+        final Employee EMPLOYEE_EXPECTED = employeePopulator.employeeExample1();
+
+        EntityManager em = createEntityManager();
+        Query query = em.createQuery("SELECT e.id, e.lastName, VERSION(e) FROM Employee e WHERE VERSION(e) = :versionParam AND ID(e) = :idParam");
+        query.setParameter("idParam", EMPLOYEE_EXPECTED.getId());
+        query.setParameter("versionParam", EMPLOYEE_EXPECTED.getVersion());
+        Object[] result  = (Object[])query.getSingleResult();
+        assertNotNull(result);
+        assertEquals(EMPLOYEE_EXPECTED.getId(), result[0]);
+        assertEquals(EMPLOYEE_EXPECTED.getLastName(), result[1]);
+        assertEquals(EMPLOYEE_EXPECTED.getVersion(), result[2]);
+    }
+}

--- a/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpql/advanced/JUnitJPQLModifyTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpql/advanced/JUnitJPQLModifyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -379,9 +379,9 @@ public class JUnitJPQLModifyTest extends JUnitTestCase {
         EntityManager em = createEntityManager();
 
         try {
-           Query query = em.createQuery("update Employee set salary = :salary where version = :version");
+           Query query = em.createQuery("update Employee set salary = :salary where gender = :gender");
            query.setParameter("salary",  1);
-           query.setParameter("version", 2);
+           query.setParameter("gender", Employee.Gender.Male);
         }
         finally {
            if (isTransactionActive(em)){

--- a/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpql/advanced/JUnitJPQLModifyTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpql/advanced/JUnitJPQLModifyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -379,9 +379,9 @@ public class JUnitJPQLModifyTest extends JUnitTestCase {
         EntityManager em = createEntityManager();
 
         try {
-           Query query = em.createQuery("update Employee set salary = :salary where gender = :gender");
+           Query query = em.createQuery("update Employee set salary = :salary where version = :version");
            query.setParameter("salary",  1);
-           query.setParameter("gender", Employee.Gender.Male);
+           query.setParameter("version", 2);
         }
         finally {
            if (isTransactionActive(em)){

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/AbstractGrammarValidator.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/AbstractGrammarValidator.java
@@ -82,6 +82,7 @@ import org.eclipse.persistence.jpa.jpql.parser.HavingClause;
 import org.eclipse.persistence.jpa.jpql.parser.IdentificationVariable;
 import org.eclipse.persistence.jpa.jpql.parser.IdentificationVariableBNF;
 import org.eclipse.persistence.jpa.jpql.parser.IdentificationVariableDeclaration;
+import org.eclipse.persistence.jpa.jpql.parser.IdExpression;
 import org.eclipse.persistence.jpa.jpql.parser.InExpression;
 import org.eclipse.persistence.jpa.jpql.parser.IndexExpression;
 import org.eclipse.persistence.jpa.jpql.parser.InputParameter;
@@ -145,6 +146,7 @@ import org.eclipse.persistence.jpa.jpql.parser.UpdateItem;
 import org.eclipse.persistence.jpa.jpql.parser.UpdateStatement;
 import org.eclipse.persistence.jpa.jpql.parser.UpperExpression;
 import org.eclipse.persistence.jpa.jpql.parser.ValueExpression;
+import org.eclipse.persistence.jpa.jpql.parser.VersionExpression;
 import org.eclipse.persistence.jpa.jpql.parser.WhenClause;
 import org.eclipse.persistence.jpa.jpql.parser.WhereClause;
 
@@ -652,6 +654,35 @@ public abstract class AbstractGrammarValidator extends AbstractValidator {
             @Override
             public String rightParenthesisMissingKey(FunctionExpression expression) {
                 return FunctionExpression_MissingRightParenthesis;
+            }
+        };
+    }
+
+    protected AbstractSingleEncapsulatedExpressionHelper<IdExpression> buildIdExpressionHelper() {
+        return new AbstractSingleEncapsulatedExpressionHelper<>(this) {
+            @Override
+            public String encapsulatedExpressionInvalidKey(IdExpression expression) {
+                return IdExpression_InvalidExpression;
+            }
+
+            @Override
+            public String encapsulatedExpressionMissingKey(IdExpression expression) {
+                return IdExpression_MissingExpression;
+            }
+
+            @Override
+            public boolean isEncapsulatedExpressionValid(IdExpression expression) {
+                return isValid(expression.getExpression(), IdentificationVariableBNF.ID);
+            }
+
+            @Override
+            public String leftParenthesisMissingKey(IdExpression expression) {
+                return IdExpression_MissingLeftParenthesis;
+            }
+
+            @Override
+            public String rightParenthesisMissingKey(IdExpression expression) {
+                return IdExpression_MissingRightParenthesis;
             }
         };
     }
@@ -1432,6 +1463,35 @@ public abstract class AbstractGrammarValidator extends AbstractValidator {
         };
     }
 
+    protected AbstractSingleEncapsulatedExpressionHelper<VersionExpression> buildVersionExpressionHelper() {
+        return new AbstractSingleEncapsulatedExpressionHelper<>(this) {
+            @Override
+            public String encapsulatedExpressionInvalidKey(VersionExpression expression) {
+                return VersionExpression_InvalidExpression;
+            }
+
+            @Override
+            public String encapsulatedExpressionMissingKey(VersionExpression expression) {
+                return VersionExpression_MissingExpression;
+            }
+
+            @Override
+            public boolean isEncapsulatedExpressionValid(VersionExpression expression) {
+                return isValid(expression.getExpression(), IdentificationVariableBNF.ID);
+            }
+
+            @Override
+            public String leftParenthesisMissingKey(VersionExpression expression) {
+                return VersionExpression_MissingLeftParenthesis;
+            }
+
+            @Override
+            public String rightParenthesisMissingKey(VersionExpression expression) {
+                return VersionExpression_MissingRightParenthesis;
+            }
+        };
+    }
+
     protected AbstractSingleEncapsulatedExpressionHelper<CoalesceExpression> coalesceExpressionHelper() {
         AbstractSingleEncapsulatedExpressionHelper<CoalesceExpression> helper = getHelper(COALESCE);
         if (helper == null) {
@@ -1883,6 +1943,15 @@ public abstract class AbstractGrammarValidator extends AbstractValidator {
         return true;
     }
 
+    protected AbstractSingleEncapsulatedExpressionHelper<IdExpression> idExpressionHelper() {
+        AbstractSingleEncapsulatedExpressionHelper<IdExpression> helper = getHelper(ID);
+        if (helper == null) {
+            helper = buildIdExpressionHelper();
+            registerHelper(ID, helper);
+        }
+        return helper;
+    }
+
     protected AbstractSingleEncapsulatedExpressionHelper<KeyExpression> keyExpressionHelper() {
         AbstractSingleEncapsulatedExpressionHelper<KeyExpression> helper = getHelper(KEY);
         if (helper == null) {
@@ -2077,6 +2146,15 @@ public abstract class AbstractGrammarValidator extends AbstractValidator {
         if (helper == null) {
             helper = buildUpperExpressionHelper();
             registerHelper(UPPER, helper);
+        }
+        return helper;
+    }
+
+    protected AbstractSingleEncapsulatedExpressionHelper<VersionExpression> versionExpressionHelper() {
+        AbstractSingleEncapsulatedExpressionHelper<VersionExpression> helper = getHelper(VERSION);
+        if (helper == null) {
+            helper = buildVersionExpressionHelper();
+            registerHelper(VERSION, helper);
         }
         return helper;
     }
@@ -3811,6 +3889,11 @@ public abstract class AbstractGrammarValidator extends AbstractValidator {
     }
 
     @Override
+    public void visit(IdExpression expression) {
+        validateAbstractSingleEncapsulatedExpression(expression, idExpressionHelper());
+    }
+
+    @Override
     public void visit(IndexExpression expression) {
 
         // JPA 1.0 does not support an INDEX expression
@@ -4846,6 +4929,11 @@ public abstract class AbstractGrammarValidator extends AbstractValidator {
         else {
             validateAbstractSingleEncapsulatedExpression(expression, valueExpressionHelper());
         }
+    }
+
+    @Override
+    public void visit(VersionExpression expression) {
+        validateAbstractSingleEncapsulatedExpression(expression, versionExpressionHelper());
     }
 
     @Override

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/AbstractSemanticValidator.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/AbstractSemanticValidator.java
@@ -67,6 +67,7 @@ import org.eclipse.persistence.jpa.jpql.parser.HavingClause;
 import org.eclipse.persistence.jpa.jpql.parser.IdentificationVariable;
 import org.eclipse.persistence.jpa.jpql.parser.IdentificationVariableDeclaration;
 import org.eclipse.persistence.jpa.jpql.parser.InExpression;
+import org.eclipse.persistence.jpa.jpql.parser.IdExpression;
 import org.eclipse.persistence.jpa.jpql.parser.IndexExpression;
 import org.eclipse.persistence.jpa.jpql.parser.InputParameter;
 import org.eclipse.persistence.jpa.jpql.parser.JPQLExpression;
@@ -120,6 +121,7 @@ import org.eclipse.persistence.jpa.jpql.parser.UpdateItem;
 import org.eclipse.persistence.jpa.jpql.parser.UpdateStatement;
 import org.eclipse.persistence.jpa.jpql.parser.UpperExpression;
 import org.eclipse.persistence.jpa.jpql.parser.ValueExpression;
+import org.eclipse.persistence.jpa.jpql.parser.VersionExpression;
 import org.eclipse.persistence.jpa.jpql.parser.WhenClause;
 import org.eclipse.persistence.jpa.jpql.parser.WhereClause;
 import static org.eclipse.persistence.jpa.jpql.JPQLQueryProblemMessages.*;
@@ -1613,6 +1615,16 @@ public abstract class AbstractSemanticValidator extends AbstractValidator {
     }
 
     /**
+     * Validates the given {@link IdExpression}. The default behavior does not require to
+     * semantically validate it.
+     *
+     * @param expression The {@link IdExpression} to validate
+     */
+    protected void validateIdExpression(IdExpression expression) {
+        super.visit(expression);
+    }
+
+    /**
      * Validates the given {@link IndexExpression}. It validates the identification variable and
      * makes sure is it defined in <code><b>IN</b></code> or <code><b>IN</b></code> expression.
      *
@@ -2723,6 +2735,16 @@ public abstract class AbstractSemanticValidator extends AbstractValidator {
     }
 
     /**
+     * Validates the given {@link VersionExpression}. The default behavior does not require to
+     * semantically validate it.
+     *
+     * @param expression The {@link VersionExpression} to validate
+     */
+    protected void validateVersionExpression(VersionExpression expression) {
+        super.visit(expression);
+    }
+
+    /**
      * Validates the given {@link WhenClause}. The default behavior does not require to semantically
      * validate it.
      *
@@ -2958,6 +2980,11 @@ public abstract class AbstractSemanticValidator extends AbstractValidator {
     @Override
     public final void visit(IdentificationVariableDeclaration expression) {
         validateIdentificationVariableDeclaration(expression);
+    }
+
+    @Override
+    public final void visit(IdExpression expression) {
+        validateIdExpression(expression);
     }
 
     @Override
@@ -3220,6 +3247,11 @@ public abstract class AbstractSemanticValidator extends AbstractValidator {
     @Override
     public final void visit(ValueExpression expression) {
         validateValueExpression(expression);
+    }
+
+    @Override
+    public final void visit(VersionExpression expression) {
+        validateVersionExpression(expression);
     }
 
     @Override

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/JPQLQueryProblemMessages.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/JPQLQueryProblemMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -192,6 +192,10 @@ public interface JPQLQueryProblemMessages {
     String IdentificationVariableDeclaration_JoinsEndWithComma = "IDENTIFICATION_VARIABLE_DECLARATION_JOINS_END_WITH_COMMA";
     String IdentificationVariableDeclaration_JoinsHaveComma = "IDENTIFICATION_VARIABLE_DECLARATION_JOINS_HAS_COMMA";
     String IdentificationVariableDeclaration_MissingRangeVariableDeclaration = "IDENTIFICATION_VARIABLE_DECLARATION_MISSING_RANGE_VARIABLE_DECLARATION";
+    String IdExpression_InvalidExpression = "ID_EXPRESSION_INVALID_EXPRESSION";
+    String IdExpression_MissingExpression = "ID_EXPRESSION_MISSING_EXPRESSION";
+    String IdExpression_MissingLeftParenthesis = "ID_EXPRESSION_MISSING_LEFT_PARENTHESIS";
+    String IdExpression_MissingRightParenthesis = "ID_EXPRESSION_MISSING_RIGHT_PARENTHESIS";
     String IndexExpression_InvalidExpression = "INDEX_EXPRESSION_INVALID_EXPRESSION";
     String IndexExpression_InvalidJPAVersion = "INDEX_EXPRESSION_INVALID_JPA_VERSION";
     String IndexExpression_MissingExpression = "INDEX_EXPRESSION_MISSING_EXPRESSION";
@@ -434,6 +438,10 @@ public interface JPQLQueryProblemMessages {
     String ValueExpression_MissingExpression = "VALUE_EXPRESSION_MISSING_EXPRESSION";
     String ValueExpression_MissingLeftParenthesis = "VALUE_EXPRESSION_MISSING_LEFT_PARENTHESIS";
     String ValueExpression_MissingRightParenthesis = "VALUE_EXPRESSION_MISSING_RIGHT_PARENTHESIS";
+    String VersionExpression_InvalidExpression = "VERSION_EXPRESSION_INVALID_EXPRESSION";
+    String VersionExpression_MissingExpression = "VERSION_EXPRESSION_MISSING_EXPRESSION";
+    String VersionExpression_MissingLeftParenthesis = "VERSION_EXPRESSION_MISSING_LEFT_PARENTHESIS";
+    String VersionExpression_MissingRightParenthesis = "VERSION_EXPRESSION_MISSING_RIGHT_PARENTHESIS";
     String WhenClause_MissingThenExpression = "WHEN_CLAUSE_MISSING_THEN_EXPRESSION";
     String WhenClause_MissingThenIdentifier = "WHEN_CLAUSE_MISSING_THEN_IDENTIFIER";
     String WhenClause_MissingWhenExpression = "WHEN_CLAUSE_MISSING_WHEN_EXPRESSION";

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/JPQLQueryProblemResourceBundle.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/JPQLQueryProblemResourceBundle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -297,6 +297,12 @@ public final class JPQLQueryProblemResourceBundle extends ListResourceBundle {
             {"IDENTIFICATION_VARIABLE_DECLARATION_JOINS_END_WITH_COMMA",               "The JOIN expressions cannot end with a comma."},
             {"IDENTIFICATION_VARIABLE_DECLARATION_JOINS_HAS_COMMA",                    "JOIN expressions cannot be separated by a comma."},
             {"IDENTIFICATION_VARIABLE_DECLARATION_MISSING_RANGE_VARIABLE_DECLARATION", "The range variable declaration must be specified."},
+
+            // IdExpression - Grammar
+            {"ID_EXPRESSION_INVALID_EXPRESSION",        "The encapsulated expression is not a valid expression."},
+            {"ID_EXPRESSION_MISSING_EXPRESSION",        "An identification variable must be provided for an ID expression."},
+            {"ID_EXPRESSION_MISSING_LEFT_PARENTHESIS",  "The left parenthesis is missing from the ID expression."},
+            {"ID_EXPRESSION_MISSING_RIGHT_PARENTHESIS", "The right parenthesis is missing from the ID expression."},
 
             // IndexExpression - Grammar
             {"INDEX_EXPRESSION_INVALID_EXPRESSION",        "The encapsulated expression is not a valid expression."},
@@ -646,6 +652,12 @@ public final class JPQLQueryProblemResourceBundle extends ListResourceBundle {
             {"VALUE_EXPRESSION_MISSING_EXPRESSION",        "An identification variable must be provided for a VALUE expression."},
             {"VALUE_EXPRESSION_MISSING_LEFT_PARENTHESIS",  "The left parenthesis is missing from the VALUE expression."},
             {"VALUE_EXPRESSION_MISSING_RIGHT_PARENTHESIS", "The right parenthesis is missing from the VALUE expression."},
+
+            // VersionExpression - Grammar
+            {"VERSION_EXPRESSION_INVALID_EXPRESSION",        "The encapsulated expression is not a valid expression."},
+            {"VERSION_EXPRESSION_MISSING_EXPRESSION",        "An identification variable must be provided for an VERSION expression."},
+            {"VERSION_EXPRESSION_MISSING_LEFT_PARENTHESIS",  "The left parenthesis is missing from the VERSION expression."},
+            {"VERSION_EXPRESSION_MISSING_RIGHT_PARENTHESIS", "The right parenthesis is missing from the VERSION expression."},
 
             // WhenClause - Grammar
             {"WHEN_CLAUSE_MISSING_THEN_EXPRESSION", "A conditional expression must be provided for a WHEN clause."},

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/ParameterTypeVisitor.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/ParameterTypeVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -48,6 +48,7 @@ import org.eclipse.persistence.jpa.jpql.parser.Expression;
 import org.eclipse.persistence.jpa.jpql.parser.FunctionExpression;
 import org.eclipse.persistence.jpa.jpql.parser.IdentificationVariable;
 import org.eclipse.persistence.jpa.jpql.parser.InExpression;
+import org.eclipse.persistence.jpa.jpql.parser.IdExpression;
 import org.eclipse.persistence.jpa.jpql.parser.IndexExpression;
 import org.eclipse.persistence.jpa.jpql.parser.InputParameter;
 import org.eclipse.persistence.jpa.jpql.parser.KeyExpression;
@@ -80,6 +81,7 @@ import org.eclipse.persistence.jpa.jpql.parser.TrimExpression;
 import org.eclipse.persistence.jpa.jpql.parser.TypeExpression;
 import org.eclipse.persistence.jpa.jpql.parser.UpdateItem;
 import org.eclipse.persistence.jpa.jpql.parser.UpperExpression;
+import org.eclipse.persistence.jpa.jpql.parser.VersionExpression;
 import org.eclipse.persistence.jpa.jpql.parser.ValueExpression;
 import org.eclipse.persistence.jpa.jpql.parser.WhenClause;
 
@@ -365,6 +367,11 @@ public abstract class ParameterTypeVisitor extends AbstractTraverseParentVisitor
     }
 
     @Override
+    public void visit(IdExpression expression) {
+        super.visit(expression);
+    }
+
+    @Override
     public void visit(IndexExpression expression) {
         this.expression = expression;
     }
@@ -642,6 +649,11 @@ public abstract class ParameterTypeVisitor extends AbstractTraverseParentVisitor
     public void visit(ValueExpression expression) {
         // VALUE() always have a type
         this.expression = expression;
+    }
+
+    @Override
+    public void visit(VersionExpression expression) {
+        super.visit(expression);
     }
 
     @Override

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/AbstractExpressionVisitor.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/AbstractExpressionVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -180,6 +180,10 @@ public abstract class AbstractExpressionVisitor implements ExpressionVisitor {
 
     @Override
     public void visit(IdentificationVariableDeclaration expression) {
+    }
+
+    @Override
+    public void visit(IdExpression expression) {
     }
 
     @Override
@@ -424,6 +428,10 @@ public abstract class AbstractExpressionVisitor implements ExpressionVisitor {
 
     @Override
     public void visit(ValueExpression expression) {
+    }
+
+    @Override
+    public void visit(VersionExpression expression) {
     }
 
     @Override

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/AnonymousExpressionVisitor.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/AnonymousExpressionVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -223,6 +223,11 @@ public abstract class AnonymousExpressionVisitor implements ExpressionVisitor {
 
     @Override
     public void visit(IdentificationVariableDeclaration expression) {
+        visit((Expression) expression);
+    }
+
+    @Override
+    public void visit(IdExpression expression) {
         visit((Expression) expression);
     }
 
@@ -528,6 +533,11 @@ public abstract class AnonymousExpressionVisitor implements ExpressionVisitor {
 
     @Override
     public void visit(ValueExpression expression) {
+        visit((Expression) expression);
+    }
+
+    @Override
+    public void visit(VersionExpression expression) {
         visit((Expression) expression);
     }
 

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/Expression.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/Expression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -327,6 +327,13 @@ public interface Expression {
      * The constant for 'HAVING'.
      */
     String HAVING = "HAVING";
+
+    /**
+     * The constant for 'ID'.
+     *
+     * @since 5.0
+     */
+    String ID = "ID";
 
     /**
      * The constant for 'IN'.
@@ -825,6 +832,13 @@ public interface Expression {
      * The constant for 'VALUE'.
      */
     String VALUE = "VALUE";
+
+    /**
+     * The constant for 'VERSION'.
+     *
+     * @since 5.0
+     */
+    String VERSION = "VERSION";
 
     /**
      * The constant for the identifier 'WHEN'.

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/ExpressionFactory.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/ExpressionFactory.java
@@ -171,6 +171,24 @@ public abstract class ExpressionFactory implements Comparable<ExpressionFactory>
         this.expressionRegistry = expressionRegistry;
     }
 
+    public boolean isIdentifier(WordParser wordParser, String word) {
+        boolean result = false;
+        int leadingWhitespaces = 0;
+        try {
+            wordParser.moveForwardIgnoreWhitespace(word);
+            leadingWhitespaces = wordParser.skipLeadingWhitespace();
+
+            if ('(' == wordParser.character()) {
+                result = true;
+            }
+        } finally {
+            //set wordParser to the previous state
+            wordParser.moveBackward(leadingWhitespaces);
+            wordParser.moveBackward(word);
+        }
+        return result;
+    }
+
     @Override
     public final String toString() {
         StringBuilder sb = new StringBuilder();

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/ExpressionVisitor.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/ExpressionVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -283,6 +283,13 @@ public interface ExpressionVisitor {
      * @param expression The {@link Expression} to visit
      */
     void visit(IdentificationVariableDeclaration expression);
+
+    /**
+     * Visits the {@link IdExpression} expression.
+     *
+     * @param expression The {@link Expression} to visit
+     */
+    void visit(IdExpression expression);
 
     /**
      * Visits the {@link IndexExpression} expression.
@@ -710,6 +717,13 @@ public interface ExpressionVisitor {
      * @param expression The {@link ValueExpression} to visit
      */
     void visit(ValueExpression expression);
+
+    /**
+     * Visits the {@link VersionExpression} expression.
+     *
+     * @param expression The {@link Expression} to visit
+     */
+    void visit(VersionExpression expression);
 
     /**
      * Visits the {@link WhenClause} expression.

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/IdExpression.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/IdExpression.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+//
+package org.eclipse.persistence.jpa.jpql.parser;
+
+/**
+ * The result of an ID function expression is the Entity primary
+ * key. Argument must be an identification variable.
+ *
+ * <div><b>BNF:</b> <code>expression ::= ID(identification_variable)</code></div>
+ *
+ * @since 5.0
+ * @author Radek Felcman
+ */
+public final class IdExpression extends EncapsulatedIdentificationVariableExpression {
+
+    /**
+     * The field path created as a result of transformation
+     */
+    private StateFieldPathExpression stateFieldPathExpression;
+
+    /**
+     * Creates a new <code>IdExpression</code>.
+     *
+     * @param parent The parent of this expression
+     */
+    public IdExpression(AbstractExpression parent) {
+        super(parent, ID);
+    }
+
+    @Override
+    public void accept(ExpressionVisitor visitor) {
+        this.getRoot().setIdExpression(true);
+        visitor.visit(this);
+    }
+
+    @Override
+    public JPQLQueryBNF getQueryBNF() {
+        return getQueryBNF(IdExpressionBNF.ID);
+    }
+
+    /**
+     * Returns field path created as a result of transformation.
+     *
+     * @return The path expression that is qualified by the identification variable
+     */
+    public StateFieldPathExpression getStateFieldPathExpression() {
+        return stateFieldPathExpression;
+    }
+
+    /**
+     * Sets field path created as a result of transformation.
+     */
+    public void setStateFieldPathExpression(StateFieldPathExpression stateFieldPathExpression) {
+        this.stateFieldPathExpression = stateFieldPathExpression;
+    }
+}

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/IdExpressionBNF.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/IdExpressionBNF.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+//
+package org.eclipse.persistence.jpa.jpql.parser;
+
+/**
+ * The query BNF for an id expression.
+ *
+ * <div><b>BNF:</b> <code>ID(identification_variable)</code></div>
+ *
+ * @since 5.0
+ * @author Radek Felcman
+ */
+@SuppressWarnings("nls")
+public final class IdExpressionBNF extends JPQLQueryBNF {
+
+    /**
+     * The unique identifier of this BNF rule.
+     */
+    public static final String ID = "id_function";
+
+    /**
+     * Creates a new <code>IdExpressionBNF</code>.
+     */
+    public IdExpressionBNF() {
+        super(ID);
+    }
+
+    @Override
+    protected void initialize() {
+        super.initialize();
+        registerExpressionFactory(IdExpressionFactory.ID);
+    }
+}

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/IdExpressionFactory.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/IdExpressionFactory.java
@@ -48,8 +48,12 @@ public final class IdExpressionFactory extends ExpressionFactory {
                                                  AbstractExpression expression,
                                                  boolean tolerant) {
 
-        expression = new IdExpression(parent);
-        expression.parse(wordParser, tolerant);
+        if(super.isIdentifier(wordParser, word)) {
+            expression = new IdExpression(parent);
+            expression.parse(wordParser, tolerant);
+        } else {
+            expression = null;
+        }
         return expression;
     }
 }

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/IdExpressionFactory.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/IdExpressionFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+//
+package org.eclipse.persistence.jpa.jpql.parser;
+
+import org.eclipse.persistence.jpa.jpql.WordParser;
+
+/**
+ * This {@link IdExpressionFactory} creates a new {@link IdExpression} when the portion of
+ * the query to parse starts with <b>OBJECT</b>.
+ *
+ * @see IdExpression
+ *
+ * @since 5.0
+ * @author Radek Felcman
+ */
+public final class IdExpressionFactory extends ExpressionFactory {
+
+    /**
+     * The unique identifier of this {@link IdExpressionFactory}.
+     */
+    public static final String ID = Expression.ID;
+
+    /**
+     * Creates a new <code>IdExpressionFactory</code>.
+     */
+    public IdExpressionFactory() {
+        super(ID, Expression.ID);
+    }
+
+    @Override
+    protected AbstractExpression buildExpression(AbstractExpression parent,
+                                                 WordParser wordParser,
+                                                 String word,
+                                                 JPQLQueryBNF queryBNF,
+                                                 AbstractExpression expression,
+                                                 boolean tolerant) {
+
+        expression = new IdExpression(parent);
+        expression.parse(wordParser, tolerant);
+        return expression;
+    }
+}

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/JPQLExpression.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/JPQLExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -64,6 +64,18 @@ public final class JPQLExpression extends AbstractExpression {
      * or incomplete queries.
      */
     private boolean tolerant;
+
+    /**
+     * Determines if one or more {@link IdExpression} exist in the parsed tree.
+     *
+     */
+    private boolean idExpression = false;
+
+    /**
+     * Determines if one or more {@link VersionExpression} exist in the parsed tree.
+     *
+     */
+    private boolean versionExpression = false;
 
     /**
      * If the expression could not be fully parsed, meaning some unknown text is trailing the query,
@@ -253,6 +265,34 @@ public final class JPQLExpression extends AbstractExpression {
     public boolean hasUnknownEndingStatement() {
         return unknownEndingStatement != null &&
               !unknownEndingStatement.isNull();
+    }
+
+    /**
+     * Determines if one or more {@link IdExpression} exist in the parsed tree.
+     *
+     * @return <code>true</code> one or more {@link IdExpression} exist in the parsed tree
+     * <code>false</code> if not
+     */
+    public boolean hasIdExpression() {
+        return idExpression;
+    }
+
+    public void setIdExpression(boolean idExpression) {
+        this.idExpression = idExpression;
+    }
+
+    /**
+     * Determines if one or more {@link VersionExpression} exist in the parsed tree.
+     *
+     * @return <code>true</code> one or more {@link VersionExpression} exist in the parsed tree
+     * <code>false</code> if not
+     */
+    public boolean hasVersionExpression() {
+        return versionExpression;
+    }
+
+    public void setVersionExpression(boolean versionExpression) {
+        this.versionExpression = versionExpression;
     }
 
     @Override

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/JPQLGrammar3_2.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/JPQLGrammar3_2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -20,12 +20,14 @@ import org.eclipse.persistence.jpa.jpql.JPAVersion;
 
 import static org.eclipse.persistence.jpa.jpql.parser.Expression.CAST;
 import static org.eclipse.persistence.jpa.jpql.parser.Expression.CONCAT_PIPES;
+import static org.eclipse.persistence.jpa.jpql.parser.Expression.ID;
 import static org.eclipse.persistence.jpa.jpql.parser.Expression.EXCEPT;
 import static org.eclipse.persistence.jpa.jpql.parser.Expression.INTERSECT;
 import static org.eclipse.persistence.jpa.jpql.parser.Expression.LEFT;
 import static org.eclipse.persistence.jpa.jpql.parser.Expression.REPLACE;
 import static org.eclipse.persistence.jpa.jpql.parser.Expression.RIGHT;
 import static org.eclipse.persistence.jpa.jpql.parser.Expression.UNION;
+import static org.eclipse.persistence.jpa.jpql.parser.Expression.VERSION;
 
 /**
  * This {@link JPQLGrammar} provides support for parsing JPQL queries defined in Jakarta Persistence 3.2.
@@ -124,6 +126,8 @@ public class JPQLGrammar3_2 extends AbstractJPQLGrammar {
         registerBNF(new UnionClauseBNF());
         registerBNF(new CastExpressionBNF());
         registerBNF(new DatabaseTypeQueryBNF());
+        registerBNF(new IdExpressionBNF());
+        registerBNF(new VersionExpressionBNF());
 
         // Extend some query BNFs
         addChildBNF(StringPrimaryBNF.ID,   SimpleStringExpressionBNF.ID);
@@ -135,6 +139,14 @@ public class JPQLGrammar3_2 extends AbstractJPQLGrammar {
         addChildBNF(FunctionsReturningDatetimeBNF.ID,    CastExpressionBNF.ID);
         addChildBNF(FunctionsReturningNumericsBNF.ID,    CastExpressionBNF.ID);
         addChildBNF(FunctionsReturningStringsBNF.ID,     CastExpressionBNF.ID);
+
+        // ID function
+        addChildBNF(SelectExpressionBNF.ID,              IdExpressionBNF.ID);
+        addChildBNF(ComparisonExpressionBNF.ID,          IdExpressionBNF.ID);
+
+        // VERSION function
+        addChildBNF(SelectExpressionBNF.ID,              VersionExpressionBNF.ID);
+        addChildBNF(ComparisonExpressionBNF.ID,          VersionExpressionBNF.ID);
     }
 
     @Override
@@ -146,6 +158,8 @@ public class JPQLGrammar3_2 extends AbstractJPQLGrammar {
         registerFactory(new UnionClauseFactory());
         registerFactory(new DatabaseTypeFactory());
         registerFactory(new CastExpressionFactory());
+        registerFactory(new IdExpressionFactory());
+        registerFactory(new VersionExpressionFactory());
     }
 
     @Override
@@ -166,6 +180,10 @@ public class JPQLGrammar3_2 extends AbstractJPQLGrammar {
         registerIdentifierVersion(EXCEPT,      JPAVersion.VERSION_3_2);
         registerIdentifierRole(CAST,           IdentifierRole.FUNCTION);          // FUNCTION(n, x1, ..., x2)
         registerIdentifierVersion(CAST,        JPAVersion.VERSION_3_2);
+        registerIdentifierRole(ID,           IdentifierRole.FUNCTION);          // ID(x)
+        registerIdentifierVersion(ID,        JPAVersion.VERSION_3_2);
+        registerIdentifierRole(VERSION,           IdentifierRole.FUNCTION);          // VERSION(x)
+        registerIdentifierVersion(VERSION,        JPAVersion.VERSION_3_2);
     }
 
     @Override

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/VersionExpression.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/VersionExpression.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+//
+package org.eclipse.persistence.jpa.jpql.parser;
+
+/**
+ * The result of an VERSION function expression is value Entity <code>@Version</code> field.
+ * Argument must be an identification variable.
+ * It's pure JPQL function which is transformed into {@link StateFieldPathExpression}
+ *
+ * <div><b>BNF:</b> <code>expression ::= VERSION(identification_variable)</code></div>
+ *
+ * @since 5.0
+ * @author Radek Felcman
+ */
+public final class VersionExpression extends EncapsulatedIdentificationVariableExpression {
+
+    /**
+     * The field path created as a result of transformation
+     */
+    private StateFieldPathExpression stateFieldPathExpression;
+
+    /**
+     * Creates a new <code>VersionExpression</code>.
+     *
+     * @param parent The parent of this expression
+     */
+    public VersionExpression(AbstractExpression parent) {
+        super(parent, VERSION);
+    }
+
+    @Override
+    public void accept(ExpressionVisitor visitor) {
+        this.getRoot().setVersionExpression(true);
+        visitor.visit(this);
+    }
+
+    @Override
+    public JPQLQueryBNF getQueryBNF() {
+        return getQueryBNF(VersionExpressionBNF.ID);
+    }
+
+    /**
+     * Returns field path created as a result of transformation.
+     *
+     * @return The path expression that is qualified by the identification variable
+     */
+    public StateFieldPathExpression getStateFieldPathExpression() {
+        return stateFieldPathExpression;
+    }
+
+    /**
+     * Sets field path created as a result of transformation.
+     */
+    public void setStateFieldPathExpression(StateFieldPathExpression stateFieldPathExpression) {
+        this.stateFieldPathExpression = stateFieldPathExpression;
+    }
+}

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/VersionExpressionBNF.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/VersionExpressionBNF.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+//
+package org.eclipse.persistence.jpa.jpql.parser;
+
+/**
+ * The query BNF for an version expression.
+ *
+ * <div><b>BNF:</b> <code>VERSION(identification_variable)</code></div>
+ *
+ * @since 5.0
+ * @author Radek Felcman
+ */
+@SuppressWarnings("nls")
+public final class VersionExpressionBNF extends JPQLQueryBNF {
+
+    /**
+     * The unique identifier of this BNF rule.
+     */
+    public static final String ID = "version_function";
+
+    /**
+     * Creates a new <code>VersionExpressionBNF</code>.
+     */
+    public VersionExpressionBNF() {
+        super(ID);
+    }
+
+    @Override
+    protected void initialize() {
+        super.initialize();
+        registerExpressionFactory(VersionExpressionFactory.ID);
+    }
+}

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/VersionExpressionFactory.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/VersionExpressionFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+//
+package org.eclipse.persistence.jpa.jpql.parser;
+
+import org.eclipse.persistence.jpa.jpql.WordParser;
+
+/**
+ * This {@link VersionExpressionFactory} creates a new {@link VersionExpression} when the portion of
+ * the query to parse starts with <b>VERSION</b>.
+ *
+ * @see VersionExpression
+ *
+ * @since 5.0
+ * @author Radek Felcman
+ */
+public final class VersionExpressionFactory extends ExpressionFactory {
+
+    /**
+     * The unique identifier of this {@link VersionExpressionFactory}.
+     */
+    public static final String ID = Expression.VERSION;
+
+    /**
+     * Creates a new <code>VersionExpressionFactory</code>.
+     */
+    public VersionExpressionFactory() {
+        super(ID, Expression.VERSION);
+    }
+
+    @Override
+    protected AbstractExpression buildExpression(AbstractExpression parent,
+                                                 WordParser wordParser,
+                                                 String word,
+                                                 JPQLQueryBNF queryBNF,
+                                                 AbstractExpression expression,
+                                                 boolean tolerant) {
+
+        expression = new VersionExpression(parent);
+        expression.parse(wordParser, tolerant);
+        return expression;
+    }
+}

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/VersionExpressionFactory.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/VersionExpressionFactory.java
@@ -48,8 +48,12 @@ public final class VersionExpressionFactory extends ExpressionFactory {
                                                  AbstractExpression expression,
                                                  boolean tolerant) {
 
+        if(super.isIdentifier(wordParser, word)) {
         expression = new VersionExpression(parent);
         expression.parse(wordParser, tolerant);
+        } else {
+            expression = null;
+        }
         return expression;
     }
 }

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/tools/AbstractContentAssistVisitor.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/tools/AbstractContentAssistVisitor.java
@@ -99,6 +99,7 @@ import org.eclipse.persistence.jpa.jpql.parser.FunctionExpression;
 import org.eclipse.persistence.jpa.jpql.parser.GroupByClause;
 import org.eclipse.persistence.jpa.jpql.parser.GroupByItemBNF;
 import org.eclipse.persistence.jpa.jpql.parser.HavingClause;
+import org.eclipse.persistence.jpa.jpql.parser.IdExpression;
 import org.eclipse.persistence.jpa.jpql.parser.IdentificationVariable;
 import org.eclipse.persistence.jpa.jpql.parser.IdentificationVariableDeclaration;
 import org.eclipse.persistence.jpa.jpql.parser.IdentifierRole;
@@ -176,6 +177,7 @@ import org.eclipse.persistence.jpa.jpql.parser.UpdateItem;
 import org.eclipse.persistence.jpa.jpql.parser.UpdateStatement;
 import org.eclipse.persistence.jpa.jpql.parser.UpperExpression;
 import org.eclipse.persistence.jpa.jpql.parser.ValueExpression;
+import org.eclipse.persistence.jpa.jpql.parser.VersionExpression;
 import org.eclipse.persistence.jpa.jpql.parser.WhenClause;
 import org.eclipse.persistence.jpa.jpql.parser.WhereClause;
 import org.eclipse.persistence.jpa.jpql.tools.ContentAssistProposals.ClassType;
@@ -3085,6 +3087,12 @@ public abstract class AbstractContentAssistVisitor extends AnonymousExpressionVi
     }
 
     @Override
+    public void visit(IdExpression expression) {
+        super.visit(expression);
+        visitSingleEncapsulatedExpression(expression, IdentificationVariableType.ALL);
+    }
+
+    @Override
     public void visit(IndexExpression expression) {
         super.visit(expression);
         visitSingleEncapsulatedExpression(expression, IdentificationVariableType.ALL);
@@ -4104,6 +4112,12 @@ public abstract class AbstractContentAssistVisitor extends AnonymousExpressionVi
     public void visit(ValueExpression expression) {
         super.visit(expression);
         visitSingleEncapsulatedExpression(expression, IdentificationVariableType.LEFT_COLLECTION);
+    }
+
+    @Override
+    public void visit(VersionExpression expression) {
+        super.visit(expression);
+        visitSingleEncapsulatedExpression(expression, IdentificationVariableType.ALL);
     }
 
     @Override
@@ -5966,6 +5980,12 @@ public abstract class AbstractContentAssistVisitor extends AnonymousExpressionVi
         }
 
         @Override
+        public void visit(IdExpression expression) {
+            appendable = !conditionalExpression &&
+                    expression.hasRightParenthesis();
+        }
+
+        @Override
         public void visit(IndexExpression expression) {
             appendable = !conditionalExpression &&
                       expression.hasRightParenthesis();
@@ -6474,6 +6494,12 @@ public abstract class AbstractContentAssistVisitor extends AnonymousExpressionVi
         public void visit(ValueExpression expression) {
             appendable = !conditionalExpression &&
                       expression.hasRightParenthesis();
+        }
+
+        @Override
+        public void visit(VersionExpression expression) {
+            appendable = !conditionalExpression &&
+                    expression.hasRightParenthesis();
         }
 
         @Override
@@ -7888,6 +7914,11 @@ public abstract class AbstractContentAssistVisitor extends AnonymousExpressionVi
         }
 
         @Override
+        public void visit(IdExpression expression) {
+            visitAbstractSingleEncapsulatedExpression(expression);
+        }
+
+        @Override
         public void visit(IndexExpression expression) {
             visitAbstractSingleEncapsulatedExpression(expression);
         }
@@ -8672,6 +8703,11 @@ public abstract class AbstractContentAssistVisitor extends AnonymousExpressionVi
 
         @Override
         public void visit(ValueExpression expression) {
+            visitAbstractSingleEncapsulatedExpression(expression);
+        }
+
+        @Override
+        public void visit(VersionExpression expression) {
             visitAbstractSingleEncapsulatedExpression(expression);
         }
 

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/tools/model/AbstractActualJPQLQueryFormatter.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/tools/model/AbstractActualJPQLQueryFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -149,6 +149,7 @@ import org.eclipse.persistence.jpa.jpql.tools.model.query.FromClauseStateObject;
 import org.eclipse.persistence.jpa.jpql.tools.model.query.FunctionExpressionStateObject;
 import org.eclipse.persistence.jpa.jpql.tools.model.query.GroupByClauseStateObject;
 import org.eclipse.persistence.jpa.jpql.tools.model.query.HavingClauseStateObject;
+import org.eclipse.persistence.jpa.jpql.tools.model.query.IdExpressionStateObject;
 import org.eclipse.persistence.jpa.jpql.tools.model.query.IdentificationVariableDeclarationStateObject;
 import org.eclipse.persistence.jpa.jpql.tools.model.query.IdentificationVariableStateObject;
 import org.eclipse.persistence.jpa.jpql.tools.model.query.InExpressionStateObject;
@@ -204,6 +205,7 @@ import org.eclipse.persistence.jpa.jpql.tools.model.query.UpdateItemStateObject;
 import org.eclipse.persistence.jpa.jpql.tools.model.query.UpdateStatementStateObject;
 import org.eclipse.persistence.jpa.jpql.tools.model.query.UpperExpressionStateObject;
 import org.eclipse.persistence.jpa.jpql.tools.model.query.ValueExpressionStateObject;
+import org.eclipse.persistence.jpa.jpql.tools.model.query.VersionExpressionStateObject;
 import org.eclipse.persistence.jpa.jpql.tools.model.query.WhenClauseStateObject;
 import org.eclipse.persistence.jpa.jpql.tools.model.query.WhereClauseStateObject;
 
@@ -1343,6 +1345,11 @@ public abstract class AbstractActualJPQLQueryFormatter extends BaseJPQLQueryForm
     }
 
     @Override
+    public void visit(IdExpressionStateObject stateObject) {
+        toStringEncapsulatedIdentificationVariable(stateObject);
+    }
+
+    @Override
     public void visit(IndexExpressionStateObject stateObject) {
         toStringEncapsulatedIdentificationVariable(stateObject);
     }
@@ -2100,6 +2107,11 @@ public abstract class AbstractActualJPQLQueryFormatter extends BaseJPQLQueryForm
 
     @Override
     public void visit(ValueExpressionStateObject stateObject) {
+        toStringEncapsulatedIdentificationVariable(stateObject);
+    }
+
+    @Override
+    public void visit(VersionExpressionStateObject stateObject) {
         toStringEncapsulatedIdentificationVariable(stateObject);
     }
 

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/tools/model/AbstractJPQLQueryFormatter.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/tools/model/AbstractJPQLQueryFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -67,6 +67,7 @@ import org.eclipse.persistence.jpa.jpql.tools.model.query.GroupByClauseStateObje
 import org.eclipse.persistence.jpa.jpql.tools.model.query.HavingClauseStateObject;
 import org.eclipse.persistence.jpa.jpql.tools.model.query.IdentificationVariableDeclarationStateObject;
 import org.eclipse.persistence.jpa.jpql.tools.model.query.IdentificationVariableStateObject;
+import org.eclipse.persistence.jpa.jpql.tools.model.query.IdExpressionStateObject;
 import org.eclipse.persistence.jpa.jpql.tools.model.query.InExpressionStateObject;
 import org.eclipse.persistence.jpa.jpql.tools.model.query.IndexExpressionStateObject;
 import org.eclipse.persistence.jpa.jpql.tools.model.query.InputParameterStateObject;
@@ -120,6 +121,7 @@ import org.eclipse.persistence.jpa.jpql.tools.model.query.UpdateItemStateObject;
 import org.eclipse.persistence.jpa.jpql.tools.model.query.UpdateStatementStateObject;
 import org.eclipse.persistence.jpa.jpql.tools.model.query.UpperExpressionStateObject;
 import org.eclipse.persistence.jpa.jpql.tools.model.query.ValueExpressionStateObject;
+import org.eclipse.persistence.jpa.jpql.tools.model.query.VersionExpressionStateObject;
 import org.eclipse.persistence.jpa.jpql.tools.model.query.WhenClauseStateObject;
 import org.eclipse.persistence.jpa.jpql.tools.model.query.WhereClauseStateObject;
 import static org.eclipse.persistence.jpa.jpql.parser.Expression.*;
@@ -856,6 +858,22 @@ public abstract class AbstractJPQLQueryFormatter extends BaseJPQLQueryFormatter 
     }
 
     @Override
+    public void visit(IdExpressionStateObject stateObject) {
+
+        if (stateObject.isDecorated()) {
+            toText(stateObject);
+        }
+        else {
+            writer.append(formatIdentifier(ID));
+            writer.append(formatIdentifier(LEFT_PARENTHESIS));
+            if (stateObject.hasIdentificationVariable()) {
+                writer.append(stateObject.getIdentificationVariable());
+            }
+            writer.append(formatIdentifier(RIGHT_PARENTHESIS));
+        }
+    }
+
+    @Override
     public void visit(IndexExpressionStateObject stateObject) {
 
         if (stateObject.isDecorated()) {
@@ -1403,6 +1421,22 @@ public abstract class AbstractJPQLQueryFormatter extends BaseJPQLQueryFormatter 
     @Override
     public void visit(ValueExpressionStateObject stateObject) {
         toStringEncapsulatedIdentificationVariable(stateObject);
+    }
+
+    @Override
+    public void visit(VersionExpressionStateObject stateObject) {
+
+        if (stateObject.isDecorated()) {
+            toText(stateObject);
+        }
+        else {
+            writer.append(formatIdentifier(VERSION));
+            writer.append(formatIdentifier(LEFT_PARENTHESIS));
+            if (stateObject.hasIdentificationVariable()) {
+                writer.append(stateObject.getIdentificationVariable());
+            }
+            writer.append(formatIdentifier(RIGHT_PARENTHESIS));
+        }
     }
 
     @Override

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/tools/model/BasicStateObjectBuilder.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/tools/model/BasicStateObjectBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -60,6 +60,7 @@ import org.eclipse.persistence.jpa.jpql.parser.FromClause;
 import org.eclipse.persistence.jpa.jpql.parser.FunctionExpression;
 import org.eclipse.persistence.jpa.jpql.parser.GroupByClause;
 import org.eclipse.persistence.jpa.jpql.parser.HavingClause;
+import org.eclipse.persistence.jpa.jpql.parser.IdExpression;
 import org.eclipse.persistence.jpa.jpql.parser.IdentificationVariable;
 import org.eclipse.persistence.jpa.jpql.parser.IdentificationVariableDeclaration;
 import org.eclipse.persistence.jpa.jpql.parser.InExpression;
@@ -114,6 +115,7 @@ import org.eclipse.persistence.jpa.jpql.parser.UpdateItem;
 import org.eclipse.persistence.jpa.jpql.parser.UpdateStatement;
 import org.eclipse.persistence.jpa.jpql.parser.UpperExpression;
 import org.eclipse.persistence.jpa.jpql.parser.ValueExpression;
+import org.eclipse.persistence.jpa.jpql.parser.VersionExpression;
 import org.eclipse.persistence.jpa.jpql.parser.WhenClause;
 import org.eclipse.persistence.jpa.jpql.parser.WhereClause;
 import org.eclipse.persistence.jpa.jpql.tools.model.query.AbsExpressionStateObject;
@@ -153,6 +155,7 @@ import org.eclipse.persistence.jpa.jpql.tools.model.query.FromClauseStateObject;
 import org.eclipse.persistence.jpa.jpql.tools.model.query.FunctionExpressionStateObject;
 import org.eclipse.persistence.jpa.jpql.tools.model.query.GroupByClauseStateObject;
 import org.eclipse.persistence.jpa.jpql.tools.model.query.HavingClauseStateObject;
+import org.eclipse.persistence.jpa.jpql.tools.model.query.IdExpressionStateObject;
 import org.eclipse.persistence.jpa.jpql.tools.model.query.IdentificationVariableDeclarationStateObject;
 import org.eclipse.persistence.jpa.jpql.tools.model.query.IdentificationVariableStateObject;
 import org.eclipse.persistence.jpa.jpql.tools.model.query.InExpressionStateObject;
@@ -206,6 +209,7 @@ import org.eclipse.persistence.jpa.jpql.tools.model.query.UpdateItemStateObject;
 import org.eclipse.persistence.jpa.jpql.tools.model.query.UpdateStatementStateObject;
 import org.eclipse.persistence.jpa.jpql.tools.model.query.UpperExpressionStateObject;
 import org.eclipse.persistence.jpa.jpql.tools.model.query.ValueExpressionStateObject;
+import org.eclipse.persistence.jpa.jpql.tools.model.query.VersionExpressionStateObject;
 import org.eclipse.persistence.jpa.jpql.tools.model.query.WhenClauseStateObject;
 import org.eclipse.persistence.jpa.jpql.tools.model.query.WhereClauseStateObject;
 import org.eclipse.persistence.jpa.jpql.tools.spi.IManagedTypeProvider;
@@ -987,6 +991,18 @@ public abstract class BasicStateObjectBuilder extends AbstractExpressionVisitor 
     }
 
     @Override
+    public void visit(IdExpression expression) {
+
+        IdExpressionStateObject stateObject = new IdExpressionStateObject(
+                parent,
+                literal(expression.getExpression(), LiteralType.IDENTIFICATION_VARIABLE)
+        );
+
+        stateObject.setExpression(expression);
+        this.stateObject = stateObject;
+    }
+
+    @Override
     public void visit(IndexExpression expression) {
 
         IndexExpressionStateObject stateObject = new IndexExpressionStateObject(
@@ -1648,6 +1664,18 @@ public abstract class BasicStateObjectBuilder extends AbstractExpressionVisitor 
         ValueExpressionStateObject stateObject = new ValueExpressionStateObject(
             parent,
             literal(expression.getExpression(), LiteralType.IDENTIFICATION_VARIABLE)
+        );
+
+        stateObject.setExpression(expression);
+        this.stateObject = stateObject;
+    }
+
+    @Override
+    public void visit(VersionExpression expression) {
+
+        IdExpressionStateObject stateObject = new IdExpressionStateObject(
+                parent,
+                literal(expression.getExpression(), LiteralType.IDENTIFICATION_VARIABLE)
         );
 
         stateObject.setExpression(expression);

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/tools/model/query/AbstractStateObjectVisitor.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/tools/model/query/AbstractStateObjectVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -168,6 +168,10 @@ public abstract class AbstractStateObjectVisitor implements StateObjectVisitor {
 
     @Override
     public void visit(IdentificationVariableStateObject stateObject) {
+    }
+
+    @Override
+    public void visit(IdExpressionStateObject stateObject) {
     }
 
     @Override
@@ -368,6 +372,10 @@ public abstract class AbstractStateObjectVisitor implements StateObjectVisitor {
 
     @Override
     public void visit(ValueExpressionStateObject stateObject) {
+    }
+
+    @Override
+    public void visit(VersionExpressionStateObject stateObject) {
     }
 
     @Override

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/tools/model/query/AnonymousStateObjectVisitor.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/tools/model/query/AnonymousStateObjectVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -203,6 +203,11 @@ public abstract class AnonymousStateObjectVisitor implements StateObjectVisitor 
 
     @Override
     public void visit(IdentificationVariableStateObject stateObject) {
+        visit((StateObject) stateObject);
+    }
+
+    @Override
+    public void visit(IdExpressionStateObject stateObject) {
         visit((StateObject) stateObject);
     }
 
@@ -461,6 +466,11 @@ public abstract class AnonymousStateObjectVisitor implements StateObjectVisitor 
 
     @Override
     public void visit(ValueExpressionStateObject stateObject) {
+        visit((StateObject) stateObject);
+    }
+
+    @Override
+    public void visit(VersionExpressionStateObject stateObject) {
         visit((StateObject) stateObject);
     }
 

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/tools/model/query/IdExpressionStateObject.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/tools/model/query/IdExpressionStateObject.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+//
+package org.eclipse.persistence.jpa.jpql.tools.model.query;
+
+import org.eclipse.persistence.jpa.jpql.parser.IdExpression;
+import org.eclipse.persistence.jpa.jpql.tools.model.Problem;
+
+import java.util.List;
+
+import static org.eclipse.persistence.jpa.jpql.parser.Expression.OBJECT;
+
+/**
+ * The result of an ID function expression is the Entity primary
+ * key. Argument must be an identification variable.
+ *
+ * <div><b>BNF:</b> <code>expression ::= ID(identification_variable)</code></div>
+ *
+ * @since 5.0
+ * @author Radek Felcman
+ */
+public class IdExpressionStateObject extends EncapsulatedIdentificationVariableExpressionStateObject {
+
+    /**
+     * Creates a new <code>IdExpressionStateObject</code>.
+     *
+     * @param parent The parent of this state object, which cannot be <code>null</code>
+     * @exception NullPointerException The given parent cannot be <code>null</code>
+     */
+    public IdExpressionStateObject(StateObject parent) {
+        super(parent);
+    }
+
+    /**
+     * Creates a new <code>IdExpressionStateObject</code>.
+     *
+     * @param parent The parent of this state object, which cannot be <code>null</code>
+     * @param identificationVariable The name of the identification variable
+     * @exception NullPointerException The given parent cannot be <code>null</code>
+     */
+    public IdExpressionStateObject(StateObject parent, String identificationVariable) {
+        super(parent, identificationVariable);
+    }
+
+    @Override
+    public void accept(StateObjectVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    protected void addProblems(List<Problem> problems) {
+        super.addProblems(problems);
+    }
+
+    @Override
+    public IdExpression getExpression() {
+        return (IdExpression) super.getExpression();
+    }
+
+    @Override
+    public String getIdentifier() {
+        return OBJECT;
+    }
+
+    /**
+     * Keeps a reference of the {@link IdExpression parsed object} object, which should only be
+     * done when this object is instantiated during the conversion of a parsed JPQL query into
+     * {@link StateObject StateObjects}.
+     *
+     * @param expression The {@link IdExpression parsed object} representing an <code><b>ID</b></code>
+     * expression
+     */
+    public void setExpression(IdExpression expression) {
+        super.setExpression(expression);
+    }
+}

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/tools/model/query/StateObjectVisitor.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/tools/model/query/StateObjectVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -281,6 +281,13 @@ public interface StateObjectVisitor {
      * @param stateObject The {@link IdentificationVariableStateObject} to visit
      */
     void visit(IdentificationVariableStateObject stateObject);
+
+    /**
+     * Visits the given {@link IdExpressionStateObject}.
+     *
+     * @param stateObject The {@link IdExpressionStateObject} to visit
+     */
+    void visit(IdExpressionStateObject stateObject);
 
     /**
      * Visits the given {@link IndexExpressionStateObject}.
@@ -631,6 +638,13 @@ public interface StateObjectVisitor {
      * @param stateObject The {@link ValueExpressionStateObject} to visit
      */
     void visit(ValueExpressionStateObject stateObject);
+
+    /**
+     * Visits the given {@link VersionExpressionStateObject}.
+     *
+     * @param stateObject The {@link VersionExpressionStateObject} to visit
+     */
+    void visit(VersionExpressionStateObject stateObject);
 
     /**
      * Visits the given {@link WhenClauseStateObject}.

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/tools/model/query/VersionExpressionStateObject.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/tools/model/query/VersionExpressionStateObject.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+//
+package org.eclipse.persistence.jpa.jpql.tools.model.query;
+
+import org.eclipse.persistence.jpa.jpql.parser.VersionExpression;
+import org.eclipse.persistence.jpa.jpql.tools.model.Problem;
+
+import java.util.List;
+
+import static org.eclipse.persistence.jpa.jpql.parser.Expression.VERSION;
+
+/**
+ * The result of an VERSION function expression is value Entity <code>@Version</code> field.
+ * Argument must be an identification variable.
+ *
+ * <div><b>BNF:</b> <code>expression ::= VERSION(identification_variable)</code></div>
+ *
+ * @since 5.0
+ * @author Radek Felcman
+ */
+public class VersionExpressionStateObject extends EncapsulatedIdentificationVariableExpressionStateObject {
+
+    /**
+     * Creates a new <code>VersionExpressionStateObject</code>.
+     *
+     * @param parent The parent of this state object, which cannot be <code>null</code>
+     * @exception NullPointerException The given parent cannot be <code>null</code>
+     */
+    public VersionExpressionStateObject(StateObject parent) {
+        super(parent);
+    }
+
+    /**
+     * Creates a new <code>VersionExpressionStateObject</code>.
+     *
+     * @param parent The parent of this state object, which cannot be <code>null</code>
+     * @param identificationVariable The name of the identification variable
+     * @exception NullPointerException The given parent cannot be <code>null</code>
+     */
+    public VersionExpressionStateObject(StateObject parent, String identificationVariable) {
+        super(parent, identificationVariable);
+    }
+
+    @Override
+    public void accept(StateObjectVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    protected void addProblems(List<Problem> problems) {
+        super.addProblems(problems);
+    }
+
+    @Override
+    public VersionExpression getExpression() {
+        return (VersionExpression) super.getExpression();
+    }
+
+    @Override
+    public String getIdentifier() {
+        return VERSION;
+    }
+
+    /**
+     * Keeps a reference of the {@link VersionExpression parsed object} object, which should only be
+     * done when this object is instantiated during the conversion of a parsed JPQL query into
+     * {@link StateObject StateObjects}.
+     *
+     * @param expression The {@link VersionExpression parsed object} representing an <code><b>ID</b></code>
+     * expression
+     */
+    public void setExpression(VersionExpression expression) {
+        super.setExpression(expression);
+    }
+}

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/tools/resolver/ResolverBuilder.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/tools/resolver/ResolverBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -70,6 +70,7 @@ import org.eclipse.persistence.jpa.jpql.parser.FromClause;
 import org.eclipse.persistence.jpa.jpql.parser.FunctionExpression;
 import org.eclipse.persistence.jpa.jpql.parser.GroupByClause;
 import org.eclipse.persistence.jpa.jpql.parser.HavingClause;
+import org.eclipse.persistence.jpa.jpql.parser.IdExpression;
 import org.eclipse.persistence.jpa.jpql.parser.IdentificationVariable;
 import org.eclipse.persistence.jpa.jpql.parser.IdentificationVariableDeclaration;
 import org.eclipse.persistence.jpa.jpql.parser.InExpression;
@@ -129,6 +130,7 @@ import org.eclipse.persistence.jpa.jpql.parser.UpdateItem;
 import org.eclipse.persistence.jpa.jpql.parser.UpdateStatement;
 import org.eclipse.persistence.jpa.jpql.parser.UpperExpression;
 import org.eclipse.persistence.jpa.jpql.parser.ValueExpression;
+import org.eclipse.persistence.jpa.jpql.parser.VersionExpression;
 import org.eclipse.persistence.jpa.jpql.parser.WhenClause;
 import org.eclipse.persistence.jpa.jpql.parser.WhereClause;
 import org.eclipse.persistence.jpa.jpql.tools.JPQLQueryContext;
@@ -682,6 +684,11 @@ public abstract class ResolverBuilder implements ExpressionVisitor {
     }
 
     @Override
+    public void visit(IdExpression expression) {
+        expression.getExpression().accept(this);
+    }
+
+    @Override
     public void visit(IndexExpression expression) {
         resolver = buildClassResolver(Integer.class);
     }
@@ -1123,6 +1130,11 @@ public abstract class ResolverBuilder implements ExpressionVisitor {
         // Wrap the Resolver used to determine the type of the identification
         // variable so we can return the actual type
         resolver = new ValueResolver(resolver);
+    }
+
+    @Override
+    public void visit(VersionExpression expression) {
+        expression.getExpression().accept(this);
     }
 
     @Override

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/org/eclipse/persistence/jpa/tests/jpql/AbstractGrammarValidatorTest.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/org/eclipse/persistence/jpa/tests/jpql/AbstractGrammarValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -3237,7 +3237,7 @@ public abstract class AbstractGrammarValidatorTest extends AbstractValidatorTest
     @Test
     public final void test_JPQLExpression_InvalidQuery_3() throws Exception {
 
-        String jpqlQuery  = "JPA version 2.0";
+        String jpqlQuery  = "JPA ver. 2.0";
         int startPosition = 0;
         int endPosition   = jpqlQuery.length();
 

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/org/eclipse/persistence/jpa/tests/jpql/JPQLQueries3_2.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/org/eclipse/persistence/jpa/tests/jpql/JPQLQueries3_2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -103,4 +103,19 @@ public class JPQLQueries3_2 {
                 "except Select a from Address a where a.city = 'Ottawa'";
     }
 
+    public static String query_IdFunction_Select01() {
+        return "SELECT ID(c) FROM Customer c";
+    }
+
+    public static String query_IdFunction_Where() {
+        return "SELECT c FROM Customer c WHERE ID(c) = 1";
+    }
+
+    public static String query_VersionFunction_Select01() {
+        return "SELECT VERSION(c) FROM Customer c";
+    }
+
+    public static String query_VersionFunction_Where() {
+        return "SELECT c FROM Customer c WHERE VERSION(c) = 1";
+    }
 }

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/org/eclipse/persistence/jpa/tests/jpql/parser/JPQLParserTest.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/org/eclipse/persistence/jpa/tests/jpql/parser/JPQLParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -72,6 +72,7 @@ import org.eclipse.persistence.jpa.jpql.parser.FunctionExpression;
 import org.eclipse.persistence.jpa.jpql.parser.GroupByClause;
 import org.eclipse.persistence.jpa.jpql.parser.HavingClause;
 import org.eclipse.persistence.jpa.jpql.parser.HierarchicalQueryClause;
+import org.eclipse.persistence.jpa.jpql.parser.IdExpression;
 import org.eclipse.persistence.jpa.jpql.parser.IdentificationVariable;
 import org.eclipse.persistence.jpa.jpql.parser.IdentificationVariableDeclaration;
 import org.eclipse.persistence.jpa.jpql.parser.InExpression;
@@ -138,6 +139,7 @@ import org.eclipse.persistence.jpa.jpql.parser.UpdateClause;
 import org.eclipse.persistence.jpa.jpql.parser.UpdateItem;
 import org.eclipse.persistence.jpa.jpql.parser.UpdateStatement;
 import org.eclipse.persistence.jpa.jpql.parser.UpperExpression;
+import org.eclipse.persistence.jpa.jpql.parser.VersionExpression;
 import org.eclipse.persistence.jpa.jpql.parser.WhenClause;
 import org.eclipse.persistence.jpa.jpql.parser.WhereClause;
 import org.eclipse.persistence.jpa.tests.jpql.JPQLBasicTest;
@@ -2945,6 +2947,23 @@ public abstract class JPQLParserTest extends JPQLBasicTest {
         }
     }
 
+    public static final class IdExpressionTester extends AbstractSingleEncapsulatedExpressionTester {
+
+        protected IdExpressionTester(ExpressionTester identificationVariable) {
+            super(identificationVariable);
+        }
+
+        @Override
+        protected Class<? extends AbstractSingleEncapsulatedExpression> expressionType() {
+            return IdExpression.class;
+        }
+
+        @Override
+        protected String identifier() {
+            return ID;
+        }
+    }
+
     public static final class IndexExpressionTester extends AbstractSingleEncapsulatedExpressionTester {
 
         protected IndexExpressionTester(ExpressionTester identificationVariable) {
@@ -4715,6 +4734,23 @@ public abstract class JPQLParserTest extends JPQLBasicTest {
         @Override
         protected String identifier() {
             return UPPER;
+        }
+    }
+
+    public static final class VersionExpressionTester extends AbstractSingleEncapsulatedExpressionTester {
+
+        protected VersionExpressionTester(ExpressionTester identificationVariable) {
+            super(identificationVariable);
+        }
+
+        @Override
+        protected Class<? extends AbstractSingleEncapsulatedExpression> expressionType() {
+            return VersionExpression.class;
+        }
+
+        @Override
+        protected String identifier() {
+            return VERSION;
         }
     }
 

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/org/eclipse/persistence/jpa/tests/jpql/parser/JPQLParserTester.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/org/eclipse/persistence/jpa/tests/jpql/parser/JPQLParserTester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -66,6 +66,7 @@ import org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTest.HavingClause
 import org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTest.HierarchicalQueryClauseTester;
 import org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTest.IdentificationVariableDeclarationTester;
 import org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTest.IdentificationVariableTester;
+import org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTest.IdExpressionTester;
 import org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTest.InExpressionTester;
 import org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTest.IndexExpressionTester;
 import org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTest.InputParameterTester;
@@ -126,6 +127,7 @@ import org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTest.UpdateClause
 import org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTest.UpdateItemTester;
 import org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTest.UpdateStatementTester;
 import org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTest.UpperExpressionTester;
+import org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTest.VersionExpressionTester;
 import org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTest.WhenClauseTester;
 import org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTest.WhereClauseTester;
 
@@ -1071,6 +1073,14 @@ public final class JPQLParserTester {
             rangeVariableDeclarationAs(abstractSchemaName, identificationVariable),
             spacedCollection(joins)
         );
+    }
+
+    public static IdExpressionTester id(ExpressionTester identificationVariable) {
+        return new IdExpressionTester(identificationVariable);
+    }
+
+    public static IdExpressionTester id(String identificationVariable) {
+        return id(variable(identificationVariable));
     }
 
     public static InExpressionTester in(ExpressionTester stateFieldPathExpression,
@@ -4118,6 +4128,14 @@ public final class JPQLParserTester {
         }
 
         return new IdentificationVariableTester(identificationVariable, false, nullExpression());
+    }
+
+    public static VersionExpressionTester version(ExpressionTester identificationVariable) {
+        return new VersionExpressionTester(identificationVariable);
+    }
+
+    public static VersionExpressionTester version(String identificationVariable) {
+        return version(variable(identificationVariable));
     }
 
     public static IdentificationVariableTester virtualVariable(String identificationVariable) {

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/org/eclipse/persistence/jpa/tests/jpql/parser/JPQLQueriesTest3_2.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/org/eclipse/persistence/jpa/tests/jpql/parser/JPQLQueriesTest3_2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -22,6 +22,8 @@ import static org.eclipse.persistence.jpa.tests.jpql.JPQLQueries3_2.query_Concat
 import static org.eclipse.persistence.jpa.tests.jpql.JPQLQueries3_2.query_ConcatPipes_Select02;
 import static org.eclipse.persistence.jpa.tests.jpql.JPQLQueries3_2.query_ConcatPipes_Select_Chained;
 import static org.eclipse.persistence.jpa.tests.jpql.JPQLQueries3_2.query_ConcatPipes_Where;
+import static org.eclipse.persistence.jpa.tests.jpql.JPQLQueries3_2.query_IdFunction_Select01;
+import static org.eclipse.persistence.jpa.tests.jpql.JPQLQueries3_2.query_IdFunction_Where;
 import static org.eclipse.persistence.jpa.tests.jpql.JPQLQueries3_2.query_LeftFunction_Select01;
 import static org.eclipse.persistence.jpa.tests.jpql.JPQLQueries3_2.query_LeftFunction_Select02;
 import static org.eclipse.persistence.jpa.tests.jpql.JPQLQueries3_2.query_LeftFunction_Select03;
@@ -35,6 +37,8 @@ import static org.eclipse.persistence.jpa.tests.jpql.JPQLQueries3_2.query_RightF
 import static org.eclipse.persistence.jpa.tests.jpql.JPQLQueries3_2.query_RightFunction_Select02;
 import static org.eclipse.persistence.jpa.tests.jpql.JPQLQueries3_2.query_RightFunction_Select03;
 import static org.eclipse.persistence.jpa.tests.jpql.JPQLQueries3_2.query_RightFunction_Where;
+import static org.eclipse.persistence.jpa.tests.jpql.JPQLQueries3_2.query_VersionFunction_Select01;
+import static org.eclipse.persistence.jpa.tests.jpql.JPQLQueries3_2.query_VersionFunction_Where;
 import static org.eclipse.persistence.jpa.tests.jpql.JPQLQueries3_2.query_Union01;
 import static org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTester.concatPipes;
 import static org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTester.count;
@@ -42,6 +46,7 @@ import static org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTester.exc
 import static org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTester.from;
 import static org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTester.groupBy;
 import static org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTester.having;
+import static org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTester.id;
 import static org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTester.intersect;
 import static org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTester.left;
 import static org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTester.leftJoin;
@@ -57,6 +62,7 @@ import static org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTester.sub
 import static org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTester.union;
 import static org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTester.unionAll;
 import static org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTester.variable;
+import static org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTester.version;
 import static org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTester.where;
 
 public class JPQLQueriesTest3_2 extends JPQLParserTest {
@@ -378,5 +384,57 @@ public class JPQLQueriesTest3_2 extends JPQLParserTest {
         );
 
         testQuery(query_Union01(), selectStatement);
+    }
+
+    @Test
+    public final void test_Query_IdFunction_Select01() {
+        // select id(c)
+        // FROM Customer c
+
+        ExpressionTester selectStatement = selectStatement(
+            select(id("c")),
+            from("Customer", "c"));
+
+        testQuery(query_IdFunction_Select01(), selectStatement);
+    }
+
+    @Test
+    public final void test_Query_IdFunction_Where() {
+        // SELECT c
+        // FROM Customer
+        // c WHERE ID(c).id = 1
+
+        ExpressionTester selectStatement = selectStatement(
+                select(variable("c")),
+                from("Customer", "c"),
+                where(id("c").equal(numeric(1))));
+
+        testQuery(query_IdFunction_Where(), selectStatement);
+    }
+
+    @Test
+    public final void test_Query_VersionFunction_Select01() {
+        // select version(c)
+        // FROM Customer c
+
+        ExpressionTester selectStatement = selectStatement(
+                select(version("c")),
+                from("Customer", "c"));
+
+        testQuery(query_VersionFunction_Select01(), selectStatement);
+    }
+
+    @Test
+    public final void test_Query_VersionFunction_Where() {
+        // SELECT c
+        // FROM Customer
+        // c WHERE version(c).id = 1
+
+        ExpressionTester selectStatement = selectStatement(
+                select(variable("c")),
+                from("Customer", "c"),
+                where(version("c").equal(numeric(1))));
+
+        testQuery(query_VersionFunction_Where(), selectStatement);
     }
 }


### PR DESCRIPTION
Implementation plus unit test according https://github.com/jakartaee/persistence/pull/596

There are two new JPQL functions:
- `ID(...)` to fetch Entity `@Id` value. There is support for single or composite primary key
- `VERSION(...)` to fetch attribute value from attribute marked by `@Version` annotation

These functions are specific as they are exist in JPQL only, but not in SQL like other JPQL functions where are usually similar SQL function/procedure.