### PR TITLE
[4.0] Bugfix: NullPointerException at CacheIndexMetadata.getField()

### DIFF
--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/accessors/classes/MappedSuperclassAccessor.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/accessors/classes/MappedSuperclassAccessor.java
@@ -1016,6 +1016,7 @@ public class MappedSuperclassAccessor extends ClassAccessor {
         }
 
         for (CacheIndexMetadata indexMetadata : m_cacheIndexes) {
+            indexMetadata.setProject(getProject());
             indexMetadata.process(getDescriptor(), null);
         }
     }

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/accessors/classes/MappedSuperclassAccessor.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/accessors/classes/MappedSuperclassAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at


### PR DESCRIPTION
NullPointerException raising at CacheIndexMetadata.getField() while EntityManager initialising is XML mapping (ORM) file is used with following part e.g.:
```
...
        <cache isolation="SHARED"/>
        <cache-index>
            <column-name>deptName</column-name>
        </cache-index>
...
```
