### PR TITLE
[master] Performance improvement: synchronize to java.util.concurrent.locks switch to improve performance with VirtualThreads

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ReadLockManager.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ReadLockManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -20,6 +20,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Vector;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 public class ReadLockManager {
 
@@ -45,21 +47,28 @@ public class ReadLockManager {
      */
     private final List<String> removeReadLockProblemsDetected = new ArrayList<>();
 
+    private final Lock instanceLock  = new ReentrantLock();
+
     /**
      * add a concurrency manager as deferred locks to the DLM
      */
-    public synchronized void addReadLock(ConcurrencyManager concurrencyManager) {
-        final Thread currentThread = Thread.currentThread();
-        final long currentThreadId = currentThread.getId();
-        ReadLockAcquisitionMetadata readLockAcquisitionMetadata = ConcurrencyUtil.SINGLETON.createReadLockAcquisitionMetadata(concurrencyManager);
+    public void addReadLock(ConcurrencyManager concurrencyManager) {
+        instanceLock.lock();
+        try {
+            final Thread currentThread = Thread.currentThread();
+            final long currentThreadId = currentThread.getId();
+            ReadLockAcquisitionMetadata readLockAcquisitionMetadata = ConcurrencyUtil.SINGLETON.createReadLockAcquisitionMetadata(concurrencyManager);
 
-        this.readLocks.add(FIRST_INDEX_OF_COLLECTION, concurrencyManager);
-        if(!mapThreadToReadLockAcquisitionMetadata.containsKey(currentThreadId)) {
-            List<ReadLockAcquisitionMetadata> newList = Collections.synchronizedList(new ArrayList<>());
-            mapThreadToReadLockAcquisitionMetadata.put(currentThreadId, newList );
+            this.readLocks.add(FIRST_INDEX_OF_COLLECTION, concurrencyManager);
+            if (!mapThreadToReadLockAcquisitionMetadata.containsKey(currentThreadId)) {
+                List<ReadLockAcquisitionMetadata> newList = Collections.synchronizedList(new ArrayList<>());
+                mapThreadToReadLockAcquisitionMetadata.put(currentThreadId, newList);
+            }
+            List<ReadLockAcquisitionMetadata> acquiredReadLocksInCurrentTransactionList = mapThreadToReadLockAcquisitionMetadata.get(currentThreadId);
+            acquiredReadLocksInCurrentTransactionList.add(FIRST_INDEX_OF_COLLECTION, readLockAcquisitionMetadata);
+        } finally {
+            instanceLock.unlock();
         }
-        List<ReadLockAcquisitionMetadata> acquiredReadLocksInCurrentTransactionList = mapThreadToReadLockAcquisitionMetadata.get(currentThreadId);
-        acquiredReadLocksInCurrentTransactionList.add(FIRST_INDEX_OF_COLLECTION, readLockAcquisitionMetadata);
     }
 
     /**
@@ -70,46 +79,56 @@ public class ReadLockManager {
      * @param concurrencyManager
      *            the concurrency cache key that is about to be decrement in number of readers.
      */
-    public synchronized void removeReadLock(ConcurrencyManager concurrencyManager) {
-        final Thread currentThread = Thread.currentThread();
-        final long currentThreadId = currentThread.getId();
-        boolean readLockManagerHasTracingAboutAddedReadLocksForCurrentThread = mapThreadToReadLockAcquisitionMetadata.containsKey(currentThreadId);
+    public void removeReadLock(ConcurrencyManager concurrencyManager) {
+        instanceLock.lock();
+        try {
+            final Thread currentThread = Thread.currentThread();
+            final long currentThreadId = currentThread.getId();
+            boolean readLockManagerHasTracingAboutAddedReadLocksForCurrentThread = mapThreadToReadLockAcquisitionMetadata.containsKey(currentThreadId);
 
-        if (!readLockManagerHasTracingAboutAddedReadLocksForCurrentThread) {
-            String errorMessage = ConcurrencyUtil.SINGLETON.readLockManagerProblem02ReadLockManageHasNoEntriesForThread(concurrencyManager, currentThreadId);
-            removeReadLockProblemsDetected.add(errorMessage);
-            return;
-        }
-
-        List<ReadLockAcquisitionMetadata> readLocksAcquiredDuringCurrentThread = mapThreadToReadLockAcquisitionMetadata.get(currentThreadId);
-        ReadLockAcquisitionMetadata readLockAquisitionMetadataToRemove = null;
-        for (ReadLockAcquisitionMetadata currentReadLockAcquisitionMetadata : readLocksAcquiredDuringCurrentThread) {
-            ConcurrencyManager currentCacheKeyObjectToCheck = currentReadLockAcquisitionMetadata.getCacheKeyWhoseNumberOfReadersThreadIsIncrementing();
-            boolean dtoToRemoveFound = concurrencyManager.getConcurrencyManagerId() == currentCacheKeyObjectToCheck.getConcurrencyManagerId();
-            if (dtoToRemoveFound) {
-                readLockAquisitionMetadataToRemove = currentReadLockAcquisitionMetadata;
-                break;
+            if (!readLockManagerHasTracingAboutAddedReadLocksForCurrentThread) {
+                String errorMessage = ConcurrencyUtil.SINGLETON.readLockManagerProblem02ReadLockManageHasNoEntriesForThread(concurrencyManager, currentThreadId);
+                removeReadLockProblemsDetected.add(errorMessage);
+                return;
             }
-        }
 
-        if (readLockAquisitionMetadataToRemove == null) {
-            String errorMessage = ConcurrencyUtil.SINGLETON.readLockManagerProblem03ReadLockManageHasNoEntriesForThread(concurrencyManager, currentThreadId);
-            removeReadLockProblemsDetected.add(errorMessage);
-            return;
-        }
-        this.readLocks.remove(concurrencyManager);
-        readLocksAcquiredDuringCurrentThread.remove(readLockAquisitionMetadataToRemove);
+            List<ReadLockAcquisitionMetadata> readLocksAcquiredDuringCurrentThread = mapThreadToReadLockAcquisitionMetadata.get(currentThreadId);
+            ReadLockAcquisitionMetadata readLockAquisitionMetadataToRemove = null;
+            for (ReadLockAcquisitionMetadata currentReadLockAcquisitionMetadata : readLocksAcquiredDuringCurrentThread) {
+                ConcurrencyManager currentCacheKeyObjectToCheck = currentReadLockAcquisitionMetadata.getCacheKeyWhoseNumberOfReadersThreadIsIncrementing();
+                boolean dtoToRemoveFound = concurrencyManager.getConcurrencyManagerId() == currentCacheKeyObjectToCheck.getConcurrencyManagerId();
+                if (dtoToRemoveFound) {
+                    readLockAquisitionMetadataToRemove = currentReadLockAcquisitionMetadata;
+                    break;
+                }
+            }
 
-        if (readLocksAcquiredDuringCurrentThread.isEmpty()) {
-            mapThreadToReadLockAcquisitionMetadata.remove(currentThreadId);
+            if (readLockAquisitionMetadataToRemove == null) {
+                String errorMessage = ConcurrencyUtil.SINGLETON.readLockManagerProblem03ReadLockManageHasNoEntriesForThread(concurrencyManager, currentThreadId);
+                removeReadLockProblemsDetected.add(errorMessage);
+                return;
+            }
+            this.readLocks.remove(concurrencyManager);
+            readLocksAcquiredDuringCurrentThread.remove(readLockAquisitionMetadataToRemove);
+
+            if (readLocksAcquiredDuringCurrentThread.isEmpty()) {
+                mapThreadToReadLockAcquisitionMetadata.remove(currentThreadId);
+            }
+        } finally {
+            instanceLock.unlock();
         }
     }
 
     /**
      * Return a set of the deferred locks
      */
-    public synchronized List<ConcurrencyManager> getReadLocks() {
-        return Collections.unmodifiableList(readLocks);
+    public List<ConcurrencyManager> getReadLocks() {
+        instanceLock.lock();
+        try {
+            return Collections.unmodifiableList(readLocks);
+        } finally {
+            instanceLock.unlock();
+        }
     }
 
     /**
@@ -119,8 +138,13 @@ public class ReadLockManager {
      * @param problemDetected
      *            the detected problem
      */
-    public synchronized void addRemoveReadLockProblemsDetected(String problemDetected) {
-        removeReadLockProblemsDetected.add(problemDetected);
+    public void addRemoveReadLockProblemsDetected(String problemDetected) {
+        instanceLock.lock();
+        try {
+            removeReadLockProblemsDetected.add(problemDetected);
+        } finally {
+            instanceLock.unlock();
+        }
     }
 
     /** Getter for {@link #mapThreadToReadLockAcquisitionMetadata} */
@@ -142,8 +166,13 @@ public class ReadLockManager {
      *         any read lock acquired in the tracing we definitely do not want this object instance to be thrown out
      *         from our main tracing. It is probably revealing problems in read lock acquisition and released.
      */
-    public synchronized boolean isEmpty() {
-        return readLocks.isEmpty() && removeReadLockProblemsDetected.isEmpty();
+    public boolean isEmpty() {
+        instanceLock.lock();
+        try {
+            return readLocks.isEmpty() && removeReadLockProblemsDetected.isEmpty();
+        } finally {
+            instanceLock.unlock();
+        }
     }
 
     /**
@@ -156,16 +185,20 @@ public class ReadLockManager {
      * or to go about doing
      */
     @Override
-    public synchronized ReadLockManager clone() {
-        ReadLockManager clone = new ReadLockManager();
-        clone.readLocks.addAll(this.readLocks);
-        for (Map.Entry<Long, List<ReadLockAcquisitionMetadata>> currentEntry : this.mapThreadToReadLockAcquisitionMetadata.entrySet()) {
-            Long key = currentEntry.getKey();
-            List<ReadLockAcquisitionMetadata> value = currentEntry.getValue();
-            clone.mapThreadToReadLockAcquisitionMetadata.put(key, new ArrayList<>(value));
+    public ReadLockManager clone() {
+        instanceLock.lock();
+        try {
+            ReadLockManager clone = new ReadLockManager();
+            clone.readLocks.addAll(this.readLocks);
+            for (Map.Entry<Long, List<ReadLockAcquisitionMetadata>> currentEntry : this.mapThreadToReadLockAcquisitionMetadata.entrySet()) {
+                Long key = currentEntry.getKey();
+                List<ReadLockAcquisitionMetadata> value = currentEntry.getValue();
+                clone.mapThreadToReadLockAcquisitionMetadata.put(key, new ArrayList<>(value));
+            }
+            clone.removeReadLockProblemsDetected.addAll(this.removeReadLockProblemsDetected);
+            return clone;
+        } finally {
+            instanceLock.unlock();
         }
-        clone.removeReadLockProblemsDetected.addAll(this.removeReadLockProblemsDetected);
-        return clone;
     }
-
 }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/WriteLockManager.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/WriteLockManager.java
@@ -44,6 +44,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static java.util.Collections.unmodifiableMap;
 
@@ -127,6 +131,10 @@ public class WriteLockManager {
     /*  the first element in this list will be the prevailing thread */
     protected ExposedNodeLinkedList prevailingQueue;
 
+    private final Lock toWaitOnLock = new ReentrantLock();
+    private final Lock instancePrevailingQueueLock = new ReentrantLock();
+    private final Condition toWaitOnLockCondition = toWaitOnLock.newCondition();
+
     public WriteLockManager() {
         this.prevailingQueue = new ExposedNodeLinkedList();
     }
@@ -172,14 +180,17 @@ public class WriteLockManager {
                 // using the exact same approach we have been adding to the concurrency manager
                 ConcurrencyUtil.SINGLETON.determineIfReleaseDeferredLockAppearsToBeDeadLocked(toWaitOn, whileStartTimeMillis, lockManager, readLockManager, ALLOW_INTERRUPTED_EXCEPTION_TO_BE_FIRED_UP_TRUE);
 
-                synchronized (toWaitOn) {
+                toWaitOnLock.lock();
+                try {
                     try {
                         if (toWaitOn.isAcquired()) {//last minute check to insure it is still locked.
-                            toWaitOn.wait(ConcurrencyUtil.SINGLETON.getAcquireWaitTime());// wait for lock on object to be released
+                            toWaitOnLockCondition.await(ConcurrencyUtil.SINGLETON.getAcquireWaitTime(), TimeUnit.MILLISECONDS);// wait for lock on object to be released
                         }
                     } catch (InterruptedException ex) {
                         // Ignore exception thread should continue.
                     }
+                } finally {
+                    toWaitOnLock.unlock();
                 }
                 Object waitObject = toWaitOn.getObject();
                 // Object may be null for loss of identity.
@@ -424,8 +435,11 @@ public class WriteLockManager {
                                 // set the QueueNode to be the node from the
                                 // linked list for quick removal upon
                                 // acquiring all locks
-                                synchronized (this.prevailingQueue) {
+                                instancePrevailingQueueLock.lock();
+                                try {
                                     mergeManager.setQueueNode(this.prevailingQueue.addLastElement(mergeManager));
+                                } finally {
+                                    instancePrevailingQueueLock.unlock();
                                 }
                             }
 
@@ -435,14 +449,15 @@ public class WriteLockManager {
                             try {
                                 if (activeCacheKey != null){
                                     //wait on the lock of the object that we couldn't get.
-                                    synchronized (activeCacheKey) {
+                                    activeCacheKey.getInstanceLock().lock();
+                                    try {
                                         // verify that the cache key is still locked before we wait on it, as
                                         //it may have been released since we tried to acquire it.
                                         if (activeCacheKey.isAcquired() && (activeCacheKey.getActiveThread() != Thread.currentThread())) {
                                                 Thread thread = activeCacheKey.getActiveThread();
                                                 if (thread.isAlive()){
                                                     long time = System.currentTimeMillis();
-                                                    activeCacheKey.wait(MAX_WAIT);
+                                                    activeCacheKey.getInstanceLockCondition().await(MAX_WAIT, TimeUnit.MILLISECONDS);
                                                     if (System.currentTimeMillis() - time >= MAX_WAIT){
                                                         Object[] params = new Object[]{MAX_WAIT /1000, descriptor.getJavaClassName(), activeCacheKey.getKey(), thread.getName()};
                                                         StringBuilder buffer = new StringBuilder(TraceLocalization.buildMessage("max_time_exceeded_for_acquirerequiredlocks_wait", params));
@@ -464,6 +479,8 @@ public class WriteLockManager {
                                                     }
                                                 }
                                             }
+                                        } finally {
+                                            activeCacheKey.getInstanceLock().unlock();
                                         }
                                     }
                             } catch (InterruptedException exception) {
@@ -502,8 +519,11 @@ public class WriteLockManager {
         }finally {
             if (mergeManager.getWriteLockQueued() != null) {
                 //the merge manager entered the wait queue and must be cleaned up
-                synchronized(this.prevailingQueue) {
+                instancePrevailingQueueLock.lock();
+                try {
                     this.prevailingQueue.remove(mergeManager.getQueueNode());
+                } finally {
+                    instancePrevailingQueueLock.unlock();
                 }
                 mergeManager.setWriteLockQueued(null);
             }

--- a/performance/eclipselink.perf.test/el-test.performance.properties
+++ b/performance/eclipselink.perf.test/el-test.performance.properties
@@ -12,5 +12,4 @@
 
 warmup.iterations=20
 run.iterations=20
-jmh.resultFile=jmh-result.csv
 jmh.resultFormat=csv

--- a/performance/eclipselink.perf.test/pom.xml
+++ b/performance/eclipselink.perf.test/pom.xml
@@ -189,15 +189,15 @@
                 </configuration>
                 <executions>
                     <execution>
-                        <id>test-performance-benchmark</id>
+                        <id>test-core-performance-benchmark</id>
                         <configuration>
                             <arguments>
                                 <argument>${warmup.iterations}</argument>
                                 <argument>${run.iterations}</argument>
-                                <argument>${project.build.directory}/${jmh.resultFile}</argument>
+                                <argument>${project.build.directory}/jmh-core-result.txt</argument>
                                 <argument>${jmh.resultFormat}</argument>
                             </arguments>
-                            <mainClass>org.eclipse.persistence.testing.perf.Benchmarks</mainClass>
+                            <mainClass>org.eclipse.persistence.testing.perf.CoreBenchmarks</mainClass>
                         </configuration>
                         <phase>test</phase>
                         <goals>
@@ -205,12 +205,44 @@
                         </goals>
                     </execution>
                     <execution>
-                        <id>test-performance-jpa-benchmark</id>
+                        <id>test-moxy-performance-benchmark</id>
                         <configuration>
                             <arguments>
                                 <argument>${warmup.iterations}</argument>
                                 <argument>${run.iterations}</argument>
-                                <argument>${project.build.directory}/jpa-${jmh.resultFile}</argument>
+                                <argument>${project.build.directory}/jmh-moxy-result.txt</argument>
+                                <argument>${jmh.resultFormat}</argument>
+                            </arguments>
+                            <mainClass>org.eclipse.persistence.testing.perf.MOXyBenchmarks</mainClass>
+                        </configuration>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>test-jpa-metadata-performance-benchmark</id>
+                        <configuration>
+                            <arguments>
+                                <argument>${warmup.iterations}</argument>
+                                <argument>${run.iterations}</argument>
+                                <argument>${project.build.directory}/jmh-jpa-metadata-result.txt</argument>
+                                <argument>${jmh.resultFormat}</argument>
+                            </arguments>
+                            <mainClass>org.eclipse.persistence.testing.perf.JPAMetadataBenchmarks</mainClass>
+                        </configuration>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>test-jpa-performance-benchmark</id>
+                        <configuration>
+                            <arguments>
+                                <argument>${warmup.iterations}</argument>
+                                <argument>${run.iterations}</argument>
+                                <argument>${project.build.directory}/jmh-jpa-result.txt</argument>
                                 <argument>${jmh.resultFormat}</argument>
                             </arguments>
                             <mainClass>org.eclipse.persistence.testing.perf.JPABenchmarks</mainClass>

--- a/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/CoreBenchmarks.java
+++ b/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/CoreBenchmarks.java
@@ -11,27 +11,26 @@
  */
 
 // Contributors:
-//              Oracle - initial implementation
+//     Oracle - initial implementation
 package org.eclipse.persistence.testing.perf;
 
-import org.eclipse.persistence.testing.perf.jpa.tests.basic.JPAReadLargeAmmountCacheTests;
-import org.eclipse.persistence.testing.perf.jpa.tests.basic.JPAReadLargeAmmountNoCacheTests;
-import org.eclipse.persistence.testing.perf.jpa.tests.basic.JPAReadSmallAmmountCacheTests;
-import org.eclipse.persistence.testing.perf.jpa.tests.basic.JPAReadSmallAmmountNoCacheTests;
+import org.eclipse.persistence.testing.perf.core.ConcurrencyManagerBenchmark;
 import org.openjdk.jmh.results.format.ResultFormatType;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
-public class JPABenchmarks {
-
+/**
+ * This class wraps core module related benchmarks. It is analogy to JUnit suites.
+ *
+ */
+public class CoreBenchmarks {
     public static void main(String[] args) throws RunnerException {
 
         int warmupIterations = 20;
         int measurementIterations = 20;
-        int threads = 10;
-        String resultFile = "jmh-jpa-result.txt";
+        String resultFile = "jmh-core-result.txt";
         String resultFormat = "text";
 
         if (null != args && args.length == 4) {
@@ -42,17 +41,13 @@ public class JPABenchmarks {
         }
 
         Options opt = new OptionsBuilder()
-                .include(getInclude(JPAReadSmallAmmountCacheTests.class))
-                .include(getInclude(JPAReadSmallAmmountNoCacheTests.class))
-                .include(getInclude(JPAReadLargeAmmountCacheTests.class))
-                .include(getInclude(JPAReadLargeAmmountNoCacheTests.class))
-                .jvmArgsPrepend("-javaagent:" + System.getProperty("eclipselink.agent"))
+                .include(getInclude(ConcurrencyManagerBenchmark.class))
                 .result(resultFile)
                 .resultFormat(ResultFormatType.valueOf(resultFormat.toUpperCase()))
                 .warmupIterations(warmupIterations)
                 .measurementIterations(measurementIterations)
                 .forks(1)
-                .threads(threads)
+                .threads(50)
                 .build();
 
         new Runner(opt).run();

--- a/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/JPAMetadataBenchmarks.java
+++ b/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/JPAMetadataBenchmarks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,27 +11,25 @@
  */
 
 // Contributors:
-//              Oracle - initial implementation
+//              ljungmann - initial implementation
 package org.eclipse.persistence.testing.perf;
 
-import org.eclipse.persistence.testing.perf.jpa.tests.basic.JPAReadLargeAmmountCacheTests;
-import org.eclipse.persistence.testing.perf.jpa.tests.basic.JPAReadLargeAmmountNoCacheTests;
-import org.eclipse.persistence.testing.perf.jpa.tests.basic.JPAReadSmallAmmountCacheTests;
-import org.eclipse.persistence.testing.perf.jpa.tests.basic.JPAReadSmallAmmountNoCacheTests;
+import org.eclipse.persistence.testing.perf.jpa.tests.basic.JPAMetadataProcessingTests;
+import org.eclipse.persistence.testing.perf.jpa.tests.basic.MethodHandleComparisonTests;
+
 import org.openjdk.jmh.results.format.ResultFormatType;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
-public class JPABenchmarks {
+public class JPAMetadataBenchmarks {
 
     public static void main(String[] args) throws RunnerException {
 
         int warmupIterations = 20;
         int measurementIterations = 20;
-        int threads = 10;
-        String resultFile = "jmh-jpa-result.txt";
+        String resultFile = "jmh-jpa-metadata-result.txt";
         String resultFormat = "text";
 
         if (null != args && args.length == 4) {
@@ -42,17 +40,14 @@ public class JPABenchmarks {
         }
 
         Options opt = new OptionsBuilder()
-                .include(getInclude(JPAReadSmallAmmountCacheTests.class))
-                .include(getInclude(JPAReadSmallAmmountNoCacheTests.class))
-                .include(getInclude(JPAReadLargeAmmountCacheTests.class))
-                .include(getInclude(JPAReadLargeAmmountNoCacheTests.class))
+                .include(getInclude(JPAMetadataProcessingTests.class))
+                .include(getInclude(MethodHandleComparisonTests.class))
                 .jvmArgsPrepend("-javaagent:" + System.getProperty("eclipselink.agent"))
                 .result(resultFile)
                 .resultFormat(ResultFormatType.valueOf(resultFormat.toUpperCase()))
                 .warmupIterations(warmupIterations)
                 .measurementIterations(measurementIterations)
                 .forks(1)
-                .threads(threads)
                 .build();
 
         new Runner(opt).run();

--- a/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/MOXyBenchmarks.java
+++ b/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/MOXyBenchmarks.java
@@ -33,12 +33,12 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
  * @author Martin Vojtek (martin.vojtek@oracle.com)
  *
  */
-public class Benchmarks {
+public class MOXyBenchmarks {
     public static void main(String[] args) throws RunnerException {
 
         int warmupIterations = 20;
         int measurementIterations = 20;
-        String resultFile = "jmh-result.txt";
+        String resultFile = "jmh-moxy-result.txt";
         String resultFormat = "text";
 
         if (null != args && args.length == 4) {

--- a/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/core/ConcurrencyManagerBenchmark.java
+++ b/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/core/ConcurrencyManagerBenchmark.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial implementation
+package org.eclipse.persistence.testing.perf.core;
+
+import org.eclipse.persistence.internal.helper.ConcurrencyManager;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * This benchmark verify performance of {@code org.eclipse.persistence.internal.helper.ConcurrencyManager}.
+ *
+ */
+@State(Scope.Benchmark)
+public class ConcurrencyManagerBenchmark {
+
+    @Benchmark
+    public void testAcquireRelease(Blackhole bh) throws Exception {
+        ConcurrencyManager concurrencyManager = new ConcurrencyManager();
+        concurrencyManager.acquire();
+        concurrencyManager.release();
+    }
+}

--- a/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/jpa/model/basic/DetailEntity.java
+++ b/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/jpa/model/basic/DetailEntity.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//              Oracle - initial implementation
+package org.eclipse.persistence.testing.perf.jpa.model.basic;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "P2_DETAIL")
+public class DetailEntity {
+    @Id
+    private long id;
+
+    private String name;
+
+    @ManyToOne()
+    @JoinColumn(name = "MASTER_ID_FK")
+    private MasterEntity master;
+
+    public DetailEntity() {
+    }
+
+    public DetailEntity(long id) {
+        this.id = id;
+    }
+
+    public DetailEntity(long id, String name, MasterEntity master) {
+        this.id = id;
+        this.name = name;
+        this.master = master;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public MasterEntity getMaster() {
+        return master;
+    }
+
+    public void setMaster(MasterEntity master) {
+        this.master = master;
+    }
+
+    @Override
+    public String toString() {
+        return "DetailEntity{" +
+                "id=" + id +
+                ", name='" + name +
+                '}';
+    }
+}

--- a/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/jpa/model/basic/MasterEntity.java
+++ b/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/jpa/model/basic/MasterEntity.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//              Oracle - initial implementation
+package org.eclipse.persistence.testing.perf.jpa.model.basic;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "P2_MASTER")
+public class MasterEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    private String name;
+
+    @OneToMany(mappedBy = "master", fetch = FetchType.EAGER)
+    private List<DetailEntity> details = new ArrayList<>();
+
+    public MasterEntity() {
+    }
+
+    public MasterEntity(long id) {
+        this.id = id;
+    }
+    
+    public MasterEntity(long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public MasterEntity(String name) {
+        this.name = name;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<DetailEntity> getDetails() {
+        return details;
+    }
+
+    public void setDetails(List<DetailEntity> details) {
+        this.details = details;
+    }
+
+    @Override
+    public String toString() {
+        return "MasterEntity{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", details=" + details +
+                '}';
+    }
+}

--- a/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/jpa/tests/basic/JPAReadAbstract.java
+++ b/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/jpa/tests/basic/JPAReadAbstract.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//              Oracle - initial implementation
+package org.eclipse.persistence.testing.perf.jpa.tests.basic;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Persistence;
+import jakarta.persistence.EntityManagerFactory;
+
+import org.eclipse.persistence.testing.perf.jpa.model.basic.DetailEntity;
+import org.eclipse.persistence.testing.perf.jpa.model.basic.MasterEntity;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.TearDown;
+
+/**
+ * Benchmarks for JPA reading data.
+ *
+ * @author Oracle
+ */
+public abstract class JPAReadAbstract {
+
+    public static final int DETAIL_ID_STEP = 10000;
+
+    private EntityManagerFactory emf = Persistence.createEntityManagerFactory(getPersistenceUnitName());
+
+    @Setup
+    public void setup() {
+        EntityManager em = emf.createEntityManager();
+        prepareData(em);
+    }
+
+    @TearDown
+    public void tearDown() {
+        emf.close();
+    }
+
+    /**
+     * Read MasterEntity and DetailEntity (fetch = FetchType.EAGER).
+     */
+    @Benchmark
+    public void testReadEntity() {
+        EntityManager em = null;
+        try {
+            em = emf.createEntityManager();
+            for (long i = 1; i <= getMasterSize(); i++) {
+                MasterEntity masterEntity = em.find(MasterEntity.class, i);
+                if (masterEntity == null) {
+                    throw new RuntimeException("MasterEntity is null!");
+                }
+                if (masterEntity.getDetails().size() < getDetailSize()) {
+                    throw new RuntimeException("No of DetailEntities is |" + masterEntity.getDetails().size() + "| less than expected |" + getDetailSize() + "|!");
+                }
+            }
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        } finally {
+            if (em != null) {
+                em.close();
+            }
+        }
+    }
+
+    private void prepareData(EntityManager em) {
+        try {
+            em.getTransaction().begin();
+            for (int i = 1; i <= getMasterSize(); i++) {
+                MasterEntity masterEntity = new MasterEntity(i, "Master name " + i);
+                em.persist(masterEntity);
+                for (int j = 1; j <= getDetailSize(); j++) {
+                    DetailEntity detailEntity = new DetailEntity(i * DETAIL_ID_STEP + j, "Detail name " + j, masterEntity);
+                    masterEntity.getDetails().add(detailEntity);
+                    em.persist(detailEntity);
+                }
+            }
+            em.getTransaction().commit();
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+        }
+    }
+
+    public abstract String getPersistenceUnitName();
+
+    public abstract int getMasterSize();
+
+    public abstract int getDetailSize();
+}

--- a/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/jpa/tests/basic/JPAReadLargeAmmountAbstract.java
+++ b/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/jpa/tests/basic/JPAReadLargeAmmountAbstract.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//              Oracle - initial implementation
+package org.eclipse.persistence.testing.perf.jpa.tests.basic;
+
+/**
+ * Benchmarks for JPA reading data (large amount - 10000 rows per each request em.find()).
+ *
+ * @author Oracle
+ */
+public abstract class JPAReadLargeAmmountAbstract extends JPAReadAbstract {
+
+    public int getMasterSize() {
+        return 10;
+    }
+
+    public int getDetailSize() {
+        return DETAIL_ID_STEP;
+    }
+}

--- a/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/jpa/tests/basic/JPAReadLargeAmmountCacheTests.java
+++ b/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/jpa/tests/basic/JPAReadLargeAmmountCacheTests.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//              Oracle - initial implementation
+package org.eclipse.persistence.testing.perf.jpa.tests.basic;
+
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+/**
+ * Benchmarks for JPA reading data (large amount - 10000 rows per each request em.find()) with JPA L2 cache enabled.
+ *
+ * @author Oracle
+ */
+@State(Scope.Benchmark)
+//@BenchmarkMode(Mode.AverageTime)
+public class JPAReadLargeAmmountCacheTests extends JPAReadLargeAmmountAbstract {
+
+    public String getPersistenceUnitName() {
+        return "jpa-performance-read-cache";
+    }
+}

--- a/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/jpa/tests/basic/JPAReadLargeAmmountNoCacheTests.java
+++ b/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/jpa/tests/basic/JPAReadLargeAmmountNoCacheTests.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//              Oracle - initial implementation
+package org.eclipse.persistence.testing.perf.jpa.tests.basic;
+
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+/**
+ * Benchmarks for JPA reading data (large amount - 10000 rows per each request em.find()) with JPA L2 cache disabled.
+ *
+ * @author Oracle
+ */
+@State(Scope.Benchmark)
+//@BenchmarkMode(Mode.AverageTime)
+public class JPAReadLargeAmmountNoCacheTests extends JPAReadLargeAmmountAbstract {
+
+    public String getPersistenceUnitName() {
+        return "jpa-performance-read-no-cache";
+    }
+}

--- a/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/jpa/tests/basic/JPAReadSmallAmmountAbstract.java
+++ b/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/jpa/tests/basic/JPAReadSmallAmmountAbstract.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//              Oracle - initial implementation
+package org.eclipse.persistence.testing.perf.jpa.tests.basic;
+
+/**
+ * Benchmarks for JPA reading data (small amount - up 20 rows per each request em.find()).
+ *
+ * @author Oracle
+ */
+public abstract class JPAReadSmallAmmountAbstract extends JPAReadAbstract {
+
+    public int getMasterSize() {
+        return 10;
+    }
+
+    public int getDetailSize() {
+        return 10;
+    }
+}

--- a/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/jpa/tests/basic/JPAReadSmallAmmountCacheTests.java
+++ b/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/jpa/tests/basic/JPAReadSmallAmmountCacheTests.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//              Oracle - initial implementation
+package org.eclipse.persistence.testing.perf.jpa.tests.basic;
+
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+/**
+ * Benchmarks for JPA reading data (small amount - up 20 rows per each request em.find()) with JPA L2 cache enabled.
+ *
+ * @author Oracle
+ */
+@State(Scope.Benchmark)
+//@BenchmarkMode(Mode.AverageTime)
+public class JPAReadSmallAmmountCacheTests extends JPAReadSmallAmmountAbstract {
+
+    public String getPersistenceUnitName() {
+        return "jpa-performance-read-cache";
+    }
+}

--- a/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/jpa/tests/basic/JPAReadSmallAmmountNoCacheTests.java
+++ b/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/jpa/tests/basic/JPAReadSmallAmmountNoCacheTests.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//              Oracle - initial implementation
+package org.eclipse.persistence.testing.perf.jpa.tests.basic;
+
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+/**
+ * Benchmarks for JPA reading data (small amount - up 20 rows per each request em.find()) with JPA L2 cache disabled.
+ *
+ * @author Oracle
+ */
+@State(Scope.Benchmark)
+//@BenchmarkMode(Mode.AverageTime)
+public class JPAReadSmallAmmountNoCacheTests extends JPAReadSmallAmmountAbstract {
+
+    public String getPersistenceUnitName() {
+        return "jpa-performance-read-no-cache";
+    }
+}

--- a/performance/eclipselink.perf.test/src/test/resources/META-INF/persistence.xml
+++ b/performance/eclipselink.perf.test/src/test/resources/META-INF/persistence.xml
@@ -46,4 +46,31 @@
             <property name="jakarta.persistence.jdbc.password"    value="@pwd@"/>
         </properties>
     </persistence-unit>
+    <persistence-unit name="jpa-performance-read-cache">
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+        <class>org.eclipse.persistence.testing.perf.jpa.model.basic.MasterEntity</class>
+        <class>org.eclipse.persistence.testing.perf.jpa.model.basic.DetailEntity</class>
+        <properties>
+            <property name="jakarta.persistence.jdbc.driver"      value="@driver@"/>
+            <property name="jakarta.persistence.jdbc.url"         value="@url@"/>
+            <property name="jakarta.persistence.jdbc.user"        value="@user@"/>
+            <property name="jakarta.persistence.jdbc.password"    value="@pwd@"/>
+            <property name="eclipselink.ddl-generation" value="drop-and-create-tables"/>
+        </properties>
+    </persistence-unit>
+    <persistence-unit name="jpa-performance-read-no-cache">
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+        <class>org.eclipse.persistence.testing.perf.jpa.model.basic.MasterEntity</class>
+        <class>org.eclipse.persistence.testing.perf.jpa.model.basic.DetailEntity</class>
+        <properties>
+            <property name="jakarta.persistence.jdbc.driver"      value="@driver@"/>
+            <property name="jakarta.persistence.jdbc.url"         value="@url@"/>
+            <property name="jakarta.persistence.jdbc.user"        value="@user@"/>
+            <property name="jakarta.persistence.jdbc.password"    value="@pwd@"/>
+            <property name="eclipselink.cache.shared.default" value="false"/>
+            <property name="eclipselink.cache.size.default" value="0"/>
+            <property name="eclipselink.query-results-cache" value="false"/>
+            <property name="eclipselink.ddl-generation" value="drop-and-create-tables"/>
+        </properties>
+    </persistence-unit>
 </persistence>


### PR DESCRIPTION
This change improves EclipseLink performance with higher versions of the JDK (21 and above).
It's about replacement of `synchronized` keyword and `wait()`, `notify()` methods by objects from `java.util.concurrent.locks.*` package.
Additionally there are some new performance tests to verify it.
Performance tests were executed against:
```
java version "21.0.2" 2024-01-16 LTS
Java(TM) SE Runtime Environment (build 21.0.2+13-LTS-58)
Java HotSpot(TM) 64-Bit Server VM (build 21.0.2+13-LTS-58, mixed mode, sharing)
```
and
```
openjdk version "23-loom" 2024-09-17
OpenJDK Runtime Environment (build 23-loom+2-48)
OpenJDK 64-Bit Server VM (build 23-loom+2-48, mixed mode, sharing)
```

Test results are there and in the attachment.

```
::::::::::::::
jmh-core-result_ReentrantLock_23Loom.txt
::::::::::::::
"Benchmark","Mode","Threads","Samples","Score","Score Error (99.9%)","Unit"
"org.eclipse.persistence.testing.perf.core.ConcurrencyManagerBenchmark.testAcquireRelease","thrpt",50,20,14539906.393462,14499.932272,"ops/s"
::::::::::::::
jmh-core-result_ReentrantLock.txt
::::::::::::::
"Benchmark","Mode","Threads","Samples","Score","Score Error (99.9%)","Unit"
"org.eclipse.persistence.testing.perf.core.ConcurrencyManagerBenchmark.testAcquireRelease","thrpt",50,20,25688207.297074,289398.625373,"ops/s"
::::::::::::::
jmh-core-result_synchronized_23Loom.txt
::::::::::::::
"Benchmark","Mode","Threads","Samples","Score","Score Error (99.9%)","Unit"
"org.eclipse.persistence.testing.perf.core.ConcurrencyManagerBenchmark.testAcquireRelease","thrpt",50,20,26326687.706285,27374.470204,"ops/s"
::::::::::::::
jmh-core-result_synchronized.txt
::::::::::::::
"Benchmark","Mode","Threads","Samples","Score","Score Error (99.9%)","Unit"
"org.eclipse.persistence.testing.perf.core.ConcurrencyManagerBenchmark.testAcquireRelease","thrpt",50,20,14879434.497816,21578.277354,"ops/s"
::::::::::::::
jmh-jpa-result_ReentrantLock_23Loom.txt
::::::::::::::
"Benchmark","Mode","Threads","Samples","Score","Score Error (99.9%)","Unit"
"org.eclipse.persistence.testing.perf.jpa.tests.basic.JPAReadSmallAmmountCacheTests.testReadEntity","thrpt",10,20,26578.825758,37.901222,"ops/s"
"org.eclipse.persistence.testing.perf.jpa.tests.basic.JPAReadSmallAmmountNoCacheTests.testReadEntity","thrpt",10,20,2272.829450,24.614292,"ops/s"
::::::::::::::
jmh-jpa-result_ReentrantLock.txt
::::::::::::::
"Benchmark","Mode","Threads","Samples","Score","Score Error (99.9%)","Unit"
"org.eclipse.persistence.testing.perf.jpa.tests.basic.JPAReadSmallAmmountCacheTests.testReadEntity","thrpt",10,20,18715.361709,39.353958,"ops/s"
"org.eclipse.persistence.testing.perf.jpa.tests.basic.JPAReadSmallAmmountNoCacheTests.testReadEntity","thrpt",10,20,2222.755556,10.028602,"ops/s"
::::::::::::::
jmh-jpa-result_synchronized_23Loom.txt
::::::::::::::
"Benchmark","Mode","Threads","Samples","Score","Score Error (99.9%)","Unit"
"org.eclipse.persistence.testing.perf.jpa.tests.basic.JPAReadSmallAmmountCacheTests.testReadEntity","thrpt",10,20,21450.585389,140.540877,"ops/s"
"org.eclipse.persistence.testing.perf.jpa.tests.basic.JPAReadSmallAmmountNoCacheTests.testReadEntity","thrpt",10,20,2300.783588,16.072768,"ops/s"
::::::::::::::
jmh-jpa-result_synchronized.txt
::::::::::::::
"Benchmark","Mode","Threads","Samples","Score","Score Error (99.9%)","Unit"
"org.eclipse.persistence.testing.perf.jpa.tests.basic.JPAReadSmallAmmountCacheTests.testReadEntity","thrpt",10,20,17686.481014,21.467243,"ops/s"
"org.eclipse.persistence.testing.perf.jpa.tests.basic.JPAReadSmallAmmountNoCacheTests.testReadEntity","thrpt",10,20,2207.724608,19.088328,"ops/s"
```

[perfTestsResults.tar.gz](https://github.com/eclipse-ee4j/eclipselink/files/15090355/perfTestsResults.tar.gz)
