### PR TITLE
[2.7] Performance improvement: synchronize to java.util.concurrent.locks switch to improve performance with VirtualThreads - backport from master

### DIFF
--- a/antbuild.xml
+++ b/antbuild.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -71,6 +71,10 @@
         - test-oxm : runs MOXY oxm tests
         - test-sdo : runs SDO tests
         - test-sdo-srg : runs SDO SRG
+        - test-core-perf: runs the core performance tests
+        - test-moxy-perf: run the MOXy performance tests
+        - test-jpa-metadata-perf: run the JPA metadata performance tests
+        - test-jpa-perf: run the JPA performance tests
 
         It may require some configuration of the build.properties to run.
     -->
@@ -1967,6 +1971,15 @@
     </target>
     <target name="test-perf" description="run the performance tests">
         <ant antfile="antbuild.xml" dir="${eclipselink.perf.test}" target="test"/>
+    </target>
+    <target name="test-core-perf" description="run the core performance tests">
+        <ant antfile="antbuild.xml" dir="${eclipselink.perf.test}" target="test-core"/>
+    </target>
+    <target name="test-moxy-perf" description="run the MOXy performance tests">
+        <ant antfile="antbuild.xml" dir="${eclipselink.perf.test}" target="test-moxy"/>
+    </target>
+    <target name="test-jpa-metadata-perf" description="run the performance tests">
+        <ant antfile="antbuild.xml" dir="${eclipselink.perf.test}" target="test-jpa-metadata"/>
     </target>
     <target name="test-jpa-perf" description="run the performance tests">
         <ant antfile="antbuild.xml" dir="${eclipselink.perf.test}" target="test-jpa"/>

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/helper/ConcurrencyManager.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/helper/ConcurrencyManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -20,8 +20,12 @@ import java.io.StringWriter;
 import java.security.AccessController;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.eclipse.persistence.config.SystemProperties;
 import org.eclipse.persistence.exceptions.ConcurrencyException;
@@ -76,6 +80,9 @@ public class ConcurrencyManager implements Serializable {
     // was set to 0. It should happen if an entity being shared by two threads.
     private final AtomicLong totalNumberOfKeysReleasedForReadingBlewUpExceptionDueToCacheKeyHavingReachedCounterZero = new AtomicLong(0);
 
+    private final Lock instanceLock  = new ReentrantLock();
+    private final Condition instanceLockCondition = instanceLock.newCondition();
+
     private static final Map<Thread, ConcurrencyManager> THREADS_TO_WAIT_ON_ACQUIRE_READ_LOCK = new ConcurrentHashMap<>();
     private static final Map<Thread, String> THREADS_TO_WAIT_ON_ACQUIRE_READ_LOCK_NAME_OF_METHOD_CREATING_TRACE = new ConcurrentHashMap<>();
     private static final Map<Thread, ConcurrencyManager> THREADS_TO_WAIT_ON_ACQUIRE = new ConcurrentHashMap<>();
@@ -115,55 +122,60 @@ public class ConcurrencyManager implements Serializable {
      * This should be called before entering a critical section.
      * called with true from the merge process, if true then the refresh will not refresh the object
      */
-    public synchronized void acquire(boolean forMerge) throws ConcurrencyException {
-        //Flag the time when we start the while loop
-        final long whileStartTimeMillis = System.currentTimeMillis();
-        Thread currentThread = Thread.currentThread();
-        DeferredLockManager lockManager = getDeferredLockManager(currentThread);
-        ReadLockManager readLockManager = getReadLockManager(currentThread);
+    public void acquire(boolean forMerge) throws ConcurrencyException {
+        instanceLock.lock();
+        try {
+            //Flag the time when we start the while loop
+            final long whileStartTimeMillis = System.currentTimeMillis();
+            Thread currentThread = Thread.currentThread();
+            DeferredLockManager lockManager = getDeferredLockManager(currentThread);
+            ReadLockManager readLockManager = getReadLockManager(currentThread);
 
-        // Waiting to acquire cache key will now start on the while loop
-        // NOTE: this step bares no influence in acquiring or not acquiring locks
-        // is just storing debug metadata that we can use when we detect the system is frozen in a dead lock
-        final boolean currentThreadWillEnterTheWhileWait = ((this.activeThread != null) || (this.numberOfReaders.get() > 0)) && (this.activeThread != currentThread);
-        if(currentThreadWillEnterTheWhileWait) {
-            putThreadAsWaitingToAcquireLockForWriting(currentThread, ACQUIRE_METHOD_NAME);
-        }
-        while (((this.activeThread != null) || (this.numberOfReaders.get() > 0)) && (this.activeThread != Thread.currentThread())) {
-            // This must be in a while as multiple threads may be released, or another thread may rush the acquire after one is released.
-            try {
-                this.numberOfWritersWaiting.incrementAndGet();
-                wait(ConcurrencyUtil.SINGLETON.getAcquireWaitTime());
-                // Run a method that will fire up an exception if we having been sleeping for too long
-                ConcurrencyUtil.SINGLETON.determineIfReleaseDeferredLockAppearsToBeDeadLocked(this, whileStartTimeMillis, lockManager, readLockManager, ConcurrencyUtil.SINGLETON.isAllowInterruptedExceptionFired());
-            } catch (InterruptedException exception) {
-                // If the thread is interrupted we want to make sure we release all of the locks the thread was owning
-                releaseAllLocksAcquiredByThread(lockManager);
-                // Improve concurrency manager metadata
-                // Waiting to acquire cache key is is over
-                if (currentThreadWillEnterTheWhileWait) {
-                    removeThreadNoLongerWaitingToAcquireLockForWriting(currentThread);
+            // Waiting to acquire cache key will now start on the while loop
+            // NOTE: this step bares no influence in acquiring or not acquiring locks
+            // is just storing debug metadata that we can use when we detect the system is frozen in a dead lock
+            final boolean currentThreadWillEnterTheWhileWait = ((this.activeThread != null) || (this.numberOfReaders.get() > 0)) && (this.activeThread != currentThread);
+            if (currentThreadWillEnterTheWhileWait) {
+                putThreadAsWaitingToAcquireLockForWriting(currentThread, ACQUIRE_METHOD_NAME);
+            }
+            while (((this.activeThread != null) || (this.numberOfReaders.get() > 0)) && (this.activeThread != Thread.currentThread())) {
+                // This must be in a while as multiple threads may be released, or another thread may rush the acquire after one is released.
+                try {
+                    this.numberOfWritersWaiting.incrementAndGet();
+                    instanceLockCondition.await(ConcurrencyUtil.SINGLETON.getAcquireWaitTime(), TimeUnit.MILLISECONDS);
+                    // Run a method that will fire up an exception if we having been sleeping for too long
+                    ConcurrencyUtil.SINGLETON.determineIfReleaseDeferredLockAppearsToBeDeadLocked(this, whileStartTimeMillis, lockManager, readLockManager, ConcurrencyUtil.SINGLETON.isAllowInterruptedExceptionFired());
+                } catch (InterruptedException exception) {
+                    // If the thread is interrupted we want to make sure we release all of the locks the thread was owning
+                    releaseAllLocksAcquiredByThread(lockManager);
+                    // Improve concurrency manager metadata
+                    // Waiting to acquire cache key is is over
+                    if (currentThreadWillEnterTheWhileWait) {
+                        removeThreadNoLongerWaitingToAcquireLockForWriting(currentThread);
+                    }
+                    throw ConcurrencyException.waitWasInterrupted(exception.getMessage());
+                } finally {
+                    // Since above we increments the number of writers
+                    // whether or not the thread is exploded by an interrupt
+                    // we need to make sure we decrement the number of writer to not allow the code to be corrupted
+                    this.numberOfWritersWaiting.decrementAndGet();
                 }
-                throw ConcurrencyException.waitWasInterrupted(exception.getMessage());
-            } finally {
-                // Since above we increments the number of writers
-                // whether or not the thread is exploded by an interrupt
-                // we need to make sure we decrement the number of writer to not allow the code to be corrupted
-                this.numberOfWritersWaiting.decrementAndGet();
+            } // end of while loop
+            // Waiting to acquire cache key is is over
+            if (currentThreadWillEnterTheWhileWait) {
+                removeThreadNoLongerWaitingToAcquireLockForWriting(currentThread);
             }
-        } // end of while loop
-        // Waiting to acquire cache key is is over
-        if(currentThreadWillEnterTheWhileWait) {
-            removeThreadNoLongerWaitingToAcquireLockForWriting(currentThread);
-        }
-        if (this.activeThread == null) {
-            this.activeThread = Thread.currentThread();
-            if (shouldTrackStack){
-                this.stack = new Exception();
+            if (this.activeThread == null) {
+                this.activeThread = Thread.currentThread();
+                if (shouldTrackStack) {
+                    this.stack = new Exception();
+                }
             }
+            this.lockedByMergeManager = forMerge;
+            this.depth.incrementAndGet();
+        } finally {
+            instanceLock.unlock();
         }
-        this.lockedByMergeManager = forMerge;
-        this.depth.incrementAndGet();
     }
 
     /**
@@ -181,13 +193,18 @@ public class ConcurrencyManager implements Serializable {
      * Added for CR 2317
      * called with true from the merge process, if true then the refresh will not refresh the object
      */
-    public synchronized boolean acquireNoWait(boolean forMerge) throws ConcurrencyException {
-        if ((this.activeThread == null && this.numberOfReaders.get() == 0) || (this.activeThread == Thread.currentThread())) {
-            //if I own the lock increment depth
-            acquire(forMerge);
-            return true;
-        } else {
-            return false;
+    public boolean acquireNoWait(boolean forMerge) throws ConcurrencyException {
+        instanceLock.lock();
+        try {
+            if ((this.activeThread == null && this.numberOfReaders.get() == 0) || (this.activeThread == Thread.currentThread())) {
+                //if I own the lock increment depth
+                acquire(forMerge);
+                return true;
+            } else {
+                return false;
+            }
+        } finally {
+            instanceLock.unlock();
         }
     }
 
@@ -197,27 +214,32 @@ public class ConcurrencyManager implements Serializable {
      * Added for CR 2317
      * called with true from the merge process, if true then the refresh will not refresh the object
      */
-    public synchronized boolean acquireWithWait(boolean forMerge, int wait) throws ConcurrencyException {
-        final Thread currentThread = Thread.currentThread();
-        if ((this.activeThread == null && this.numberOfReaders.get() == 0) || (this.activeThread == currentThread)) {
-            // if I own the lock increment depth
-            acquire(forMerge);
-            return true;
-        } else {
-            try {
-                putThreadAsWaitingToAcquireLockForWriting(currentThread, ACQUIRE_WITH_WAIT_METHOD_NAME);
-                wait(wait);
-            } catch (InterruptedException e) {
-                return false;
-            } finally {
-                removeThreadNoLongerWaitingToAcquireLockForWriting(currentThread);
-            }
-            if ((this.activeThread == null && this.numberOfReaders.get() == 0)
-                    || (this.activeThread == currentThread)) {
+    public boolean acquireWithWait(boolean forMerge, int wait) throws ConcurrencyException {
+        instanceLock.lock();
+        try {
+            final Thread currentThread = Thread.currentThread();
+            if ((this.activeThread == null && this.numberOfReaders.get() == 0) || (this.activeThread == currentThread)) {
+                // if I own the lock increment depth
                 acquire(forMerge);
                 return true;
+            } else {
+                try {
+                    putThreadAsWaitingToAcquireLockForWriting(currentThread, ACQUIRE_WITH_WAIT_METHOD_NAME);
+                    instanceLockCondition.await(wait, TimeUnit.MILLISECONDS);
+                } catch (InterruptedException e) {
+                    return false;
+                } finally {
+                    removeThreadNoLongerWaitingToAcquireLockForWriting(currentThread);
+                }
+                if ((this.activeThread == null && this.numberOfReaders.get() == 0)
+                        || (this.activeThread == currentThread)) {
+                    acquire(forMerge);
+                    return true;
+                }
+                return false;
             }
-            return false;
+        } finally {
+            instanceLock.unlock();
         }
     }
 
@@ -227,14 +249,19 @@ public class ConcurrencyManager implements Serializable {
      * Added for Bug 5840635
      * Call with true from the merge process, if true then the refresh will not refresh the object.
      */
-    public synchronized boolean acquireIfUnownedNoWait(boolean forMerge) throws ConcurrencyException {
-        // Only acquire lock if active thread is null. Do not check current thread.
-        if (this.activeThread == null && this.numberOfReaders.get() == 0) {
-             // if lock is unowned increment depth
-            acquire(forMerge);
-            return true;
-        } else {
-            return false;
+    public boolean acquireIfUnownedNoWait(boolean forMerge) throws ConcurrencyException {
+        instanceLock.lock();
+        try {
+            // Only acquire lock if active thread is null. Do not check current thread.
+            if (this.activeThread == null && this.numberOfReaders.get() == 0) {
+                // if lock is unowned increment depth
+                acquire(forMerge);
+                return true;
+            } else {
+                return false;
+            }
+        } finally {
+            instanceLock.unlock();
         }
     }
 
@@ -250,7 +277,8 @@ public class ConcurrencyManager implements Serializable {
             putDeferredLock(currentThread, lockManager);
         }
         lockManager.incrementDepth();
-        synchronized (this) {
+        instanceLock.lock();
+        try {
             final long whileStartTimeMillis = System.currentTimeMillis();
             final boolean currentThreadWillEnterTheWhileWait = this.numberOfReaders.get() != 0;
             if(currentThreadWillEnterTheWhileWait) {
@@ -265,7 +293,7 @@ public class ConcurrencyManager implements Serializable {
                 //the object is not being built.
                 try {
                     this.numberOfWritersWaiting.incrementAndGet();
-                    wait(ConcurrencyUtil.SINGLETON.getAcquireWaitTime());
+                    instanceLockCondition.await(ConcurrencyUtil.SINGLETON.getAcquireWaitTime(), TimeUnit.MILLISECONDS);
                     ConcurrencyUtil.SINGLETON.determineIfReleaseDeferredLockAppearsToBeDeadLocked(this, whileStartTimeMillis, lockManager, readLockManager, ConcurrencyUtil.SINGLETON.isAllowInterruptedExceptionFired());
                 } catch (InterruptedException exception) {
                     // If the thread is interrupted we want to make sure we release all of the locks the thread was owning
@@ -290,6 +318,8 @@ public class ConcurrencyManager implements Serializable {
                     AbstractSessionLog.getLog().log(SessionLog.FINER, SessionLog.CACHE, "acquiring_deferred_lock", ((CacheKey)this).getObject(), currentThread.getName());
                 }
             }
+        } finally {
+            instanceLock.unlock();
         }
     }
 
@@ -323,48 +353,58 @@ public class ConcurrencyManager implements Serializable {
      * Wait on any writer.
      * Allow concurrent reads.
      */
-    public synchronized void acquireReadLock() throws ConcurrencyException {
-        final Thread currentThread = Thread.currentThread();
-        final long whileStartTimeMillis = System.currentTimeMillis();
-        DeferredLockManager lockManager = getDeferredLockManager(currentThread);
-        ReadLockManager readLockManager = getReadLockManager(currentThread);
-        final boolean currentThreadWillEnterTheWhileWait = (this.activeThread != null) && (this.activeThread != currentThread);
-        if (currentThreadWillEnterTheWhileWait) {
-            putThreadAsWaitingToAcquireLockForReading(currentThread, ACQUIRE_READ_LOCK_METHOD_NAME);
-        }
-        // Cannot check for starving writers as will lead to deadlocks.
-        while ((this.activeThread != null) && (this.activeThread != Thread.currentThread())) {
-            try {
-                wait(ConcurrencyUtil.SINGLETON.getAcquireWaitTime());
-                ConcurrencyUtil.SINGLETON.determineIfReleaseDeferredLockAppearsToBeDeadLocked(this, whileStartTimeMillis, lockManager, readLockManager, ConcurrencyUtil.SINGLETON.isAllowInterruptedExceptionFired());
-            } catch (InterruptedException exception) {
-                releaseAllLocksAcquiredByThread(lockManager);
-                if (currentThreadWillEnterTheWhileWait) {
-                    removeThreadNoLongerWaitingToAcquireLockForReading(currentThread);
-                }
-                throw ConcurrencyException.waitWasInterrupted(exception.getMessage());
-            }
-        }
-        if (currentThreadWillEnterTheWhileWait) {
-            removeThreadNoLongerWaitingToAcquireLockForReading(currentThread);
-        }
+    public void acquireReadLock() throws ConcurrencyException {
+        instanceLock.lock();
         try {
-            addReadLockToReadLockManager();
+            final Thread currentThread = Thread.currentThread();
+            final long whileStartTimeMillis = System.currentTimeMillis();
+            DeferredLockManager lockManager = getDeferredLockManager(currentThread);
+            ReadLockManager readLockManager = getReadLockManager(currentThread);
+            final boolean currentThreadWillEnterTheWhileWait = (this.activeThread != null) && (this.activeThread != currentThread);
+            if (currentThreadWillEnterTheWhileWait) {
+                putThreadAsWaitingToAcquireLockForReading(currentThread, ACQUIRE_READ_LOCK_METHOD_NAME);
+            }
+            // Cannot check for starving writers as will lead to deadlocks.
+            while ((this.activeThread != null) && (this.activeThread != Thread.currentThread())) {
+                try {
+                    instanceLockCondition.await(ConcurrencyUtil.SINGLETON.getAcquireWaitTime(), TimeUnit.MILLISECONDS);
+                    ConcurrencyUtil.SINGLETON.determineIfReleaseDeferredLockAppearsToBeDeadLocked(this, whileStartTimeMillis, lockManager, readLockManager, ConcurrencyUtil.SINGLETON.isAllowInterruptedExceptionFired());
+                } catch (InterruptedException exception) {
+                    releaseAllLocksAcquiredByThread(lockManager);
+                    if (currentThreadWillEnterTheWhileWait) {
+                        removeThreadNoLongerWaitingToAcquireLockForReading(currentThread);
+                    }
+                    throw ConcurrencyException.waitWasInterrupted(exception.getMessage());
+                }
+            }
+            if (currentThreadWillEnterTheWhileWait) {
+                removeThreadNoLongerWaitingToAcquireLockForReading(currentThread);
+            }
+            try {
+                addReadLockToReadLockManager();
+            } finally {
+                this.numberOfReaders.incrementAndGet();
+                this.totalNumberOfKeysAcquiredForReading.incrementAndGet();
+            }
         } finally {
-            this.numberOfReaders.incrementAndGet();
-            this.totalNumberOfKeysAcquiredForReading.incrementAndGet();
+            instanceLock.unlock();
         }
     }
 
     /**
      * If this is acquired return false otherwise acquire readlock and return true
      */
-    public synchronized boolean acquireReadLockNoWait() {
-        if ((this.activeThread == null) || (this.activeThread == Thread.currentThread())) {
-            acquireReadLock();
-            return true;
-        } else {
-            return false;
+    public boolean acquireReadLockNoWait() {
+        instanceLock.lock();
+        try {
+            if ((this.activeThread == null) || (this.activeThread == Thread.currentThread())) {
+                acquireReadLock();
+                return true;
+            } else {
+                return false;
+            }
+        } finally {
+            instanceLock.unlock();
         }
     }
 
@@ -579,19 +619,24 @@ public class ConcurrencyManager implements Serializable {
      * The notify will release the first thread waiting on the object,
      * if no threads are waiting it will do nothing.
      */
-    public synchronized void release() throws ConcurrencyException {
-        if (this.depth.get() == 0) {
-            throw ConcurrencyException.signalAttemptedBeforeWait();
-        } else {
-            this.depth.decrementAndGet();
-        }
-        if (this.depth.get() == 0) {
-            this.activeThread = null;
-            if (shouldTrackStack){
-                this.stack = null;
+    public void release() throws ConcurrencyException {
+        instanceLock.lock();
+        try {
+            if (this.depth.get() == 0) {
+                throw ConcurrencyException.signalAttemptedBeforeWait();
+            } else {
+                this.depth.decrementAndGet();
             }
-            this.lockedByMergeManager = false;
-            notifyAll();
+            if (this.depth.get() == 0) {
+                this.activeThread = null;
+                if (shouldTrackStack) {
+                    this.stack = null;
+                }
+                this.lockedByMergeManager = false;
+                instanceLockCondition.signalAll();
+            }
+        } finally {
+            instanceLock.unlock();
         }
     }
 
@@ -684,25 +729,30 @@ public class ConcurrencyManager implements Serializable {
      * Decrement the number of readers.
      * Used to allow concurrent reads.
      */
-    public synchronized void releaseReadLock() throws ConcurrencyException {
-        if (this.numberOfReaders.get() == 0) {
-            this.totalNumberOfKeysReleasedForReadingBlewUpExceptionDueToCacheKeyHavingReachedCounterZero.incrementAndGet();
-            try {
-                removeReadLockFromReadLockManager();
-            } catch (Exception e) {
-                AbstractSessionLog.getLog().logThrowable(SessionLog.SEVERE, SessionLog.CACHE, e);
+    public void releaseReadLock() throws ConcurrencyException {
+        instanceLock.lock();
+        try {
+            if (this.numberOfReaders.get() == 0) {
+                this.totalNumberOfKeysReleasedForReadingBlewUpExceptionDueToCacheKeyHavingReachedCounterZero.incrementAndGet();
+                try {
+                    removeReadLockFromReadLockManager();
+                } catch (Exception e) {
+                    AbstractSessionLog.getLog().logThrowable(SessionLog.SEVERE, SessionLog.CACHE, e);
+                }
+                throw ConcurrencyException.signalAttemptedBeforeWait();
+            } else {
+                try {
+                    removeReadLockFromReadLockManager();
+                } finally {
+                    this.numberOfReaders.decrementAndGet();
+                    this.totalNumberOfKeysReleasedForReading.incrementAndGet();
+                }
             }
-            throw ConcurrencyException.signalAttemptedBeforeWait();
-        } else {
-            try {
-                removeReadLockFromReadLockManager();
-            } finally {
-                this.numberOfReaders.decrementAndGet();
-                this.totalNumberOfKeysReleasedForReading.incrementAndGet();
+            if (this.numberOfReaders.get() == 0) {
+                instanceLockCondition.signalAll();
             }
-        }
-        if (this.numberOfReaders.get() == 0) {
-            notifyAll();
+        } finally {
+            instanceLock.unlock();
         }
     }
 
@@ -751,15 +801,20 @@ public class ConcurrencyManager implements Serializable {
         this.numberOfWritersWaiting.set(numberOfWritersWaiting);
     }
 
-    public synchronized void transitionToDeferredLock() {
-        Thread currentThread = Thread.currentThread();
-        DeferredLockManager lockManager = getDeferredLockManager(currentThread);
-        if (lockManager == null) {
-            lockManager = new DeferredLockManager();
-            putDeferredLock(currentThread, lockManager);
+    public void transitionToDeferredLock() {
+        instanceLock.lock();
+        try {
+            Thread currentThread = Thread.currentThread();
+            DeferredLockManager lockManager = getDeferredLockManager(currentThread);
+            if (lockManager == null) {
+                lockManager = new DeferredLockManager();
+                putDeferredLock(currentThread, lockManager);
+            }
+            lockManager.incrementDepth();
+            lockManager.addActiveLock(this);
+        } finally {
+            instanceLock.unlock();
         }
-        lockManager.incrementDepth();
-        lockManager.addActiveLock(this);
     }
 
     /**
@@ -1043,5 +1098,13 @@ public class ConcurrencyManager implements Serializable {
      */
     public static void setJustificationWhyMethodIsBuildingObjectCompleteReturnsFalse(String justification) {
         THREADS_WAITING_TO_RELEASE_DEFERRED_LOCKS_BUILD_OBJECT_COMPLETE_GOES_NOWHERE.put(Thread.currentThread(), justification);
+    }
+
+    public Lock getInstanceLock() {
+        return this.instanceLock;
+    }
+
+    public Condition getInstanceLockCondition() {
+        return this.instanceLockCondition;
     }
 }

--- a/performance/eclipselink.perf.test/antbuild.properties
+++ b/performance/eclipselink.perf.test/antbuild.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2023 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at
@@ -28,23 +28,22 @@ report.dir=reports
 
 asm.jar=org.eclipse.persistence.asm.jar
 persistence22.jar=jakarta.persistence_2.2.3.jar
-#TODO in master there will be jakarta.json-api.jar
+jaxb-api.jar=jakarta.xml.bind-api.jar
 json-api.jar=jakarta.json.jar
 json-impl.jar=jakarta.json.jar
-jmh-core.jar=jmh-core-0.9.3.jar
-jmh-generator-annprocess.jar=jmh-generator-annprocess-0.9.3.jar
-commons-math.jar=commons-math3-3.3.jar
+jmh-core.jar=jmh-core-1.37.jar
+jmh-generator-annprocess.jar=jmh-generator-annprocess-1.37.jar
+commons-math.jar=commons-math3-3.6.1.jar
 
 # JSR-303/349/380 Dependency Definitions
 ----------------------------------------------
 javax.validation.jar=jakarta.validation-api.jar
 validation-impl.jar=org.glassfish.bean-validator.jar
 # Hibernate-validator dependencies.
-jboss-logging.jar=jboss-logging-3.4.3.Final.jar
-javax.el.jar=javax.el-3.0.1-b12.jar
+jboss-logging.jar=jboss-logging.jar
+javax.el-api.jar=jakarta.el-api.jar
 classmate.jar=classmate-1.6.0.jar
 
 warmup.iterations=20
 run.iterations=20
-jmh.resultFile=jmh-result.csv
 jmh.resultFormat=csv

--- a/performance/eclipselink.perf.test/antbuild.xml
+++ b/performance/eclipselink.perf.test/antbuild.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -80,11 +80,12 @@
     <property name="javax.validation.lib"   value="${perftest.2.common.plugins.dir}/${javax.validation.jar}"/>
     <property name="jpa21.lib"   value="${perftest.2.trunk.dir}/jpa/plugins/${persistence22.jar}"/>
 
+    <property name="jaxb-api.lib" value="${perftest.2.common.plugins.dir}/${jaxb-api.jar}"/>
     <property name="json-api.lib" value="${perftest.2.common.plugins.dir}/${json-api.jar}"/>
     <property name="json-impl.lib" value="${perftest.2.common.plugins.dir}/${json-impl.jar}"/>
     <property name="validation-impl.lib"   value="${perftest.2.common.plugins.dir}/${validation-impl.jar}"/>
-    <property name="jboss-logging.lib"   value="${extensions.depend.dir}/${jboss-logging.jar}"/>
-    <property name="javax.el-api.lib"   value="${extensions.depend.dir}/${javax.el-api.jar}"/>
+    <property name="jboss-logging.lib"   value="${perftest.2.common.plugins.dir}/${jboss-logging.jar}"/>
+    <property name="javax.el-api.lib"   value="${perftest.2.common.plugins.dir}/${javax.el-api.jar}"/>
     <property name="classmate.lib"   value="${extensions.depend.dir}/${classmate.jar}"/>
 
     <property name="jmh-core.lib" value="${extensions.depend.dir}/${jmh-core.jar}"/>
@@ -100,6 +101,7 @@
     <path id="perf.compile.path">
         <pathelement path="${jmh-core.lib}"/>
         <pathelement path="${jmh-generator-annprocess.lib}"/>
+        <pathelement path="${jaxb-api.lib}"/>
         <pathelement path="${json-api.lib}"/>
         <pathelement path="${jpa21.lib}"/>
         <pathelement path="${perftest.2.core.dir}/target/${classes.dir}"/>
@@ -119,6 +121,7 @@
         <pathelement path="${javax.el-api.lib}"/>
         <pathelement path="${classmate.lib}"/>
         <pathelement path="${asm.lib}"/>
+        <pathelement path="${jaxb-api.lib}"/>
         <pathelement path="${json-api.lib}"/>
         <pathelement path="${json-impl.lib}"/>
         <pathelement path="${perftest.2.moxy.dir}/target/${classes.dir}"/>
@@ -131,6 +134,8 @@
     <path id="perf.compile.against.jar.path">
         <pathelement path="${jmh-core.lib}"/>
         <pathelement path="${jmh-generator-annprocess.lib}"/>
+        <pathelement path="${jpa21.lib}"/>
+        <pathelement path="${jaxb-api.lib}"/>
         <pathelement path="${json-api.lib}"/>
         <pathelement path="${jpa21.lib}"/>
         <pathelement path="${eclipselink.lib}"/>
@@ -141,6 +146,7 @@
         <pathelement path="${jmh-generator-annprocess.lib}"/>
         <pathelement path="${commons-math.lib}"/>
         <pathelement path="${jpa21.lib}"/>
+        <pathelement path="${jaxb-api.lib}"/>
         <pathelement path="${jdbc.driver.lib}"/>
         <pathelement path="${javax.validation.lib}"/>
         <pathelement path="${validation-impl.lib}"/>
@@ -157,13 +163,22 @@
     <!-- Test targets -->
     <target name="test" depends="clean, clean-reports, filter-tokens, compile-and-run-tests"
             description="run perf tests"/>
-    <target name="test-against-jar"
-            depends="clean, clean-reports, filter-tokens, compile-and-run-tests-against-jar"
-            description="run perf tests against eclipselink.jar"/>
+
+    <target name="test-core"
+            depends="clean, clean-reports, filter-tokens, compile-and-run-core-tests-against-jar"
+            description="run JPA metadata perf tests against eclipselink.jar"/>
+
+    <target name="test-moxy"
+            depends="clean, clean-reports, filter-tokens, compile-and-run-moxy-tests-against-jar"
+            description="run JPA metadata perf tests against eclipselink.jar"/>
+
+    <target name="test-jpa-metadata"
+            depends="clean, clean-reports, filter-tokens, compile-and-run-jpa-metadata-tests-against-jar"
+            description="run JPA metadata perf tests against eclipselink.jar"/>
 
     <target name="test-jpa"
-            depends="clean, clean-reports, filter-tokens, compile-and-run-tests-against-jar"
-            description="run perf tests against eclipselink.jar"/>
+            depends="clean, clean-reports, filter-tokens, compile-and-run-jpa-tests-against-jar"
+            description="run JPA perf tests against eclipselink.jar"/>
 
     <!-- Build targets -->
     <target name="compile-tests" depends="clean" description="build perf test classes">
@@ -180,7 +195,25 @@
         <run_perf_tests runpathref="perf.run.path"/>
     </target>
 
-    <target name="compile-and-run-tests-against-jar" depends="compile-tests-against-jar" description="build and run perf tests against eclipselink.jar">
+    <target name="compile-and-run-core-tests-against-jar" depends="compile-tests-against-jar" description="build and run core perf tests against eclipselink.jar">
+        <available file="${eclipselink.lib}" property="eclipselink.lib.exists"/>
+        <fail unless="${eclipselink.lib.exists}" message="${eclipselink.lib} not found"/>
+        <run_core_perf_tests runpathref="perf.run.against.jar.path"/>
+    </target>
+
+    <target name="compile-and-run-moxy-tests-against-jar" depends="compile-tests-against-jar" description="build and run MOXy perf tests against eclipselink.jar">
+        <available file="${eclipselink.lib}" property="eclipselink.lib.exists"/>
+        <fail unless="${eclipselink.lib.exists}" message="${eclipselink.lib} not found"/>
+        <run_moxy_perf_tests runpathref="perf.run.against.jar.path"/>
+    </target>
+
+    <target name="compile-and-run-jpa-metadata-tests-against-jar" depends="compile-tests-against-jar" description="build and run JPA metadata perf tests against eclipselink.jar">
+        <available file="${eclipselink.lib}" property="eclipselink.lib.exists"/>
+        <fail unless="${eclipselink.lib.exists}" message="${eclipselink.lib} not found"/>
+        <run_jpa_metadata_perf_tests runpathref="perf.run.against.jar.path"/>
+    </target>
+
+    <target name="compile-and-run-jpa-tests-against-jar" depends="compile-tests-against-jar" description="build and run JPA perf tests against eclipselink.jar">
         <available file="${eclipselink.lib}" property="eclipselink.lib.exists"/>
         <fail unless="${eclipselink.lib.exists}" message="${eclipselink.lib} not found"/>
         <run_jpa_perf_tests runpathref="perf.run.against.jar.path"/>
@@ -213,17 +246,31 @@
         <copy file="${persistence.xml}.template" tofile="${persistence.xml}" overwrite="true"/>
     </target>
 
-    <macrodef name="run_jpa_perf_tests">
+    <macrodef name="run_core_perf_tests">
         <attribute name="runpathref" />
         <sequential>
-            <run_perf_test runpathref="@{runpathref}" clsname="org.eclipse.persistence.testing.perf.JPABenchmarks"/>
+            <run_perf_test runpathref="@{runpathref}" clsname="org.eclipse.persistence.testing.perf.CoreBenchmarks" resultFile="jmh-core-result.txt"/>
         </sequential>
     </macrodef>
 
-    <macrodef name="run_perf_tests">
+    <macrodef name="run_moxy_perf_tests">
         <attribute name="runpathref" />
         <sequential>
-            <run_perf_test runpathref="@{runpathref}" clsname="org.eclipse.persistence.testing.perf.Benchmarks"/>
+            <run_perf_test runpathref="@{runpathref}" clsname="org.eclipse.persistence.testing.perf.MOXyBenchmarks" resultFile="jmh-moxy-result.txt"/>
+        </sequential>
+    </macrodef>
+
+    <macrodef name="run_jpa_metadata_perf_tests">
+        <attribute name="runpathref" />
+        <sequential>
+            <run_perf_test runpathref="@{runpathref}" clsname="org.eclipse.persistence.testing.perf.JPAMetadataBenchmarks" resultFile="jmh-jpa-metadata-result.txt"/>
+        </sequential>
+    </macrodef>
+
+    <macrodef name="run_jpa_perf_tests">
+        <attribute name="runpathref" />
+        <sequential>
+            <run_perf_test runpathref="@{runpathref}" clsname="org.eclipse.persistence.testing.perf.JPABenchmarks" resultFile="jmh-jpa-result.txt"/>
         </sequential>
     </macrodef>
 
@@ -231,6 +278,7 @@
     <macrodef name="run_perf_test">
         <attribute name="runpathref"/>
         <attribute name="clsname"/>
+        <attribute name="resultFile"/>
         <sequential>
             <property name="eclipselink.agent.path" location="${eclipselink.lib}"/>
             <java classname="@{clsname}" dir="${report.dir}" fork="true" failonerror="false">
@@ -238,7 +286,7 @@
                 <jvmarg line="${additional.jvmargs}"/>
                 <arg value="${warmup.iterations}"/>
                 <arg value="${run.iterations}"/>
-                <arg value="${jmh.resultFile}"/>
+                <arg value="@{resultFile}"/>
                 <arg value="${jmh.resultFormat}"/>
                 <classpath>
                     <path refid="@{runpathref}"/>

--- a/performance/eclipselink.perf.test/resource/META-INF/persistence.xml
+++ b/performance/eclipselink.perf.test/resource/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -44,6 +44,33 @@
             <property name="javax.persistence.jdbc.url"         value="@url@"/>
             <property name="javax.persistence.jdbc.user"        value="@user@"/>
             <property name="javax.persistence.jdbc.password"    value="@pwd@"/>
+        </properties>
+    </persistence-unit>
+    <persistence-unit name="jpa-performance-read-cache">
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+        <class>org.eclipse.persistence.testing.perf.jpa.model.basic.MasterEntity</class>
+        <class>org.eclipse.persistence.testing.perf.jpa.model.basic.DetailEntity</class>
+        <properties>
+            <property name="javax.persistence.jdbc.driver"      value="@driver@"/>
+            <property name="javax.persistence.jdbc.url"         value="@url@"/>
+            <property name="javax.persistence.jdbc.user"        value="@user@"/>
+            <property name="javax.persistence.jdbc.password"    value="@pwd@"/>
+            <property name="eclipselink.ddl-generation" value="drop-and-create-tables"/>
+        </properties>
+    </persistence-unit>
+    <persistence-unit name="jpa-performance-read-no-cache">
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+        <class>org.eclipse.persistence.testing.perf.jpa.model.basic.MasterEntity</class>
+        <class>org.eclipse.persistence.testing.perf.jpa.model.basic.DetailEntity</class>
+        <properties>
+            <property name="javax.persistence.jdbc.driver"      value="@driver@"/>
+            <property name="javax.persistence.jdbc.url"         value="@url@"/>
+            <property name="javax.persistence.jdbc.user"        value="@user@"/>
+            <property name="javax.persistence.jdbc.password"    value="@pwd@"/>
+            <property name="eclipselink.cache.shared.default" value="false"/>
+            <property name="eclipselink.cache.size.default" value="0"/>
+            <property name="eclipselink.query-results-cache" value="false"/>
+            <property name="eclipselink.ddl-generation" value="drop-and-create-tables"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/performance/eclipselink.perf.test/src/org/eclipse/persistence/testing/perf/CoreBenchmarks.java
+++ b/performance/eclipselink.perf.test/src/org/eclipse/persistence/testing/perf/CoreBenchmarks.java
@@ -11,27 +11,26 @@
  */
 
 // Contributors:
-//              Oracle - initial implementation
+//     Oracle - initial implementation
 package org.eclipse.persistence.testing.perf;
 
-import org.eclipse.persistence.testing.perf.jpa.tests.basic.JPAReadLargeAmmountCacheTests;
-import org.eclipse.persistence.testing.perf.jpa.tests.basic.JPAReadLargeAmmountNoCacheTests;
-import org.eclipse.persistence.testing.perf.jpa.tests.basic.JPAReadSmallAmmountCacheTests;
-import org.eclipse.persistence.testing.perf.jpa.tests.basic.JPAReadSmallAmmountNoCacheTests;
+import org.eclipse.persistence.testing.perf.core.ConcurrencyManagerBenchmark;
 import org.openjdk.jmh.results.format.ResultFormatType;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
-public class JPABenchmarks {
-
+/**
+ * This class wraps core module related benchmarks. It is analogy to JUnit suites.
+ *
+ */
+public class CoreBenchmarks {
     public static void main(String[] args) throws RunnerException {
 
         int warmupIterations = 20;
         int measurementIterations = 20;
-        int threads = 10;
-        String resultFile = "jmh-jpa-result.txt";
+        String resultFile = "jmh-core-result.txt";
         String resultFormat = "text";
 
         if (null != args && args.length == 4) {
@@ -42,17 +41,13 @@ public class JPABenchmarks {
         }
 
         Options opt = new OptionsBuilder()
-                .include(getInclude(JPAReadSmallAmmountCacheTests.class))
-                .include(getInclude(JPAReadSmallAmmountNoCacheTests.class))
-                .include(getInclude(JPAReadLargeAmmountCacheTests.class))
-                .include(getInclude(JPAReadLargeAmmountNoCacheTests.class))
-                .jvmArgsPrepend("-javaagent:" + System.getProperty("eclipselink.agent"))
+                .include(getInclude(ConcurrencyManagerBenchmark.class))
                 .result(resultFile)
                 .resultFormat(ResultFormatType.valueOf(resultFormat.toUpperCase()))
                 .warmupIterations(warmupIterations)
                 .measurementIterations(measurementIterations)
                 .forks(1)
-                .threads(threads)
+                .threads(50)
                 .build();
 
         new Runner(opt).run();

--- a/performance/eclipselink.perf.test/src/org/eclipse/persistence/testing/perf/JPAMetadataBenchmarks.java
+++ b/performance/eclipselink.perf.test/src/org/eclipse/persistence/testing/perf/JPAMetadataBenchmarks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,27 +11,25 @@
  */
 
 // Contributors:
-//              Oracle - initial implementation
+//              ljungmann - initial implementation
 package org.eclipse.persistence.testing.perf;
 
-import org.eclipse.persistence.testing.perf.jpa.tests.basic.JPAReadLargeAmmountCacheTests;
-import org.eclipse.persistence.testing.perf.jpa.tests.basic.JPAReadLargeAmmountNoCacheTests;
-import org.eclipse.persistence.testing.perf.jpa.tests.basic.JPAReadSmallAmmountCacheTests;
-import org.eclipse.persistence.testing.perf.jpa.tests.basic.JPAReadSmallAmmountNoCacheTests;
+import org.eclipse.persistence.testing.perf.jpa.tests.basic.JPAMetadataProcessingTests;
+import org.eclipse.persistence.testing.perf.jpa.tests.basic.MethodHandleComparisonTests;
+
 import org.openjdk.jmh.results.format.ResultFormatType;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
-public class JPABenchmarks {
+public class JPAMetadataBenchmarks {
 
     public static void main(String[] args) throws RunnerException {
 
         int warmupIterations = 20;
         int measurementIterations = 20;
-        int threads = 10;
-        String resultFile = "jmh-jpa-result.txt";
+        String resultFile = "jmh-jpa-metadata-result.txt";
         String resultFormat = "text";
 
         if (null != args && args.length == 4) {
@@ -42,17 +40,14 @@ public class JPABenchmarks {
         }
 
         Options opt = new OptionsBuilder()
-                .include(getInclude(JPAReadSmallAmmountCacheTests.class))
-                .include(getInclude(JPAReadSmallAmmountNoCacheTests.class))
-                .include(getInclude(JPAReadLargeAmmountCacheTests.class))
-                .include(getInclude(JPAReadLargeAmmountNoCacheTests.class))
+                .include(getInclude(JPAMetadataProcessingTests.class))
+                .include(getInclude(MethodHandleComparisonTests.class))
                 .jvmArgsPrepend("-javaagent:" + System.getProperty("eclipselink.agent"))
                 .result(resultFile)
                 .resultFormat(ResultFormatType.valueOf(resultFormat.toUpperCase()))
                 .warmupIterations(warmupIterations)
                 .measurementIterations(measurementIterations)
                 .forks(1)
-                .threads(threads)
                 .build();
 
         new Runner(opt).run();

--- a/performance/eclipselink.perf.test/src/org/eclipse/persistence/testing/perf/MOXyBenchmarks.java
+++ b/performance/eclipselink.perf.test/src/org/eclipse/persistence/testing/perf/MOXyBenchmarks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -33,12 +33,12 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
  * @author Martin Vojtek (martin.vojtek@oracle.com)
  *
  */
-public class Benchmarks {
+public class MOXyBenchmarks {
     public static void main(String[] args) throws RunnerException {
 
         int warmupIterations = 20;
         int measurementIterations = 20;
-        String resultFile = "jmh-result.txt";
+        String resultFile = "jmh-moxy-result.txt";
         String resultFormat = "text";
 
         if (null != args && args.length == 4) {

--- a/performance/eclipselink.perf.test/src/org/eclipse/persistence/testing/perf/core/ConcurrencyManagerBenchmark.java
+++ b/performance/eclipselink.perf.test/src/org/eclipse/persistence/testing/perf/core/ConcurrencyManagerBenchmark.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial implementation
+package org.eclipse.persistence.testing.perf.core;
+
+import org.eclipse.persistence.internal.helper.ConcurrencyManager;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * This benchmark verify performance of {@code org.eclipse.persistence.internal.helper.ConcurrencyManager}.
+ *
+ */
+@State(Scope.Benchmark)
+public class ConcurrencyManagerBenchmark {
+
+    @Benchmark
+    public void testAcquireRelease(Blackhole bh) throws Exception {
+        ConcurrencyManager concurrencyManager = new ConcurrencyManager();
+        concurrencyManager.acquire();
+        concurrencyManager.release();
+    }
+}

--- a/performance/eclipselink.perf.test/src/org/eclipse/persistence/testing/perf/jpa/model/basic/DetailEntity.java
+++ b/performance/eclipselink.perf.test/src/org/eclipse/persistence/testing/perf/jpa/model/basic/DetailEntity.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//              Oracle - initial implementation
+package org.eclipse.persistence.testing.perf.jpa.model.basic;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "P2_DETAIL")
+public class DetailEntity {
+    @Id
+    private long id;
+
+    private String name;
+
+    @ManyToOne()
+    @JoinColumn(name = "MASTER_ID_FK")
+    private MasterEntity master;
+
+    public DetailEntity() {
+    }
+
+    public DetailEntity(long id) {
+        this.id = id;
+    }
+
+    public DetailEntity(long id, String name, MasterEntity master) {
+        this.id = id;
+        this.name = name;
+        this.master = master;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public MasterEntity getMaster() {
+        return master;
+    }
+
+    public void setMaster(MasterEntity master) {
+        this.master = master;
+    }
+
+    @Override
+    public String toString() {
+        return "DetailEntity{" +
+                "id=" + id +
+                ", name='" + name +
+                '}';
+    }
+}

--- a/performance/eclipselink.perf.test/src/org/eclipse/persistence/testing/perf/jpa/model/basic/MasterEntity.java
+++ b/performance/eclipselink.perf.test/src/org/eclipse/persistence/testing/perf/jpa/model/basic/MasterEntity.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//              Oracle - initial implementation
+package org.eclipse.persistence.testing.perf.jpa.model.basic;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "P2_MASTER")
+public class MasterEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    private String name;
+
+    @OneToMany(mappedBy = "master", fetch = FetchType.EAGER)
+    private List<DetailEntity> details = new ArrayList<>();
+
+    public MasterEntity() {
+    }
+
+    public MasterEntity(long id) {
+        this.id = id;
+    }
+    
+    public MasterEntity(long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public MasterEntity(String name) {
+        this.name = name;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<DetailEntity> getDetails() {
+        return details;
+    }
+
+    public void setDetails(List<DetailEntity> details) {
+        this.details = details;
+    }
+
+    @Override
+    public String toString() {
+        return "MasterEntity{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", details=" + details +
+                '}';
+    }
+}

--- a/performance/eclipselink.perf.test/src/org/eclipse/persistence/testing/perf/jpa/tests/basic/JPAReadAbstract.java
+++ b/performance/eclipselink.perf.test/src/org/eclipse/persistence/testing/perf/jpa/tests/basic/JPAReadAbstract.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//              Oracle - initial implementation
+package org.eclipse.persistence.testing.perf.jpa.tests.basic;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Persistence;
+import javax.persistence.EntityManagerFactory;
+
+import org.eclipse.persistence.testing.perf.jpa.model.basic.DetailEntity;
+import org.eclipse.persistence.testing.perf.jpa.model.basic.MasterEntity;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.TearDown;
+
+/**
+ * Benchmarks for JPA reading data.
+ *
+ * @author Oracle
+ */
+public abstract class JPAReadAbstract {
+
+    public static final int DETAIL_ID_STEP = 10000;
+
+    private EntityManagerFactory emf = Persistence.createEntityManagerFactory(getPersistenceUnitName());
+
+    @Setup
+    public void setup() {
+        EntityManager em = emf.createEntityManager();
+        prepareData(em);
+    }
+
+    @TearDown
+    public void tearDown() {
+        emf.close();
+    }
+
+    /**
+     * Read MasterEntity and DetailEntity (fetch = FetchType.EAGER).
+     */
+    @Benchmark
+    public void testReadEntity() {
+        EntityManager em = null;
+        try {
+            em = emf.createEntityManager();
+            for (long i = 1; i <= getMasterSize(); i++) {
+                MasterEntity masterEntity = em.find(MasterEntity.class, i);
+                if (masterEntity == null) {
+                    throw new RuntimeException("MasterEntity is null!");
+                }
+                if (masterEntity.getDetails().size() < getDetailSize()) {
+                    throw new RuntimeException("No of DetailEntities is |" + masterEntity.getDetails().size() + "| less than expected |" + getDetailSize() + "|!");
+                }
+            }
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        } finally {
+            if (em != null) {
+                em.close();
+            }
+        }
+    }
+
+    private void prepareData(EntityManager em) {
+        try {
+            em.getTransaction().begin();
+            for (int i = 1; i <= getMasterSize(); i++) {
+                MasterEntity masterEntity = new MasterEntity(i, "Master name " + i);
+                em.persist(masterEntity);
+                for (int j = 1; j <= getDetailSize(); j++) {
+                    DetailEntity detailEntity = new DetailEntity(i * DETAIL_ID_STEP + j, "Detail name " + j, masterEntity);
+                    masterEntity.getDetails().add(detailEntity);
+                    em.persist(detailEntity);
+                }
+            }
+            em.getTransaction().commit();
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+        }
+    }
+
+    public abstract String getPersistenceUnitName();
+
+    public abstract int getMasterSize();
+
+    public abstract int getDetailSize();
+}

--- a/performance/eclipselink.perf.test/src/org/eclipse/persistence/testing/perf/jpa/tests/basic/JPAReadLargeAmmountAbstract.java
+++ b/performance/eclipselink.perf.test/src/org/eclipse/persistence/testing/perf/jpa/tests/basic/JPAReadLargeAmmountAbstract.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//              Oracle - initial implementation
+package org.eclipse.persistence.testing.perf.jpa.tests.basic;
+
+/**
+ * Benchmarks for JPA reading data (large amount - 10000 rows per each request em.find()).
+ *
+ * @author Oracle
+ */
+public abstract class JPAReadLargeAmmountAbstract extends JPAReadAbstract {
+
+    public int getMasterSize() {
+        return 10;
+    }
+
+    public int getDetailSize() {
+        return DETAIL_ID_STEP;
+    }
+}

--- a/performance/eclipselink.perf.test/src/org/eclipse/persistence/testing/perf/jpa/tests/basic/JPAReadLargeAmmountCacheTests.java
+++ b/performance/eclipselink.perf.test/src/org/eclipse/persistence/testing/perf/jpa/tests/basic/JPAReadLargeAmmountCacheTests.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//              Oracle - initial implementation
+package org.eclipse.persistence.testing.perf.jpa.tests.basic;
+
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+/**
+ * Benchmarks for JPA reading data (large amount - 10000 rows per each request em.find()) with JPA L2 cache enabled.
+ *
+ * @author Oracle
+ */
+@State(Scope.Benchmark)
+//@BenchmarkMode(Mode.AverageTime)
+public class JPAReadLargeAmmountCacheTests extends JPAReadLargeAmmountAbstract {
+
+    public String getPersistenceUnitName() {
+        return "jpa-performance-read-cache";
+    }
+}

--- a/performance/eclipselink.perf.test/src/org/eclipse/persistence/testing/perf/jpa/tests/basic/JPAReadLargeAmmountNoCacheTests.java
+++ b/performance/eclipselink.perf.test/src/org/eclipse/persistence/testing/perf/jpa/tests/basic/JPAReadLargeAmmountNoCacheTests.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//              Oracle - initial implementation
+package org.eclipse.persistence.testing.perf.jpa.tests.basic;
+
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+/**
+ * Benchmarks for JPA reading data (large amount - 10000 rows per each request em.find()) with JPA L2 cache disabled.
+ *
+ * @author Oracle
+ */
+@State(Scope.Benchmark)
+//@BenchmarkMode(Mode.AverageTime)
+public class JPAReadLargeAmmountNoCacheTests extends JPAReadLargeAmmountAbstract {
+
+    public String getPersistenceUnitName() {
+        return "jpa-performance-read-no-cache";
+    }
+}

--- a/performance/eclipselink.perf.test/src/org/eclipse/persistence/testing/perf/jpa/tests/basic/JPAReadSmallAmmountAbstract.java
+++ b/performance/eclipselink.perf.test/src/org/eclipse/persistence/testing/perf/jpa/tests/basic/JPAReadSmallAmmountAbstract.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//              Oracle - initial implementation
+package org.eclipse.persistence.testing.perf.jpa.tests.basic;
+
+/**
+ * Benchmarks for JPA reading data (small amount - up 20 rows per each request em.find()).
+ *
+ * @author Oracle
+ */
+public abstract class JPAReadSmallAmmountAbstract extends JPAReadAbstract {
+
+    public int getMasterSize() {
+        return 10;
+    }
+
+    public int getDetailSize() {
+        return 10;
+    }
+}

--- a/performance/eclipselink.perf.test/src/org/eclipse/persistence/testing/perf/jpa/tests/basic/JPAReadSmallAmmountCacheTests.java
+++ b/performance/eclipselink.perf.test/src/org/eclipse/persistence/testing/perf/jpa/tests/basic/JPAReadSmallAmmountCacheTests.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//              Oracle - initial implementation
+package org.eclipse.persistence.testing.perf.jpa.tests.basic;
+
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+/**
+ * Benchmarks for JPA reading data (small amount - up 20 rows per each request em.find()) with JPA L2 cache enabled.
+ *
+ * @author Oracle
+ */
+@State(Scope.Benchmark)
+//@BenchmarkMode(Mode.AverageTime)
+public class JPAReadSmallAmmountCacheTests extends JPAReadSmallAmmountAbstract {
+
+    public String getPersistenceUnitName() {
+        return "jpa-performance-read-cache";
+    }
+}

--- a/performance/eclipselink.perf.test/src/org/eclipse/persistence/testing/perf/jpa/tests/basic/JPAReadSmallAmmountNoCacheTests.java
+++ b/performance/eclipselink.perf.test/src/org/eclipse/persistence/testing/perf/jpa/tests/basic/JPAReadSmallAmmountNoCacheTests.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//              Oracle - initial implementation
+package org.eclipse.persistence.testing.perf.jpa.tests.basic;
+
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+/**
+ * Benchmarks for JPA reading data (small amount - up 20 rows per each request em.find()) with JPA L2 cache disabled.
+ *
+ * @author Oracle
+ */
+@State(Scope.Benchmark)
+//@BenchmarkMode(Mode.AverageTime)
+public class JPAReadSmallAmmountNoCacheTests extends JPAReadSmallAmmountAbstract {
+
+    public String getPersistenceUnitName() {
+        return "jpa-performance-read-no-cache";
+    }
+}


### PR DESCRIPTION
This change improves EclipseLink performance with higher versions of the JDK (21 and above). It's about replacement of synchronized keyword and wait(), notify() methods by objects from java.util.concurrent.locks.* package. Additionally, there are some new performance tests to verify it and performance tests refresh.
Backport from #2116

(cherry picked from commit 1f0cf759092beb031ccc2e5a6950f239f15b5b55)