### PR TITLE
[4.0] Dependencies, Maven plugin and org.eclipse.ee4j:project versions upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@
         <junit.version>4.13.2</junit.version>
         <!-- CQ #24079 -->
         <mongodb.version>3.12.14</mongodb.version>
-        <mysql.version>8.4.00</mysql.version>
+        <mysql.version>8.4.0</mysql.version>
         <mariadb.version>3.3.3</mariadb.version>
         <mssql.version>12.6.1.jre11</mssql.version>
         <pgsql.version>42.7.3</pgsql.version>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.7</version>
+        <version>1.0.9</version>
         <relativePath/>
     </parent>
 
@@ -112,7 +112,7 @@
         <spotbugs.exclude/>
         <spotbugs.skip>false</spotbugs.skip>
         <spotbugs.threshold>Normal</spotbugs.threshold>
-        <spotbugs.version>4.7.3</spotbugs.version>
+        <spotbugs.version>4.8.4</spotbugs.version>
         <findsecbugs.version>1.11.0</findsecbugs.version>
         <dependency-check.failonerror>false</dependency-check.failonerror>
 
@@ -191,77 +191,77 @@
         <javadoc.postfixTitle>API Reference</javadoc.postfixTitle>
 
         <!--Eclipse Dependencies version-->
-        <eclipselink.asm.version>9.6.0</eclipselink.asm.version>
-        <asm.version>9.6</asm.version>
-        <activation-api.version>2.1.2</activation-api.version>
-        <angus-activation.version>2.0.1</angus-activation.version>
+        <eclipselink.asm.version>9.7.0</eclipselink.asm.version>
+        <asm.version>9.7</asm.version>
+        <activation-api.version>2.1.3</activation-api.version>
+        <angus-activation.version>2.0.2</angus-activation.version>
         <annotation.version>2.1.1</annotation.version>
         <cdi.version>4.0.1</cdi.version>
         <ejb.version>4.0.1</ejb.version>
         <el-api.version>5.0.1</el-api.version>
         <el.version>5.0.0-M1</el.version>
         <glassfish.version>7.0.5</glassfish.version>
-        <jaxwsrt.version>4.0.1</jaxwsrt.version>
-        <jaxb.version>4.0.3</jaxb.version>
-        <jaxb.api.version>4.0.0</jaxb.api.version>
-        <soap.api.version>3.0.0</soap.api.version>
-        <jersey.version>3.1.2</jersey.version>
+        <jaxwsrt.version>4.0.2</jaxwsrt.version>
+        <jaxb.version>4.0.5</jaxb.version>
+        <jaxb.api.version>4.0.2</jaxb.api.version>
+        <soap.api.version>3.0.2</soap.api.version>
+        <jersey.version>3.1.6</jersey.version>
         <jms.version>3.1.0</jms.version>
-        <json.version>2.1.2</json.version>
+        <json.version>2.1.3</json.version>
         <jpa.api.version>3.1.0</jpa.api.version>
         <mail-api.version>2.1.2</mail-api.version>
-        <angus-mail.version>2.0.2</angus-mail.version>
+        <angus-mail.version>2.0.3</angus-mail.version>
         <oracle.ddlparser.version>3.0.1</oracle.ddlparser.version>
-        <org.glassfish.corba.version>4.2.4</org.glassfish.corba.version>
-        <parsson.version>1.1.2</parsson.version>
+        <org.glassfish.corba.version>4.2.5</org.glassfish.corba.version>
+        <parsson.version>1.1.6</parsson.version>
         <resource.version>2.1.0</resource.version>
         <servlet.version>6.0.0</servlet.version>
         <transaction.version>2.0.1</transaction.version>
         <validation.version>3.0.2</validation.version>
-        <ws-api.version>4.0.0</ws-api.version>
+        <ws-api.version>4.0.2</ws-api.version>
         <ws-rs.version>3.1.0</ws-rs.version>
 
         <!--Third-Party Dependencies version-->
         <!-- CQ #23046 -->
         <apache.felix.framework.version>7.0.5</apache.felix.framework.version>
         <!-- CQ #21133 -->
-        <ant.version>1.10.13</ant.version>
+        <ant.version>1.10.14</ant.version>
         <aspectj.version>1.9.19</aspectj.version>
         <commonj.sdo.version>2.1.1</commonj.sdo.version>
         <derby.version>10.15.2.0</derby.version>
-        <db2.version>11.5.8.0</db2.version>
+        <db2.version>11.5.9.0</db2.version>
         <!-- CQ #21134, 21135, 21136, 21137 -->
-        <exam.version>4.13.2</exam.version>
+        <exam.version>4.13.4</exam.version>
         <hamcrest.version>1.3</hamcrest.version>
         <!-- CQ #23048 -->
-        <hibernate.version>8.0.0.Final</hibernate.version>
-        <checkstyle.version>10.12.0</checkstyle.version>
+        <hibernate.version>8.0.1.Final</hibernate.version>
+        <checkstyle.version>10.16.0</checkstyle.version>
         <!-- CQ #23049 -->
-        <jgroups.version>5.2.14.Final</jgroups.version>
-        <jmh.version>1.36</jmh.version>
+        <jgroups.version>5.3.6.Final</jgroups.version>
+        <jmh.version>1.37</jmh.version>
         <junit.version>4.13.2</junit.version>
         <!-- CQ #24079 -->
         <mongodb.version>3.12.14</mongodb.version>
-        <mysql.version>8.0.33</mysql.version>
-        <mariadb.version>3.1.4</mariadb.version>
-        <mssql.version>12.2.0.jre11</mssql.version>
-        <pgsql.version>42.6.0</pgsql.version>
+        <mysql.version>8.4.00</mysql.version>
+        <mariadb.version>3.3.3</mariadb.version>
+        <mssql.version>12.6.1.jre11</mssql.version>
+        <pgsql.version>42.7.3</pgsql.version>
         <!-- CQ #21139, 21140 -->
-        <logback.version>1.4.7</logback.version>
-        <oracle.jdbc.version>23.2.0.0</oracle.jdbc.version>
+        <logback.version>1.5.6</logback.version>
+        <oracle.jdbc.version>23.3.0.23.09</oracle.jdbc.version>
         <!-- CQ #2437 -->
-        <oracle.aqapi.version>23.2.0.0</oracle.aqapi.version>
+        <oracle.aqapi.version>23.3.1.0</oracle.aqapi.version>
         <oracle.fmw.version>12.2.1-2-0</oracle.fmw.version>
         <!-- CQ #21141 -->
         <oracle.nosql.version>18.3.10</oracle.nosql.version>
         <!-- CQ #24195 -->
-        <oracle.nosql.sdk.version>5.4.10</oracle.nosql.sdk.version>
+        <oracle.nosql.sdk.version>5.4.14</oracle.nosql.sdk.version>
         <!-- CQ #21142 -->
         <osgi.version>6.0.0</osgi.version>
         <!-- CQ #21143 -->
-        <slf4j.version>2.0.7</slf4j.version>
+        <slf4j.version>2.0.12</slf4j.version>
         <!-- CQ #23051, 23052, 23053, 53054, 53055 -->
-        <springframework.version>5.3.25</springframework.version>
+        <springframework.version>5.3.34</springframework.version>
         <!-- CQ #23233 -->
         <weld-se.version>5.1.0.Final</weld-se.version>
         <weblogic.version>12.2.1-3</weblogic.version>
@@ -269,10 +269,10 @@
         <wsdl4j.version>1.6.3</wsdl4j.version>
 
         <!--Documentation Dependencies version-->
-        <asciidoctorj.version>2.5.7</asciidoctorj.version>
-        <asciidoctorj.pdf.version>2.3.4</asciidoctorj.pdf.version>
-        <asciidoctorj.epub.version>1.5.1</asciidoctorj.epub.version>
-        <jruby.version>9.2.21.0</jruby.version>
+        <asciidoctorj.version>3.0.0-alpha.2</asciidoctorj.version>
+        <asciidoctorj.pdf.version>2.3.15</asciidoctorj.pdf.version>
+        <asciidoctorj.epub.version>2.1.0</asciidoctorj.epub.version>
+        <jruby.version>9.4.7.0</jruby.version>
         <!--JRuby - this version works with asciidoctorj-pdf-->
 <!--        <jruby.version>9.4.0.0</jruby.version>-->
     </properties>
@@ -1073,12 +1073,12 @@
                 <plugin>
                     <groupId>com.googlecode.maven-download-plugin</groupId>
                     <artifactId>download-maven-plugin</artifactId>
-                    <version>1.6.8</version>
+                    <version>1.9.0</version>
                 </plugin>
                 <plugin>
                     <groupId>com.sun.wts.tools.ant</groupId>
                     <artifactId>package-rename-task</artifactId>
-                    <version>1.5.2</version>
+                    <version>1.6.0</version>
                 </plugin>
                 <plugin>
                     <groupId>de.empulse.eclipselink</groupId>
@@ -1098,37 +1098,37 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>3.6.0</version>
+                    <version>3.7.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.3.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.11.0</version>
+                    <version>3.13.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.6.0</version>
+                    <version>3.6.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.1.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.4.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>3.2.5</version>
                     <configuration>
                         <useModulePath>false</useModulePath>
                         <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
@@ -1137,17 +1137,17 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-install-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.1.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.4.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.5.0</version>
+                    <version>3.6.3</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -1162,17 +1162,17 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>4.0.0-M8</version>
+                    <version>4.0.0-M13</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.3.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>3.2.5</version>
                     <configuration>
                         <useModulePath>false</useModulePath>
                         <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
@@ -1181,17 +1181,17 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-report-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>3.2.5</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
-                    <version>3.3.2</version>
+                    <version>3.4.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.cargo</groupId>
                     <artifactId>cargo-maven3-plugin</artifactId>
-                    <version>1.10.7</version>
+                    <version>1.10.13</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.gmaven</groupId>
@@ -1201,7 +1201,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>aspectj-maven-plugin</artifactId>
-                    <version>1.14.0</version>
+                    <version>1.15.0</version>
                     <dependencies>
                         <dependency>
                             <groupId>org.aspectj</groupId>
@@ -1218,7 +1218,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>3.4.0</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -1228,12 +1228,12 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>sql-maven-plugin</artifactId>
-                    <version>1.5</version>
+                    <version>3.0.0</version>
                     <dependencies>
                         <dependency>
                             <groupId>${db.driver.groupId}</groupId>
@@ -1245,7 +1245,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>xml-maven-plugin</artifactId>
-                    <version>1.0.2</version>
+                    <version>1.1.0</version>
                 </plugin>
                 <!--This plugin (g:org.kuali.maven.plugins) is used instead typical org.codehaus.mojo:properties-maven-plugin:1.0.0
                     due bug: "Circular property definition" if expression like this is used in the Maven pom
@@ -1265,7 +1265,7 @@
                     <!-- see https://github.com/eclipse-ee4j/eclipselink-build-support -->
                     <groupId>org.eclipse.persistence</groupId>
                     <artifactId>eclipselink-testbuild-plugin</artifactId>
-                    <version>1.0.0</version>
+                    <version>1.1.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.carlspring.maven</groupId>
@@ -1297,7 +1297,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.3.1</version>
                     <dependencies>
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
@@ -1318,7 +1318,7 @@
                 <plugin>
                     <groupId>com.github.spotbugs</groupId>
                     <artifactId>spotbugs-maven-plugin</artifactId>
-                    <version>4.7.3.4</version>
+                    <version>4.8.4.0</version>
                     <dependencies>
                         <dependency>
                             <groupId>com.github.spotbugs</groupId>
@@ -1342,7 +1342,7 @@
                 <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
-                    <version>8.2.1</version>
+                    <version>9.1.0</version>
                     <configuration>
 <!--                        <failBuildOnCVSS>7</failBuildOnCVSS>-->
                         <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
@@ -1356,7 +1356,7 @@
                 <plugin>
                     <groupId>org.asciidoctor</groupId>
                     <artifactId>asciidoctor-maven-plugin</artifactId>
-                    <version>2.2.4</version>
+                    <version>3.0.0</version>
                     <dependencies>
                         <dependency>
                             <groupId>org.jruby</groupId>
@@ -1383,7 +1383,7 @@
                 <plugin>
                     <groupId>org.wildfly.plugins</groupId>
                     <artifactId>wildfly-maven-plugin</artifactId>
-                    <version>4.1.0.Beta5</version>
+                    <version>5.0.0.Final</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -1674,7 +1674,7 @@
                                     <version>[11,)</version>
                                 </requireJavaVersion>
                                 <requireMavenVersion>
-                                    <version>[3.6.3,)</version>
+                                    <version>[3.8.5,)</version>
                                 </requireMavenVersion>
                             </rules>
                         </configuration>
@@ -2113,7 +2113,7 @@
                         <plugin>
                             <groupId>org.jacoco</groupId>
                             <artifactId>jacoco-maven-plugin</artifactId>
-                            <version>0.8.10</version>
+                            <version>0.8.12</version>
                         </plugin>
                     </plugins>
                 </pluginManagement>


### PR DESCRIPTION
There are a few notes about this change:

Maven plugins were upgraded to the latest available versions
Dependencies were upgraded to the versions which accept JDK 11 and Jakarta EE 10
Project parent pom was updated to 1.0.9