### PR TITLE
[master] Performance tests improvement - use EmulatedDB

### DIFF
--- a/foundation/org.eclipse.persistence.core.test.framework/src/main/java/org/eclipse/persistence/testing/tests/performance/emulateddb/EmulatedConnection.java
+++ b/foundation/org.eclipse.persistence.core.test.framework/src/main/java/org/eclipse/persistence/testing/tests/performance/emulateddb/EmulatedConnection.java
@@ -45,6 +45,7 @@ import java.util.concurrent.Executor;
 public class EmulatedConnection implements Connection {
     protected Map<String, List<DatabaseRecord>> rows;
     protected Connection connection;
+    protected DatabaseMetaData databaseMetaData;
 
     public EmulatedConnection() {
         this.rows = new HashMap<>();
@@ -327,10 +328,10 @@ public class EmulatedConnection implements Connection {
      */
     @Override
     public DatabaseMetaData getMetaData() throws SQLException {
-        if (connection != null) {
-            return connection.getMetaData();
+        if (this.databaseMetaData == null) {
+            this.databaseMetaData = new EmulatedDatabaseMetaData();
         }
-        return null;
+        return this.databaseMetaData;
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core.test.framework/src/main/java/org/eclipse/persistence/testing/tests/performance/emulateddb/EmulatedConnection.java
+++ b/foundation/org.eclipse.persistence.core.test.framework/src/main/java/org/eclipse/persistence/testing/tests/performance/emulateddb/EmulatedConnection.java
@@ -46,9 +46,17 @@ public class EmulatedConnection implements Connection {
     protected Map<String, List<DatabaseRecord>> rows;
     protected Connection connection;
     protected DatabaseMetaData databaseMetaData;
+    private String url;
+    private Properties info;
 
     public EmulatedConnection() {
         this.rows = new HashMap<>();
+    }
+
+    public EmulatedConnection(String url, Properties info) {
+        this();
+        this.url = url;
+        this.info = info;
     }
 
     public EmulatedConnection(Connection connection) {
@@ -328,8 +336,11 @@ public class EmulatedConnection implements Connection {
      */
     @Override
     public DatabaseMetaData getMetaData() throws SQLException {
+        if (connection != null) {
+            return connection.getMetaData();
+        }
         if (this.databaseMetaData == null) {
-            this.databaseMetaData = new EmulatedDatabaseMetaData();
+            this.databaseMetaData = new EmulatedDatabaseMetaData(this);
         }
         return this.databaseMetaData;
     }
@@ -1022,4 +1033,12 @@ public class EmulatedConnection implements Connection {
 
     @Override
     public void setSchema(String schema) throws SQLException {}
+
+    public String getURL() {
+        return this.url;
+    }
+
+    public Properties getInfo() {
+        return this.info;
+    }
 }

--- a/foundation/org.eclipse.persistence.core.test.framework/src/main/java/org/eclipse/persistence/testing/tests/performance/emulateddb/EmulatedDatabaseMetaData.java
+++ b/foundation/org.eclipse.persistence.core.test.framework/src/main/java/org/eclipse/persistence/testing/tests/performance/emulateddb/EmulatedDatabaseMetaData.java
@@ -21,6 +21,13 @@ import java.sql.RowIdLifetime;
 import java.sql.SQLException;
 
 public class EmulatedDatabaseMetaData implements DatabaseMetaData {
+
+    private EmulatedConnection connection;
+
+    public EmulatedDatabaseMetaData(EmulatedConnection emulatedConnection) {
+        this.connection = emulatedConnection;
+    }
+
     @Override
     public boolean allProceduresAreCallable() throws SQLException {
         return false;
@@ -33,11 +40,14 @@ public class EmulatedDatabaseMetaData implements DatabaseMetaData {
 
     @Override
     public String getURL() throws SQLException {
-        return null;
+        return connection.getURL();
     }
 
     @Override
     public String getUserName() throws SQLException {
+        if (connection.getInfo() != null) {
+            return connection.getInfo().getProperty("user");
+        }
         return null;
     }
 
@@ -68,7 +78,7 @@ public class EmulatedDatabaseMetaData implements DatabaseMetaData {
 
     @Override
     public String getDatabaseProductName() throws SQLException {
-        return "EclipseLink Emulated Driver";
+        return "EclipseLink Emulated Driver - DB";
     }
 
     @Override
@@ -78,17 +88,17 @@ public class EmulatedDatabaseMetaData implements DatabaseMetaData {
 
     @Override
     public String getDriverName() throws SQLException {
-        return null;
+        return "EclipseLink Emulated Driver";
     }
 
     @Override
     public String getDriverVersion() throws SQLException {
-        return null;
+        return "1.0";
     }
 
     @Override
     public int getDriverMajorVersion() {
-        return 0;
+        return 1;
     }
 
     @Override

--- a/foundation/org.eclipse.persistence.core.test.framework/src/main/java/org/eclipse/persistence/testing/tests/performance/emulateddb/EmulatedDatabaseMetaData.java
+++ b/foundation/org.eclipse.persistence.core.test.framework/src/main/java/org/eclipse/persistence/testing/tests/performance/emulateddb/EmulatedDatabaseMetaData.java
@@ -1,0 +1,903 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.testing.tests.performance.emulateddb;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.RowIdLifetime;
+import java.sql.SQLException;
+
+public class EmulatedDatabaseMetaData implements DatabaseMetaData {
+    @Override
+    public boolean allProceduresAreCallable() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean allTablesAreSelectable() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public String getURL() throws SQLException {
+        return null;
+    }
+
+    @Override
+    public String getUserName() throws SQLException {
+        return null;
+    }
+
+    @Override
+    public boolean isReadOnly() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean nullsAreSortedHigh() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean nullsAreSortedLow() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean nullsAreSortedAtStart() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean nullsAreSortedAtEnd() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public String getDatabaseProductName() throws SQLException {
+        return "EclipseLink Emulated Driver";
+    }
+
+    @Override
+    public String getDatabaseProductVersion() throws SQLException {
+        return "1.0";
+    }
+
+    @Override
+    public String getDriverName() throws SQLException {
+        return null;
+    }
+
+    @Override
+    public String getDriverVersion() throws SQLException {
+        return null;
+    }
+
+    @Override
+    public int getDriverMajorVersion() {
+        return 0;
+    }
+
+    @Override
+    public int getDriverMinorVersion() {
+        return 0;
+    }
+
+    @Override
+    public boolean usesLocalFiles() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean usesLocalFilePerTable() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsMixedCaseIdentifiers() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean storesUpperCaseIdentifiers() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean storesLowerCaseIdentifiers() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean storesMixedCaseIdentifiers() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsMixedCaseQuotedIdentifiers() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean storesUpperCaseQuotedIdentifiers() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean storesLowerCaseQuotedIdentifiers() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean storesMixedCaseQuotedIdentifiers() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public String getIdentifierQuoteString() throws SQLException {
+        return null;
+    }
+
+    @Override
+    public String getSQLKeywords() throws SQLException {
+        return null;
+    }
+
+    @Override
+    public String getNumericFunctions() throws SQLException {
+        return null;
+    }
+
+    @Override
+    public String getStringFunctions() throws SQLException {
+        return null;
+    }
+
+    @Override
+    public String getSystemFunctions() throws SQLException {
+        return null;
+    }
+
+    @Override
+    public String getTimeDateFunctions() throws SQLException {
+        return null;
+    }
+
+    @Override
+    public String getSearchStringEscape() throws SQLException {
+        return null;
+    }
+
+    @Override
+    public String getExtraNameCharacters() throws SQLException {
+        return null;
+    }
+
+    @Override
+    public boolean supportsAlterTableWithAddColumn() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsAlterTableWithDropColumn() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsColumnAliasing() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean nullPlusNonNullIsNull() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsConvert() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsConvert(int fromType, int toType) throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsTableCorrelationNames() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsDifferentTableCorrelationNames() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsExpressionsInOrderBy() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsOrderByUnrelated() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsGroupBy() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsGroupByUnrelated() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsGroupByBeyondSelect() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsLikeEscapeClause() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsMultipleResultSets() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsMultipleTransactions() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsNonNullableColumns() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsMinimumSQLGrammar() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsCoreSQLGrammar() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsExtendedSQLGrammar() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsANSI92EntryLevelSQL() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsANSI92IntermediateSQL() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsANSI92FullSQL() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsIntegrityEnhancementFacility() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsOuterJoins() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsFullOuterJoins() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsLimitedOuterJoins() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public String getSchemaTerm() throws SQLException {
+        return null;
+    }
+
+    @Override
+    public String getProcedureTerm() throws SQLException {
+        return null;
+    }
+
+    @Override
+    public String getCatalogTerm() throws SQLException {
+        return null;
+    }
+
+    @Override
+    public boolean isCatalogAtStart() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public String getCatalogSeparator() throws SQLException {
+        return null;
+    }
+
+    @Override
+    public boolean supportsSchemasInDataManipulation() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsSchemasInProcedureCalls() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsSchemasInTableDefinitions() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsSchemasInIndexDefinitions() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsSchemasInPrivilegeDefinitions() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsCatalogsInDataManipulation() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsCatalogsInProcedureCalls() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsCatalogsInTableDefinitions() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsCatalogsInIndexDefinitions() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsCatalogsInPrivilegeDefinitions() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsPositionedDelete() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsPositionedUpdate() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsSelectForUpdate() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsStoredProcedures() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsSubqueriesInComparisons() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsSubqueriesInExists() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsSubqueriesInIns() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsSubqueriesInQuantifieds() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsCorrelatedSubqueries() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsUnion() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsUnionAll() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsOpenCursorsAcrossCommit() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsOpenCursorsAcrossRollback() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsOpenStatementsAcrossCommit() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsOpenStatementsAcrossRollback() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public int getMaxBinaryLiteralLength() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public int getMaxCharLiteralLength() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public int getMaxColumnNameLength() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public int getMaxColumnsInGroupBy() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public int getMaxColumnsInIndex() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public int getMaxColumnsInOrderBy() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public int getMaxColumnsInSelect() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public int getMaxColumnsInTable() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public int getMaxConnections() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public int getMaxCursorNameLength() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public int getMaxIndexLength() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public int getMaxSchemaNameLength() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public int getMaxProcedureNameLength() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public int getMaxCatalogNameLength() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public int getMaxRowSize() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public boolean doesMaxRowSizeIncludeBlobs() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public int getMaxStatementLength() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public int getMaxStatements() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public int getMaxTableNameLength() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public int getMaxTablesInSelect() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public int getMaxUserNameLength() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public int getDefaultTransactionIsolation() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public boolean supportsTransactions() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsTransactionIsolationLevel(int level) throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsDataDefinitionAndDataManipulationTransactions() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsDataManipulationTransactionsOnly() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean dataDefinitionCausesTransactionCommit() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean dataDefinitionIgnoredInTransactions() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public ResultSet getProcedures(String catalog, String schemaPattern, String procedureNamePattern) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public ResultSet getProcedureColumns(String catalog, String schemaPattern, String procedureNamePattern, String columnNamePattern) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public ResultSet getTables(String catalog, String schemaPattern, String tableNamePattern, String[] types) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public ResultSet getSchemas() throws SQLException {
+        return null;
+    }
+
+    @Override
+    public ResultSet getCatalogs() throws SQLException {
+        return null;
+    }
+
+    @Override
+    public ResultSet getTableTypes() throws SQLException {
+        return null;
+    }
+
+    @Override
+    public ResultSet getColumns(String catalog, String schemaPattern, String tableNamePattern, String columnNamePattern) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public ResultSet getColumnPrivileges(String catalog, String schema, String table, String columnNamePattern) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public ResultSet getTablePrivileges(String catalog, String schemaPattern, String tableNamePattern) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public ResultSet getBestRowIdentifier(String catalog, String schema, String table, int scope, boolean nullable) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public ResultSet getVersionColumns(String catalog, String schema, String table) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public ResultSet getPrimaryKeys(String catalog, String schema, String table) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public ResultSet getImportedKeys(String catalog, String schema, String table) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public ResultSet getExportedKeys(String catalog, String schema, String table) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public ResultSet getCrossReference(String parentCatalog, String parentSchema, String parentTable, String foreignCatalog, String foreignSchema, String foreignTable) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public ResultSet getTypeInfo() throws SQLException {
+        return null;
+    }
+
+    @Override
+    public ResultSet getIndexInfo(String catalog, String schema, String table, boolean unique, boolean approximate) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public boolean supportsResultSetType(int type) throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsResultSetConcurrency(int type, int concurrency) throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean ownUpdatesAreVisible(int type) throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean ownDeletesAreVisible(int type) throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean ownInsertsAreVisible(int type) throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean othersUpdatesAreVisible(int type) throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean othersDeletesAreVisible(int type) throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean othersInsertsAreVisible(int type) throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean updatesAreDetected(int type) throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean deletesAreDetected(int type) throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean insertsAreDetected(int type) throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsBatchUpdates() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public ResultSet getUDTs(String catalog, String schemaPattern, String typeNamePattern, int[] types) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        return null;
+    }
+
+    @Override
+    public boolean supportsSavepoints() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsNamedParameters() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsMultipleOpenResults() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsGetGeneratedKeys() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public ResultSet getSuperTypes(String catalog, String schemaPattern, String typeNamePattern) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public ResultSet getSuperTables(String catalog, String schemaPattern, String tableNamePattern) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public ResultSet getAttributes(String catalog, String schemaPattern, String typeNamePattern, String attributeNamePattern) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public boolean supportsResultSetHoldability(int holdability) throws SQLException {
+        return false;
+    }
+
+    @Override
+    public int getResultSetHoldability() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public int getDatabaseMajorVersion() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public int getDatabaseMinorVersion() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public int getJDBCMajorVersion() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public int getJDBCMinorVersion() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public int getSQLStateType() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public boolean locatorsUpdateCopy() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean supportsStatementPooling() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public RowIdLifetime getRowIdLifetime() throws SQLException {
+        return null;
+    }
+
+    @Override
+    public ResultSet getSchemas(String catalog, String schemaPattern) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public boolean supportsStoredFunctionsUsingCallSyntax() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean autoCommitFailureClosesAllResultSets() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public ResultSet getClientInfoProperties() throws SQLException {
+        return null;
+    }
+
+    @Override
+    public ResultSet getFunctions(String catalog, String schemaPattern, String functionNamePattern) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public ResultSet getFunctionColumns(String catalog, String schemaPattern, String functionNamePattern, String columnNamePattern) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public ResultSet getPseudoColumns(String catalog, String schemaPattern, String tableNamePattern, String columnNamePattern) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public boolean generatedKeyAlwaysReturned() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        return false;
+    }
+}

--- a/foundation/org.eclipse.persistence.core.test.framework/src/main/java/org/eclipse/persistence/testing/tests/performance/emulateddb/EmulatedDriver.java
+++ b/foundation/org.eclipse.persistence.core.test.framework/src/main/java/org/eclipse/persistence/testing/tests/performance/emulateddb/EmulatedDriver.java
@@ -27,7 +27,9 @@ public class EmulatedDriver implements Driver {
     static {
         try {
             DriverManager.registerDriver(new EmulatedDriver());
-        } catch (Exception ignore) {}
+        } catch (SQLException e) {
+            throw new ExceptionInInitializerError(e);
+        }
     }
 
     /** Allow toggling of emulation. */
@@ -66,7 +68,11 @@ public class EmulatedDriver implements Driver {
             return null;
         }
         if (connection == null) {
-            connection = new EmulatedConnection(DriverManager.getConnection(url.substring("emulate:".length()), info));
+            if ("jdbc:emulateddriver".equals(url)) {
+                connection = new EmulatedConnection();
+            } else {
+                connection = new EmulatedConnection(DriverManager.getConnection(url.substring("emulate:".length()), info));
+            }
         }
         return connection;
     }
@@ -84,7 +90,7 @@ public class EmulatedDriver implements Driver {
      */
     @Override
     public boolean acceptsURL(String url) throws SQLException {
-        return url.contains("emulate:");
+        return url.contains("emulate:") || url.contains("jdbc:emulateddriver");
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core.test.framework/src/main/java/org/eclipse/persistence/testing/tests/performance/emulateddb/EmulatedDriver.java
+++ b/foundation/org.eclipse.persistence.core.test.framework/src/main/java/org/eclipse/persistence/testing/tests/performance/emulateddb/EmulatedDriver.java
@@ -69,7 +69,7 @@ public class EmulatedDriver implements Driver {
         }
         if (connection == null) {
             if ("jdbc:emulateddriver".equals(url)) {
-                connection = new EmulatedConnection();
+                connection = new EmulatedConnection(url, info);
             } else {
                 connection = new EmulatedConnection(DriverManager.getConnection(url.substring("emulate:".length()), info));
             }

--- a/foundation/org.eclipse.persistence.core.test.framework/src/main/resources/META-INF/services/java.sql.Driver
+++ b/foundation/org.eclipse.persistence.core.test.framework/src/main/resources/META-INF/services/java.sql.Driver
@@ -1,0 +1,1 @@
+org.eclipse.persistence.testing.tests.performance.emulateddb.EmulatedDriver

--- a/foundation/org.eclipse.persistence.core.test.framework/src/main/resources/META-INF/services/java.sql.Driver
+++ b/foundation/org.eclipse.persistence.core.test.framework/src/main/resources/META-INF/services/java.sql.Driver
@@ -1,1 +1,0 @@
-org.eclipse.persistence.testing.tests.performance.emulateddb.EmulatedDriver

--- a/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/jpa/tests/basic/JPAReadAbstract.java
+++ b/performance/eclipselink.perf.test/src/test/java/org/eclipse/persistence/testing/perf/jpa/tests/basic/JPAReadAbstract.java
@@ -18,11 +18,20 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.Persistence;
 import jakarta.persistence.EntityManagerFactory;
 
+import org.eclipse.persistence.internal.helper.DatabaseField;
+import org.eclipse.persistence.internal.sessions.AbstractSession;
+import org.eclipse.persistence.internal.sessions.ArrayRecord;
+import org.eclipse.persistence.sessions.DatabaseRecord;
 import org.eclipse.persistence.testing.perf.jpa.model.basic.DetailEntity;
 import org.eclipse.persistence.testing.perf.jpa.model.basic.MasterEntity;
+import org.eclipse.persistence.testing.tests.performance.emulateddb.EmulatedConnection;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.TearDown;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Vector;
 
 /**
  * Benchmarks for JPA reading data.
@@ -38,7 +47,15 @@ public abstract class JPAReadAbstract {
     @Setup
     public void setup() {
         EntityManager em = emf.createEntityManager();
-        prepareData(em);
+        try {
+            prepareData(em);
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        } finally {
+            if (em != null) {
+                em.close();
+            }
+        }
     }
 
     @TearDown
@@ -59,6 +76,9 @@ public abstract class JPAReadAbstract {
                 if (masterEntity == null) {
                     throw new RuntimeException("MasterEntity is null!");
                 }
+                if (masterEntity.getId() != i) {
+                    throw new RuntimeException("MasterEntity ID:\t" + masterEntity.getId() + " doesn't match with find key:\t" + i);
+                }
                 if (masterEntity.getDetails().size() < getDetailSize()) {
                     throw new RuntimeException("No of DetailEntities is |" + masterEntity.getDetails().size() + "| less than expected |" + getDetailSize() + "|!");
                 }
@@ -72,25 +92,22 @@ public abstract class JPAReadAbstract {
         }
     }
 
-    private void prepareData(EntityManager em) {
-        try {
-            em.getTransaction().begin();
-            for (int i = 1; i <= getMasterSize(); i++) {
-                MasterEntity masterEntity = new MasterEntity(i, "Master name " + i);
-                em.persist(masterEntity);
-                for (int j = 1; j <= getDetailSize(); j++) {
-                    DetailEntity detailEntity = new DetailEntity(i * DETAIL_ID_STEP + j, "Detail name " + j, masterEntity);
-                    masterEntity.getDetails().add(detailEntity);
-                    em.persist(detailEntity);
-                }
+    private synchronized void prepareData(EntityManager em) {
+        AbstractSession session = em.unwrap(AbstractSession.class);
+        EmulatedConnection conn = (EmulatedConnection)session.getAccessor().getConnection();
+        Vector<DatabaseField> masterFields = new Vector<>(session.getDescriptor(MasterEntity.class).getAllFields());
+        DatabaseField[] masterFieldsArray = masterFields.toArray(new DatabaseField[0]);
+        Vector<DatabaseField> detailFields = new Vector<>(session.getDescriptor(DetailEntity.class).getAllFields());
+        DatabaseField[] detailFieldsArray = detailFields.toArray(new DatabaseField[0]);
+        for (int i = 1; i <= getMasterSize(); i++) {
+            List<DatabaseRecord> masterRows = new ArrayList<>(getMasterSize());
+            masterRows.add(new ArrayRecord(masterFields, masterFieldsArray, new Object[]{i, "Master name " + i}));
+            conn.putRows("SELECT ID, NAME FROM P2_MASTER WHERE (ID = " + i + ")", masterRows);
+            List<DatabaseRecord> detailRows = new ArrayList<>(getDetailSize());
+            for (int j = 1; j <= getDetailSize(); j++) {
+                detailRows.add(new ArrayRecord(detailFields, detailFieldsArray, new Object[] {i * DETAIL_ID_STEP + j, "Detail name " + i * DETAIL_ID_STEP + j, i}));
             }
-            em.getTransaction().commit();
-        } catch (Throwable e) {
-            throw new RuntimeException(e);
-        } finally {
-            if (em.getTransaction().isActive()) {
-                em.getTransaction().rollback();
-            }
+            conn.putRows("SELECT ID, NAME, MASTER_ID_FK FROM P2_DETAIL WHERE (MASTER_ID_FK = " + i + ")", detailRows);
         }
     }
 

--- a/performance/eclipselink.perf.test/src/test/resources/META-INF/persistence.xml
+++ b/performance/eclipselink.perf.test/src/test/resources/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -51,11 +51,8 @@
         <class>org.eclipse.persistence.testing.perf.jpa.model.basic.MasterEntity</class>
         <class>org.eclipse.persistence.testing.perf.jpa.model.basic.DetailEntity</class>
         <properties>
-            <property name="jakarta.persistence.jdbc.driver"      value="@driver@"/>
-            <property name="jakarta.persistence.jdbc.url"         value="@url@"/>
-            <property name="jakarta.persistence.jdbc.user"        value="@user@"/>
-            <property name="jakarta.persistence.jdbc.password"    value="@pwd@"/>
-            <property name="eclipselink.ddl-generation" value="drop-and-create-tables"/>
+            <property name="jakarta.persistence.jdbc.driver" value="org.eclipse.persistence.testing.tests.performance.emulateddb.EmulatedDriver"/>
+            <property name="jakarta.persistence.jdbc.url" value="jdbc:emulateddriver"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="jpa-performance-read-no-cache">
@@ -63,14 +60,11 @@
         <class>org.eclipse.persistence.testing.perf.jpa.model.basic.MasterEntity</class>
         <class>org.eclipse.persistence.testing.perf.jpa.model.basic.DetailEntity</class>
         <properties>
-            <property name="jakarta.persistence.jdbc.driver"      value="@driver@"/>
-            <property name="jakarta.persistence.jdbc.url"         value="@url@"/>
-            <property name="jakarta.persistence.jdbc.user"        value="@user@"/>
-            <property name="jakarta.persistence.jdbc.password"    value="@pwd@"/>
+            <property name="jakarta.persistence.jdbc.driver" value="org.eclipse.persistence.testing.tests.performance.emulateddb.EmulatedDriver"/>
+            <property name="jakarta.persistence.jdbc.url" value="jdbc:emulateddriver"/>
             <property name="eclipselink.cache.shared.default" value="false"/>
             <property name="eclipselink.cache.size.default" value="0"/>
             <property name="eclipselink.query-results-cache" value="false"/>
-            <property name="eclipselink.ddl-generation" value="drop-and-create-tables"/>
         </properties>
     </persistence-unit>
 </persistence>


### PR DESCRIPTION
This change in EclipseLink JPA performance tests replace physical database by emulated one.
Emulation is based on `org.eclipse.persistence.testing.tests.performance.emulateddb.*` classes (JDBC driver).
There are some fixes like new required `EmulatedDatabaseMetaData` class and change in `EmulatedStatement` to distinguish passed SQL queries with parameters.