### PR TITLE
[2.7] MOXy SchemaGenerator WSDL Namespace order switch

### DIFF
--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/MOXySystemProperties.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/MOXySystemProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -78,6 +78,14 @@ public final class MOXySystemProperties {
      */
     public static final String MOXY_LOG_PAYLOAD = "eclipselink.logging.payload.moxy";
 
+    /**
+     * Property to control disable/enable sorting of generated XML Schemas by MOXy SchemaGenerator.
+     *
+     * Usage: set to {@link Boolean#TRUE} to enable sorting by XML Namespace URI or {@link Boolean#FALSE} to disable it.
+     * By default it is enabled {@link Boolean#TRUE}.
+     *
+     */
+    public static final String MOXY_SCHEMA_GENERATOR_SORT = "org.eclipse.persistence.moxy.schema.generator.sort";
 
     public static final Boolean xmlIdExtension = getBoolean(XML_ID_EXTENSION);
 
@@ -90,6 +98,8 @@ public final class MOXySystemProperties {
     public static final String moxyLoggingLevel = PrivilegedAccessHelper.getSystemProperty(MOXY_LOGGING_LEVEL, String.valueOf(AbstractSessionLog.INFO_LABEL));
 
     public static final Boolean moxyLogPayload = PrivilegedAccessHelper.getSystemPropertyBoolean(MOXY_LOG_PAYLOAD, false);
+
+    public static final Boolean moxySchemaGeneratorSort = PrivilegedAccessHelper.getSystemPropertyBoolean(MOXY_SCHEMA_GENERATOR_SORT, true);
 
     /**
      * Returns value of system property.

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/compiler/Generator.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/compiler/Generator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -33,6 +33,7 @@ import org.eclipse.persistence.internal.oxm.mappings.Descriptor;
 import org.eclipse.persistence.internal.oxm.schema.SchemaModelProject;
 import org.eclipse.persistence.internal.oxm.schema.model.Schema;
 import org.eclipse.persistence.internal.oxm.schema.model.SchemaCompareByNamespace;
+import org.eclipse.persistence.jaxb.MOXySystemProperties;
 import org.eclipse.persistence.jaxb.TypeMappingInfo;
 import org.eclipse.persistence.jaxb.javamodel.Helper;
 import org.eclipse.persistence.jaxb.javamodel.JavaClass;
@@ -234,7 +235,7 @@ public class Generator {
 
         java.util.Collection<Schema> schemas = schemaGenerator.getAllSchemas();
         // make sure that schemas will be passed to the output in specified order
-        if (schemas instanceof List) {
+        if (schemas instanceof List && MOXySystemProperties.moxySchemaGeneratorSort) {
             ((List)schemas).sort(new SchemaCompareByNamespace());
         }
         for(Schema schema : schemas) {

--- a/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/compiler/SchemaGenerator.java
+++ b/moxy/org.eclipse.persistence.moxy/src/org/eclipse/persistence/jaxb/compiler/SchemaGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -63,6 +63,7 @@ import org.eclipse.persistence.internal.oxm.schema.model.SimpleContent;
 import org.eclipse.persistence.internal.oxm.schema.model.SimpleType;
 import org.eclipse.persistence.internal.oxm.schema.model.TypeDefParticle;
 import org.eclipse.persistence.internal.oxm.schema.model.TypeDefParticleOwner;
+import org.eclipse.persistence.jaxb.MOXySystemProperties;
 import org.eclipse.persistence.jaxb.compiler.builder.TransformerPropertyBuilder;
 import org.eclipse.persistence.jaxb.compiler.facets.DecimalMaxFacet;
 import org.eclipse.persistence.jaxb.compiler.facets.DecimalMinFacet;
@@ -154,7 +155,9 @@ public class SchemaGenerator {
         this.arrayClassesToGeneratedClasses = arrayClassesToGeneratedClasses;
 
         //sort input classes before schema name (like schema1.xsd, schema2.xsd....) is generated and assigned
-        typeInfoClasses.sort(new JavaClassCompareByNamespace(typeInfo));
+        if (MOXySystemProperties.moxySchemaGeneratorSort) {
+            typeInfoClasses.sort(new JavaClassCompareByNamespace(typeInfo));
+        }
         for (JavaClass javaClass : typeInfoClasses) {
             addSchemaComponents(javaClass);
         }


### PR DESCRIPTION
This switch allows users use previous unordered behavior before PR #365.