### PR TITLE
[master] Oracle proxy authentication test fix

### DIFF
--- a/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.proxyauthentication/src/test/java/org/eclipse/persistence/testing/tests/jpa/proxyauthentication/ProxyAuthenticationServerTest.java
+++ b/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.proxyauthentication/src/test/java/org/eclipse/persistence/testing/tests/jpa/proxyauthentication/ProxyAuthenticationServerTest.java
@@ -301,7 +301,7 @@ public class ProxyAuthenticationServerTest extends JUnitTestCase {
             empId = employee.getId();
             commitTransaction(em);
         } catch (Exception ex) {
-            if (!ex.getMessage().contains("ORA-00942: table or view does not exist")){
+            if (!(ex.getMessage().contains("java.sql.SQLSyntaxErrorException") && ex.getMessage().contains("ORA-00942"))) {
                 ex.printStackTrace();
                 fail("it's not the right exception");
             }
@@ -363,7 +363,7 @@ public class ProxyAuthenticationServerTest extends JUnitTestCase {
             em.persist(employee);
             em.flush();
         } catch (Exception ex) {
-            if (!ex.getMessage().contains("ORA-00942: table or view does not exist")){
+            if (!(ex.getMessage().contains("java.sql.SQLSyntaxErrorException") && ex.getMessage().contains("ORA-00942"))) {
                 ex.printStackTrace();
                 fail("it's not the right exception");
             }


### PR DESCRIPTION
Remove too strong dependency on Oracle error message. There is message change between Oracle 23c and Oracle 23ai.