### PR TITLE
[2.7] Oracle proxy authentication test fix

### DIFF
--- a/foundation/eclipselink.extension.oracle.test/src/org/eclipse/persistence/testing/tests/jpa/proxyauthentication/ProxyAuthenticationServerTestSuite.java
+++ b/foundation/eclipselink.extension.oracle.test/src/org/eclipse/persistence/testing/tests/jpa/proxyauthentication/ProxyAuthenticationServerTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -277,7 +277,7 @@ public class ProxyAuthenticationServerTestSuite extends JUnitTestCase {
             empId = employee.getId();
             commitTransaction(em);
         } catch (Exception ex) {
-            if (ex.getMessage().indexOf("ORA-00942: table or view does not exist") == -1){
+            if (!(ex.getMessage().contains("java.sql.SQLSyntaxErrorException") && ex.getMessage().contains("ORA-00942"))) {
                 ex.printStackTrace();
                 fail("it's not the right exception");
             }
@@ -337,7 +337,7 @@ public class ProxyAuthenticationServerTestSuite extends JUnitTestCase {
             em.persist(employee);
             em.flush();
         } catch (Exception ex) {
-            if (ex.getMessage().indexOf("ORA-00942: table or view does not exist") == -1){
+            if (!(ex.getMessage().contains("java.sql.SQLSyntaxErrorException") && ex.getMessage().contains("ORA-00942"))) {
                 ex.printStackTrace();
                 fail("it's not the right exception");
             }


### PR DESCRIPTION
Remove too strong dependency on Oracle error message. There is change between Oracle 23c and Oracle 23ai.