### PR TITLE
[3.0] Oracle proxy authentication test fix - backport from master

### DIFF
--- a/foundation/org.eclipse.persistence.oracle.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/proxyauthentication/ProxyAuthenticationServerTestSuite.java
+++ b/foundation/org.eclipse.persistence.oracle.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/proxyauthentication/ProxyAuthenticationServerTestSuite.java
@@ -295,7 +295,7 @@ public class ProxyAuthenticationServerTestSuite extends JUnitTestCase {
             empId = employee.getId();
             commitTransaction(em);
         } catch (Exception ex) {
-            if (ex.getMessage().indexOf("ORA-00942: table or view does not exist") == -1){
+            if (!(ex.getMessage().contains("java.sql.SQLSyntaxErrorException") && ex.getMessage().contains("ORA-00942"))) {
                 ex.printStackTrace();
                 fail("it's not the right exception");
             }
@@ -357,7 +357,7 @@ public class ProxyAuthenticationServerTestSuite extends JUnitTestCase {
             em.persist(employee);
             em.flush();
         } catch (Exception ex) {
-            if (ex.getMessage().indexOf("ORA-00942: table or view does not exist") == -1){
+            if (!(ex.getMessage().contains("java.sql.SQLSyntaxErrorException") && ex.getMessage().contains("ORA-00942"))) {
                 ex.printStackTrace();
                 fail("it's not the right exception");
             }


### PR DESCRIPTION
Remove too strong dependency on Oracle error message. There is change between Oracle 23c and Oracle 23ai.