### PR TITLE
[4.0] Maven build - org.eclipse.persistence.javadoc module fix

### DIFF
--- a/docs/docs.api/pom.xml
+++ b/docs/docs.api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.documentation</artifactId>
-        <version>5.0.0-SNAPSHOT</version>
+        <version>4.0.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -254,7 +254,7 @@
 
         <dependency>
             <groupId>org.mongodb</groupId>
-            <artifactId>mongodb-driver-sync</artifactId>
+            <artifactId>mongo-java-driver</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
- parent pom version
- MongoDB driver dependency