### PR TITLE
Allow escaping of '?' using '??' in SQL expression (#1935)

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/jpa/jpql/ExpressionBuilderVisitor.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/jpa/jpql/ExpressionBuilderVisitor.java
@@ -1068,6 +1068,8 @@ final class ExpressionBuilderVisitor implements EclipseLinkExpressionVisitor {
                 }
 
                 queryExpression = queryExpressions.remove(0);
+                // ensure the session is set for the 'SQL' operator
+                queryExpression.getBuilder().setSession(queryContext.getSession());
 
                 // SQL
                 if (identifier == org.eclipse.persistence.jpa.jpql.parser.Expression.SQL) {


### PR DESCRIPTION
Backport of #1935 to 4.0
Allow escaping of '?' using '??' in SQL expression and testEscapedQuestionMarkInSQLOperator to test ?? in SQL operator