### PR TITLE
queryTimeoutUnit is not copied to DataModifyQuery in executeUpdate

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/DatabaseQuery.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/DatabaseQuery.java
@@ -1898,6 +1898,7 @@ public abstract class DatabaseQuery implements Cloneable, Serializable {
         this.argumentTypeNames = query.argumentTypeNames;
         this.argumentValues = query.argumentValues;
         this.queryTimeout = query.queryTimeout;
+        this.queryTimeoutUnit = query.queryTimeoutUnit;
         this.redirector = query.redirector;
         this.sessionName = query.sessionName;
         this.shouldBindAllParameters = query.shouldBindAllParameters;

--- a/jpa/eclipselink.jpa.testapps/jpa.test.composite.advanced/src/test/java/org/eclipse/persistence/testing/tests/jpa/composite/advanced/EntityManagerJUnitTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.composite.advanced/src/test/java/org/eclipse/persistence/testing/tests/jpa/composite/advanced/EntityManagerJUnitTest.java
@@ -266,6 +266,7 @@ public class EntityManagerJUnitTest extends JUnitTestCase {
         tests.add("testIncorrectBatchQueryHint");
 // can't join different dbs tests.add("testFetchQueryHint");
         tests.add("testBatchQueryHint");
+        tests.add("testCopyFromQuery");
         tests.add("testQueryHints");
         tests.add("testParallelMultipleFactories");
         tests.add("testMultipleFactories");
@@ -4979,6 +4980,16 @@ public class EntityManagerJUnitTest extends JUnitTestCase {
         if(factory3.isOpen()) {
             fail("after factory3.close() factory3 is open");
         }
+    }
+
+    public void testCopyFromQuery() {
+        EntityManager em = (EntityManager)getEntityManagerFactory().createEntityManager().getDelegate();
+        Query query = em.createQuery("SELECT OBJECT(e) FROM Employee e WHERE e.firstName = 'testCopyFromQuery'");
+        query.setHint(QueryHints.QUERY_TIMEOUT_UNIT, "SECONDS");
+        ObjectLevelReadQuery olrQuery = (ObjectLevelReadQuery)((JpaQuery)query).getDatabaseQuery();
+        DataModifyQuery copyQuery = new DataModifyQuery();
+        copyQuery.copyFromQuery(olrQuery);
+        assertEquals("QUERY_TIMEOUT_UNIT is not matching.", copyQuery.getQueryTimeoutUnit(), olrQuery.getQueryTimeoutUnit());
     }
 
     // The class will be used to test QueryHints.RESULT_COLLECTION_TYPE


### PR DESCRIPTION
This PR fixes issues at https://github.com/eclipse-ee4j/eclipselink/issues/1056

In the fix, the queryTimeoutUnit is also copied which was missed earlier

Added testcase at jpa/eclipselink.jpa.testapps/jpa.test.composite.advanced/src/test/java/org/eclipse/persistence/testing/tests/jpa/composite/advanced/EntityManagerJUnitTest.java