### PR TITLE
[4.0] detach() fixes (#2037) - backport from master

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/descriptors/DescriptorIterator.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/descriptors/DescriptorIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,14 +16,6 @@
 //       - 541873: ENTITYMANAGER.DETACH() TRIGGERS LAZY LOADING INTO THE PERSISTENCE CONTEXT
 package org.eclipse.persistence.internal.descriptors;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.IdentityHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.Stack;
-
 import org.eclipse.persistence.descriptors.ClassDescriptor;
 import org.eclipse.persistence.exceptions.DescriptorException;
 import org.eclipse.persistence.indirection.IndirectCollection;
@@ -34,6 +26,15 @@ import org.eclipse.persistence.internal.sessions.AbstractSession;
 import org.eclipse.persistence.mappings.DatabaseMapping;
 import org.eclipse.persistence.queries.AttributeGroup;
 import org.eclipse.persistence.queries.FetchGroup;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Stack;
 
 /**
  * This class provides a generic way of using the descriptor information
@@ -53,6 +54,7 @@ public abstract class DescriptorIterator {
     public static final int CascadePrivateParts = 2;
     public static final int CascadeAllParts = 3;
     protected Map visitedObjects;
+    protected Map<Integer, DatabaseMapping> visitedMappings;
     protected Stack visitedStack;
     protected AbstractSession session;
     protected DatabaseMapping currentMapping;
@@ -92,6 +94,7 @@ public abstract class DescriptorIterator {
     protected DescriptorIterator() {
         // 2612538 - the default size of Map (32) is appropriate
         this.visitedObjects = new IdentityHashMap();
+        this.visitedMappings = new HashMap<>();
         this.visitedStack = new Stack();
         this.cascadeDepth = CascadeAllParts;
         this.shouldIterateOverIndirectionObjects = true;// process the objects contained by ValueHolders...
@@ -156,6 +159,10 @@ public abstract class DescriptorIterator {
 
     public Map getVisitedObjects() {
         return visitedObjects;
+    }
+
+    public Map<Integer, DatabaseMapping> getVisitedMappings() {
+        return visitedMappings;
     }
 
     /**
@@ -271,8 +278,15 @@ public abstract class DescriptorIterator {
             internalIterateIndirectContainer(container);
         }
 
-        if (shouldIterateOverUninstantiatedIndirectionObjects() || (shouldIterateOverIndirectionObjects() && container.isInstantiated()) || isForDetach()) {
+        //Extended condition to allow to detach entities in the lazy loaded collections but without instantiation
+        //and basic check to avoid StackOverflowError in cyclic detach
+        if (shouldIterateOverUninstantiatedIndirectionObjects() ||
+            (shouldIterateOverIndirectionObjects() && container.isInstantiated()) ||
+            (isForDetach() && !getVisitedMappings().containsKey(mapping.hashCode() + container.hashCode()) && getVisitedMappings().size() < 100)) {
             // force instantiation only if specified
+            if (isForDetach()) {
+                getVisitedMappings().put(mapping.hashCode() + container.hashCode(), mapping);
+            }
             mapping.iterateOnRealAttributeValue(this, container);
         } else if (shouldIterateOverIndirectionObjects()) {
             // PERF: Allow the indirect container to iterate any cached elements.
@@ -441,7 +455,9 @@ public abstract class DescriptorIterator {
             this.currentItem = currentItemOriginal;
         } else {
             for (DatabaseMapping mapping : mappings) {
-                mapping.iterate(this);
+                if (this.cascadeCondition.shouldCascade(mapping)) {
+                    mapping.iterate(this);
+                }
             }
         }
     }
@@ -691,8 +707,12 @@ public abstract class DescriptorIterator {
         public CascadeCondition() {
         }
 
+        public boolean shouldCascade(DatabaseMapping mapping){
+            return shouldCascadeAllParts() || (shouldCascadePrivateParts() && mapping.isPrivateOwned());
+        }
+
         public boolean shouldNotCascade(DatabaseMapping mapping){
-            return !(shouldCascadeAllParts() || (shouldCascadePrivateParts() && mapping.isPrivateOwned()));
+            return !shouldCascade(mapping);
         }
     }
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
@@ -5687,8 +5687,13 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
         if (forDetach){
             CascadeCondition detached = iterator.new CascadeCondition(){
                 @Override
+                public boolean shouldCascade(DatabaseMapping mapping){
+                    return mapping.isForeignReferenceMapping() && ((ForeignReferenceMapping)mapping).isCascadeDetach();
+                }
+
+                @Override
                 public boolean shouldNotCascade(DatabaseMapping mapping){
-                    return ! (mapping.isForeignReferenceMapping() && ((ForeignReferenceMapping)mapping).isCascadeDetach());
+                    return !shouldCascade(mapping);
                 }
             };
             iterator.setCascadeCondition(detached);

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced/pom.xml
@@ -83,6 +83,7 @@
                             <includes>
                                 <include>**/JPAAdvancedTestModel</include>
                                 <include>**/advanced/*Test</include>
+                                <include>**/advanced/EntityManagerJUnitTestSuite</include>
                             </includes>
                         </configuration>
                     </execution>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced/src/main/java/org/eclipse/persistence/testing/models/jpa/advanced/Material.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced/src/main/java/org/eclipse/persistence/testing/models/jpa/advanced/Material.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -18,6 +18,7 @@ package org.eclipse.persistence.testing.models.jpa.advanced;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
@@ -42,8 +43,11 @@ public class Material {
     @OneToOne
     private MaterialHist lastHist;
 
-    @OneToMany(mappedBy = "material", cascade = { CascadeType.PERSIST, CascadeType.DETACH })
+    @OneToMany(mappedBy = "material", cascade = { CascadeType.PERSIST, CascadeType.DETACH }, fetch = FetchType.LAZY)
     private List<PlanArbeitsgang> restproduktionsweg = new ArrayList<>();
+
+    @OneToMany(mappedBy = "material", cascade = { CascadeType.PERSIST }, fetch = FetchType.LAZY)
+    private List<PlanArbeitsgang> restproduktionswegNoCascadeDetach = new ArrayList<>();
 
     private String ident;
 
@@ -95,6 +99,14 @@ public class Material {
 
     public void setRestproduktionsweg(List<PlanArbeitsgang> restproduktionsweg) {
         this.restproduktionsweg = restproduktionsweg;
+    }
+
+    public List<PlanArbeitsgang> getRestproduktionswegNoCascadeDetach() {
+        return restproduktionswegNoCascadeDetach;
+    }
+
+    public void setRestproduktionswegNoCascadeDetach(List<PlanArbeitsgang> restproduktionswegDetach) {
+        this.restproduktionswegNoCascadeDetach = restproduktionswegDetach;
     }
 
     @Override

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced/src/main/resources/META-INF/persistence.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced/src/main/resources/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -72,6 +72,20 @@
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level" value="OFF"/>
+            <!-- Since we don't exclude unlisted classes here, we will       -->
+            <!-- eventually hit the multitenant entities which turn native   -->
+            <!-- sql queries off by default, so we need to be explicit here  -->
+            <!--  and turn them on                                           -->
+            <property name="eclipselink.jdbc.allow-native-sql-queries" value="true"/>
+        </properties>
+    </persistence-unit>
+
+    <persistence-unit name="customizeAddTarget">
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+        <exclude-unlisted-classes>false</exclude-unlisted-classes>
+        <properties>
+            <property name="eclipselink.logging.level" value="OFF"/>
+            <property name="eclipselink.descriptor.customizer.Employee" value="org.eclipse.persistence.testing.models.jpa.advanced.AddTargetCustomizer"/>
             <!-- Since we don't exclude unlisted classes here, we will       -->
             <!-- eventually hit the multitenant entities which turn native   -->
             <!-- sql queries off by default, so we need to be explicit here  -->


### PR DESCRIPTION
There are two fixes for EntityManager.detach():
- Lazy collections are fetched on detach
- StackOverflowError because of cyclic DETACH

plus fixes in jpa.test.advanced module



(cherry picked from commit 4027605eb60a9e8c6fb762ed8e30221071269dc2)