### PR TITLE
[3.0] DatabasePlatform.wasFailureCommunicationBased() fix - backport from master

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
@@ -3205,7 +3205,7 @@ public class DatabasePlatform extends DatasourcePlatform {
              // By default use the JDBC isValid API unless a ping SQL has been set.
              // The ping SQL is set by most platforms, but user could set to null to used optimized JDBC check if desired.
              try {
-                 return connection.isValid(IS_VALID_TIMEOUT);
+                 return !connection.isValid(IS_VALID_TIMEOUT);
              } catch (Throwable failed) {
                  // Catch throwable as old JDBC drivers may not support isValid.
                  return false;


### PR DESCRIPTION
Signed-off-by: Radek Felcman <radek.felcman@oracle.com>
(cherry picked from commit 3b5da43aac99ba5ce8b7b4531521128cf37e0a7d)