### PR TITLE
[master] Jakarta Persistence 3.2: fix for JPQL with generated this alias with WHERE condition enclosed by braces

### DIFF
--- a/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpql/advanced/JUnitJPQLJakartaDataNoAliasTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpql/advanced/JUnitJPQLJakartaDataNoAliasTest.java
@@ -100,6 +100,9 @@ public class JUnitJPQLJakartaDataNoAliasTest extends JUnitTestCase {
         suite.addTest(new JUnitJPQLJakartaDataNoAliasTest("testNoAliasFromWhere"));
         suite.addTest(new JUnitJPQLJakartaDataNoAliasTest("testNoAliasFromWhereAnd"));
         suite.addTest(new JUnitJPQLJakartaDataNoAliasTest("testNoAliasFromWhereAndUPPER"));
+        suite.addTest(new JUnitJPQLJakartaDataNoAliasTest("testNoAliasWhereWithBraces01"));
+        suite.addTest(new JUnitJPQLJakartaDataNoAliasTest("testNoAliasWhereWithBraces02"));
+        suite.addTest(new JUnitJPQLJakartaDataNoAliasTest("testNoAliasWhereWithBraces03"));
         suite.addTest(new JUnitJPQLJakartaDataNoAliasTest("testGeneratedSelectNoAliasFromWhere"));
         suite.addTest(new JUnitJPQLJakartaDataNoAliasTest("testGeneratedSelect"));
         suite.addTest(new JUnitJPQLJakartaDataNoAliasTest("testUpdateQueryLengthInAssignmentAndExpression"));
@@ -238,6 +241,50 @@ public class JUnitJPQLJakartaDataNoAliasTest extends JUnitTestCase {
         WrapperTypes tlWrapperTypes = (WrapperTypes) getPersistenceUnitServerSession().executeQuery(tlQuery);
         Assert.assertTrue("NoAliasFromWhereAndUPPER Test Failed", comparer.compareObjects(wrapperTypes, tlWrapperTypes));
     }
+
+    public void testNoAliasWhereWithBraces01() {
+        EntityManager em = createEntityManager();
+
+        Query wrapperTypesQuery = em.createQuery("FROM WrapperTypes WHERE (id = :idParam)");
+        wrapperTypesQuery.setParameter("idParam", wrapperId);
+        WrapperTypes wrapperTypes = (WrapperTypes) wrapperTypesQuery.getResultList().get(0);
+        clearCache();
+        ReadObjectQuery tlQuery = new ReadObjectQuery(WrapperTypes.class);
+        tlQuery.setSelectionCriteria(tlQuery.getExpressionBuilder().get("id").equal(wrapperId));
+
+        WrapperTypes tlWrapperTypes = (WrapperTypes) getPersistenceUnitServerSession().executeQuery(tlQuery);
+        Assert.assertTrue("NoAliasWhereWithBraces01 Test Failed", comparer.compareObjects(wrapperTypes, tlWrapperTypes));
+    }
+
+    public void testNoAliasWhereWithBraces02() {
+        EntityManager em = createEntityManager();
+
+        Query wrapperTypesQuery = em.createQuery("FROM WrapperTypes WHERE ((id = :idParam))");
+        wrapperTypesQuery.setParameter("idParam", wrapperId);
+        WrapperTypes wrapperTypes = (WrapperTypes) wrapperTypesQuery.getResultList().get(0);
+        clearCache();
+        ReadObjectQuery tlQuery = new ReadObjectQuery(WrapperTypes.class);
+        tlQuery.setSelectionCriteria(tlQuery.getExpressionBuilder().get("id").equal(wrapperId));
+
+        WrapperTypes tlWrapperTypes = (WrapperTypes) getPersistenceUnitServerSession().executeQuery(tlQuery);
+        Assert.assertTrue("NoAliasWhereWithBraces02 Test Failed", comparer.compareObjects(wrapperTypes, tlWrapperTypes));
+    }
+
+    public void testNoAliasWhereWithBraces03() {
+        EntityManager em = createEntityManager();
+
+        Query wrapperTypesQuery = em.createQuery("FROM WrapperTypes WHERE (id <= :idParam AND UPPER(stringData) NOT LIKE UPPER(:stringParam) AND UPPER(stringData) NOT LIKE 'dgdgs') ORDER BY id DESC, stringData");
+        wrapperTypesQuery.setParameter("idParam", wrapperId);
+        wrapperTypesQuery.setParameter("stringParam", "asdadads");
+        WrapperTypes wrapperTypes = (WrapperTypes) wrapperTypesQuery.getResultList().get(0);
+        clearCache();
+        ReadObjectQuery tlQuery = new ReadObjectQuery(WrapperTypes.class);
+        tlQuery.setSelectionCriteria(tlQuery.getExpressionBuilder().get("id").equal(wrapperId));
+
+        WrapperTypes tlWrapperTypes = (WrapperTypes) getPersistenceUnitServerSession().executeQuery(tlQuery);
+        Assert.assertTrue("NoAliasWhereWithBraces03 Test Failed", comparer.compareObjects(wrapperTypes, tlWrapperTypes));
+    }
+
 
     public void testGeneratedSelect() {
         EntityManager em = createEntityManager();

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/AbstractExpression.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/AbstractExpression.java
@@ -525,7 +525,7 @@ public abstract class AbstractExpression implements Expression {
      * @return  Parent expression
      */
     public final ParentExpression getParentExpression() {
-        if (this instanceof ParentExpression parentExpression) {
+        if (!(this instanceof SubExpression) && this instanceof ParentExpression parentExpression) {
             return parentExpression;
         } else if (parent == null) {
             return null;

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/AbstractExpression.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/AbstractExpression.java
@@ -525,10 +525,8 @@ public abstract class AbstractExpression implements Expression {
      * @return  Parent expression
      */
     public final ParentExpression getParentExpression() {
-        if (!(this instanceof SubExpression) && this instanceof ParentExpression parentExpression) {
-            return parentExpression;
-        } else if (parent == null) {
-            return null;
+        if (!(this.isSubExpression()) && (this.isParentExpression())) {
+            return (ParentExpression)this;
         } else {
             return parent.getParentExpression();
         }
@@ -604,6 +602,10 @@ public abstract class AbstractExpression implements Expression {
         return false;
     }
 
+    public boolean isParentExpression() {
+        return false;
+    }
+
     /**
      * Determines whether the parsing is complete based on what is left in the given text. The text
      * is never empty.
@@ -640,6 +642,10 @@ public abstract class AbstractExpression implements Expression {
      */
     protected boolean isTolerant() {
         return getRoot().isTolerant();
+    }
+
+    protected boolean isSubExpression() {
+        return false;
     }
 
     /**

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/IdentificationVariable.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/IdentificationVariable.java
@@ -95,8 +95,24 @@ public final class IdentificationVariable extends AbstractExpression {
      */
     public IdentificationVariable(AbstractExpression parent, String identificationVariable) {
         super(parent, identificationVariable);
-        if (!Expression.THIS.equalsIgnoreCase(identificationVariable) && getParentExpression().isGenerateThisPrefix()) {
+        //In subqueries "this" generation is not allowed. There are expected qualified IdentificationVariable from query string
+        if (!Expression.THIS.equalsIgnoreCase(identificationVariable) && getParentExpression().isGenerateThisPrefix() && !isInsideSubquery()) {
             this.setVirtualIdentificationVariable(Expression.THIS);
+        }
+    }
+
+    private boolean isInsideSubquery() {
+        boolean result = isSubquery(this);
+        return result;
+    }
+
+    private boolean isSubquery(Expression expression) {
+        if (expression == null) {
+            return false;
+        } else if (expression instanceof AbstractSelectStatement && expression.getParent() != null && expression.getParent() instanceof SubExpression) {
+            return true;
+        } else {
+            return isSubquery(expression.getParent());
         }
     }
 

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/JPQLExpression.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/JPQLExpression.java
@@ -266,6 +266,11 @@ public final class JPQLExpression extends AbstractExpression implements ParentEx
         this.generateThisPrefix = generateThisPrefix;
     }
 
+    @Override
+    public boolean isParentExpression() {
+        return true;
+    }
+
     public boolean isJakartaData() {
         return this.jakartaData;
     }

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/ParentExpression.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/ParentExpression.java
@@ -23,4 +23,5 @@ public interface ParentExpression extends Expression {
 
     void setGenerateThisPrefix(boolean generateThisPrefix);
 
+    boolean isParentExpression();
 }

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/SubExpression.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/SubExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2024 Contributors to the Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -55,6 +55,16 @@ public final class SubExpression extends AbstractSingleEncapsulatedExpression im
     @Override
     public void setGenerateThisPrefix(boolean generateThisPrefix) {
         this.generateThisPrefix = generateThisPrefix;
+    }
+
+    @Override
+    public boolean isParentExpression() {
+        return true;
+    }
+
+    @Override
+    public boolean isSubExpression() {
+        return true;
     }
 
     @Override

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/org/eclipse/persistence/jpa/tests/jpql/parser/JPQLExpressionTestJakartaData.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/org/eclipse/persistence/jpa/tests/jpql/parser/JPQLExpressionTestJakartaData.java
@@ -87,8 +87,26 @@ public final class JPQLExpressionTestJakartaData extends JPQLParserTest {
     }
 
     @Test
-    public void testNoAliasFromWhere() {
+    public void testNoAliasFromWhere01() {
         JPQLExpression jpqlExpression = checkAliasFrom("SELECT this FROM NoAliasEntity WHERE id1 = :id1", Expression.THIS);
+        checkAliasesWhere(jpqlExpression, Expression.THIS);
+    }
+
+    @Test
+    public void testNoAliasFromWhere02() {
+        JPQLExpression jpqlExpression = checkAliasFrom("SELECT this FROM NoAliasEntity WHERE (id1 = :id1)", Expression.THIS);
+        checkAliasesWhere(jpqlExpression, Expression.THIS);
+    }
+
+    @Test
+    public void testNoAliasFromWhere03() {
+        JPQLExpression jpqlExpression = checkAliasFrom("SELECT this FROM NoAliasEntity WHERE (ID <= :idParam AND UPPER(name) NOT LIKE UPPER(:nameParam) AND UPPER(name) NOT LIKE 'dgdgs') ORDER BY ID DESC, name", Expression.THIS);
+        checkAliasesWhere(jpqlExpression, Expression.THIS);
+    }
+
+    @Test
+    public void testNoAliasFromWhere04() {
+        JPQLExpression jpqlExpression = checkAliasFrom("SELECT this FROM NoAliasEntity WHERE (:rate * ID <= :max AND :rate * ID >= :min) ORDER BY name", Expression.THIS);
         checkAliasesWhere(jpqlExpression, Expression.THIS);
     }
 


### PR DESCRIPTION
Fixes issue for Jakarta Data expressions like `FROM Prime WHERE ( numberId = 1 )` when where expression is enclosed by braces. In origin JPQL are braces in where expression supported by default according Jakarta Persistence 3.2 specification - 4.6.1. Conditional Expression Composition.

Fixes #2234 #2235