### PR TITLE
[2.7] OptimisticLockException while using L2 cache fix - backport from master

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -1078,6 +1078,9 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
             }
         }
         try {
+            if (isConsideredInvalid(original, parentCacheKey, descriptor) && unitOfWorkCacheKey.getObject() != null) {
+                original = unitOfWorkCacheKey.getObject();
+            }
             // bug:6167576   Must acquire the lock before cloning.
             workingClone = builder.instantiateWorkingCopyClone(original, this);
             // PERF: Cache the primary key if implements PersistenceEntity.

--- a/jpa/eclipselink.jpa.test/resource/eclipselink-annotation-model/osgi/persistence.xml
+++ b/jpa/eclipselink.jpa.test/resource/eclipselink-annotation-model/osgi/persistence.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2019 IBM Corporation. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -177,4 +177,17 @@
         </properties>
     </persistence-unit>
 
+    <persistence-unit name="pu-with-dynamic-weaving" transaction-type="RESOURCE_LOCAL">
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+        <class>org.eclipse.persistence.testing.models.jpa.weave.IsolatedEntity</class>
+        <class>org.eclipse.persistence.testing.models.jpa.weave.Location</class>
+        <class>org.eclipse.persistence.testing.models.jpa.weave.Node</class>
+        <class>org.eclipse.persistence.testing.models.jpa.weave.Order</class>
+        <exclude-unlisted-classes>true</exclude-unlisted-classes>
+        <shared-cache-mode>DISABLE_SELECTIVE</shared-cache-mode>
+        <properties>
+            <property name="eclipselink.weaving" value="true"/>
+            <property name="javax.persistence.schema-generation.database.action" value="drop-and-create"/>
+        </properties>
+    </persistence-unit>
 </persistence>

--- a/jpa/eclipselink.jpa.test/resource/eclipselink-annotation-model/persistence.xml
+++ b/jpa/eclipselink.jpa.test/resource/eclipselink-annotation-model/persistence.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2024 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2019 IBM Corporation. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -607,4 +607,17 @@
         </properties>
     </persistence-unit>
 
+    <persistence-unit name="pu-with-dynamic-weaving" transaction-type="RESOURCE_LOCAL">
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+        <class>org.eclipse.persistence.testing.models.jpa.weave.IsolatedEntity</class>
+        <class>org.eclipse.persistence.testing.models.jpa.weave.Location</class>
+        <class>org.eclipse.persistence.testing.models.jpa.weave.Node</class>
+        <class>org.eclipse.persistence.testing.models.jpa.weave.Order</class>
+        <exclude-unlisted-classes>true</exclude-unlisted-classes>
+        <shared-cache-mode>DISABLE_SELECTIVE</shared-cache-mode>
+        <properties>
+            <property name="eclipselink.weaving" value="true"/>
+            <property name="javax.persistence.schema-generation.database.action" value="drop-and-create"/>
+        </properties>
+    </persistence-unit>
 </persistence>

--- a/jpa/eclipselink.jpa.test/resource/eclipselink-annotation-model/spring/persistence.xml
+++ b/jpa/eclipselink.jpa.test/resource/eclipselink-annotation-model/spring/persistence.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -250,4 +250,17 @@
         </properties>
     </persistence-unit>
 
+    <persistence-unit name="pu-with-dynamic-weaving" transaction-type="RESOURCE_LOCAL">
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+        <class>org.eclipse.persistence.testing.models.jpa.weave.IsolatedEntity</class>
+        <class>org.eclipse.persistence.testing.models.jpa.weave.Location</class>
+        <class>org.eclipse.persistence.testing.models.jpa.weave.Node</class>
+        <class>org.eclipse.persistence.testing.models.jpa.weave.Order</class>
+        <exclude-unlisted-classes>true</exclude-unlisted-classes>
+        <shared-cache-mode>DISABLE_SELECTIVE</shared-cache-mode>
+        <properties>
+            <property name="eclipselink.weaving" value="true"/>
+            <property name="javax.persistence.schema-generation.database.action" value="drop-and-create"/>
+        </properties>
+    </persistence-unit>
 </persistence>

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/weave/IsolatedEntity.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/weave/IsolatedEntity.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.persistence.testing.models.jpa.weave;
+
+import java.util.Objects;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Version;
+
+@Entity
+@Table(name="JPA21_ISOLATED_ENTITY")
+public class IsolatedEntity {
+
+    @Id
+    protected String id;
+
+    @Version
+    protected Integer version;
+
+    public IsolatedEntity() {
+        super();
+    }
+
+    public IsolatedEntity(String id) {
+        this.id = id;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        IsolatedEntity that = (IsolatedEntity) o;
+        return Objects.equals(id, that.id) && Objects.equals(version, that.version);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, version);
+    }
+}

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/weave/Location.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/weave/Location.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.persistence.testing.models.jpa.weave;
+
+import java.util.Objects;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.Version;
+
+@Entity
+@Table(name="JPA21_LOCATION")
+public class Location {
+
+    @Id
+    protected Long id;
+
+    protected String locationId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    protected Node node;
+
+    @Version
+    protected Integer version;
+
+    public Location(long id, String locationId) {
+        this.id = id;
+        this.locationId = locationId;
+    }
+
+    protected Location() {
+    }
+
+    public Long getId() {
+        return this.id;
+    }
+
+    public String getLocationId() {
+        return this.locationId;
+    }
+
+    public Node getNode() {
+        return node;
+    }
+
+    public void setNode(Node node) {
+        this.node = node;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Location location = (Location) o;
+        return Objects.equals(id, location.id) && Objects.equals(locationId, location.locationId) && Objects.equals(node, location.node) && Objects.equals(version, location.version);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, locationId, node, version);
+    }
+}

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/weave/Node.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/weave/Node.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.persistence.testing.models.jpa.weave;
+
+import java.util.Objects;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Version;
+
+@Entity
+@Table(name="JPA21_NODE")
+public class Node {
+
+    @Id
+    protected String id;
+
+    protected int availableBufferCapacity = 10;
+
+    @Version
+    protected Integer version;
+
+    public Node(String id) {
+        this.id = id;
+    }
+
+    protected Node() {
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public int getAvailableBufferCapacity() {
+        return availableBufferCapacity;
+    }
+
+    public void reserveBufferCapacity() {
+        availableBufferCapacity--;
+    }
+
+    public Integer getVersion() {
+        return version;
+    }
+
+/*
+    public void setVersion(Integer version) {
+        this.version = version;
+    }
+*/
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Node node = (Node) o;
+        return availableBufferCapacity == node.availableBufferCapacity && Objects.equals(id, node.id) && Objects.equals(version, node.version);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, availableBufferCapacity, version);
+    }
+}

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/weave/Order.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/models/jpa/weave/Order.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.persistence.testing.models.jpa.weave;
+
+import java.util.Objects;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.Version;
+
+@Entity
+@Table(name="JPA21_ORDER_1")
+public class Order {
+
+    @Id
+    protected Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    protected Node node;
+
+    @Version
+    protected Integer version;
+
+    protected Order() {
+    }
+
+    public Order(long id) {
+
+        this.id = id;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Node getNode() {
+        return node;
+    }
+
+    public void setNode(Node destinationNode) {
+        this.node = destinationNode;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Order order = (Order) o;
+        return Objects.equals(id, order.id) && Objects.equals(node, order.node) && Objects.equals(version, order.version);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, node, version);
+    }
+}

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/FullRegressionTestSuite.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/FullRegressionTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2020 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -54,6 +54,7 @@ import org.eclipse.persistence.testing.tests.jpa.advanced.ReportQueryConstructor
 import org.eclipse.persistence.testing.tests.jpa.advanced.ReportQueryMultipleReturnTestSuite;
 import org.eclipse.persistence.testing.tests.jpa.advanced.SQLResultSetMappingTestSuite;
 import org.eclipse.persistence.testing.tests.jpa.advanced.UpdateAllQueryAdvancedJunitTest;
+import org.eclipse.persistence.testing.tests.jpa.advanced.WeaveVersionTestSuite;
 import org.eclipse.persistence.testing.tests.jpa.advanced.compositepk.AdvancedCompositePKJunitTest;
 import org.eclipse.persistence.testing.tests.jpa.advanced.concurrency.ConcurrencyTest;
 import org.eclipse.persistence.testing.tests.jpa.advanced.concurrency.LifecycleJUnitTest;
@@ -162,6 +163,7 @@ public class FullRegressionTestSuite extends TestSuite {
         suite.addTest(NamedQueryJUnitTest.suite());
         suite.addTest(EntityEmbeddableTest.suite());
         suite.addTest(InvalidNamedQueryTest.suite());
+        suite.addTest(WeaveVersionTestSuite.suite());
         fullSuite.addTest(suite);
 
         // Inheritance model.

--- a/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/advanced/WeaveVersionTestSuite.java
+++ b/jpa/eclipselink.jpa.test/src/org/eclipse/persistence/testing/tests/jpa/advanced/WeaveVersionTestSuite.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.persistence.testing.tests.jpa.advanced;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+
+import junit.framework.Test;
+import junit.framework.TestSuite;
+
+import org.eclipse.persistence.testing.framework.junit.JUnitTestCase;
+import org.eclipse.persistence.testing.models.jpa.weave.IsolatedEntity;
+import org.eclipse.persistence.testing.models.jpa.weave.Location;
+import org.eclipse.persistence.testing.models.jpa.weave.Node;
+import org.eclipse.persistence.testing.models.jpa.weave.Order;
+
+public class WeaveVersionTestSuite extends JUnitTestCase {
+
+    private static final String NODE_01 = "NODE_01";
+    private static final String LOCATION_01 = "LOCATION_01";
+    private static final String PROCESS_01 = "PROCESS_01";
+
+    public WeaveVersionTestSuite() {
+    }
+
+    public WeaveVersionTestSuite(String name) {
+        super(name);
+        setPuName(getPersistenceUnitName());
+    }
+
+    @Override
+    public String getPersistenceUnitName() {
+        return "pu-with-dynamic-weaving";
+    }
+
+    public static Test suite() {
+        TestSuite suite = new TestSuite();
+        suite.setName("WeaveVersionTestSuite");
+        suite.addTest(new WeaveVersionTestSuite("testWeavedEntitiesWithVersionL2Cache"));
+        return suite;
+    }
+
+    @Override
+    public void setUp() {
+        EntityManager em = createEntityManager();
+        beginTransaction(em);
+        try {
+            Node node = new Node(NODE_01);
+            em.persist(node);
+            Location destinationLocation = new Location(1L, LOCATION_01);
+            destinationLocation.setNode(node);
+            em.persist(destinationLocation);
+            commitTransaction(em);
+        } finally {
+            if (this.isTransactionActive(em)) {
+                rollbackTransaction(em);
+            }
+            closeEntityManager(em);
+        }
+    }
+
+    //Sequence of steps which triggered org.eclipse.persistence.exceptions.OptimisticLockException before related fix was applied.
+    //Required conditions are: JPA L2 cache enabled, Weaving enabled and @Version field annotation is used
+    public void testWeavedEntitiesWithVersionL2Cache() {
+        EntityManagerFactory emf = getEntityManagerFactory();
+        cleanup();
+        emf.getCache().evictAll();
+
+        //Step 01
+        {
+            final long toKey = 1L;
+
+            EntityManager em = createEntityManager();
+            beginTransaction(em);
+            try {
+                Order order = new Order(toKey);
+                em.persist(order);
+                em.flush();
+                Location location = em
+                        .createQuery("SELECT l FROM Location l WHERE l.locationId=:locationId", Location.class)
+                        .setParameter("locationId", LOCATION_01)
+                        .getSingleResult();
+                order.setNode(location.getNode());
+                commitTransaction(em);
+            } finally {
+                if (this.isTransactionActive(em)) {
+                    rollbackTransaction(em);
+                }
+                closeEntityManager(em);
+            }
+        }
+
+        //Step 02
+        {
+            final long toKey = 1L;
+
+            EntityManager em = createEntityManager();
+            beginTransaction(em);
+            try {
+                IsolatedEntity serialProcess = new IsolatedEntity(PROCESS_01);
+                em.persist(serialProcess);
+                em.flush();
+                Order order = em.find(Order.class, toKey);
+                order.getNode().reserveBufferCapacity();
+                em.merge(order);
+                em.merge(order.getNode());
+                commitTransaction(em);
+            } finally {
+                if (this.isTransactionActive(em)) {
+                    rollbackTransaction(em);
+                }
+                closeEntityManager(em);
+            }
+
+        }
+        cleanup();
+        emf.getCache().evictAll();
+
+        //Step 03
+        {
+            final long toKey = 2L;
+
+            EntityManager em = createEntityManager();
+            beginTransaction(em);
+            try {
+                Order order = new Order(toKey);
+                em.persist(order);
+                em.flush();
+                Location destinationLocation = em
+                        .createQuery("SELECT l FROM Location l WHERE l.locationId=:locationId", Location.class)
+                        .setParameter("locationId", LOCATION_01)
+                        .getSingleResult();
+                order.setNode(destinationLocation.getNode());
+                commitTransaction(em);
+            } finally {
+                if (this.isTransactionActive(em)) {
+                    rollbackTransaction(em);
+                }
+                closeEntityManager(em);
+            }
+        }
+
+        //Step 04
+        {
+            final long toKey = 2L;
+
+            EntityManager em = createEntityManager();
+            beginTransaction(em);
+            try {
+                IsolatedEntity serialProcess = new IsolatedEntity(PROCESS_01);
+                em.persist(serialProcess);
+                em.flush();
+                Order order = em.find(Order.class, toKey);
+                order.getNode().reserveBufferCapacity();
+                em.merge(order);
+                em.merge(order.getNode());
+            } finally {
+                if (this.isTransactionActive(em)) {
+                    rollbackTransaction(em);
+                }
+                closeEntityManager(em);
+            }
+        }
+    }
+
+    public void cleanup() {
+        EntityManager em = createEntityManager();
+        em.getTransaction().begin();
+        try {
+            em.createQuery("delete from IsolatedEntity s").executeUpdate();
+            em.createQuery("delete from Order t").executeUpdate();
+            em.createQuery("UPDATE Node tn SET tn.availableBufferCapacity =10").executeUpdate();
+            commitTransaction(em);
+        } finally {
+            if (this.isTransactionActive(em)) {
+                rollbackTransaction(em);
+            }
+            closeEntityManager(em);
+        }
+    }
+
+    @Override
+    public void tearDown() {
+        EntityManager em = createEntityManager();
+        em.getTransaction().begin();
+        try {
+            em.createQuery("delete from Location l").executeUpdate();
+            em.createQuery("delete from Order t").executeUpdate();
+            em.createQuery("delete from Node t").executeUpdate();
+            em.createQuery("delete from IsolatedEntity s").executeUpdate();
+            commitTransaction(em);
+        } finally {
+            if (this.isTransactionActive(em)) {
+                rollbackTransaction(em);
+            }
+            closeEntityManager(em);
+        }
+    }
+}


### PR DESCRIPTION
Under specific conditions is `org.eclipse.persistence.exceptions.OptimisticLockException` incorrectly thrown.
Environment conditions are:

- JPA L2 cache enabled
- Weaving is applied to used entities
- `@Version` annotation is used

Test `org.eclipse.persistence.testing.tests.advanced2.weave.WeaveVersionTest#testWeavedEntitiesWithVersionL2Cache` describe sequence of steps which leads into  `org.eclipse.persistence.exceptions.OptimisticLockException` if fix is not applied.

Purpose of fix in `org.eclipse.persistence.internal.sessions.UnitOfWorkImpl#cloneAndRegisterObject(java.lang.Object, org.eclipse.persistence.internal.identitymaps.CacheKey, org.eclipse.persistence.internal.identitymaps.CacheKey, org.eclipse.persistence.descriptors.ClassDescriptor)` is update current working object with non-invalidated version from `UnitOfWork` scope if `original` is still invalid.