### PR TITLE
Fix malformed sql

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/FieldExpression.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/FieldExpression.java
@@ -292,7 +292,11 @@ public class FieldExpression extends DataExpression {
             }
             if ((descriptor != null) && descriptor.hasTablePerClassPolicy()) {
                 field = field.clone();
-                field.setTable(descriptor.getDefaultTable());
+                DatabaseTable table = descriptor.getDefaultTable();
+                if((field.getTableName().length() != 0) && descriptor.getTableNames().contains(field.getTableName())) {
+                    table = descriptor.getTable(field.getTableName());
+                }
+                field.setTable(table);
             }
         }
         FieldExpression expression = new FieldExpression(field, getBaseExpression().rebuildOn(newBase));
@@ -329,7 +333,11 @@ public class FieldExpression extends DataExpression {
             }
             if ((descriptor != null) && descriptor.hasTablePerClassPolicy()) {
                 field = field.clone();
-                field.setTable(descriptor.getDefaultTable());
+                DatabaseTable table = descriptor.getDefaultTable();
+                if((field.getTableName().length() != 0) && descriptor.getTableNames().contains(field.getTableName())) {
+                    table = descriptor.getTable(field.getTableName());
+                }
+                field.setTable(table);
             }
         }
         return twistedBase.getField(field);


### PR DESCRIPTION
Credit to @luiseufrasio
Malformed SQL when using SecondaryTable & PrimaryKeyJoinColumn annotations

Exception [EclipseLink-4002] (Eclipse Persistence Services - 2.6.8.payara-p3): org.eclipse.persistence.exceptions.DatabaseException Internal Exception: com.ibm.db2.jcc.am.SqlSyntaxErrorException: DB2 SQL Error: SQLCODE=-206, SQLSTATE=42703, SQLERRMC=T0.HCSO#, DRIVER=4.32.28 Error Code: -206 Call: SELECT t0.HDSO#, t1.HCSO#, t0.HDCUST, t0.HDYEAR, t0.HDRLSO, t1.HCUSER FROM SOHDS0 t0, SOHC t1 WHERE ((t0.HDSO# = ?) AND (t0.HCSO# = t0.HDSO#)) bind => [123] Query: ReadObjectQuery(name="readSalesOrder" referenceClass=FleetSalesOrder sql="SELECT t0.HDSO#, t1.HCSO#, t0.HDCUST, t0.HDYEAR, t0.HDRLSO, t1.HCUSER FROM SOHDS0 t0, SOHC t1 WHERE ((t0.HDSO# = ?) AND (t0.HCSO# = t0.HDSO#))")

 

The AND clause at the very end should have condition t1.HCSO# = t0.HDSO#