### PR TITLE
[master] Enum attribute in JPQL is broken when entity identifier is omitted or is 'this.' - bugfix and unit tests

### DIFF
--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced/src/main/java/org/eclipse/persistence/testing/models/jpa/advanced/AdvancedTableCreator.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced/src/main/java/org/eclipse/persistence/testing/models/jpa/advanced/AdvancedTableCreator.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 1998, 2022 IBM Corporation. All rights reserved.
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -2655,6 +2655,16 @@ public class AdvancedTableCreator extends TogglingFastTableCreator {
         fieldHEIGHT.setUnique(false);
         fieldHEIGHT.setShouldAllowNull(true);
         table.addField(fieldHEIGHT);
+
+        FieldDefinition fieldSTATUS = new FieldDefinition();
+        fieldSTATUS.setName("STATUS");
+        fieldSTATUS.setTypeName("VARCHAR");
+        fieldSTATUS.setSize(32);
+        fieldSTATUS.setIsPrimaryKey(false);
+        fieldSTATUS.setIsIdentity(false);
+        fieldSTATUS.setUnique(false);
+        fieldSTATUS.setShouldAllowNull(true);
+        table.addField(fieldSTATUS);
 
         return table;
     }

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced/src/main/java/org/eclipse/persistence/testing/models/jpa/advanced/Room.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced/src/main/java/org/eclipse/persistence/testing/models/jpa/advanced/Room.java
@@ -43,14 +43,32 @@ import java.util.Collection;
         })
 })
 public class Room implements Serializable, Cloneable {
+
+    public enum Status {
+        FREE, OCCUPIED;
+    }
+
     @Id
     private int id;
     private int width;
     private int length;
     private int height;
+    private Status status;
 
     @OneToMany(mappedBy="room", cascade=CascadeType.ALL, fetch=FetchType.LAZY)
     private Collection<Door> doors;
+
+    public Room() {
+    }
+
+    public Room(int id, int width, int length, int height, Status status) {
+        this.id = id;
+        this.width = width;
+        this.length = length;
+        this.height = height;
+        this.status = status;
+        this.doors = doors;
+    }
 
     public int getId() {
         return id;
@@ -82,6 +100,14 @@ public class Room implements Serializable, Cloneable {
 
     public void setHeight(int height) {
         this.height = height;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
     }
 
     public Collection<Door> getDoors() {

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/AbstractPathExpression.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/AbstractPathExpression.java
@@ -212,7 +212,7 @@ public abstract class AbstractPathExpression extends AbstractExpression {
                 identificationVariable = buildNullExpression();
             }
             else {
-                identificationVariable = new IdentificationVariable(this, paths.get(0));
+                identificationVariable = new IdentificationVariable(this, paths.get(0), false);
             }
         }
     }


### PR DESCRIPTION
Fixes #2185 