### PR TITLE
Left Join Fetch on Embeddable ElementColection fails & NamedQuery wit…

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
@@ -3051,7 +3051,7 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
             return null;
         }
         if (descriptor.isDescriptorTypeAggregate()) {
-            throw ValidationException.cannotRegisterAggregateObjectInUnitOfWork(object.getClass());
+            return null;
         }
         Object registeredObject = checkIfAlreadyRegistered(object, descriptor);
         if (registeredObject == null) {

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metamodel/ManagedTypeImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metamodel/ManagedTypeImpl.java
@@ -87,6 +87,7 @@ import org.eclipse.persistence.internal.queries.ContainerPolicy;
 import org.eclipse.persistence.internal.security.PrivilegedAccessHelper;
 import org.eclipse.persistence.internal.security.PrivilegedGetDeclaredField;
 import org.eclipse.persistence.internal.security.PrivilegedGetDeclaredMethod;
+import org.eclipse.persistence.internal.sessions.AbstractSession;
 import org.eclipse.persistence.logging.AbstractSessionLog;
 import org.eclipse.persistence.logging.SessionLog;
 import org.eclipse.persistence.mappings.CollectionMapping;
@@ -1326,6 +1327,18 @@ public abstract class ManagedTypeImpl<X> extends TypeImpl<X> implements ManagedT
             }
 
             this.members.put(mapping.getAttributeName(), member);
+        }
+    }
+
+    public void preinitaliseMappings(AbstractSession session) {
+        for (DatabaseMapping mapping : getDescriptor().getMappings()) {
+            try {
+                mapping.preInitialize(session);
+            } catch (NullPointerException npe) {
+                // A NPE gets thrown if the expected method is not present for the mapping
+                AbstractSessionLog.getLog().log(SessionLog.FINE, "Caught NPE when preinitializing database mapping",
+                        npe.getMessage());
+            }
         }
     }
 

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metamodel/MetamodelImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metamodel/MetamodelImpl.java
@@ -497,8 +497,13 @@ public class MetamodelImpl implements Metamodel, Serializable {
             }
         }
 
-        //1 - process all non-mappedSuperclass types first, so we pick up attribute types
-        //2 - process mappedSuperclass types and lookup collection attribute types on inheriting entity types when field is not set
+        //1 - preinitalise all mappings so attribute types are set
+        //2 - process all non-mappedSuperclass types first so we pick up attribute types
+        //3 - process mappedSuperclass types and lookup collection attribute types on inheriting entity types when field is not set
+
+        for(ManagedTypeImpl<?> managedType : new ArrayList<>(managedTypes.values())) {
+            managedType.preinitaliseMappings(session);
+        }
 
         /*
          * Delayed-Initialization (process all mappings) of all Managed types
@@ -510,7 +515,7 @@ public class MetamodelImpl implements Metamodel, Serializable {
             managedType.initialize();
         }
 
-        // 3 - process all the Id attributes on each IdentifiableType
+        // 4 - process all the Id attributes on each IdentifiableType
         for(ManagedTypeImpl<?> potentialIdentifiableType : managedTypes.values()) {
             if(potentialIdentifiableType.isIdentifiableType()) {
                 ((IdentifiableTypeImpl<?>)potentialIdentifiableType).initializeIdAttributes();


### PR DESCRIPTION
# Left Join Fetch
The error occurs when the Entities are compared to see if there is any change done and thus an update needs to be done to the database.

 

[2020-09-01T12:05:10.724+0200] [Payara 5.201] [WARNING] [] [javax.enterprise.web] [tid: _ThreadID=107 _ThreadName=http-thread-pool::http-listener-1(4)] [timeMillis: 1598954710724] [levelValue: 900] [[
StandardWrapperValve[be.rubus.payara.support.ticket1455.ApplicationConfig]: Servlet.service() for servlet be.rubus.payara.support.ticket1455.ApplicationConfig threw exception
java.lang.NullPointerException
at org.eclipse.persistence.internal.descriptors.InstanceVariableAttributeAccessor.getAttributeValueFromObject(InstanceVariableAttributeAccessor.java:83)
at org.eclipse.persistence.mappings.DatabaseMapping.getAttributeValueFromObject(DatabaseMapping.java:691)
at org.eclipse.persistence.mappings.foundation.AbstractDirectMapping.compareObjects(AbstractDirectMapping.java:412)
at org.eclipse.persistence.mappings.foundation.AbstractDirectMapping.compareForChange(AbstractDirectMapping.java:386)
at org.eclipse.persistence.descriptors.changetracking.DeferredChangeDetectionPolicy.createObjectChangeSetThroughComparison(DeferredChangeDetectionPolicy.java:192)
at org.eclipse.persistence.descriptors.changetracking.DeferredChangeDetectionPolicy.createObjectChangeSet(DeferredChangeDetectionPolicy.java:152)
at org.eclipse.persistence.descriptors.changetracking.DeferredChangeDetectionPolicy.calculateChanges(DeferredChangeDetectionPolicy.java:95)
at org.eclipse.persistence.descriptors.changetracking.DeferredChangeDetectionPolicy.calculateChangesForExistingObject(DeferredChangeDetectionPolicy.java:61)
at org.eclipse.persistence.internal.sessions.UnitOfWorkImpl.calculateChanges(UnitOfWorkImpl.java:713)
at org.eclipse.persistence.internal.sessions.UnitOfWorkImpl.commitToDatabaseWithChangeSet(UnitOfWorkImpl.java:1568)
at org.eclipse.persistence.internal.sessions.UnitOfWorkImpl.issueSQLbeforeCompletion(UnitOfWorkImpl.java:3258)
at org.eclipse.persistence.internal.sessions.RepeatableWriteUnitOfWork.issueSQLbeforeCompletion(RepeatableWriteUnitOfWork.java:357)
at org.eclipse.persistence.transaction.AbstractSynchronizationListener.beforeCompletion(AbstractSynchronizationListener.java:160)
at org.eclipse.persistence.transaction.JTASynchronizationListener.beforeCompletion(JTASynchronizationListener.java:70)
at com.sun.enterprise.transaction.JavaEETransactionImpl.commit(JavaEETransactionImpl.java:480)

When not using  Left Join Fetch, no error occurs.

# Named Query
When defining a NamedQuery that has EclipseLink hints, the query fails with an exception



Exception [EclipseLink-7081] (Eclipse Persistence Services - 2.7.6.payara-p1): org.eclipse.persistence.exceptions.ValidationException
Exception Description: The aggregate object [class be.rubus.payara.support.ticket1455.model.Tag] cannot be directly registered in the UnitOfWork.  It must be associated with the source (owner) object.
	at org.eclipse.persistence.exceptions.ValidationException.cannotRegisterAggregateObjectInUnitOfWork(ValidationException.java:622)
 

The offending NamedQuery, org.eclipse.persistence.config.QueryHints



@NamedQuery(
        name = "getAllBlogPosts_fail",
        query = "SELECT i FROM BlogPost i",
        hints = {
                @QueryHint(
                        name = QueryHints.REFRESH,
                        value = HintValues.TRUE
                ),
                @QueryHint(
                        name = QueryHints.LEFT_FETCH,
                        value = "i.tags"
                )
        }
)