### PR TITLE
[master] IndexOutOfBoundsException when JPQL has embeddable or relational attributes without the optional entity identification variable - bugfix and unit tests

### DIFF
--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced/src/main/java/org/eclipse/persistence/testing/models/jpa/advanced/Door.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced/src/main/java/org/eclipse/persistence/testing/models/jpa/advanced/Door.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -44,6 +44,17 @@ public class Door implements Serializable, Cloneable {
 
     @ManyToOne(cascade=CascadeType.ALL, fetch=FetchType.LAZY)
     private Room room;
+
+    public Door() {
+    }
+
+    public Door(int id, int width, int height, Room room, Date warrantyDate) {
+        this.id = id;
+        this.width = width;
+        this.height = height;
+        this.room = room;
+        WarrantyDate = warrantyDate;
+    }
 
     public int getId() {
         return id;

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced/src/main/java/org/eclipse/persistence/testing/models/jpa/advanced/Room.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced/src/main/java/org/eclipse/persistence/testing/models/jpa/advanced/Room.java
@@ -28,7 +28,7 @@ import org.eclipse.persistence.config.QueryHints;
 import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.List;
 
 @Entity
 @Table(name="CMP3_ROOM")
@@ -56,7 +56,7 @@ public class Room implements Serializable, Cloneable {
     private Status status;
 
     @OneToMany(mappedBy="room", cascade=CascadeType.ALL, fetch=FetchType.LAZY)
-    private Collection<Door> doors;
+    private List<Door> doors;
 
     public Room() {
     }
@@ -110,11 +110,11 @@ public class Room implements Serializable, Cloneable {
         this.status = status;
     }
 
-    public Collection<Door> getDoors() {
+    public List<Door> getDoors() {
         return doors;
     }
 
-    public void setDoors(Collection<Door> doors) {
+    public void setDoors(List<Door> doors) {
         this.doors = doors;
     }
 

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/AbstractSemanticValidator.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/AbstractSemanticValidator.java
@@ -2421,7 +2421,18 @@ public abstract class AbstractSemanticValidator extends AbstractValidator {
                         // Third path extension did not validate the path expression, continue validating it
                         else {
                             type = helper.getType(expression);
-
+                            if (type == null && expression.getParentExpression().isGenerateImplicitThisAlias()) {
+                                //Seems path is not available. Try again with new virtual "this" IdentificationVariable.
+                                // Remove the used identification variable since it is not
+                                // Entity identification variable as generated/implicit "this" is expected.
+                                usedIdentificationVariables.remove(expression.getIdentificationVariable());
+                                //Add generated/implicit "this" alias.
+                                expression.setVirtualIdentificationVariable(Expression.THIS);
+                                type = helper.getType(expression);
+                                if (helper.isTypeResolvable(type)) {
+                                    return valid;
+                                }
+                            }
                             // Does not resolve to a valid path
                             if (!helper.isTypeResolvable(type)) {
                                 addProblem(expression, StateFieldPathExpression_NotResolvable, expression.toActualText());

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/AbstractPathExpression.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/AbstractPathExpression.java
@@ -323,7 +323,7 @@ public abstract class AbstractPathExpression extends AbstractExpression {
      *
      * @param variableName The identification variable that was generated to identify the "root" object
      */
-    protected final void setVirtualIdentificationVariable(String variableName) {
+    public final void setVirtualIdentificationVariable(String variableName) {
 
         identificationVariable = new IdentificationVariable(this, variableName, true);
 

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/org/eclipse/persistence/jpa/tests/jpql/parser/JPQLExpressionTestJakartaData.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/org/eclipse/persistence/jpa/tests/jpql/parser/JPQLExpressionTestJakartaData.java
@@ -28,6 +28,7 @@ import static org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTester.max
 import static org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTester.new_;
 import static org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTester.numeric;
 import static org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTester.orderBy;
+import static org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTester.orderByItem;
 import static org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTester.orderByItemAsc;
 import static org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTester.orderByItemDesc;
 import static org.eclipse.persistence.jpa.tests.jpql.parser.JPQLParserTester.path;
@@ -269,6 +270,25 @@ public final class JPQLExpressionTestJakartaData extends JPQLParserTest {
                 where(and(equal(virtualVariable("this", "customerId"), inputParameter(":customerIdParam")),
                         equal(virtualVariable("this", "status"), path("com.oracle.jpa.bugtest.Rebate.Status.PAID")))),
                 orderBy(orderByItemDesc(virtualVariable("this", "amount")), orderByItemAsc(virtualVariable("this", "id")))
+        );
+
+        testJakartaDataQuery(inputJPQLQuery, selectStatement);
+    }
+
+    // Covers https://github.com/eclipse-ee4j/eclipselink/issues/2188
+    // This is just basic syntax tests. Semantic validation from org.eclipse.persistence.core Maven module is required for full test
+    // to resolve that path "location.address.city" is correct.
+    // Full test is in org.eclipse.persistence.jpa.testapps.jpql Maven module
+    @Test
+    public void testSelectWithImplicitThisAliasAndRelationalAttributes() {
+
+        String inputJPQLQuery = "FROM Business WHERE location.address.city=:cityParam ORDER BY name";
+
+        SelectStatementTester selectStatement = selectStatement(
+                select(variable("this")),
+                from("Business", "{this}"),
+                where(equal(path("location.address.city"), inputParameter(":cityParam"))),
+                orderBy(orderByItem(virtualVariable("this", "name")))
         );
 
         testJakartaDataQuery(inputJPQLQuery, selectStatement);


### PR DESCRIPTION
Fixes #2188 
Location and execution context of this fix is different, than other `this` fixes.
This one is located in `org.eclipse.persistence.jpa.jpql.AbstractSemanticValidator#validateStateFieldPathExpression` and executed by `org.eclipse.persistence.internal.jpa.jpql.HermesParser#validate` in `org.eclipse.persistence.core` module when project and descriptors are available. Reason behind this is, that code has to distinguish between possible Enum or mapping path, which is not available in JPQL parser context.
