### PR TITLE
Fixed persistence provider check in createEntityManagerFactory(PersistenceConfiguration)

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/PersistenceUnitProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/PersistenceUnitProperties.java
@@ -85,6 +85,19 @@ import java.util.concurrent.TimeUnit;
 public final class PersistenceUnitProperties {
 
     /**
+     * The {@code jakarta.persistence.provider} property specifies the name
+     * of a provider-specific implementation of {@link jakarta.persistence.spi.PersistenceProvider}.
+     * This property overrides the value specified in the persistence.xml.
+     * <p>
+     * <b>Allowed Values:</b>
+     * <ul>
+     * <li>fully qualified name of the provider-specific implementation class
+     * <li>{@link Class} instance of the provider-specific implementation class
+     * </ul>
+     */
+    public static final String PROVIDER = "jakarta.persistence.provider";
+
+    /**
      * The {@code jakarta.persistence.transactionType} property specifies the
      * transaction type for the persistence unit. This property overrides the
      * value specified in the persistence.xml.

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/jpa/PersistenceProvider.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/jpa/PersistenceProvider.java
@@ -320,6 +320,7 @@ public class PersistenceProvider implements jakarta.persistence.spi.PersistenceP
         return JavaSECMPInitializer.getJavaSECMPInitializer(classLoader);
     }
 
+    // Package visibility is required for jUnit
     /**
      * The Persistence bootstrap class must locate all the persistence providers using the PersistenceProviderResolver
      * mechanism described in Section 9.3 and call createEntityManagerFactory on them in turn until an appropriate backing
@@ -334,7 +335,7 @@ public class PersistenceProvider implements jakarta.persistence.spi.PersistenceP
      *
      * @since Jakarta Persistence 3.2
      */
-    private static boolean isProviderEclipseLink(PersistenceConfiguration configuration) {
+    static boolean isProviderEclipseLink(PersistenceConfiguration configuration) {
         // Property jakarta.persistence.provider has higher priority, EclipseLink accepts it also as class.
         if (configuration.properties().containsKey(PersistenceUnitProperties.PROVIDER)) {
             return isProviderPropertyEclipseLink(configuration.properties().get(PersistenceUnitProperties.PROVIDER));
@@ -349,7 +350,7 @@ public class PersistenceProvider implements jakarta.persistence.spi.PersistenceP
     /**
      * Need to check that the provider property is null or set for EclipseLink
      */
-    public boolean checkForProviderProperty(Map<?, ?> properties) {
+    public static boolean checkForProviderProperty(Map<?, ?> properties) {
         return !properties.containsKey(PersistenceUnitProperties.PROVIDER)
                 || isProviderPropertyEclipseLink(properties.get(PersistenceUnitProperties.PROVIDER));
     }

--- a/jpa/org.eclipse.persistence.jpa/src/test/java/org/eclipse/persistence/jpa/PersistenceProviderTest.java
+++ b/jpa/org.eclipse.persistence.jpa/src/test/java/org/eclipse/persistence/jpa/PersistenceProviderTest.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 1998, 2024 IBM Corporation. All rights reserved.
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/jpa/org.eclipse.persistence.jpa/src/test/java/org/eclipse/persistence/jpa/PersistenceProviderTest.java
+++ b/jpa/org.eclipse.persistence.jpa/src/test/java/org/eclipse/persistence/jpa/PersistenceProviderTest.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024 IBM Corporation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.persistence.jpa;
+
+import java.util.Map;
+
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.PersistenceConfiguration;
+import jakarta.persistence.spi.PersistenceUnitInfo;
+import jakarta.persistence.spi.ProviderUtil;
+import org.eclipse.persistence.config.PersistenceUnitProperties;
+import org.eclipse.persistence.internal.jpa.EntityManagerFactoryProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class PersistenceProviderTest {
+
+    @Test
+    void testCheckForProviderPropertyWithoutProperty() {
+        Map<String, Object> properties = Map.of();
+        boolean result = PersistenceProvider.checkForProviderProperty(properties);
+        assertTrue(result);
+    }
+
+    @Test
+    void testCheckForProviderPropertyWithProviderClass() {
+        Map<String, Object> properties = Map.of(
+                PersistenceUnitProperties.PROVIDER, PersistenceProvider.class
+        );
+        boolean result = PersistenceProvider.checkForProviderProperty(properties);
+        assertTrue(result);
+    }
+
+    @Test
+    void testCheckForProviderPropertyWithProviderString() {
+        Map<String, Object> properties = Map.of(
+                PersistenceUnitProperties.PROVIDER, PersistenceProvider.class.getName()
+        );
+        boolean result = PersistenceProvider.checkForProviderProperty(properties);
+        assertTrue(result);
+    }
+
+    @Test
+    void testCheckForProviderPropertyWithEMFProviderClass() {
+        Map<String, Object> properties = Map.of(
+                PersistenceUnitProperties.PROVIDER, EntityManagerFactoryProvider.class
+        );
+        boolean result = PersistenceProvider.checkForProviderProperty(properties);
+        assertTrue(result);
+    }
+
+    @Test
+    void testCheckForProviderPropertyWithEMFProviderString() {
+        Map<String, Object> properties = Map.of(
+                PersistenceUnitProperties.PROVIDER, EntityManagerFactoryProvider.class.getName()
+        );
+        boolean result = PersistenceProvider.checkForProviderProperty(properties);
+        assertTrue(result);
+    }
+
+    @Test
+    void testCheckForProviderPropertyWithUnsupportedClass() {
+        Map<String, Object> properties = Map.of(
+                PersistenceUnitProperties.PROVIDER, Unsupported.class
+        );
+        boolean result = PersistenceProvider.checkForProviderProperty(properties);
+        assertFalse(result);
+    }
+
+    @Test
+    void testCheckForProviderPropertyWithUnsupportedString() {
+        Map<String, Object> properties = Map.of(
+                PersistenceUnitProperties.PROVIDER, Unsupported.class.getName()
+        );
+        boolean result = PersistenceProvider.checkForProviderProperty(properties);
+        assertFalse(result);
+    }
+
+    @Test
+    void testIsProviderEclipseLinkWithoutProvider() {
+        PersistenceConfiguration configuration = new PersistenceConfiguration("Test");
+        boolean result = PersistenceProvider.isProviderEclipseLink(configuration);
+        assertTrue(result);
+    }
+
+    @Test
+    void testIsProviderEclipseLinkWithProvider() {
+        PersistenceConfiguration configuration = new PersistenceConfiguration("Test");
+        configuration.provider(PersistenceProvider.class.getName());
+        boolean result = PersistenceProvider.isProviderEclipseLink(configuration);
+        assertTrue(result);
+    }
+
+    @Test
+    void testIsProviderEclipseLinkWithEMFProvider() {
+        PersistenceConfiguration configuration = new PersistenceConfiguration("Test");
+        configuration.provider(EntityManagerFactoryProvider.class.getName());
+        boolean result = PersistenceProvider.isProviderEclipseLink(configuration);
+        assertTrue(result);
+    }
+
+    @Test
+    void testIsProviderEclipseLinkWithUnsupportedProvider() {
+        PersistenceConfiguration configuration = new PersistenceConfiguration("Test");
+        configuration.provider(Unsupported.class.getName());
+        boolean result = PersistenceProvider.isProviderEclipseLink(configuration);
+        assertFalse(result);
+    }
+
+    @Test
+    void testIsProviderEclipseLinkWithProviderStringProperty() {
+        Map<String, Object> properties = Map.of(
+                PersistenceUnitProperties.PROVIDER, PersistenceProvider.class.getName()
+        );
+        PersistenceConfiguration configuration = new PersistenceConfiguration("Test");
+        configuration.properties(properties);
+        boolean result = PersistenceProvider.isProviderEclipseLink(configuration);
+        assertTrue(result);
+    }
+
+    @Test
+    void testIsProviderEclipseLinkWithEMFProviderStringProperty() {
+        Map<String, Object> properties = Map.of(
+                PersistenceUnitProperties.PROVIDER, EntityManagerFactoryProvider.class.getName()
+        );
+        PersistenceConfiguration configuration = new PersistenceConfiguration("Test");
+        configuration.properties(properties);
+        boolean result = PersistenceProvider.isProviderEclipseLink(configuration);
+        assertTrue(result);
+    }
+
+    @Test
+    void testIsProviderEclipseLinkWithUnsupportedProviderStringProperty() {
+        Map<String, Object> properties = Map.of(
+                PersistenceUnitProperties.PROVIDER, Unsupported.class.getName()
+        );
+        PersistenceConfiguration configuration = new PersistenceConfiguration("Test");
+        configuration.properties(properties);
+        boolean result = PersistenceProvider.isProviderEclipseLink(configuration);
+        assertFalse(result);
+    }
+
+    @Test
+    void testIsProviderEclipseLinkWithProviderClassProperty() {
+        Map<String, Object> properties = Map.of(
+                PersistenceUnitProperties.PROVIDER, PersistenceProvider.class
+        );
+        PersistenceConfiguration configuration = new PersistenceConfiguration("Test");
+        configuration.properties(properties);
+        boolean result = PersistenceProvider.isProviderEclipseLink(configuration);
+        assertTrue(result);
+    }
+
+    @Test
+    void testIsProviderEclipseLinkWithEMFProviderClassProperty() {
+        Map<String, Object> properties = Map.of(
+                PersistenceUnitProperties.PROVIDER, EntityManagerFactoryProvider.class
+        );
+        PersistenceConfiguration configuration = new PersistenceConfiguration("Test");
+        configuration.properties(properties);
+        boolean result = PersistenceProvider.isProviderEclipseLink(configuration);
+        assertTrue(result);
+    }
+
+    @Test
+    void testIsProviderEclipseLinkWithUnsupportedProviderClassProperty() {
+        Map<String, Object> properties = Map.of(
+                PersistenceUnitProperties.PROVIDER, Unsupported.class
+        );
+        PersistenceConfiguration configuration = new PersistenceConfiguration("Test");
+        configuration.properties(properties);
+        boolean result = PersistenceProvider.isProviderEclipseLink(configuration);
+        assertFalse(result);
+    }
+
+
+    @Test
+    void testIsProviderEclipseLinkWithProviderStringPropertyOverride() {
+        Map<String, Object> properties = Map.of(
+                PersistenceUnitProperties.PROVIDER, PersistenceProvider.class.getName()
+        );
+        PersistenceConfiguration configuration = new PersistenceConfiguration("Test");
+        // Provider is set as unsupported, but supported property must override it
+        configuration.provider(Unsupported.class.getName());
+        configuration.properties(properties);
+        boolean result = PersistenceProvider.isProviderEclipseLink(configuration);
+        assertTrue(result);
+    }
+
+    @Test
+    void testIsProviderEclipseLinkWithEMFProviderStringPropertyOverride() {
+        Map<String, Object> properties = Map.of(
+                PersistenceUnitProperties.PROVIDER, EntityManagerFactoryProvider.class.getName()
+        );
+        PersistenceConfiguration configuration = new PersistenceConfiguration("Test");
+        // Provider is set as unsupported, but supported property must override it
+        configuration.provider(Unsupported.class.getName());
+        configuration.properties(properties);
+        boolean result = PersistenceProvider.isProviderEclipseLink(configuration);
+        assertTrue(result);
+    }
+
+    @Test
+    void testIsProviderEclipseLinkWithUnsupportedProviderStringPropertyOverride() {
+        Map<String, Object> properties = Map.of(
+                PersistenceUnitProperties.PROVIDER, Unsupported.class.getName()
+        );
+        PersistenceConfiguration configuration = new PersistenceConfiguration("Test");
+        // Provider is set as supported, but unsupported property must override it
+        configuration.provider(PersistenceProvider.class.getName());
+        configuration.properties(properties);
+        boolean result = PersistenceProvider.isProviderEclipseLink(configuration);
+        assertFalse(result);
+    }
+
+    // PersistenceProvider that shall fail the check
+    private static final class Unsupported implements jakarta.persistence.spi.PersistenceProvider {
+
+        @Override
+        public EntityManagerFactory createEntityManagerFactory(String emName, Map<?, ?> map) {
+            return null;
+        }
+
+        @Override
+        public EntityManagerFactory createEntityManagerFactory(PersistenceConfiguration configuration) {
+            return null;
+        }
+
+        @Override
+        public EntityManagerFactory createContainerEntityManagerFactory(PersistenceUnitInfo info, Map<?, ?> map) {
+            return null;
+        }
+
+        @Override
+        public void generateSchema(PersistenceUnitInfo info, Map<?, ?> map) {
+
+        }
+
+        @Override
+        public boolean generateSchema(String persistenceUnitName, Map<?, ?> map) {
+            return false;
+        }
+
+        @Override
+        public ProviderUtil getProviderUtil() {
+            return null;
+        }
+
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1287,7 +1287,7 @@
                     <!-- see https://github.com/eclipse-ee4j/eclipselink-build-support -->
                     <groupId>org.eclipse.persistence</groupId>
                     <artifactId>eclipselink-testbuild-plugin</artifactId>
-                    <version>1.1.0</version>
+                    <version>1.1.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.carlspring.maven</groupId>


### PR DESCRIPTION
Added `jakarta.persistence.provider` to `PersistenceUnitProperties`
Added provider class check to `PersistenceProvider#createEntityManagerFactory(PersistenceConfiguration)`
Optimized provider check code.