### PR TITLE
[master] UUID field type mapping - PostgreSQLPlatform

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/PostgreSQLPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/PostgreSQLPlatform.java
@@ -438,6 +438,8 @@ public class PostgreSQLPlatform extends DatabasePlatform {
         fieldTypeMapping.put(java.time.OffsetDateTime.class, new FieldTypeDefinition("TIMESTAMP", false));
         fieldTypeMapping.put(java.time.OffsetTime.class, new FieldTypeDefinition("TIME", false));
 
+        fieldTypeMapping.put(java.util.UUID.class, new FieldTypeDefinition("UUID", false));
+
         return fieldTypeMapping;
     }
 


### PR DESCRIPTION
Add support for UUID DB type in PostgreSQL for DDL generation.
This type is supported by PostgreSQL from 2008 see
https://www.postgresql.org/docs/9.3/release-8-3.html
This is why target class is `PostgreSQLPlatform`.
Fixes #2190 