### PR TITLE
Fixes : Db2: Eclipselink creates table with Db2 data type DOUBLE instead of REAL for a Java float

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/DB2Platform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/DB2Platform.java
@@ -311,7 +311,7 @@ public class DB2Platform extends org.eclipse.persistence.platform.database.Datab
 
         fieldTypeMapping.put(Integer.class, new FieldTypeDefinition("INTEGER", false));
         fieldTypeMapping.put(Long.class, new FieldTypeDefinition("BIGINT", false));
-        fieldTypeMapping.put(Float.class, new FieldTypeDefinition("FLOAT", false));
+        fieldTypeMapping.put(Float.class, new FieldTypeDefinition("REAL", false));
         fieldTypeMapping.put(Double.class, new FieldTypeDefinition("FLOAT", false));
         fieldTypeMapping.put(Short.class, new FieldTypeDefinition("SMALLINT", false));
         fieldTypeMapping.put(Byte.class, new FieldTypeDefinition("SMALLINT", false));


### PR DESCRIPTION
This PR contains the fix for issue #2282 