### PR TITLE
Fix calling stored procs on Postgres, and enable some tests

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
@@ -1438,16 +1438,6 @@ public class DatabasePlatform extends DatasourcePlatform {
     }
 
     /**
-     * Returns true if this platform complies with the expected behavior from
-     * a jdbc execute call. Most platforms do, some have issues:
-     *
-     * @see PostgreSQLPlatform
-     */
-    public boolean isJDBCExecuteCompliant() {
-        return true;
-    }
-
-    /**
      * Return true is the given exception occurred as a result of a lock
      * time out exception (WAIT clause). If sub-platform supports this clause,
      * this method should be necessary checks should be made.

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2019, 2022 IBM Corporation. All rights reserved.
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -1435,6 +1435,17 @@ public class DatabasePlatform extends DatasourcePlatform {
      */
     public boolean isInformixOuterJoin() {
         return false;
+    }
+
+    /**
+     * Returns true if this platform complies with the expected behavior from
+     * a jdbc execute call. Most platforms do, some have issues:
+     *
+     * @see PostgreSQLPlatform
+     */
+    @Deprecated(forRemoval = true)
+    public boolean isJDBCExecuteCompliant() {
+        return true;
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/PostgreSQLPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/PostgreSQLPlatform.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2019, 2023 IBM Corporation. All rights reserved.
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/PostgreSQLPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/PostgreSQLPlatform.java
@@ -306,20 +306,6 @@ public class PostgreSQLPlatform extends DatabasePlatform {
     }
 
     /**
-     * Calling a stored procedure query on PostgreSQL with no output parameters
-     * always returns true from an execute call regardless if a result set is
-     * returned or not. This flag will help avoid throwing a JPA mandated
-     * exception on an executeUpdate call (which calls jdbc execute and checks
-     * the return value to ensure no results sets are returned (true))
-     *
-     * @see PostgreSQLPlatform
-     */
-    @Override
-    public boolean isJDBCExecuteCompliant() {
-        return false;
-    }
-
-    /**
      * INTERNAL: Answers whether platform is Postgres.
      */
     @Override
@@ -520,7 +506,7 @@ public class PostgreSQLPlatform extends DatabasePlatform {
      */
     @Override
     public String getProcedureBeginString() {
-        return "AS $$  BEGIN ";
+        return "$$  BEGIN ";
     }
 
     /**
@@ -528,55 +514,17 @@ public class PostgreSQLPlatform extends DatabasePlatform {
      */
     @Override
     public String getProcedureEndString() {
-        return "; END ; $$ LANGUAGE plpgsql;";
+        return "END; $$ LANGUAGE plpgsql;";
     }
 
     /**
-     * INTERNAL: Used for sp calls.  PostGreSQL uses a different method for executing StoredProcedures than other platforms.
+     * INTERNAL: Used for sp calls.
      */
     @Override
-    public String buildProcedureCallString(StoredProcedureCall call, AbstractSession session, AbstractRecord row) {
-        StringWriter tailWriter = new StringWriter();
-        StringWriter writer = new StringWriter();
-        boolean outParameterFound = false;
-
-        tailWriter.write(call.getProcedureName());
-        tailWriter.write("(");
-
-        int indexFirst = call.getFirstParameterIndexForCallString();
-        int size = call.getParameters().size();
-        String nextBindString = "?";
-
-        for (int index = indexFirst; index < size; index++) {
-             String name = call.getProcedureArgumentNames().get(index);
-             Object parameter = call.getParameters().get(index);
-             ParameterType parameterType = call.getParameterTypes().get(index);
-             // If the argument is optional and null, ignore it.
-             if (!call.hasOptionalArguments() || !call.getOptionalArguments().contains(parameter) || (row.get(parameter) != null)) {
-                  if (!DatasourceCall.isOutputParameterType(parameterType)) {
-                       tailWriter.write(nextBindString);
-                       nextBindString = ", ?";
-                  } else {
-                       if (outParameterFound) {
-                            //multiple outs found
-                            throw ValidationException.multipleOutParamsNotSupported(Helper.getShortClassName(this), call.getProcedureName());
-                       }
-                       outParameterFound = true; //PostGreSQL uses a very different header to execute when there are out params
-                  }
-             }
-        }
-        tailWriter.write(")");
-
-        if (outParameterFound) {
-             writer.write("{?= CALL ");
-             tailWriter.write("}");
-        } else {
-             writer.write("SELECT * FROM ");
-        }
-        writer.write(tailWriter.toString());
-
-        return writer.toString();
+    public String getProcedureCallHeader() {
+        return "CALL ";
     }
+
     /**
      * INTERNAL Used for stored function calls.
      */

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/storedproc/TestStoredProcedures.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/storedproc/TestStoredProcedures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -30,6 +30,7 @@ import org.eclipse.persistence.jpa.test.framework.EmfRunner;
 import org.eclipse.persistence.jpa.test.framework.Property;
 import org.eclipse.persistence.platform.database.DatabasePlatform;
 import org.eclipse.persistence.sessions.DatabaseSession;
+import org.eclipse.persistence.tools.schemaframework.FieldDefinition;
 import org.eclipse.persistence.tools.schemaframework.SchemaManager;
 import org.eclipse.persistence.tools.schemaframework.StoredProcedureDefinition;
 
@@ -190,17 +191,22 @@ public class TestStoredProcedures {
         //Setup a stored procedure
         EntityManager em = emf.createEntityManager();
         try {
+            DatabaseSession dbs = ((EntityManagerImpl)em).getDatabaseSession();
+            SchemaManager manager = new SchemaManager(dbs);
+            Platform platform = dbs.getDatasourcePlatform();
+
             StoredProcedureDefinition proc = new StoredProcedureDefinition();
             proc.setName("simple_order_procedure");
 
             proc.addArgument("in_param_one", String.class, 10);
             proc.addArgument("in_param_two", String.class, 10);
             proc.addArgument("in_param_three", String.class, 10);
-            proc.addOutputArgument("out_param_one", String.class, 30);
-
-            DatabaseSession dbs = ((EntityManagerImpl)em).getDatabaseSession();
-            SchemaManager manager = new SchemaManager(dbs);
-            Platform platform = dbs.getDatasourcePlatform();
+            if (platform.isPostgreSQL()) {
+                // PG only supports OUT in 14+
+                proc.addInOutputArgument(new FieldDefinition("out_param_one", String.class, 30));
+            } else {
+                proc.addOutputArgument("out_param_one", String.class, 30);
+            }
 
             //Add more platform specific diction to support more platforms
             if(platform.isMySQL()) {

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/storedproc/TestStoredProcedures.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/storedproc/TestStoredProcedures.java
@@ -121,6 +121,8 @@ public class TestStoredProcedures {
      */
     @Test
     public void testStoredProcedure_SetOrdered_NamedParameters() {
+        Assume.assumeFalse("pgjdbc does not support named parameters", getPlatform(storedProcedureEmf).isPostgreSQL());
+
         EntityManager em = storedProcedureEmf.createEntityManager();
         try {
             StoredProcedureQuery storedProcedure = em.createStoredProcedureQuery("simple_order_procedure");
@@ -152,6 +154,8 @@ public class TestStoredProcedures {
      */
     @Test
     public void testStoredProcedure_SetUnordered_NamedParameters() {
+        Assume.assumeFalse("pgjdbc does not support named parameters", getPlatform(storedProcedureEmf).isPostgreSQL());
+
         EntityManager em = storedProcedureEmf.createEntityManager();
         try {
             StoredProcedureQuery storedProcedure = em.createStoredProcedureQuery("simple_order_procedure");
@@ -201,7 +205,7 @@ public class TestStoredProcedures {
             //Add more platform specific diction to support more platforms
             if(platform.isMySQL()) {
                 proc.addStatement("SET out_param_one = CONCAT('One: ',in_param_one,' Two: ',in_param_two,' Three: ',in_param_three)");
-            } else if(platform.isOracle()) {
+            } else if(platform.isOracle() || platform.isPostgreSQL()) {
                 proc.addStatement("out_param_one := 'One: ' || in_param_one || ' Two: ' || in_param_two || ' Three: ' || in_param_three");
             } else if (platform.isDB2() || platform.isDB2Z()) {
                 proc.addStatement("SET out_param_one = 'One: ' || in_param_one || ' Two: ' || in_param_two || ' Three: ' || in_param_three");

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/StoredProcedureQueryImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/StoredProcedureQueryImpl.java
@@ -379,11 +379,7 @@ public class StoredProcedureQueryImpl extends QueryImpl implements StoredProcedu
 
             // If the return value is true indicating a result set then throw an exception.
             if (execute()) {
-                if (getActiveSession().getPlatform().isJDBCExecuteCompliant()) {
-                    throw new IllegalStateException(ExceptionLocalization.buildMessage("incorrect_spq_query_for_execute_update"));
-                } else {
-                    return getUpdateCount();
-                }
+                throw new IllegalStateException(ExceptionLocalization.buildMessage("incorrect_spq_query_for_execute_update"));
             } else {
                 return getUpdateCount();
             }

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/StoredProcedureQueryImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/StoredProcedureQueryImpl.java
@@ -379,7 +379,11 @@ public class StoredProcedureQueryImpl extends QueryImpl implements StoredProcedu
 
             // If the return value is true indicating a result set then throw an exception.
             if (execute()) {
-                throw new IllegalStateException(ExceptionLocalization.buildMessage("incorrect_spq_query_for_execute_update"));
+                if (getActiveSession().getPlatform().isJDBCExecuteCompliant()) {
+                    throw new IllegalStateException(ExceptionLocalization.buildMessage("incorrect_spq_query_for_execute_update"));
+                } else {
+                    return getUpdateCount();
+                }
             } else {
                 return getUpdateCount();
             }


### PR DESCRIPTION
Fixes calling stored procedures on Postgres. Without this change, EclipseLink does `SELECT * FROM name_of_proc` which causes an exception. This change also removes the `isJDBCExecuteCompliant()` method, which is not needed anymore as far as I can tell, and enables a few stored procedure tests for Postgres to prevent regressions.

This PR targets the 4.0 branch but would also need to be done for 5.0.