### PR TITLE
Fix #2075 Slow startup because of low entropy for PRNG

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/SystemProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/SystemProperties.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -270,6 +271,18 @@ public final class SystemProperties {
      * </ul>
      */
     public static final String ASM_SERVICE = "eclipselink.asm.service";
+
+    /**
+     * <p>
+     * This property control the random number generator (RNG) used for password encryption.
+     * <p>
+     * <b>Allowed Values</b> (case sensitive String)<b>:</b>
+     * <ul>
+     * <li>"{@code false}" (DEFAULT) - use default RNG of Java platform
+     * <li>"{@code true}" - use RNG indicated by the securerandom.strongAlgorithms security property of Java platform
+     * </ul>
+     */
+    public static final String SECURITY_ENCRYPTOR_USE_STRONG_RANDOM_NUMBER_GENERATOR = "eclipselink.security.encryptor.use.strong.random.number.generator";
 
     private SystemProperties() {
         // no instance please

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/security/JCEEncryptor.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/security/JCEEncryptor.java
@@ -128,14 +128,16 @@ public final class JCEEncryptor implements org.eclipse.persistence.security.Secu
             byte[] ivGCM = new byte[IV_GCM_LENGTH];
             SecureRandom random = null;
             String useStrongRNG = PrivilegedAccessHelper.getSystemProperty(SystemProperties.SECURITY_ENCRYPTOR_USE_STRONG_RANDOM_NUMBER_GENERATOR);
-            if (Boolean.parseBoolean(useStrongRNG)) {
+            if (useStrongRNG == null || useStrongRNG.equalsIgnoreCase("false")) {
+                random = new SecureRandom();
+            } else if (useStrongRNG.equalsIgnoreCase("true")) {
                 try {
                     random = SecureRandom.getInstanceStrong();
                 } catch (NoSuchAlgorithmException e) {
                     throw new RuntimeException(e);
                 }
             } else {
-                random = new SecureRandom();
+                throw ValidationException.invalidBooleanValueForProperty(useStrongRNG, SystemProperties.SECURITY_ENCRYPTOR_USE_STRONG_RANDOM_NUMBER_GENERATOR);
             }
             random.nextBytes(ivGCM);
             return ivGCM;

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/security/JCEEncryptor.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/security/JCEEncryptor.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,6 +15,7 @@
 //     Oracle - initial API and implementation from Oracle TopLink
 package org.eclipse.persistence.internal.security;
 
+import org.eclipse.persistence.config.SystemProperties;
 import org.eclipse.persistence.exceptions.ConversionException;
 import org.eclipse.persistence.exceptions.ValidationException;
 import org.eclipse.persistence.internal.helper.Helper;
@@ -125,10 +127,15 @@ public final class JCEEncryptor implements org.eclipse.persistence.security.Secu
         private static byte[] getIvGCM() {
             byte[] ivGCM = new byte[IV_GCM_LENGTH];
             SecureRandom random = null;
-            try {
-                random = SecureRandom.getInstanceStrong();
-            } catch (NoSuchAlgorithmException e) {
-                throw new RuntimeException(e);
+            String useStrongRNG = PrivilegedAccessHelper.getSystemProperty(SystemProperties.SECURITY_ENCRYPTOR_USE_STRONG_RANDOM_NUMBER_GENERATOR);
+            if (Boolean.parseBoolean(useStrongRNG)) {
+                try {
+                    random = SecureRandom.getInstanceStrong();
+                } catch (NoSuchAlgorithmException e) {
+                    throw new RuntimeException(e);
+                }
+            } else {
+                random = new SecureRandom();
             }
             random.nextBytes(ivGCM);
             return ivGCM;

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/security/PrivilegedAccessHelper.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/security/PrivilegedAccessHelper.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -73,6 +74,7 @@ public class PrivilegedAccessHelper {
             SystemProperties.CONCURRENCY_MANAGER_ACQUIRE_WAIT_TIME, SystemProperties.CONCURRENCY_MANAGER_BUILD_OBJECT_COMPLETE_WAIT_TIME, SystemProperties.CONCURRENCY_MANAGER_MAX_SLEEP_TIME,
             SystemProperties.CONCURRENCY_MANAGER_MAX_FREQUENCY_DUMP_TINY_MESSAGE, SystemProperties.CONCURRENCY_MANAGER_MAX_FREQUENCY_DUMP_MASSIVE_MESSAGE,
             SystemProperties.CONCURRENCY_MANAGER_ALLOW_INTERRUPTED_EXCEPTION, SystemProperties.CONCURRENCY_MANAGER_ALLOW_CONCURRENCY_EXCEPTION, SystemProperties.CONCURRENCY_MANAGER_ALLOW_STACK_TRACE_READ_LOCK,
+            SystemProperties.SECURITY_ENCRYPTOR_USE_STRONG_RANDOM_NUMBER_GENERATOR,
             ServerPlatformBase.JMX_REGISTER_RUN_MBEAN_PROPERTY, ServerPlatformBase.JMX_REGISTER_DEV_MBEAN_PROPERTY,
             XMLPlatformFactory.XML_PLATFORM_PROPERTY};
     private final static Set<String> legalPropertiesSet = Set.of(legalProperties);


### PR DESCRIPTION
Fixes #2075.

To address hang-up due to blocking PRNG returned by  `SecureRandom.getInstanceStrong()`, this pull request introduces  a system property (`eclipselink.security.encryptor.use.strong.random.number.generator`) to switch  `SecureRandom.getInstanceStrong()` and `new SecureRandom()`.
`new SecureRandom()` returns the default PRNG of Java platform [1].

Since `SecureRandom.getInstanceStrong()` may return a blocking PRNG and is not recommended in server-side code (see [2]),  we prefer to use `new SecureRandom()` as the default setting.
Users can change the behavior by configuring the system property if they want.

[1] https://docs.oracle.com/en/java/javase/21/security/java-cryptography-architecture-jca-reference-guide.html#GUID-AEB77CD8-D28F-4BBE-B9E5-160B5DC35D36
[2] https://www.blackduck.com/blog/proper-use-of-javas-securerandom.html