### PR TITLE
[master] ConcurrencyException "Max number of attempts to lock object" in WriteLockManager - bugfix

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/AbstractSession.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/AbstractSession.java
@@ -2811,7 +2811,8 @@ public abstract class AbstractSession extends CoreAbstractSession<ClassDescripto
                cacheKey.acquireDeferredLock();
                original = cacheKey.getObject();
                if (original == null) {
-                   synchronized (cacheKey) {
+                   cacheKey.getInstanceLock().lock();
+                   try {
                        if (cacheKey.isAcquired()) {
                            try {
                                cacheKey.wait();
@@ -2820,6 +2821,8 @@ public abstract class AbstractSession extends CoreAbstractSession<ClassDescripto
                            }
                        }
                        original = cacheKey.getObject();
+                   } finally {
+                       cacheKey.getInstanceLock().unlock();
                    }
                }
                cacheKey.releaseDeferredLock();

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/IsolatedClientSessionIdentityMapAccessor.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/IsolatedClientSessionIdentityMapAccessor.java
@@ -269,7 +269,8 @@ public class IsolatedClientSessionIdentityMapAccessor extends org.eclipse.persis
         // in which GC could remove the object and we would end up with a null pointer
         // as well we must inspect the cacheKey without locking on it.
         if ((cacheKey != null) && (shouldReturnInvalidatedObjects || !descriptor.getCacheInvalidationPolicy().isInvalidated(cacheKey))) {
-            synchronized (cacheKey) {
+            cacheKey.getInstanceLock().lock();
+            try {
                 //if the object in the cachekey is null but the key is acquired then
                 //someone must be rebuilding it or creating a new one.  Sleep until
                 // it's finished. A plain wait here would be more efficient but we may not
@@ -285,6 +286,8 @@ public class IsolatedClientSessionIdentityMapAccessor extends org.eclipse.persis
                 if (objectFromCache == null) {
                     return null;
                 }
+            } finally {
+                cacheKey.getInstanceLock().unlock();
             }
         } else {
             return null;

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/ObjectChangeSet.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/ObjectChangeSet.java
@@ -536,7 +536,8 @@ public class ObjectChangeSet implements Serializable, Comparable<ObjectChangeSet
                         session.getParent().log(SessionLog.SEVERE, SessionLog.CACHE, "entity_not_available_during_merge", new Object[]{descriptor.getJavaClassName(), cacheKey.getKey(), Thread.currentThread().getName(), cacheKey.getActiveThread()});
                         break;
                     }
-                    synchronized (cacheKey) {
+                    cacheKey.getInstanceLock().lock();
+                    try {
                         if (cacheKey.isAcquired()) {
                             try {
                                 cacheKey.wait(10);
@@ -545,6 +546,8 @@ public class ObjectChangeSet implements Serializable, Comparable<ObjectChangeSet
                             }
                         }
                         domainObject = cacheKey.getObject();
+                    } finally {
+                        cacheKey.getInstanceLock().unlock();
                     }
                 }
                 cacheKey.releaseDeferredLock();

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkIdentityMapAccessor.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkIdentityMapAccessor.java
@@ -173,7 +173,8 @@ public class UnitOfWorkIdentityMapAccessor extends IdentityMapAccessor {
         // in which GC could remove the object and we would end up with a null pointer
         // as well we must inspect the cacheKey without locking on it.
         if ((cacheKey != null) && (shouldReturnInvalidatedObjects || !descriptor.getCacheInvalidationPolicy().isInvalidated(cacheKey))) {
-            synchronized (cacheKey) {
+            cacheKey.getInstanceLock().lock();
+            try {
                 //if the object in the cachekey is null but the key is acquired then
                 //someone must be rebuilding it or creating a new one.  Sleep until
                 // it's finished. A plain wait here would be more efficient but we may not
@@ -186,6 +187,8 @@ public class UnitOfWorkIdentityMapAccessor extends IdentityMapAccessor {
                     }
                 } catch (InterruptedException ex) {
                 }
+            } finally {
+                cacheKey.getInstanceLock().unlock();
             }
 
             // check for inheritance.


### PR DESCRIPTION
Fixes #2319 in `WriteLockManager` by `toWaitOn.getInstanceLockCondition().await(MAX_WAIT, TimeUnit.MILLISECONDS);` to wait for lock on object (`CacheKey`) to be released.
Before this fix there was 
`toWaitOnLockCondition.await(ConcurrencyUtil.SINGLETON.getAcquireWaitTime(), TimeUnit.MILLISECONDS);`
which was
`toWaitOnLockCondition.await(0, TimeUnit.MILLISECONDS);` in case of default persistence settings -> Zero time ammount to wait. 
Additionally there are some other migrations from `synchronized` to ReentrantLock usage for CacheKey related code.