### PR TITLE
[4.0] UUID field type mapping - PostgreSQLPlatform (#2284) - backport from master

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/PostgreSQLPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/PostgreSQLPlatform.java
@@ -440,6 +440,8 @@ public class PostgreSQLPlatform extends DatabasePlatform {
         fieldTypeMapping.put(java.time.OffsetDateTime.class, new FieldTypeDefinition("TIMESTAMP", false));
         fieldTypeMapping.put(java.time.OffsetTime.class, new FieldTypeDefinition("TIME", false));
 
+        fieldTypeMapping.put(java.util.UUID.class, new FieldTypeDefinition("UUID", false));
+
         return fieldTypeMapping;
     }
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/PostgreSQLPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/PostgreSQLPlatform.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2019, 2023 IBM Corporation. All rights reserved.
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at


### PR DESCRIPTION
Add support for UUID DB type in PostgreSQL for DDL generation.
This type is supported by PostgreSQL from 2008 see
https://www.postgresql.org/docs/9.3/release-8-3.html
This is why target class is `PostgreSQLPlatform`.
Fixes #2190 

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>
(cherry picked from commit 28ffe73f20ec4b4a200951ca26a21c3b39048355)