### PR TITLE
[master] JDK 24 build fixes

### DIFF
--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/schemagen/customizedmapping/xmlelementref/WrappedByteArray.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/schemagen/customizedmapping/xmlelementref/WrappedByteArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -36,7 +36,7 @@ public class WrappedByteArray {
      *
      * @return
      *     possible object is
-     *     {@link JAXBElement }{@code byte[]}
+     *     {@code JAXBElement<byte[]>}
      *
      */
     public JAXBElement<byte[]> getInByteArray() {
@@ -48,7 +48,7 @@ public class WrappedByteArray {
      *
      * @param value
      *     allowed object is
-     *     {@link JAXBElement }{@code byte[]}
+     *     {@code JAXBElement<byte[]>}
      *
      */
     public void setInByteArray(JAXBElement<byte[]> value) {

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/schemagen/customizedmapping/xmlelementref/WrappedByteArray.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/schemagen/customizedmapping/xmlelementref/WrappedByteArray.java
@@ -36,7 +36,7 @@ public class WrappedByteArray {
      *
      * @return
      *     possible object is
-     *     {@link JAXBElement }{@code <}{@link byte[]}{@code >}
+     *     {@link JAXBElement }{@code byte[]}
      *
      */
     public JAXBElement<byte[]> getInByteArray() {
@@ -48,7 +48,7 @@ public class WrappedByteArray {
      *
      * @param value
      *     allowed object is
-     *     {@link JAXBElement }{@code <}{@link byte[]}{@code >}
+     *     {@link JAXBElement }{@code byte[]}
      *
      */
     public void setInByteArray(JAXBElement<byte[]> value) {

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/xmlelementrefs/adapter/ObjectFactory.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/xmlelementrefs/adapter/ObjectFactory.java
@@ -53,7 +53,7 @@ public class ObjectFactory {
  }
 
  /**
-  * Create an instance of {@link JAXBElement }{@code <}{@link byte[]}{@code >}}
+  * Create an instance of {@link JAXBElement }{@code byte[]}
   *
   */
  @XmlElementDecl(namespace = "", name = "e1", scope = Foo.class)
@@ -63,7 +63,7 @@ public class ObjectFactory {
  }
 
  /**
-  * Create an instance of {@link JAXBElement }{@code <}{@link byte[]}{@code >}}
+  * Create an instance of {@link JAXBElement }{@code byte[]}
   *
   */
  @XmlElementDecl(namespace = "", name = "e2", scope = Foo.class)

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/xmlelementrefs/adapter/ObjectFactory.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/xmlelementrefs/adapter/ObjectFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -53,7 +53,7 @@ public class ObjectFactory {
  }
 
  /**
-  * Create an instance of {@link JAXBElement }{@code byte[]}
+  * Create an instance of {@code JAXBElement<byte[]>}
   *
   */
  @XmlElementDecl(namespace = "", name = "e1", scope = Foo.class)
@@ -63,7 +63,7 @@ public class ObjectFactory {
  }
 
  /**
-  * Create an instance of {@link JAXBElement }{@code byte[]}
+  * Create an instance of {@code JAXBElement<byte[]>}
   *
   */
  @XmlElementDecl(namespace = "", name = "e2", scope = Foo.class)


### PR DESCRIPTION
There are just some javadoc related issues which leads into errors and block EclipseLink build on JDK 24.
There are not fixed any compiler warning messages.