### PR TITLE
[4.0] DatasourceAccessor ReentrantLock fix plus new SpringBoot test

### DIFF
--- a/etc/jenkins/pr_verify.groovy
+++ b/etc/jenkins/pr_verify.groovy
@@ -189,6 +189,15 @@ spec:
                 }
             }
         }
+        stage('JPA Spring, JPA Spring Boot') {
+            steps {
+                container('el-build') {
+                    sh """
+                                mvn -B -V verify -pl :org.eclipse.persistence.jpa.spring.test,:org.eclipse.persistence.jpa.springboot.test -P staging,mysql
+                            """
+                }
+            }
+        }
         stage('JPA Modelgen, JPA JSE, WDF, JPARS, DBWS, DBWS Builder, Distribution') {
             steps {
                 container('el-build') {

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatasourceAccessor.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatasourceAccessor.java
@@ -155,7 +155,7 @@ public abstract class DatasourceAccessor implements Accessor {
 
     protected ConnectionPool pool;
 
-    private final Lock instanceLock  = new ReentrantLock();
+    private Lock instanceLock  = new ReentrantLock();
 
     /**
      *    Default Constructor.
@@ -174,6 +174,7 @@ public abstract class DatasourceAccessor implements Accessor {
     public Object clone() {
         try {
             DatasourceAccessor accessor = (DatasourceAccessor)super.clone();
+            accessor.instanceLock = new ReentrantLock();
             if(accessor.customizer != null) {
                 accessor.customizer.setAccessor(accessor);
             }

--- a/jpa/eclipselink.jpa.spring.test/src/it/resources/appContext.properties
+++ b/jpa/eclipselink.jpa.spring.test/src/it/resources/appContext.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,13 +14,13 @@
 #Properties for Spring Container application context files.
 
 #jdbc driver
-jdbc.driverClassName=%%driverClass%%
-jdbc.url=%%dbURL%%
-jdbc.username=%%dbUser%%
-jdbc.password=%%dbPassword%%
+jdbc.driverClassName=@driverClass@
+jdbc.url=@dbURL@
+jdbc.username=@dbUser@
+jdbc.password=@dbPassword@
 
 #platform
-platform=%%dbPlatform%%
+platform=@dbPlatform@
 
 #persistence.xml location
 #persistence.location=resource/foundation/spring/META-INF/persistence.xml

--- a/jpa/eclipselink.jpa.springboot.test/pom.xml
+++ b/jpa/eclipselink.jpa.springboot.test/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2024 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -18,9 +18,9 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
 
-    <name>EclipseLink JPA Spring Test</name>
+    <name>EclipseLink JPA Spring Boot Test</name>
     <groupId>org.eclipse.persistence</groupId>
-    <artifactId>org.eclipse.persistence.jpa.spring.test</artifactId>
+    <artifactId>org.eclipse.persistence.jpa.springboot.test</artifactId>
     <packaging>jar</packaging>
 
     <parent>
@@ -47,10 +47,9 @@
     </properties>
 
     <dependencies>
-        <!--Test dependencies-->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
             <scope>test</scope>
         </dependency>
         <!--Other modules-->
@@ -60,12 +59,6 @@
             <artifactId>org.eclipse.persistence.jpa</artifactId>
             <scope>test</scope>
         </dependency>
-        <!--EclipseLink JPA test framework-->
-        <dependency>
-            <groupId>org.eclipse.persistence</groupId>
-            <artifactId>org.eclipse.persistence.jpa.test.framework</artifactId>
-            <scope>test</scope>
-        </dependency>
         <!--API dependencies-->
         <dependency>
             <groupId>jakarta.transaction</groupId>
@@ -73,31 +66,35 @@
             <scope>test</scope>
         </dependency>
         <!--Other libraries dependencies-->
+        <!-- Spring Boot Data JPA -->
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hibernate</groupId>
+                    <artifactId>hibernate-entitymanager</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.hibernate</groupId>
+                    <artifactId>hibernate-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- Spring Boot Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-instrument</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-orm</artifactId>
-            <scope>test</scope>
-        </dependency>
+        <!-- Spring FW -->
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-tx</artifactId>
-            <scope>test</scope>
-        </dependency>
+
         <!--JDBC driver (test dependency)-->
         <dependency>
             <groupId>${db.driver.groupId}</groupId>
@@ -117,29 +114,6 @@
         </testResources>
 
         <plugins>
-            <!--Required for EL Weaving (-javaagent:${org.eclipse.persistence:org.eclipse.persistence.jpa:jar})-->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <!--Resolve dependencies into Maven properties like ${org.eclipse.persistence:org.eclipse.persistence.jpa:jar} for JPA module-->
-                    <execution>
-                        <id>get-test-classpath-to-properties</id>
-                        <goals>
-                            <goal>properties</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <compilerArgs>
-                        <arg>-Werror</arg>
-                    </compilerArgs>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -157,40 +131,14 @@
                 </configuration>
                 <executions>
                     <execution>
-                        <id>test-jpa-spring-local</id>
+                        <id>test-jpa-springboot</id>
                         <goals>
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
-                            <!--EclipseLink Weaving is enabled.
-                                When it will be disabled by -Dignore it leads into test errors
-                                ...SpringJunitTestCase.testAddressVH:182 Exception when Address value holder retrieved-->
-                            <!--<argLine>-Dignore</argLine>-->
-                            <argLine>-javaagent:${org.eclipse.persistence:org.eclipse.persistence.jpa:jar}</argLine>
-                            <reportNameSuffix>test-jpa-spring</reportNameSuffix>
+                            <reportNameSuffix>test-jpa-springboot</reportNameSuffix>
                             <includes>
-                                <include>**.spring.TestLocalEMF</include>
-                                <include>**.spring.TestLocalEMFtransactional</include>
-                                <include>**.spring.dao.TestLocalEMFwithDao</include>
-                            </includes>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>test-jpa-spring-container</id>
-                        <goals>
-                            <goal>integration-test</goal>
-                        </goals>
-                        <configuration>
-                            <argLine>-javaagent:${org.springframework:spring-instrument:jar}</argLine>
-                            <!--EclipseLink Weaving is enabled.
-                                When it will be disabled by -Dignore it leads into test errors
-                                ...SpringJunitTestCase.testAddressVH:182 Exception when Address value holder retrieved-->
-                            <!--<argLine>-Dignore</argLine>-->
-                            <reportNameSuffix>test-jpa-spring</reportNameSuffix>
-                            <includes>
-                                <include>**.spring.TestContainerEMF</include>
-                                <include>**.spring.TestContainerEMFtransactional</include>
-                                <include>**.spring.dao.TestContainerEMFwithDao</include>
+                                <include>org.eclipse.persistence.testing.tests.jpa.springboot.TestPersonRepository</include>
                             </includes>
                         </configuration>
                     </execution>
@@ -199,9 +147,6 @@
                         <goals>
                             <goal>verify</goal>
                         </goals>
-                        <configuration>
-                            <skip>${integration.test.skip.verify}</skip>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -227,18 +172,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>oracle</id>
-            <dependencies>
-                <!--db.platform=org.eclipse.persistence.platform.database.oracle.Oracle12Platform comes from there-->
-                <dependency>
-                    <groupId>org.eclipse.persistence</groupId>
-                    <artifactId>org.eclipse.persistence.oracle</artifactId>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles>
 </project>

--- a/jpa/eclipselink.jpa.springboot.test/src/it/java/org/eclipse/persistence/testing/models/jpa/springboot/Person.java
+++ b/jpa/eclipselink.jpa.springboot.test/src/it/java/org/eclipse/persistence/testing/models/jpa/springboot/Person.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.testing.models.jpa.springboot;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.util.Objects;
+
+@Entity
+@Table(name="SPRINGBOOT_PERSON")
+public class Person {
+
+    @Id
+    private Integer id;
+    private String firstName;
+    private String lastName;
+
+    public Person() {
+    }
+
+    public Person(Integer id, String firstName, String lastName) {
+        this.id = id;
+        this.firstName = firstName;
+        this.lastName = lastName;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Person person = (Person) o;
+        return Objects.equals(id, person.id) && Objects.equals(firstName, person.firstName) && Objects.equals(lastName, person.lastName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, firstName, lastName);
+    }
+}

--- a/jpa/eclipselink.jpa.springboot.test/src/it/java/org/eclipse/persistence/testing/models/jpa/springboot/PersonRepository.java
+++ b/jpa/eclipselink.jpa.springboot.test/src/it/java/org/eclipse/persistence/testing/models/jpa/springboot/PersonRepository.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.testing.models.jpa.springboot;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PersonRepository extends JpaRepository<Person, Integer> {
+
+    Person findPersonById(Integer id);
+
+    List<Person> queryAllByIdGreaterThan(Integer idIsGreaterThan);
+}

--- a/jpa/eclipselink.jpa.springboot.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/springboot/EclipseLinkJpaConfiguration.java
+++ b/jpa/eclipselink.jpa.springboot.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/springboot/EclipseLinkJpaConfiguration.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.testing.tests.jpa.springboot;
+
+import org.eclipse.persistence.config.PersistenceUnitProperties;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.orm.jpa.JpaBaseConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.JpaProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.instrument.classloading.InstrumentationLoadTimeWeaver;
+import org.springframework.orm.jpa.vendor.AbstractJpaVendorAdapter;
+import org.springframework.orm.jpa.vendor.EclipseLinkJpaVendorAdapter;
+import org.springframework.transaction.jta.JtaTransactionManager;
+
+import javax.sql.DataSource;
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class EclipseLinkJpaConfiguration extends JpaBaseConfiguration {
+
+    protected EclipseLinkJpaConfiguration(DataSource dataSource, JpaProperties properties, ObjectProvider<JtaTransactionManager> jtaTransactionManager) {
+        super(dataSource, properties, jtaTransactionManager);
+    }
+
+    @Override
+    protected AbstractJpaVendorAdapter createJpaVendorAdapter() {
+        return new EclipseLinkJpaVendorAdapter();
+    }
+
+    @Override
+    protected Map<String, Object> getVendorProperties() {
+        HashMap<String, Object> map = new HashMap<>();
+        map.put(PersistenceUnitProperties.WEAVING, detectWeavingMode());
+        map.put(PersistenceUnitProperties.DDL_GENERATION, "drop-and-create-tables");
+        return map;
+    }
+
+    private String detectWeavingMode() {
+        return InstrumentationLoadTimeWeaver.isInstrumentationAvailable() ? "true" : "static";
+    }
+}

--- a/jpa/eclipselink.jpa.springboot.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/springboot/PersonApplication.java
+++ b/jpa/eclipselink.jpa.springboot.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/springboot/PersonApplication.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.testing.tests.jpa.springboot;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@SpringBootApplication
+@EnableJpaRepositories("org.eclipse.persistence.testing.models.jpa.springboot")
+public class PersonApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(PersonApplication.class, args);
+    }
+}

--- a/jpa/eclipselink.jpa.springboot.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/springboot/TestPersonRepository.java
+++ b/jpa/eclipselink.jpa.springboot.test/src/it/java/org/eclipse/persistence/testing/tests/jpa/springboot/TestPersonRepository.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.testing.tests.jpa.springboot;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.eclipse.persistence.testing.models.jpa.springboot.Person;
+import org.eclipse.persistence.testing.models.jpa.springboot.PersonRepository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ContextConfiguration(classes = { PersonApplication.class, EclipseLinkJpaConfiguration.class })
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class TestPersonRepository {
+
+    Person PERSONS[] = new Person[] {
+            new Person(1, "John", "Doe")
+    };
+
+    @Autowired
+    private PersonRepository personRepository;
+
+    @Test
+    public void testPerson() {
+        Person person = personRepository.findPersonById(PERSONS[0].getId());
+        assertEquals(PERSONS[0], person);
+    }
+
+    @BeforeEach
+    public void setUp() {
+        personRepository.deleteAll();
+        personRepository.save(PERSONS[0]);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        personRepository.deleteAll();
+    }
+}

--- a/jpa/eclipselink.jpa.springboot.test/src/it/resources/META-INF/persistence.xml
+++ b/jpa/eclipselink.jpa.springboot.test/src/it/resources/META-INF/persistence.xml
@@ -1,0 +1,24 @@
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0,
+    or the Eclipse Distribution License v. 1.0 which is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+
+    SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+-->
+
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd" version="3.0">
+
+    <persistence-unit name="default" transaction-type="RESOURCE_LOCAL">
+        <class>org.eclipse.persistence.testing.models.jpa.springboot.Person</class>
+        <properties>
+            <property name="eclipselink.logging.level" value="INFO"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/jpa/eclipselink.jpa.springboot.test/src/it/resources/application.properties
+++ b/jpa/eclipselink.jpa.springboot.test/src/it/resources/application.properties
@@ -1,0 +1,31 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0,
+# or the Eclipse Distribution License v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+# Contributors:
+#     Oracle - initial API and implementation
+
+
+#Properties for Spring Container application context files.
+
+logging.level.root=info
+
+#jdbc driver
+spring.datasource.driver-class-name=@driverClass@
+spring.datasource.url=@dbURL@
+spring.datasource.username=@dbUser@
+spring.datasource.password=@dbPassword@
+
+# create and drop table, good for testing, production set to none or comment it
+spring.jpa.hibernate.ddl-auto=create-drop
+
+# Hikari pool
+#maximum pool size
+spring.datasource.hikari.maximum-pool-size=10

--- a/pom.xml
+++ b/pom.xml
@@ -248,7 +248,7 @@
         <mssql.version>12.6.1.jre11</mssql.version>
         <pgsql.version>42.7.3</pgsql.version>
         <!-- CQ #21139, 21140 -->
-        <logback.version>1.5.6</logback.version>
+        <logback.version>1.5.8</logback.version>
         <oracle.jdbc.version>23.3.0.23.09</oracle.jdbc.version>
         <!-- CQ #2437 -->
         <oracle.aqapi.version>23.3.1.0</oracle.aqapi.version>
@@ -262,7 +262,8 @@
         <!-- CQ #21143 -->
         <slf4j.version>2.0.12</slf4j.version>
         <!-- CQ #23051, 23052, 23053, 53054, 53055 -->
-        <springframework.version>5.3.34</springframework.version>
+        <springframework.version>6.2.1</springframework.version>
+        <springboot.version>3.4.0</springboot.version>
         <!-- CQ #23233 -->
         <weld-se.version>5.1.0.Final</weld-se.version>
         <weblogic.version>12.2.1-3</weblogic.version>
@@ -993,6 +994,16 @@
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-tx</artifactId>
                 <version>${springframework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-data-jpa</artifactId>
+                <version>${springboot.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-test</artifactId>
+                <version>${springboot.version}</version>
             </dependency>
             <!--JDBC drivers-->
             <dependency>
@@ -2180,6 +2191,8 @@
                 <module>jpa/eclipselink.jpa.helidon.test</module>
                 <!--JPA Spring test module-->
                 <module>jpa/eclipselink.jpa.spring.test</module>
+                <!--JPA Spring Boot test module-->
+                <module>jpa/eclipselink.jpa.springboot.test</module>
                 <!--JPA WDF test module-->
                 <module>jpa/eclipselink.jpa.wdf.test</module>
 


### PR DESCRIPTION
Fixes #2219
Issue with `DatasourceAccessor` `ReentratLock` which was after migration accidentally shared across `DatasourceAccessor` instances as new instances are in some cases created due a `clone()` method and not by `new DatasourceAccessor()`.
There is new Spring Boot test module with HikariCP Datasource as this issue was discovered in this environment, but this initial test doesn't cover mentioned bug scenario due a missing information from customer.
Update in booth Spring test modules to execute them in CI environment.