### PR TITLE
[4.0] ConcurrencyException "Max number of attempts to lock object" in WriteLockManager - bugfix - backport from master

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/WriteLockManager.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/WriteLockManager.java
@@ -476,7 +476,7 @@ public class WriteLockManager {
                                         }
                                     }
                                 } catch (InterruptedException exception) {
-                                    throw org.eclipse.persistence.exceptions.ConcurrencyException.waitWasInterrupted(exception.getMessage());
+                                    throw ConcurrencyException.waitWasInterrupted(exception.getMessage());
                                 } finally {
                                     activeCacheKey.getInstanceLock().unlock();
                                 }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/WriteLockManager.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/WriteLockManager.java
@@ -131,7 +131,6 @@ public class WriteLockManager {
     /*  the first element in this list will be the prevailing thread */
     protected ExposedNodeLinkedList prevailingQueue;
 
-    private final Lock toWaitOnLock = new ReentrantLock();
     private final Lock instancePrevailingQueueLock = new ReentrantLock();
 
     public WriteLockManager() {

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/AbstractSession.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/AbstractSession.java
@@ -2805,7 +2805,8 @@ public abstract class AbstractSession extends CoreAbstractSession<ClassDescripto
                cacheKey.acquireDeferredLock();
                original = cacheKey.getObject();
                if (original == null) {
-                   synchronized (cacheKey) {
+                   cacheKey.getInstanceLock().lock();
+                   try {
                        if (cacheKey.isAcquired()) {
                            try {
                                cacheKey.wait();
@@ -2814,6 +2815,8 @@ public abstract class AbstractSession extends CoreAbstractSession<ClassDescripto
                            }
                        }
                        original = cacheKey.getObject();
+                   } finally {
+                       cacheKey.getInstanceLock().unlock();
                    }
                }
                cacheKey.releaseDeferredLock();

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/IsolatedClientSessionIdentityMapAccessor.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/IsolatedClientSessionIdentityMapAccessor.java
@@ -263,7 +263,8 @@ public class IsolatedClientSessionIdentityMapAccessor extends org.eclipse.persis
         // in which GC could remove the object and we would end up with a null pointer
         // as well we must inspect the cacheKey without locking on it.
         if ((cacheKey != null) && (shouldReturnInvalidatedObjects || !descriptor.getCacheInvalidationPolicy().isInvalidated(cacheKey))) {
-            synchronized (cacheKey) {
+            cacheKey.getInstanceLock().lock();
+            try {
                 //if the object in the cachekey is null but the key is acquired then
                 //someone must be rebuilding it or creating a new one.  Sleep until
                 // it's finished. A plain wait here would be more efficient but we may not
@@ -279,6 +280,8 @@ public class IsolatedClientSessionIdentityMapAccessor extends org.eclipse.persis
                 if (objectFromCache == null) {
                     return null;
                 }
+            } finally {
+                cacheKey.getInstanceLock().unlock();
             }
         } else {
             return null;

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/ObjectChangeSet.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/ObjectChangeSet.java
@@ -534,7 +534,8 @@ public class ObjectChangeSet implements Serializable, Comparable<ObjectChangeSet
                         session.getParent().log(SessionLog.SEVERE, SessionLog.CACHE, "entity_not_available_during_merge", new Object[]{descriptor.getJavaClassName(), cacheKey.getKey(), Thread.currentThread().getName(), cacheKey.getActiveThread()});
                         break;
                     }
-                    synchronized (cacheKey) {
+                    cacheKey.getInstanceLock().lock();
+                    try {
                         if (cacheKey.isAcquired()) {
                             try {
                                 cacheKey.wait(10);
@@ -543,6 +544,8 @@ public class ObjectChangeSet implements Serializable, Comparable<ObjectChangeSet
                             }
                         }
                         domainObject = cacheKey.getObject();
+                    } finally {
+                        cacheKey.getInstanceLock().unlock();
                     }
                 }
                 cacheKey.releaseDeferredLock();

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkIdentityMapAccessor.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkIdentityMapAccessor.java
@@ -171,7 +171,8 @@ public class UnitOfWorkIdentityMapAccessor extends IdentityMapAccessor {
         // in which GC could remove the object and we would end up with a null pointer
         // as well we must inspect the cacheKey without locking on it.
         if ((cacheKey != null) && (shouldReturnInvalidatedObjects || !descriptor.getCacheInvalidationPolicy().isInvalidated(cacheKey))) {
-            synchronized (cacheKey) {
+            cacheKey.getInstanceLock().lock();
+            try {
                 //if the object in the cachekey is null but the key is acquired then
                 //someone must be rebuilding it or creating a new one.  Sleep until
                 // it's finished. A plain wait here would be more efficient but we may not
@@ -184,6 +185,8 @@ public class UnitOfWorkIdentityMapAccessor extends IdentityMapAccessor {
                     }
                 } catch (InterruptedException ex) {
                 }
+            } finally {
+                cacheKey.getInstanceLock().unlock();
             }
 
             // check for inheritance.


### PR DESCRIPTION
Fixes #2319 in `WriteLockManager` by `toWaitOn.getInstanceLockCondition().await(MAX_WAIT, TimeUnit.MILLISECONDS);` to wait for lock on object (`CacheKey`) to be released.
Before this fix there was 
`toWaitOnLockCondition.await(ConcurrencyUtil.SINGLETON.getAcquireWaitTime(), TimeUnit.MILLISECONDS);`
which was
`toWaitOnLockCondition.await(0, TimeUnit.MILLISECONDS);` in case of default persistence settings -> Zero time ammount to wait. 
Additionally there are some other migrations from `synchronized` to ReentrantLock usage for CacheKey related code.