### PR TITLE
[4.0] NPE in QueryBasedValueHolder due to #2181 - bugfix

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/indirection/IndirectList.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/indirection/IndirectList.java
@@ -100,7 +100,7 @@ public class IndirectList<E> extends Vector<E> implements CollectionChangeTracke
      */
     private boolean useLazyInstantiation = true;
 
-    private final Lock instanceLock  = new ReentrantLock();
+    private Lock instanceLock  = new ReentrantLock();
 
     /**
      * PUBLIC:
@@ -355,16 +355,19 @@ public class IndirectList<E> extends Vector<E> implements CollectionChangeTracke
     */
     @Override
     public Object clone() {
-        instanceLock.lock();
+        //Keep origin pointer to lock in local variable as instance variable is updated inside
+        Lock lock = instanceLock;
+        lock.lock();
         try {
             IndirectList<E> result = (IndirectList<E>)super.clone();
             result.delegate = (Vector<E>)this.getDelegate().clone();
             result.valueHolder = new ValueHolder<>(result.delegate);
+            result.instanceLock = new ReentrantLock();
             result.attributeName = null;
             result.changeListener = null;
             return result;
         } finally {
-            instanceLock.unlock();
+            lock.unlock();
         }
     }
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/indirection/IndirectMap.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/indirection/IndirectMap.java
@@ -76,7 +76,7 @@ public class IndirectMap<K, V> extends Hashtable<K, V> implements CollectionChan
     /** Store load factor for lazy init. */
     protected float loadFactor = 0.75f;
 
-    private final Lock instanceLock  = new ReentrantLock();
+    private Lock instanceLock  = new ReentrantLock();
 
     /**
      * PUBLIC:
@@ -186,16 +186,19 @@ public class IndirectMap<K, V> extends Hashtable<K, V> implements CollectionChan
     */
     @Override
     public Object clone() {
-        instanceLock.lock();
+        //Keep origin pointer to lock in local variable as instance variable is updated inside
+        Lock lock = instanceLock;
+        lock.lock();
         try {
             IndirectMap<K, V> result = (IndirectMap<K, V>)super.clone();
             result.delegate = (Hashtable<K, V>)this.getDelegate().clone();
             result.valueHolder = new ValueHolder<>(result.delegate);
+            result.instanceLock = new ReentrantLock();
             result.attributeName = null;
             result.changeListener = null;
             return result;
         } finally {
-            instanceLock.unlock();
+            lock.unlock();
         }
     }
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/indirection/DatabaseValueHolder.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/indirection/DatabaseValueHolder.java
@@ -346,7 +346,7 @@ public abstract class DatabaseValueHolder<T> implements WeavedAttributeValueHold
         }
     }
 
-    public Lock getInstanceLock() {
+    Lock getInstanceLock() {
         return this.instanceLock;
     }
 }


### PR DESCRIPTION
Fixes #2317
There is regression bug introduced in #2181 . Scope of new `ReentrantLock` variable `instanceLock` was in case of new object instances created by `clone()` method across all cloned instances instead of one `instanceLock` per each instance.
In case of `UnitOfWorkValueHolder` incorrect lock was used `wrappedValueHolderLock` vs `wrappedValueHolder.getInstanceLock()`