### PR TITLE
[master] Initialize platform specific identity sequences for remote entity manager - bugfix

### DIFF
--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2024 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -829,7 +829,10 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
                             writeDDL(deployProperties, getDatabaseSession(deployProperties), classLoaderToUse);
                         }
                     }
-                    // Initialize platform specific identity sequences.
+                    // Initialize platform specific identity sequences plus connect accessor to DB (in case of remote disconnected session).
+                    if (getDatabaseSession().isRemoteSession() && !getDatabaseSession().getAccessor().isConnected()) {
+                        getDatabaseSession().getAccessor().connect(getDatabaseSession().getLogin(), getDatabaseSession());
+                    }
                     session.getDatasourcePlatform().initIdentitySequences(getDatabaseSession(), MetadataProject.DEFAULT_IDENTITY_GENERATOR);
                     updateTunerPostDeploy(deployProperties, classLoaderToUse);
                     this.deployLock.release();


### PR DESCRIPTION
Fix for a bug which happens with Oracle platform and remote EntityManager only. Discovered by `org.eclipse.persistence.testing.tests.jpa.remote.RemoteEntityManagerTest`.
DB Accessor behind `org.eclipse.persistence.sessions.remote.RemoteSession` is not connected before `<platform>..initIdentitySequences(...)` call.
This issue happens on Oracle platform only because other platforms have `initIdentitySequences(...)` empty.