### PR TITLE
[master] Jakarta Persistence 3.2: fix for JPQL with generated this alias in @NamedQuery

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/jpa/jpql/HermesParser.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/jpa/jpql/HermesParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2024 Contributors to the Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -276,19 +276,7 @@ public final class HermesParser implements JPAQueryBuilder {
                                            AbstractSession session) {
 
         try {
-            String version = Version.getVersion();
-            String majorMinorVersion = version.substring(0, version.indexOf(".", version.indexOf(".") + 1));
-            EclipseLinkVersion elVersion = EclipseLinkVersion.value(majorMinorVersion);
-            boolean isJakartaDataVersion = elVersion.isNewerThanOrEqual(EclipseLinkVersion.VERSION_5_0) || isJakartaDataValidationLevel();
-            // Parse the JPQL query with the most recent JPQL grammar
-            JPQLExpression jpqlExpression = new JPQLExpression(
-                jpqlQuery,
-                DefaultEclipseLinkJPQLGrammar.instance(),
-                JPQLStatementBNF.ID,
-                isTolerant(),
-                isJakartaDataVersion
-            );
-
+            JPQLExpression jpqlExpression = buildJPQLExpression(jpqlQuery);
             // Create a context that caches the information contained in the JPQL query
             // (especially from the FROM clause)
             JPQLQueryContext queryContext = new JPQLQueryContext(jpqlGrammar());
@@ -466,5 +454,21 @@ public final class HermesParser implements JPAQueryBuilder {
             UpdateQueryVisitor visitor = new UpdateQueryVisitor(queryContext, query);
             expression.accept(visitor);
         }
+    }
+
+    JPQLExpression buildJPQLExpression(CharSequence jpqlQuery) {
+        String version = Version.getVersion();
+        String majorMinorVersion = version.substring(0, version.indexOf(".", version.indexOf(".") + 1));
+        EclipseLinkVersion elVersion = EclipseLinkVersion.value(majorMinorVersion);
+        boolean isJakartaDataVersion = elVersion.isNewerThanOrEqual(EclipseLinkVersion.VERSION_5_0) || isJakartaDataValidationLevel();
+        // Parse the JPQL query with the most recent JPQL grammar
+        JPQLExpression jpqlExpression = new JPQLExpression(
+                jpqlQuery,
+                DefaultEclipseLinkJPQLGrammar.instance(),
+                JPQLStatementBNF.ID,
+                isTolerant(),
+                isJakartaDataVersion
+        );
+        return jpqlExpression;
     }
 }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/jpa/jpql/JPQLQueryHelper.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/jpa/jpql/JPQLQueryHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,6 +14,7 @@
 //     Oracle - initial API and implementation
 package org.eclipse.persistence.internal.jpa.jpql;
 
+import org.eclipse.persistence.config.PersistenceUnitProperties;
 import org.eclipse.persistence.descriptors.ClassDescriptor;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
 import org.eclipse.persistence.jpa.jpql.Assert;
@@ -79,7 +80,9 @@ public class JPQLQueryHelper {
     public List<ClassDescriptor> getClassDescriptors(CharSequence jpqlQuery, AbstractSession session) {
 
         // Parse the JPQL query
-        JPQLExpression jpqlExpression = new JPQLExpression(jpqlQuery, jpqlGrammar, true);
+        HermesParser hermesParser = new HermesParser();
+        hermesParser.setValidationLevel((String)session.getProperty(PersistenceUnitProperties.JPQL_VALIDATION));
+        JPQLExpression jpqlExpression = hermesParser.buildJPQLExpression(jpqlQuery);
 
         // Create the context and cache the information
         JPQLQueryContext queryContext = new JPQLQueryContext(jpqlGrammar);

--- a/jpa/eclipselink.jpa.testapps/jpa.test.datatypes/src/main/java/org/eclipse/persistence/testing/models/jpa/datatypes/WrapperTypes.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.datatypes/src/main/java/org/eclipse/persistence/testing/models/jpa/datatypes/WrapperTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -18,6 +18,8 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
 import jakarta.persistence.Table;
 import jakarta.persistence.TableGenerator;
 
@@ -28,6 +30,9 @@ import static jakarta.persistence.GenerationType.TABLE;
 
 @Entity
 @Table(name = "CMP3_WRAPPER_TYPES")
+@NamedQueries({
+        @NamedQuery(name = "WrapperTypes.noAliasFindById", query = "FROM WrapperTypes WHERE id = :idParam")
+})
 public class WrapperTypes implements java.io.Serializable {
 
     private int id;

--- a/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpql/advanced/JUnitJPQLJakartaDataNoAliasTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpql/advanced/JUnitJPQLJakartaDataNoAliasTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2024 Contributors to the Eclipse Foundation. All rights reserved
  *
  * This program and the accompanying materials are made available under the
@@ -107,6 +107,7 @@ public class JUnitJPQLJakartaDataNoAliasTest extends JUnitTestCase {
         suite.addTest(new JUnitJPQLJakartaDataNoAliasTest("testNoAliasWhereWithBraces02"));
         suite.addTest(new JUnitJPQLJakartaDataNoAliasTest("testNoAliasWhereWithBraces03"));
         suite.addTest(new JUnitJPQLJakartaDataNoAliasTest("testGeneratedSelectNoAliasFromWhere"));
+        suite.addTest(new JUnitJPQLJakartaDataNoAliasTest("testGeneratedSelectNoAliasFromWhere_NamedQuery"));
         suite.addTest(new JUnitJPQLJakartaDataNoAliasTest("testGeneratedSelect"));
         suite.addTest(new JUnitJPQLJakartaDataNoAliasTest("testUpdateQueryLengthInAssignmentAndExpression"));
         suite.addTest(new JUnitJPQLJakartaDataNoAliasTest("testSelectQueryLengthInAssignmentAndExpression"));
@@ -322,6 +323,21 @@ public class JUnitJPQLJakartaDataNoAliasTest extends JUnitTestCase {
         WrapperTypes tlWrapperTypes = (WrapperTypes) getPersistenceUnitServerSession().executeQuery(tlQuery);
         Assert.assertTrue("GeneratedSelectNoAliasFromWhere Test Failed", comparer.compareObjects(wrapperTypes, tlWrapperTypes));
     }
+
+
+    public void testGeneratedSelectNoAliasFromWhere_NamedQuery() {
+        EntityManager em = createEntityManager();
+        Query wrapperTypesQuery = em.createNamedQuery("WrapperTypes.noAliasFindById");
+        wrapperTypesQuery.setParameter("idParam", wrapperId);
+        WrapperTypes wrapperTypes = (WrapperTypes) wrapperTypesQuery.getResultList().get(0);
+        clearCache();
+        ReadObjectQuery tlQuery = new ReadObjectQuery(WrapperTypes.class);
+        tlQuery.setSelectionCriteria(tlQuery.getExpressionBuilder().get("id").equal(wrapperId));
+
+        WrapperTypes tlWrapperTypes = (WrapperTypes) getPersistenceUnitServerSession().executeQuery(tlQuery);
+        Assert.assertTrue("GeneratedSelectNoAliasFromWhere Test Failed", comparer.compareObjects(wrapperTypes, tlWrapperTypes));
+    }
+
 
     public void testUpdateQueryLengthInAssignmentAndExpression() {
         resetRooms(false);


### PR DESCRIPTION
Fixes #2253 . Before this fix, different parser validation settings (more strict) were applied to JPQL queries stored in `@NamedQuery`, than JPQL queries created by `em.createQuery(...)`.