### PR TITLE
Issue #2339 - JPQL query for all entities in descending order returns no results on Oracle

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/expressions/Expression.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/expressions/Expression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, 2024 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -54,7 +54,6 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.io.StringWriter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
@@ -4802,7 +4801,7 @@ public abstract class Expression implements Serializable, Cloneable {
 
         //bug6070214: unique field aliases need to be generated when required.
         if (statement.getUseUniqueFieldAliases()){
-            printer.printString(" AS " + statement.generatedAlias(field.getNameDelimited(printer.getPlatform())));
+            printer.printString(" AS " + statement.generatedAlias(field));
         }
     }
 

--- a/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpql/advanced/AdvancedQueryTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpql/advanced/AdvancedQueryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2024 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -164,6 +164,8 @@ public class AdvancedQueryTest extends JUnitTestCase {
         suite.addTest(new AdvancedQueryTest("testVersionChangeWithWriteLock"));
         suite.addTest(new AdvancedQueryTest("testNamedQueryAnnotationOverwritePersistenceXML"));
         suite.addTest(new AdvancedQueryTest("testFloatSortWithPessimisticLock"));
+        suite.addTest(new AdvancedQueryTest("testFloatQualifiedIdProjectionWithPessimisticLock"));
+        suite.addTest(new AdvancedQueryTest("testFloatSimpleIdProjectionWithPessimisticLock"));
         suite.addTest(new AdvancedQueryTest("testTearDown"));
         return suite;
     }

--- a/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpql/advanced/AdvancedQueryTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpql/advanced/AdvancedQueryTest.java
@@ -2734,4 +2734,42 @@ public class AdvancedQueryTest extends JUnitTestCase {
         assertEquals(70077, entities.get(1).getId());
     }
 
+    // Based on reproduction scenario from issue #2339
+    public void testFloatQualifiedIdProjectionWithPessimisticLock() {
+        EntityManager em = createEntityManager();
+        beginTransaction(em);
+        List<Integer> results;
+        try {
+            results = em.createQuery("SELECT f.id FROM EntityFloat f ORDER BY f.width DESC", Integer.class)
+                    .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+                    .setMaxResults(1)
+                    .getResultList();
+            commitTransaction(em);
+        } catch (PersistenceException ex) {
+            rollbackTransaction(em);
+            throw ex;
+        }
+        assertEquals(1, results.size());
+        assertEquals(70077, results.get(0).intValue());
+    }
+
+    // Based on reproduction scenario from issue #2339
+    public void testFloatSimpleIdProjectionWithPessimisticLock() {
+        EntityManager em = createEntityManager();
+        beginTransaction(em);
+        List<Integer> results;
+        try {
+            results = em.createQuery("SELECT id FROM EntityFloat ORDER BY width DESC", Integer.class)
+                    .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+                    .setMaxResults(1)
+                    .getResultList();
+            commitTransaction(em);
+        } catch (PersistenceException ex) {
+            rollbackTransaction(em);
+            throw ex;
+        }
+        assertEquals(1, results.size());
+        assertEquals(70077, results.get(0).intValue());
+    }
+
 }


### PR DESCRIPTION
Fixed printSQLSelectStatement in Oracle Platform. It was not working properly when projection expression was present in the query (e.g. `SELECT e.id from Entity e` instead of `SELECT e from Entity e`).
Added simple test to verify test-case from the bug.