### PR TITLE
[master] DeadLock detection diagnostic - WriteLockManager.acquireLocksForClonemessage change

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ConcurrencyUtil.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ConcurrencyUtil.java
@@ -1146,6 +1146,7 @@ public class ConcurrencyUtil {
         allRelevantThreads.addAll(concurrencyManagerState.getUnifiedMapOfThreadsStuckTryingToAcquireWriteLock().keySet());
         allRelevantThreads.addAll(concurrencyManagerState.getDeferredLockManagerMapClone().keySet());
         allRelevantThreads.addAll(concurrencyManagerState.getReadLockManagerMapClone().keySet());
+        allRelevantThreads.addAll(concurrencyManagerState.getMapThreadToWaitOnAcquireReadLockClone().keySet());
 
         // (b) print information about all threads
         StringWriter writer = new StringWriter();

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/WriteLockManager.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/WriteLockManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2024 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -170,7 +170,7 @@ public class WriteLockManager {
                 // to indicate that the current thread is now stuck trying to acquire some arbitrary
                 // cache key for writing
                 lastCacheKeyWeNeededToWaitToAcquire = toWaitOn;
-                lastCacheKeyWeNeededToWaitToAcquire.putThreadAsWaitingToAcquireLockForWriting(currentThread, ACQUIRE_LOCK_FOR_CLONE_METHOD_NAME);
+                lastCacheKeyWeNeededToWaitToAcquire.putThreadAsWaitingToAcquireLockForReading(currentThread, ACQUIRE_LOCK_FOR_CLONE_METHOD_NAME);
 
                 // Since we know this one of those methods that can appear in the dead locks
                 // we threads frozen here forever inside of the wait that used to have no timeout
@@ -206,7 +206,7 @@ public class WriteLockManager {
             throw ConcurrencyException.maxTriesLockOnCloneExceded(objectForClone);
         } finally {
             if (lastCacheKeyWeNeededToWaitToAcquire != null) {
-                lastCacheKeyWeNeededToWaitToAcquire.removeThreadNoLongerWaitingToAcquireLockForWriting(currentThread);
+                lastCacheKeyWeNeededToWaitToAcquire.removeThreadNoLongerWaitingToAcquireLockForReading(currentThread);
             }
             if (!successful) {//did not acquire locks but we are exiting
                 for (Iterator lockedList = lockedObjects.values().iterator(); lockedList.hasNext();) {

--- a/jpa/eclipselink.jpa.testapps/jpa.test.diagnostic.deadlock/src/test/java/org/eclipse/persistence/testing/tests/jpa/deadlock/diagnostic/CacheDeadLockManagersTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.diagnostic.deadlock/src/test/java/org/eclipse/persistence/testing/tests/jpa/deadlock/diagnostic/CacheDeadLockManagersTest.java
@@ -36,12 +36,9 @@ import org.eclipse.persistence.testing.framework.junit.JUnitTestCaseHelper;
 import org.eclipse.persistence.testing.models.jpa.deadlock.diagnostic.CacheDeadLockDetectionDetail;
 import org.eclipse.persistence.testing.models.jpa.deadlock.diagnostic.CacheDeadLockDetectionMaster;
 import org.eclipse.persistence.testing.models.jpa.deadlock.diagnostic.DeadLockDiagnosticTableCreator;
-import org.junit.Assert;
 
 import java.util.Map;
 import java.util.concurrent.Semaphore;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 
 public class CacheDeadLockManagersTest extends JUnitTestCase {
 
@@ -120,6 +117,9 @@ public class CacheDeadLockManagersTest extends JUnitTestCase {
             Map map = writeLockManager.acquireLocksForClone(result, descriptor, cacheKey, serverSession);
         } catch (Exception e) {
             assertEquals(2, logWrapper.getMessageCount(WriteLockManager.class.getName() + ".acquireLocksForClone"));
+            //WriteLockManager.acquireLocksForClone acquire read lock, not write lock -> not any "...acquire writing.." message
+            assertEquals(0, logWrapper.getMessageCount("waitingOnAcquireWritingCacheKey: true  waiting to acquire writing: --- CacheKey  (org.eclipse.persistence.testing.models.jpa.deadlock.diagnostic.CacheDeadLockDetectionMaster):  (primaryKey: 1)"));
+            assertEquals(1, logWrapper.getMessageCount("Waiting to acquire (read lock): --- CacheKey  (org.eclipse.persistence.testing.models.jpa.deadlock.diagnostic.CacheDeadLockDetectionMaster):  (primaryKey: 1)"));
         } finally {
             if (em != null) {
                 if (em.isOpen()) {


### PR DESCRIPTION
Fixes #2173
There is incorrect log output in case if deadlock is detected and dump triggered in `WriteLockManager.acquireLocksForClonemessage()`. Mentioned method acquire read lock instead of write lock -> logged output was incorrect.
See log output before
```
...
Concurrency manager - Page 01 end - thread dump about all threads at time of event
Concurrency manager - Page 02 start - information about threads waiting to acquire (write/deferred) cache keys 
Total number of threads waiting to acquire lock: 1

[currentThreadNumber: 1] [ThreadName: main]: Waiting to acquire (write/deferred): --- CacheKey  (org.eclipse.persistence.testing.models.jpa.deadlock.diagnostic.CacheDeadLockDetectionMaster):  (primaryKey: 1) (object hash code: 1680621693) (cacheKeyClass: org.eclipse.persistence.internal.identitymaps.HardCacheWeakIdentityMap.ReferenceCacheKey) (cacheKey hash code: 452415295) (current cache key owner/activeThread: main) (getNumberOfReaders: 0)  (concurrencyManagerId: 89) (concurrencyManagerCreationDate: 2025-02-27 10:37:09.693)  (totalNumberOfTimeCacheKeyAcquiredForReading:  3)  (totalNumberOfTimeCacheKeyReleasedForReading:  3)  (totalNumberOfTimeCacheKeyReleasedForReadingBlewUpExceptionDueToCacheKeyHavingReachedCounterZero:  0)  (depth: 1) ---
[methodNameThatGotStuckWaitingToAcquire: org.eclipse.persistence.internal.helper.WriteLockManager.acquireLocksForClone(...)] 
Concurrency manager - Page 02 end - information about threads waiting to acquire (write/deferred) cache keys
Concurrency manager - Page 03 start - information about threads waiting to acquire read cache keys 
Total number of threads waiting to acquire read locks: 0 

Concurrency manager - Page 03 end - information about threads waiting to acquire read cache keys
Concurrency manager - Page 04 start - information about threads waiting on release deferred locks (waiting for other thread to finish building the objects deferred) 
Total number of threads waiting to acquire lock: 0 

Concurrency manager - Page 04 end - information about threads waiting on release deferred locks (waiting for other thread to finish building the objects deferred)
Concurrency manager - Page 05 start (currentThreadNumber: 1 of totalNumberOfThreads: 1)  - detailed information about specific thread 
Thread: main
ThreadWaitingToReleaseDeferredLocks: false
 waitingOnAcquireWritingCacheKey: true  waiting to acquire writing: --- CacheKey  (org.eclipse.persistence.testing.models.jpa.deadlock.diagnostic.CacheDeadLockDetectionMaster):  (primaryKey: 1) (object hash code: 1680621693) (cacheKeyClass: org.eclipse.persistence.internal.identitymaps.HardCacheWeakIdentityMap.ReferenceCacheKey) (cacheKey hash code: 452415295) (current cache key owner/activeThread: main) (getNumberOfReaders: 0)  (concurrencyManagerId: 89) (concurrencyManagerCreationDate: 2025-02-27 10:37:09.693)  (totalNumberOfTimeCacheKeyAcquiredForReading:  3)  (totalNumberOfTimeCacheKeyReleasedForReading:  3)  (totalNumberOfTimeCacheKeyReleasedForReadingBlewUpExceptionDueToCacheKeyHavingReachedCounterZero:  0)  (depth: 1) ---
 waitingOnAcquireReadCacheKey: false
 writeManagerThreadPrimaryKeysWithChangesToBeMerged: false
Summary of active locks owned by thread main Listing of all ACTIVE Locks.
Thread Name: main 
0 Active locks. The lockManager for this thread is null. 

Summary of deferred locks (could not be acquired and cause thread to wait for object building to complete) of thread main Listing of all DEFERRED Locks.
Thread Name: main 
0 deferred locks. The lockManager for this thread is null. 

 waitingToReleaseDeferredLocksJustification: information not available. 
Summary of read locks acquired by thread main Listing of all READ Locks. Step 001 - sparse summary loop over all read locks acquired:
Thread Name: main 
0 read locks. The lockManager for this thread is null. 

Concurrency manager - Page 05 end (currentThreadNumber: 1 of totalNumberOfThreads: 1)  - detailed information about specific thread
Concurrency manager - Page 06 start - information about cache keys and threads needing them 
Total number of cacheKeys to describe: 1 

-------------- [currentCacheKeyNumber: 1 of 1]--------------
[currentCacheKeyNumber: 1] [CacheKey: --- CacheKey  (org.eclipse.persistence.testing.models.jpa.deadlock.diagnostic.CacheDeadLockDetectionMaster):  (primaryKey: 1) (object hash code: 1680621693) (cacheKeyClass: org.eclipse.persistence.internal.identitymaps.HardCacheWeakIdentityMap.ReferenceCacheKey) (cacheKey hash code: 452415295) (current cache key owner/activeThread: main) (getNumberOfReaders: 0)  (concurrencyManagerId: 89) (concurrencyManagerCreationDate: 2025-02-27 10:37:09.693)  (totalNumberOfTimeCacheKeyAcquiredForReading:  3)  (totalNumberOfTimeCacheKeyReleasedForReading:  3)  (totalNumberOfTimeCacheKeyReleasedForReadingBlewUpExceptionDueToCacheKeyHavingReachedCounterZero:  0)  (depth: 1) --- ]:
[currentCacheKeyNumber: 1] threadsThatAcquiredActiveLock: []
[currentCacheKeyNumber: 1] threadsThatAcquiredDeferredLock: []
[currentCacheKeyNumber: 1] threadsThatAcquiredReadLock:  []
[currentCacheKeyNumber: 1] threadsKnownToBeStuckTryingToAcquireLock:  [main]
[currentCacheKeyNumber: 1] threadsKnownToBeStuckTryingToAcquireLockForReading:  []
[currentCacheKeyNumber: 1] threads doing object building with root on this cache key (not yet supported)...

Concurrency manager - Page 06 end - information about cache keys and threads needing them
Concurrency manager - Page 07 start - dead lock explanation
We were not able to determine to determine a set of threads that went into dead lock.deadlock algorithm took 1 ms to try to find deadlock.
Concurrency manager - Page 07 end - dead lock explanation
Concurrency manager - Page 08 start - Threads in MergeManager Acquiring Cache Keys for Clones to be merged into eclipselink server session cache of originals
 This section provides information about threads within the MergeManager that require cache keys for merging clones with changes.
 Specifically, it focuses on the threads working in the context of an ObjectChangeSet where the server session CacheKey is found to still have CacheKy.object null,
 and the CacheKey is acquired by a competing thread (typically an ObjectBuilder thread).
Total number of threads waiting to see lock being released: 0

Concurrency manager - Page 08 end - Threads in MergeManager Acquiring Cache Keys for Clones to be merged into eclipselink server session cache of originals
End full concurrency manager state (massive) dump No: 1
...
```
and after change
```
...
Concurrency manager - Page 01 end - thread dump about all threads at time of event
Concurrency manager - Page 02 start - information about threads waiting to acquire (write/deferred) cache keys 
Total number of threads waiting to acquire lock: 0

Concurrency manager - Page 02 end - information about threads waiting to acquire (write/deferred) cache keys
Concurrency manager - Page 03 start - information about threads waiting to acquire read cache keys 
Total number of threads waiting to acquire read locks: 1 

[currentThreadNumber: 1] [ThreadName: main ]: Waiting to acquire (read lock): --- CacheKey  (org.eclipse.persistence.testing.models.jpa.deadlock.diagnostic.CacheDeadLockDetectionMaster):  (primaryKey: 1) (object hash code: 1224595497) (cacheKeyClass: org.eclipse.persistence.internal.identitymaps.HardCacheWeakIdentityMap.ReferenceCacheKey) (cacheKey hash code: 1147061049) (current cache key owner/activeThread: main) (getNumberOfReaders: 0)  (concurrencyManagerId: 66) (concurrencyManagerCreationDate: 2025-02-27 11:28:07.714)  (totalNumberOfTimeCacheKeyAcquiredForReading:  3)  (totalNumberOfTimeCacheKeyReleasedForReading:  3)  (totalNumberOfTimeCacheKeyReleasedForReadingBlewUpExceptionDueToCacheKeyHavingReachedCounterZero:  0)  (depth: 1) ---
[methodNameThatGotStuckWaitingToAcquire: org.eclipse.persistence.internal.helper.WriteLockManager.acquireLocksForClone(...)]  
Concurrency manager - Page 03 end - information about threads waiting to acquire read cache keys
Concurrency manager - Page 04 start - information about threads waiting on release deferred locks (waiting for other thread to finish building the objects deferred) 
Total number of threads waiting to acquire lock: 0 

Concurrency manager - Page 04 end - information about threads waiting on release deferred locks (waiting for other thread to finish building the objects deferred)
Concurrency manager - Page 05 start (currentThreadNumber: 1 of totalNumberOfThreads: 1)  - detailed information about specific thread 
Thread: main
ThreadWaitingToReleaseDeferredLocks: false
 waitingOnAcquireWritingCacheKey: false
 waitingOnAcquireReadCacheKey: true   waiting to acquire reading: --- CacheKey  (org.eclipse.persistence.testing.models.jpa.deadlock.diagnostic.CacheDeadLockDetectionMaster):  (primaryKey: 1) (object hash code: 1224595497) (cacheKeyClass: org.eclipse.persistence.internal.identitymaps.HardCacheWeakIdentityMap.ReferenceCacheKey) (cacheKey hash code: 1147061049) (current cache key owner/activeThread: main) (getNumberOfReaders: 0)  (concurrencyManagerId: 66) (concurrencyManagerCreationDate: 2025-02-27 11:28:07.714)  (totalNumberOfTimeCacheKeyAcquiredForReading:  3)  (totalNumberOfTimeCacheKeyReleasedForReading:  3)  (totalNumberOfTimeCacheKeyReleasedForReadingBlewUpExceptionDueToCacheKeyHavingReachedCounterZero:  0)  (depth: 1) ---
 writeManagerThreadPrimaryKeysWithChangesToBeMerged: false
Summary of active locks owned by thread main Listing of all ACTIVE Locks.
Thread Name: main 
0 Active locks. The lockManager for this thread is null. 

Summary of deferred locks (could not be acquired and cause thread to wait for object building to complete) of thread main Listing of all DEFERRED Locks.
Thread Name: main 
0 deferred locks. The lockManager for this thread is null. 

 waitingToReleaseDeferredLocksJustification: information not available. 
Summary of read locks acquired by thread main Listing of all READ Locks. Step 001 - sparse summary loop over all read locks acquired:
Thread Name: main 
0 read locks. The lockManager for this thread is null. 

Concurrency manager - Page 05 end (currentThreadNumber: 1 of totalNumberOfThreads: 1)  - detailed information about specific thread
Concurrency manager - Page 06 start - information about cache keys and threads needing them 
Total number of cacheKeys to describe: 1 

-------------- [currentCacheKeyNumber: 1 of 1]--------------
[currentCacheKeyNumber: 1] [CacheKey: --- CacheKey  (org.eclipse.persistence.testing.models.jpa.deadlock.diagnostic.CacheDeadLockDetectionMaster):  (primaryKey: 1) (object hash code: 1224595497) (cacheKeyClass: org.eclipse.persistence.internal.identitymaps.HardCacheWeakIdentityMap.ReferenceCacheKey) (cacheKey hash code: 1147061049) (current cache key owner/activeThread: main) (getNumberOfReaders: 0)  (concurrencyManagerId: 66) (concurrencyManagerCreationDate: 2025-02-27 11:28:07.714)  (totalNumberOfTimeCacheKeyAcquiredForReading:  3)  (totalNumberOfTimeCacheKeyReleasedForReading:  3)  (totalNumberOfTimeCacheKeyReleasedForReadingBlewUpExceptionDueToCacheKeyHavingReachedCounterZero:  0)  (depth: 1) --- ]:
[currentCacheKeyNumber: 1] threadsThatAcquiredActiveLock: []
[currentCacheKeyNumber: 1] threadsThatAcquiredDeferredLock: []
[currentCacheKeyNumber: 1] threadsThatAcquiredReadLock:  []
[currentCacheKeyNumber: 1] threadsKnownToBeStuckTryingToAcquireLock:  []
[currentCacheKeyNumber: 1] threadsKnownToBeStuckTryingToAcquireLockForReading:  [main]
[currentCacheKeyNumber: 1] threads doing object building with root on this cache key (not yet supported)...

Concurrency manager - Page 06 end - information about cache keys and threads needing them
Concurrency manager - Page 07 start - dead lock explanation
We were not able to determine to determine a set of threads that went into dead lock.deadlock algorithm took 1 ms to try to find deadlock.
Concurrency manager - Page 07 end - dead lock explanation
Concurrency manager - Page 08 start - Threads in MergeManager Acquiring Cache Keys for Clones to be merged into eclipselink server session cache of originals
 This section provides information about threads within the MergeManager that require cache keys for merging clones with changes.
 Specifically, it focuses on the threads working in the context of an ObjectChangeSet where the server session CacheKey is found to still have CacheKy.object null,
 and the CacheKey is acquired by a competing thread (typically an ObjectBuilder thread).
Total number of threads waiting to see lock being released: 0

Concurrency manager - Page 08 end - Threads in MergeManager Acquiring Cache Keys for Clones to be merged into eclipselink server session cache of originals
End full concurrency manager state (massive) dump No: 1
...

```

This change is also covered by `org.eclipse.persistence.testing.tests.jpa.deadlock.diagnostic.CacheDeadLockManagersTest#testWriteLockManagerAcquireLocksForClone` test.