### PR TITLE
[3.0] MOXy Test Fix in JDK 21

### DIFF
--- a/moxy/org.eclipse.persistence.moxy/pom.xml
+++ b/moxy/org.eclipse.persistence.moxy/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -228,6 +228,7 @@
                             <reportNameSuffix>test-moxy-jaxb</reportNameSuffix>
                             <forkCount>1</forkCount>
                             <reuseForks>false</reuseForks>
+                            <argLine>--add-opens java.base/java.math=ALL-UNNAMED</argLine>
                             <includes>
                                 <include>org.eclipse.persistence.testing.jaxb.JAXBTestSuite</include>
                                 <include>org.eclipse.persistence.testing.jaxb.JAXBTestSuite2</include>


### PR DESCRIPTION
This is fix for
`Unable to make field final int java.math.RoundingMode.oldMode accessible: module java.base does not "opens java.math" to unnamed module`
 issue which happens in non JPMS enabled 3.0 version in MOXy tests.