### PR TITLE
[3.0] Random JPA WDF test failures - TestFlush entity collisions

### DIFF
--- a/jpa/eclipselink.jpa.wdf.test/src/it/java/org/eclipse/persistence/testing/tests/wdf/jpa1/entitymanager/TestFlush.java
+++ b/jpa/eclipselink.jpa.wdf.test/src/it/java/org/eclipse/persistence/testing/tests/wdf/jpa1/entitymanager/TestFlush.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2005, 2015 SAP. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -49,9 +49,9 @@ public class TestFlush extends JPA1Base {
         EntityManager em = env.getEntityManager();
         try {
             // case 1: direct relationship Employee -> Cubicle (new) - 1:1
-            Department dep = new Department(1, "dep");
-            Employee emp1 = new Employee(2, "first", "last", dep);
-            Cubicle cub1 = new Cubicle(Integer.valueOf(3), Integer.valueOf(3), "color", emp1);
+            Department dep = new Department(501, "dep");
+            Employee emp1 = new Employee(502, "first", "last", dep);
+            Cubicle cub1 = new Cubicle(Integer.valueOf(503), Integer.valueOf(503), "color", emp1);
             emp1.setCubicle(cub1);
             env.beginTransaction(em);
             em.persist(dep);
@@ -79,8 +79,8 @@ public class TestFlush extends JPA1Base {
             verify(!env.isTransactionActive(em), "Transaction still active");
             verify(flushFailed, "flush succeeded although there is a relation to an unmanaged entity");
             // case 2: direct relationship Employee -> Project (new) - n:m
-            dep = new Department(4, "dep");
-            emp1 = new Employee(5, "first", "last", dep);
+            dep = new Department(504, "dep");
+            emp1 = new Employee(505, "first", "last", dep);
             Project proj = new Project("project");
             Set<Project> emp1Projects = new HashSet<Project>();
             emp1Projects.add(proj);
@@ -114,9 +114,9 @@ public class TestFlush extends JPA1Base {
             verify(!env.isTransactionActive(em), "Transaction still active");
             verify(flushFailed, "flush succeeded although there is a relation to an unmanaged entity");
             // case 3: indirect relationship Employee -> Project -> Employee (new)
-            dep = new Department(7, "dep");
-            emp1 = new Employee(8, "first1", "last1", dep);
-            Employee emp2 = new Employee(9, "first2", "last2", dep);
+            dep = new Department(507, "dep");
+            emp1 = new Employee(508, "first1", "last1", dep);
+            Employee emp2 = new Employee(509, "first2", "last2", dep);
             proj = new Project("project");
             emp1Projects = new HashSet<Project>();
             emp1Projects.add(proj);

--- a/jpa/eclipselink.jpa.wdf.test/src/it/java/org/eclipse/persistence/testing/tests/wdf/jpa1/entitymanager/TestGetReference.java
+++ b/jpa/eclipselink.jpa.wdf.test/src/it/java/org/eclipse/persistence/testing/tests/wdf/jpa1/entitymanager/TestGetReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2005, 2015 SAP. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -181,7 +181,7 @@ public class TestGetReference extends JPA1Base {
             boolean operationFailed = false;
             env.beginTransaction(em);
             try {
-                employee = em.getReference(Employee.class, 741);
+                employee = em.getReference(Employee.class, 741); //does not exist
             } catch (EntityNotFoundException e) {
                 // $JL-EXC$ expected behavior
                 operationFailed = true;
@@ -370,7 +370,7 @@ public class TestGetReference extends JPA1Base {
             boolean operationFailed = false;
             env.beginTransaction(em);
             try {
-                emp = em.getReference(Employee.class, Integer.valueOf(99));
+                emp = em.getReference(Employee.class, Integer.valueOf(9911));
             } catch (EntityNotFoundException e) {
                 // $JL-EXC$ expected behavior
                 operationFailed = true;
@@ -448,7 +448,7 @@ public class TestGetReference extends JPA1Base {
         try {
             env.beginTransaction(em);
             try {
-                Employee emp = em.getReference(Employee.class, Integer.valueOf(99)); // versioning, entity does not exist
+                Employee emp = em.getReference(Employee.class, Integer.valueOf(9922)); // versioning, entity does not exist
                 em.remove(emp);
                 em.flush();
                 flop("PersistenceException not thrown as expected");
@@ -459,7 +459,7 @@ public class TestGetReference extends JPA1Base {
 
             env.beginTransaction(em);
             try {
-                Department dep = em.getReference(Department.class, Integer.valueOf(99)); // versioning, entity does not exist
+                Department dep = em.getReference(Department.class, Integer.valueOf(9933)); // versioning, entity does not exist
                 em.remove(dep);
                 em.flush();
                 flop("PersistenceException not thrown as expected");


### PR DESCRIPTION
This is fix for JPA WDF test . There were in some test environments random test failures as there were used same entities with same id across multiple tests. Mainly negative tests for expected PersistenceExceptions.