### PR TITLE
[3.0] Initialize platform specific identity sequences for remote entity manager - bugfix (backport from master #2357)

### DIFF
--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
@@ -813,7 +813,10 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
                             writeDDL(deployProperties, getDatabaseSession(deployProperties), classLoaderToUse);
                         }
                     }
-                    // Initialize platform specific identity sequences.
+                    // Initialize platform specific identity sequences plus connect accessor to DB (in case of remote disconnected session).
+                    if (getDatabaseSession().isRemoteSession() && !getDatabaseSession().getAccessor().isConnected()) {
+                        getDatabaseSession().getAccessor().connect(getDatabaseSession().getLogin(), getDatabaseSession());
+                    }
                     session.getDatasourcePlatform().initIdentitySequences(getDatabaseSession(), MetadataProject.DEFAULT_IDENTITY_GENERATOR);
                     updateTunerPostDeploy(deployProperties, classLoaderToUse);
                     this.deployLock.release();


### PR DESCRIPTION
Fix for a bug which happens with Oracle platform and remote EntityManager only. Discovered by `org.eclipse.persistence.testing.tests.jpa.remote.RemoteEntityManagerTest`.
DB Accessor behind `org.eclipse.persistence.sessions.remote.RemoteSession` is not connected before `<platform>..initIdentitySequences(...)` call.
This issue happens on Oracle platform only because other platforms have `initIdentitySequences(...)` empty.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>
(cherry picked from commit 3f10ccf81fddf32cc7d0718524cfa901ebb9db2b)