### PR TITLE
Optimistic lock exception with empty parameters value

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/HANAPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/HANAPlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, 2024 IBM Corporation. All rights reserved.
  * Copyright (c) 2012, 2024 SAP. All rights reserved.
  *
@@ -443,6 +443,7 @@ public final class HANAPlatform extends DatabasePlatform {
     @Override
     public int executeBatch(Statement statement, boolean isStatementPrepared) throws SQLException {
         int[] updateResult = statement.executeBatch();
+        setExecuteBatchRowCounts(updateResult);
         if (isStatementPrepared) {
             int updateCount = 0;
             for (int count : updateResult) {

--- a/foundation/org.eclipse.persistence.oracle/src/main/java/org/eclipse/persistence/platform/database/oracle/Oracle10Platform.java
+++ b/foundation/org.eclipse.persistence.oracle/src/main/java/org/eclipse/persistence/platform/database/oracle/Oracle10Platform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -73,6 +73,7 @@ public class Oracle10Platform extends Oracle9Platform  {
             int rowCount = 0;
             try {
                 rowCount = ((OraclePreparedStatement)statement).sendBatch();
+                setExecuteBatchRowCounts(new int[]{rowCount});
             } finally {
                 ((OraclePreparedStatement) statement).setExecuteBatch(1);
             }
@@ -80,6 +81,7 @@ public class Oracle10Platform extends Oracle9Platform  {
         } else {
             @SuppressWarnings("unused")
             int[] results = statement.executeBatch();
+            setExecuteBatchRowCounts(results);
             return statement.getUpdateCount();
         }
     }

--- a/foundation/org.eclipse.persistence.oracle/src/main/java/org/eclipse/persistence/platform/database/oracle/Oracle9Platform.java
+++ b/foundation/org.eclipse.persistence.oracle/src/main/java/org/eclipse/persistence/platform/database/oracle/Oracle9Platform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -860,6 +860,7 @@ public class Oracle9Platform extends Oracle8Platform {
             int rowCount = 0;
             try {
                 rowCount = ((OraclePreparedStatement)statement).sendBatch();
+                setExecuteBatchRowCounts(new int[]{rowCount});
             } finally {
                 ((OraclePreparedStatement) statement).setExecuteBatch(1);
             }

--- a/jpa/eclipselink.jpa.wdf.test/src/it/java/org/eclipse/persistence/testing/tests/wdf/jpa1/lock/TestOptimistic.java
+++ b/jpa/eclipselink.jpa.wdf.test/src/it/java/org/eclipse/persistence/testing/tests/wdf/jpa1/lock/TestOptimistic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2005, 2015 SAP. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -93,6 +93,12 @@ public class TestOptimistic extends JPA1Base {
         Object failingEntity = ole.getEntity();
         if (failingEntity != null) {
             verify(entity.equals(failingEntity), "wrong entity");
+        }
+    }
+
+    private static void assertEmptyParametersValue(OptimisticLockException ole) {
+        if (ole.getMessage().contains("parameter list")) {
+            verify(!(ole.getMessage().contains("[] parameter list")), "empty parameters value");
         }
     }
 
@@ -604,6 +610,7 @@ public class TestOptimistic extends JPA1Base {
                     }
                 } catch (OptimisticLockException ole) {
                     assertFailingEntity(i13, ole);
+                    assertEmptyParametersValue(ole);
                 } catch (PersistenceException pe) {
                     if (!tester.throwsRollbackException) {
                         assertExceptionWrapsOLE(i13, pe);


### PR DESCRIPTION
When the database platform is set as "org.eclipse.persistence.platform.database.oracle.Oracle19Platform" then we get OptismisticLockException without parameters value

This is because org.eclipse.persistence.platform.database.oracle.Oracle10Platform has its own executeBatch method where it was missed to call setExecuteBatchRowCounts which sets this parameters value

So in the fix we have tried to call setExecuteBatchRowCounts where such executeBatch method exist for different database platform

I have added new assertions for this at jpa/eclipselink.jpa.wdf.test/src/it/java/org/eclipse/persistence/testing/tests/wdf/jpa1/lock/TestOptimistic#verifyBatchOLE
