### PR TITLE
[master] SELECT ID(entityvar) only returns part of IdClass - bug fix and unit tests

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/jpa/jpql/ReportItemBuilder.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/jpa/jpql/ReportItemBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -41,6 +41,7 @@ import org.eclipse.persistence.jpa.jpql.parser.EclipseLinkAnonymousExpressionVis
 import org.eclipse.persistence.jpa.jpql.parser.EntryExpression;
 import org.eclipse.persistence.jpa.jpql.parser.ExtractExpression;
 import org.eclipse.persistence.jpa.jpql.parser.FunctionExpression;
+import org.eclipse.persistence.jpa.jpql.parser.IdExpression;
 import org.eclipse.persistence.jpa.jpql.parser.IdentificationVariable;
 import org.eclipse.persistence.jpa.jpql.parser.IndexExpression;
 import org.eclipse.persistence.jpa.jpql.parser.Join;
@@ -623,6 +624,15 @@ final class ReportItemBuilder extends JPQLFunctionsAbstractBuilder {
         IdentificationVariable identificationVariable = (IdentificationVariable) expression.getExpression();
         Expression queryExpression = queryContext.buildExpression(expression, type);
         addAttribute(identificationVariable.getText(), queryExpression);
+    }
+
+    @Override
+    public void visit(IdExpression expression) {
+        super.visit(expression);
+        if (expression.getStateFieldPathExpressions().size() > 1) {
+            //if multiple @Id attributes exists
+            multipleSelects = true;
+        }
     }
 
     private void visitAbstractSelectClause(AbstractSelectClause expression) {

--- a/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpql/advanced/JUnitJPQLFunctionsTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpql/advanced/JUnitJPQLFunctionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,14 +16,17 @@ package org.eclipse.persistence.testing.tests.jpa.jpql.advanced;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
+
 import junit.framework.Test;
 import junit.framework.TestSuite;
+
 import org.eclipse.persistence.internal.sessions.AbstractSession;
 import org.eclipse.persistence.sessions.DatabaseSession;
 import org.eclipse.persistence.testing.framework.jpa.junit.JUnitTestCase;
 import org.eclipse.persistence.testing.models.jpa.advanced.AdvancedTableCreator;
 import org.eclipse.persistence.testing.models.jpa.advanced.Employee;
 import org.eclipse.persistence.testing.models.jpa.advanced.EmployeePopulator;
+import org.eclipse.persistence.testing.models.jpa.advanced.PhoneNumber;
 import org.eclipse.persistence.testing.models.jpa.advanced.Vegetable;
 import org.eclipse.persistence.testing.models.jpa.advanced.VegetablePK;
 import org.eclipse.persistence.testing.tests.jpa.jpql.JUnitDomainObjectComparer;
@@ -86,6 +89,8 @@ public class JUnitJPQLFunctionsTest extends JUnitTestCase {
         suite.addTest(new JUnitJPQLFunctionsTest("queryID04Test"));
         suite.addTest(new JUnitJPQLFunctionsTest("queryID05CompositePKTest"));
         suite.addTest(new JUnitJPQLFunctionsTest("queryID06CompositePKTest"));
+        suite.addTest(new JUnitJPQLFunctionsTest("queryID07CompositePKTestWithIdClass"));
+        suite.addTest(new JUnitJPQLFunctionsTest("queryID08CompositePKTestWithIdClass"));
         suite.addTest(new JUnitJPQLFunctionsTest("queryVERSION1Test"));
         suite.addTest(new JUnitJPQLFunctionsTest("queryVERSION2Test"));
         suite.addTest(new JUnitJPQLFunctionsTest("queryVERSION3Test"));
@@ -202,6 +207,34 @@ public class JUnitJPQLFunctionsTest extends JUnitTestCase {
         assertEquals(VEGETABLE_ID, result[0]);
         assertEquals(VEGETABLE_COST, result[1]);
         assertEquals(VEGETABLE_ID, result[2]);
+    }
+
+    public void queryID07CompositePKTestWithIdClass(){
+        final PhoneNumber PHONE_EXPECTED = employeePopulator.employeeExample1().getPhoneNumbers().stream().findFirst().get();
+
+        EntityManager em = createEntityManager();
+        Query query = em.createQuery("SELECT ID(p) FROM PhoneNumber p WHERE p.id = :idParam AND p.type = :typeParam");
+        query.setParameter("idParam", PHONE_EXPECTED.getOwner().getId());
+        query.setParameter("typeParam", PHONE_EXPECTED.getType());
+        Object[] result  = (Object[])query.getSingleResult();
+        assertNotNull(result);
+        //result array order is important too
+        assertEquals(PHONE_EXPECTED.getOwner().getId(), result[0]);
+        assertEquals(PHONE_EXPECTED.getType(), result[1]);
+    }
+
+    public void queryID08CompositePKTestWithIdClass(){
+        final PhoneNumber PHONE_EXPECTED = employeePopulator.employeeExample1().getPhoneNumbers().stream().findFirst().get();
+
+        EntityManager em = createEntityManager();
+        Query query = em.createQuery("SELECT ID(this) FROM PhoneNumber WHERE this.id = :idParam AND this.type = :typeParam");
+        query.setParameter("idParam", PHONE_EXPECTED.getOwner().getId());
+        query.setParameter("typeParam", PHONE_EXPECTED.getType());
+        Object[] result  = (Object[])query.getSingleResult();
+        assertNotNull(result);
+        //result array order is important too
+        assertEquals(PHONE_EXPECTED.getOwner().getId(), result[0]);
+        assertEquals(PHONE_EXPECTED.getType(), result[1]);
     }
 
     public void queryVERSION1Test(){

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/IdExpression.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/IdExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,6 +15,10 @@
 //
 package org.eclipse.persistence.jpa.jpql.parser;
 
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 /**
  * The result of an ID function expression is the Entity primary
  * key. Argument must be an identification variable.
@@ -29,7 +33,7 @@ public final class IdExpression extends EncapsulatedIdentificationVariableExpres
     /**
      * The field path created as a result of transformation
      */
-    private StateFieldPathExpression stateFieldPathExpression;
+    private final Map<String, StateFieldPathExpression> stateFieldPathExpressions = new LinkedHashMap<>();
 
     /**
      * Creates a new <code>IdExpression</code>.
@@ -52,18 +56,19 @@ public final class IdExpression extends EncapsulatedIdentificationVariableExpres
     }
 
     /**
-     * Returns field path created as a result of transformation.
+     * Returns field paths created as a result of transformation.
      *
-     * @return The path expression that is qualified by the identification variable
+     * @return The path expressions that is qualified by the identification variable.
+     * There should more items, than one as multiple entity fields should be marked with ${@code @Id} and ${@code @IdClass} is used.
      */
-    public StateFieldPathExpression getStateFieldPathExpression() {
-        return stateFieldPathExpression;
+    public Collection<StateFieldPathExpression> getStateFieldPathExpressions() {
+        return stateFieldPathExpressions.values();
     }
 
     /**
-     * Sets field path created as a result of transformation.
+     * Add field path created as a result of transformation.
      */
-    public void setStateFieldPathExpression(StateFieldPathExpression stateFieldPathExpression) {
-        this.stateFieldPathExpression = stateFieldPathExpression;
+    public void addStateFieldPathExpression(StateFieldPathExpression stateFieldPathExpression) {
+        this.stateFieldPathExpressions.put(stateFieldPathExpression.getText(), stateFieldPathExpression);
     }
 }


### PR DESCRIPTION
Partially fixes #2211 . At this moment `query.getSingleResult()` return array of `Object` which content and order is same are `@Id` entity attributes. Mapping to declared `@IdClass` doesn't work yet.