### PR TITLE
[4.0] Postgres function calls with named parameters - bugfix (backport from master)

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, 2024 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -1443,7 +1443,6 @@ public class DatabasePlatform extends DatasourcePlatform {
      *
      * @see PostgreSQLPlatform
      */
-    @Deprecated(forRemoval = true)
     public boolean isJDBCExecuteCompliant() {
         return true;
     }


### PR DESCRIPTION
PostgreSQL JDBC driver doesn't accept parameters passed by names (only index way). This fix allows use it with persistence property `<property name="eclipselink.jpa.naming_into_indexed" value="true"/>` which allows EclipseLink translate naming parameters into indexed (order is important).
There is also added flag `isJDBCExecuteCompliant()` removed by some previous commit to declare if platform related JDBC driver implements complete JDBC functionality.
Fixes #2369