### PR TITLE
[master] SELECT ID(entityvar) only returns part of IdClass - bug fix and unit tests part 2.0

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/descriptors/ObjectBuilder.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/descriptors/ObjectBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2024 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -786,7 +786,14 @@ public class ObjectBuilder extends CoreObjectBuilder<AbstractRecord, AbstractSes
             TypeValue typeValue = typeValueMap.get(mapping.getAttributeName());
             typeValue.value = value;
         }
-        RecordInstantiationPolicy recordInstantiationPolicy = ((RecordInstantiationPolicy)this.descriptor.getInstantiationPolicy());
+        RecordInstantiationPolicy recordInstantiationPolicy = null;
+        if (this.descriptor.getJavaClass().isRecord()) {
+            //Usually for java.lang.Records used with @Embeddable (@EmbeddedId, @Embedded attribute) with their own descriptor
+            recordInstantiationPolicy = ((RecordInstantiationPolicy) this.descriptor.getInstantiationPolicy());
+        } else {
+            //Handle case if descriptor is for entity with IdClass (record). IdClasses doesn't have descriptor.
+            recordInstantiationPolicy = new RecordInstantiationPolicy<>(clazz);
+        }
         instanceLock.lock();
         try {
             List values = new ArrayList<>();

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/jpa/jpql/ReportItemBuilder.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/jpa/jpql/ReportItemBuilder.java
@@ -42,6 +42,7 @@ import org.eclipse.persistence.jpa.jpql.parser.EntryExpression;
 import org.eclipse.persistence.jpa.jpql.parser.ExtractExpression;
 import org.eclipse.persistence.jpa.jpql.parser.FunctionExpression;
 import org.eclipse.persistence.jpa.jpql.parser.IdExpression;
+import org.eclipse.persistence.jpa.jpql.parser.IdExpressionBNF;
 import org.eclipse.persistence.jpa.jpql.parser.IdentificationVariable;
 import org.eclipse.persistence.jpa.jpql.parser.IndexExpression;
 import org.eclipse.persistence.jpa.jpql.parser.Join;
@@ -645,6 +646,10 @@ final class ReportItemBuilder extends JPQLFunctionsAbstractBuilder {
         }
         else {
             query.returnSingleAttribute();
+        }
+        //Set flag if JPQL query has only ID(...) function as SELECT clause. Like query like SELECT ID(e) FROM Entity e...
+        if (IdExpressionBNF.ID.equals(expression.getSelectExpression().getQueryBNF().getId())) {
+            query.setHasIDFunctionSelectItemOnly(true);
         }
     }
 

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced/src/main/java/org/eclipse/persistence/testing/models/jpa/advanced/AdvancedTableCreator.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced/src/main/java/org/eclipse/persistence/testing/models/jpa/advanced/AdvancedTableCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2024 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -72,6 +72,7 @@ public class AdvancedTableCreator extends TogglingFastTableCreator {
         addTableDefinition(buildRESPONSTable());
         addTableDefinition(buildSALARYTable());
         addTableDefinition(buildVEGETABLETable());
+        addTableDefinition(buildVEGETABLE_RECORDTable());
         addTableDefinition(buildWOMANTable());
         addTableDefinition(buildWORKWEEKTable());
         addTableDefinition(buildWORLDRANKTable());
@@ -1950,6 +1951,45 @@ public class AdvancedTableCreator extends TogglingFastTableCreator {
     public TableDefinition buildVEGETABLETable() {
         TableDefinition table = new TableDefinition();
         table.setName("CMP3_VEGETABLE");
+
+        FieldDefinition fieldNAME = new FieldDefinition();
+        fieldNAME.setName("VEGETABLE_NAME");
+        fieldNAME.setTypeName("VARCHAR");
+        fieldNAME.setSize(30);
+        fieldNAME.setIsPrimaryKey(true);
+        table.addField(fieldNAME);
+
+        FieldDefinition fieldCOLOR = new FieldDefinition();
+        fieldCOLOR.setName("VEGETABLE_COLOR");
+        fieldCOLOR.setTypeName("VARCHAR");
+        fieldCOLOR.setSize(30);
+        fieldCOLOR.setIsPrimaryKey(true);
+        table.addField(fieldCOLOR);
+
+        FieldDefinition fieldCOST = new FieldDefinition();
+        fieldCOST.setName("COST");
+        fieldCOST.setTypeName("DOUBLE PRECIS");
+        fieldCOST.setSize(18);
+        table.addField(fieldCOST);
+
+        FieldDefinition fieldTAGS = new FieldDefinition();
+        fieldTAGS.setName("TAGS");
+        fieldTAGS.setTypeName("BLOB");
+        table.addField(fieldTAGS);
+
+        FieldDefinition fieldTYPE = new FieldDefinition();
+        fieldTYPE.setName("TYPE");
+        fieldTYPE.setTypeName("CHAR");
+        fieldTYPE.setSize(1);
+        fieldTYPE.setShouldAllowNull(true);
+        table.addField(fieldTYPE);
+
+        return table;
+    }
+
+    public TableDefinition buildVEGETABLE_RECORDTable() {
+        TableDefinition table = new TableDefinition();
+        table.setName("CMP3_VEGETABLE_RECORD");
 
         FieldDefinition fieldNAME = new FieldDefinition();
         fieldNAME.setName("VEGETABLE_NAME");

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced/src/main/java/org/eclipse/persistence/testing/models/jpa/advanced/VegetablePKRecord.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced/src/main/java/org/eclipse/persistence/testing/models/jpa/advanced/VegetablePKRecord.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation from Oracle TopLink
+package org.eclipse.persistence.testing.models.jpa.advanced;
+
+import java.io.Serializable;
+
+public record VegetablePKRecord(String name, String color) implements Serializable {}

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced/src/main/java/org/eclipse/persistence/testing/models/jpa/advanced/VegetableRecord.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced/src/main/java/org/eclipse/persistence/testing/models/jpa/advanced/VegetableRecord.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation from Oracle TopLink
+package org.eclipse.persistence.testing.models.jpa.advanced;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.Table;
+
+import java.io.Serializable;
+
+@Entity
+@Table(name="CMP3_VEGETABLE_RECORD")
+@IdClass(VegetablePKRecord.class)
+public class VegetableRecord implements Serializable {
+    private String name;
+    private String color;
+    private double cost;
+    private String[] tags;
+    private char type = '0';
+
+    public VegetableRecord() {}
+
+    @Id
+    @Column(name="VEGETABLE_NAME")
+    public String getName() {
+        return name;
+    }
+
+    @Id
+    @Column(name="VEGETABLE_COLOR")
+    public String getColor() {
+        return color;
+    }
+
+    public double getCost() {
+        return cost;
+    }
+
+    @Column(columnDefinition="char(1)")
+    public char getType() {
+        return type;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setColor(String color) {
+        this.color = color;
+    }
+
+    public void setType(char aType) {
+        this.type = aType;
+    }
+
+    public void setCost(double cost) {
+        this.cost = cost;
+    }
+
+    public String[] getTags() {
+        return this.tags;
+    }
+
+    public void setTags(String[] tags) {
+        this.tags = tags;
+    }
+}

--- a/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/main/resources/META-INF/persistence.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/main/resources/META-INF/persistence.xml
@@ -42,6 +42,7 @@
         <class>org.eclipse.persistence.testing.models.jpa.advanced.SmallProject</class>
         <class>org.eclipse.persistence.testing.models.jpa.advanced.SimpleRoom</class>
         <class>org.eclipse.persistence.testing.models.jpa.advanced.Vegetable</class>
+        <class>org.eclipse.persistence.testing.models.jpa.advanced.VegetableRecord</class>
         <class>org.eclipse.persistence.testing.models.jpa.advanced.Woman</class>
         <class>org.eclipse.persistence.testing.models.jpa.advanced.WorldRank</class>
         <class>org.eclipse.persistence.testing.models.jpa.advanced.entities.EntyA</class>

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2024 IBM Corporation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -1866,7 +1866,19 @@ public class EntityManagerImpl implements org.eclipse.persistence.jpa.JpaEntityM
      */
     @Override
     public <T> TypedQuery<T> createQuery(String qlString, Class<T> resultClass){
-        return (TypedQuery<T>) this.createQuery(qlString);
+        try {
+            verifyOpen();
+            EJBQueryImpl ejbqImpl;
+            try {
+                ejbqImpl = new EJBQueryImpl(qlString, this, resultClass);
+            } catch (JPQLException exception) {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("wrap_ejbql_exception") + ": " + exception.getLocalizedMessage(), exception);
+            }
+            return (TypedQuery<T>)ejbqImpl;
+        } catch (RuntimeException e) {
+            setRollbackOnly();
+            throw e;
+        }
     }
 
     /**


### PR DESCRIPTION
Remaining part of the fix for #2211 .
Fix for a case like
```
@Entity
@IdClass(VegetablePKRecord.class)
public class VegetableRecord implements Serializable {
```
There `VegetablePK.class` should be POJO or Java record and JPQL type query like:
`TypedQuery<VegetablePKRecord> query = em.createQuery("SELECT ID(this) FROM VegetableRecord WHERE this.name = :nameParam AND this.color = :colorParam", VegetablePKRecord.class);`
which result is instance of class mentioned in `@IdClass(VegetablePKRecord.class)` and as a second parameter of `.createQuery(......)`
Fixes #2211