### PR TITLE
[3.0] JPA Server side test fixes - part2 plus WebLogic Maven profile

### DIFF
--- a/etc/el-testjee.weblogic.properties
+++ b/etc/el-testjee.weblogic.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2025 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at
@@ -18,17 +18,17 @@ server.http.port=7001
 server.rmi.port=7001
 server.rmi.protocol=t3
 server.usr=weblogic
-server.pwd=weblogic1
+server.pwd=welcome1
 server.initialCtxFactory=weblogic.jndi.WLInitialContextFactory
 server.platform=weblogic
-server.platform.class=org.eclipse.persistence.platform.server.wls.WebLogic_12_Platform
+server.platform.class=weblogic-10-platform
 
 jee.client.groupId=com.oracle.weblogic
 jee.client.artifactId=wlthint3client
-jee.client.version=12.2.1-3
+jee.client.version=15.1.1.0.0
 
 skip.jee.server.installation=true
-cargo.container.installation.home=/usr/local/oracle/wls122130/wlserver
+cargo.container.installation.home=/usr/local/oracle/wls151100/wlserver
 
 server.testrunner.suffix=TestRunner#org.eclipse.persistence.testing.framework.jpa.server.TestRunner
 server.testrunner1.suffix=TestRunner1#org.eclipse.persistence.testing.framework.jpa.server.TestRunner1

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, 2022 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -61,6 +61,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Vector;
+import javax.xml.transform.dom.DOMResult;
+import org.w3c.dom.Document;
 
 // EclipseLink imports
 import org.eclipse.persistence.descriptors.ClassDescriptor;
@@ -2668,6 +2670,10 @@ public class DatabasePlatform extends DatasourcePlatform {
             statement.setBytes(index, (byte[])convertObject(parameter, ClassConstants.APBYTE));
         } else if (parameter instanceof SQLXML) {
             statement.setSQLXML(index, (SQLXML) parameter);
+        } else if (parameter instanceof Document) {
+            SQLXML sqlxml = statement.getConnection().createSQLXML();
+            sqlxml.setResult(DOMResult.class).setNode((Document)parameter);
+            statement.setSQLXML(index, sqlxml);
         } else if (parameter instanceof BindCallCustomParameter) {
             ((BindCallCustomParameter)(parameter)).set(this, statement, index, session);
         } else if (typeConverters != null && typeConverters.containsKey(parameter.getClass())){
@@ -2773,6 +2779,10 @@ public class DatabasePlatform extends DatasourcePlatform {
             statement.setBytes(name, (byte[])convertObject(parameter, ClassConstants.APBYTE));
         } else if (parameter instanceof SQLXML) {
             statement.setSQLXML(name, (SQLXML) parameter);
+        } else if (parameter instanceof Document) {
+            SQLXML sqlxml = statement.getConnection().createSQLXML();
+            sqlxml.setResult(DOMResult.class).setNode((Document)parameter);
+            statement.setSQLXML(name, sqlxml);
         } else if (parameter instanceof BindCallCustomParameter) {
             ((BindCallCustomParameter)(parameter)).set(this, statement, name, session);
         } else if (typeConverters != null && typeConverters.containsKey(parameter.getClass())){

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatasourcePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatasourcePlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, 2024 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -659,9 +659,15 @@ public class DatasourcePlatform implements Platform {
     }
 
     @Override
+    public boolean isOracle21() {
+        return false;
+    }
+
+    @Override
     public boolean isOracle23() {
         return false;
     }
+
     public boolean isPervasive(){
         return false;
     }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/Platform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/Platform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2024 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -123,9 +123,11 @@ public interface Platform extends CorePlatform<ConversionManager>, Serializable,
 
     boolean isOracle9();
 
-    boolean isOracle23();
-
     boolean isOracle12();
+
+    boolean isOracle21();
+
+    boolean isOracle23();
 
     boolean isPointBase();
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/oracle/plsql/PLSQLStoredProcedureCall.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/oracle/plsql/PLSQLStoredProcedureCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, 2022 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -512,7 +512,7 @@ public class PLSQLStoredProcedureCall extends StoredProcedureCall {
         }
         for (PLSQLargument inArg : inArguments) {
             DatabaseType type = inArg.databaseType;
-            if (platform.isOracle23() && type == OraclePLSQLTypes.PLSQLBoolean && Helper.compareVersions(platform.getDriverVersion(), "23.0.0") >= 0) {
+            if ((platform.isOracle21() || platform.isOracle23()) && type == OraclePLSQLTypes.PLSQLBoolean && Helper.compareVersions(platform.getDriverVersion(), "23.0.0") >= 0) {
                 type = JDBCTypes.BOOLEAN_TYPE;
                 inArg.databaseType = JDBCTypes.BOOLEAN_TYPE;
             }
@@ -569,7 +569,7 @@ public class PLSQLStoredProcedureCall extends StoredProcedureCall {
                 super.useNamedCursorOutputAsResultSet(outArgName);
             } else {
                 DatabaseType type = outArg.databaseType;
-                if (platform.isOracle23() && type == OraclePLSQLTypes.PLSQLBoolean && Helper.compareVersions(platform.getDriverVersion(), "23.0.0") >= 0) {
+                if ((platform.isOracle21() || platform.isOracle23()) && type == OraclePLSQLTypes.PLSQLBoolean && Helper.compareVersions(platform.getDriverVersion(), "23.0.0") >= 0) {
                     type = JDBCTypes.BOOLEAN_TYPE;
                     outArg.databaseType = JDBCTypes.BOOLEAN_TYPE;
                 }

--- a/foundation/org.eclipse.persistence.oracle/src/main/java/org/eclipse/persistence/platform/database/oracle/Oracle21Platform.java
+++ b/foundation/org.eclipse.persistence.oracle/src/main/java/org/eclipse/persistence/platform/database/oracle/Oracle21Platform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,5 +15,16 @@ package org.eclipse.persistence.platform.database.oracle;
 public class Oracle21Platform extends Oracle19Platform {
     public Oracle21Platform() {
         super();
+    }
+
+    /**
+     * INTERNAL:
+     * Check whether current platform is Oracle 21c or later.
+     * @return Always returns {@code true} for instances of Oracle 21c platform.
+     * @since 3.0.5
+     */
+    @Override
+    public boolean isOracle23() {
+        return true;
     }
 }

--- a/foundation/org.eclipse.persistence.oracle/src/main/java/org/eclipse/persistence/platform/database/oracle/Oracle21Platform.java
+++ b/foundation/org.eclipse.persistence.oracle/src/main/java/org/eclipse/persistence/platform/database/oracle/Oracle21Platform.java
@@ -24,7 +24,7 @@ public class Oracle21Platform extends Oracle19Platform {
      * @since 3.0.5
      */
     @Override
-    public boolean isOracle23() {
+    public boolean isOracle21() {
         return true;
     }
 }

--- a/jpa/eclipselink.jpa.testapps.nosql/jpa.test.nosql.mongo/pom.xml
+++ b/jpa/eclipselink.jpa.testapps.nosql/jpa.test.nosql.mongo/pom.xml
@@ -54,6 +54,26 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>eclipselink-testbuild-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>package-server-tests</id>
+                        <goals>
+                            <goal>package-testapp</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <mode>EAR</mode>
+                            <libs>
+                                <lib>org.eclipse.persistence:org.eclipse.persistence.nosql</lib>
+                                <lib>org.mongodb:mongo-java-driver</lib>
+                            </libs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>com.github.joelittlejohn.embedmongo</groupId>
                 <artifactId>embedmongo-maven-plugin</artifactId>
                 <executions>
@@ -71,7 +91,7 @@
                     </execution>
                     <execution>
                         <id>stop-mongo</id>
-                        <phase>prepare-package</phase>
+                        <phase>post-integration-test</phase>
                         <goals>
                             <goal>stop</goal>
                         </goals>

--- a/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.customfeatures/src/main/resources/META-INF/persistence.xml
+++ b/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.customfeatures/src/main/resources/META-INF/persistence.xml
@@ -16,7 +16,6 @@
     <persistence-unit name="customfeatures" transaction-type="RESOURCE_LOCAL">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
         <class>org.eclipse.persistence.testing.models.jpa.customfeatures.Employee</class>
-        <!--property name="eclipselink.logging.level" value="FINEST"/-->
         <properties>
             <property name="eclipselink.jdbc.batch-writing" value="Oracle-JDBC"/>
         </properties>

--- a/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.dcn/pom.xml
+++ b/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.dcn/pom.xml
@@ -31,7 +31,8 @@
     </dependencies>
 
     <properties>
-        <ignore.server.failures>true</ignore.server.failures>
+        <!--Disabled as multiple transactions in one test method are needed, but it's wrapped in CMP Session EJB-->
+        <server.test.skip>true</server.test.skip>
         <argLine/>
     </properties>
 

--- a/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.plsql/src/test/java/org/eclipse/persistence/testing/tests/jpa/plsql/PLSQLTest.java
+++ b/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.plsql/src/test/java/org/eclipse/persistence/testing/tests/jpa/plsql/PLSQLTest.java
@@ -330,7 +330,7 @@ public class PLSQLTest extends JUnitTestCase {
             query.setParameter("P_POSITIVEN", 1);
             query.setParameter("P_SIGNTYPE", 1);
             query.setParameter("P_NUMBER", 1);
-            if (getPlatform().isOracle23() &&  Helper.compareVersions(getPlatform().getDriverVersion(), "23.0.0") >= 0) {
+            if ((getPlatform().isOracle21() || getPlatform().isOracle23()) &&  Helper.compareVersions(getPlatform().getDriverVersion(), "23.0.0") >= 0) {
                 boolean result = (Boolean) query.getSingleResult();
                 if (!result) {
                     fail("Incorrect result.");

--- a/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.plsql/src/test/java/org/eclipse/persistence/testing/tests/jpa/plsql/XMLPLSQLTest.java
+++ b/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.plsql/src/test/java/org/eclipse/persistence/testing/tests/jpa/plsql/XMLPLSQLTest.java
@@ -22,7 +22,9 @@ public class XMLPLSQLTest extends PLSQLTest {
 
     public static Test suite() {
         TestSuite suite = new TestSuite("XMLPLSQLTest");
-        suite.addTest(new XMLPLSQLTest("testSetup"));
+        //Setup call leads into testRecordOut failure (ORA-21700: object does not exist or is marked for delete) in JEE environment
+        //Not needed there as testSetup is called in PLSQLTest.
+        // suite.addTest(new XMLPLSQLTest("testSetup"));
         suite.addTest(new XMLPLSQLTest("testSimpleProcedure"));
         suite.addTest(new XMLPLSQLTest("testSimpleFunction"));
         suite.addTest(new XMLPLSQLTest("testRecordOut"));

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced.multitenant/src/main/resources-ejb/META-INF/persistence.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced.multitenant/src/main/resources-ejb/META-INF/persistence.xml
@@ -29,7 +29,6 @@
             <property name="eclipselink.target-database" value="@database-platform@"/>
             <property name="eclipselink.weaving" value="@server-weaving@"/>
             <property name="eclipselink.validate-existence" value="true"/>
-            <property name="eclipselink.logging.level" value="${eclipselink.logging.level}"/>
             <property name="eclipselink.jdbc.allow-native-sql-queries" value="true"/>
             <property name="eclipselink.multitenant.strategy" value="external"/>
             <property name="eclipselink.logging.level" value="${eclipselink.logging.level}"/>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced/pom.xml
@@ -87,6 +87,18 @@
                             </includes>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>server-test</id>
+                        <configuration>
+                            <includes>
+<!--TODO fix later Disabled in JEE environment as test depends on core test FW classes.
+                                <include>**/JPAAdvancedTestModel</include>
+-->
+                                <include>**/advanced/*Test</include>
+                                <include>**/advanced/EntityManagerJUnitTestSuite</include>
+                            </includes>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced/src/test/java/org/eclipse/persistence/testing/tests/jpa/advanced/NamedQueryJUnitTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced/src/test/java/org/eclipse/persistence/testing/tests/jpa/advanced/NamedQueryJUnitTest.java
@@ -111,10 +111,14 @@ public class NamedQueryJUnitTest extends JUnitTestCase {
      */
     private void removeEmployee(EntityManager em, Employee employee) {
         Collection<Equipment> equipmentColl = employee.getDepartment().getEquipment().values();
+        //Ensure that entity is managed before remove
+        employee = em.find(Employee.class, employee.getId());
         em.remove(employee);
         em.remove(employee.getDepartment());
         em.remove(employee.getAddress());
         for (Equipment equipment : equipmentColl) {
+            //Ensure that entity is managed before remove
+            equipment = em.find(Equipment.class, equipment.getId());
             EquipmentCode ec = equipment.getEquipmentCode();
             em.remove(equipment);
             if (ec != null) {
@@ -212,7 +216,7 @@ public class NamedQueryJUnitTest extends JUnitTestCase {
             ex.printStackTrace();
             throw ex;
         } finally {
-            em.close();
+            closeEntityManager(em);
         }
     }
 
@@ -258,7 +262,7 @@ public class NamedQueryJUnitTest extends JUnitTestCase {
             ex.printStackTrace();
             throw ex;
         } finally {
-            em.close();
+            closeEntityManager(em);
         }
     }
 
@@ -303,7 +307,7 @@ public class NamedQueryJUnitTest extends JUnitTestCase {
             ex.printStackTrace();
             throw ex;
         } finally {
-            em.close();
+            closeEntityManager(em);
         }
     }
 
@@ -349,7 +353,7 @@ public class NamedQueryJUnitTest extends JUnitTestCase {
             ex.printStackTrace();
             throw ex;
         } finally {
-            em.close();
+            closeEntityManager(em);
         }
     }
 

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced/src/test/java/org/eclipse/persistence/testing/tests/jpa/advanced/NamedQueryJUnitTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced/src/test/java/org/eclipse/persistence/testing/tests/jpa/advanced/NamedQueryJUnitTest.java
@@ -111,14 +111,18 @@ public class NamedQueryJUnitTest extends JUnitTestCase {
      */
     private void removeEmployee(EntityManager em, Employee employee) {
         Collection<Equipment> equipmentColl = employee.getDepartment().getEquipment().values();
-        //Ensure that entity is managed before remove
-        employee = em.find(Employee.class, employee.getId());
+        if (isOnServer()) {
+            //Ensure that entity is managed before remove
+            employee = em.find(Employee.class, employee.getId());
+        }
         em.remove(employee);
         em.remove(employee.getDepartment());
         em.remove(employee.getAddress());
         for (Equipment equipment : equipmentColl) {
-            //Ensure that entity is managed before remove
-            equipment = em.find(Equipment.class, equipment.getId());
+            if (isOnServer()) {
+                //Ensure that entity is managed before remove
+                equipment = em.find(Equipment.class, equipment.getId());
+            }
             EquipmentCode ec = equipment.getEquipmentCode();
             em.remove(equipment);
             if (ec != null) {

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced/src/test/java/org/eclipse/persistence/testing/tests/jpa/advanced/PersistenceUnitProcessorTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced/src/test/java/org/eclipse/persistence/testing/tests/jpa/advanced/PersistenceUnitProcessorTest.java
@@ -36,6 +36,21 @@ import java.util.Map;
 
 public class PersistenceUnitProcessorTest extends JUnitTestCase {
 
+        /**
+     * Constructs an instance of <code>PersistenceUnitProcessorTest</code> class.
+     */
+    public PersistenceUnitProcessorTest() {
+        super();
+    }
+
+    /**
+     * Constructs an instance of <code>PersistenceUnitProcessorTest</code> class with given test case name.
+     * @param name Test case name.
+     */
+    public PersistenceUnitProcessorTest(String name) {
+        super(name);
+    }
+
     public static Test suite() {
         return new TestSuite(PersistenceUnitProcessorTest.class);
     }

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced/src/test/java/org/eclipse/persistence/testing/tests/jpa/advanced/UpdateAllQueryAdvancedJunitTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced/src/test/java/org/eclipse/persistence/testing/tests/jpa/advanced/UpdateAllQueryAdvancedJunitTest.java
@@ -16,7 +16,6 @@
 
 package org.eclipse.persistence.testing.tests.jpa.advanced;
 
-import junit.extensions.TestSetup;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 import org.eclipse.persistence.descriptors.ClassDescriptor;
@@ -112,29 +111,47 @@ public class UpdateAllQueryAdvancedJunitTest extends JUnitTestCase {
     }
 
     public static Test suite() {
-        TestSuite suite = new TestSuite(UpdateAllQueryAdvancedJunitTest.class);
+        TestSuite suite = new TestSuite();
+        suite.setName("UpdateAllQueryAdvancedJunitTest");
 
-        return new TestSetup(suite) {
-            @Override
-            protected void setUp(){
-                new AdvancedTableCreator().replaceTables(JUnitTestCase.getServerSession());
-            }
+        suite.addTest(new UpdateAllQueryAdvancedJunitTest("testSetup"));
+        suite.addTest(new UpdateAllQueryAdvancedJunitTest("testFirstNamePrefixBLAForAll"));
+        suite.addTest(new UpdateAllQueryAdvancedJunitTest("testFirstNamePrefixBLAForSalary"));
+        suite.addTest(new UpdateAllQueryAdvancedJunitTest("testDoubleSalaryForAll"));
+        suite.addTest(new UpdateAllQueryAdvancedJunitTest("testDoubleSalaryForSalary"));
+        suite.addTest(new UpdateAllQueryAdvancedJunitTest("testFirstNamePrefixBLADoubleSalaryForAll"));
+        suite.addTest(new UpdateAllQueryAdvancedJunitTest("testFirstNamePrefixBLADoubleSalaryForSalary"));
+        suite.addTest(new UpdateAllQueryAdvancedJunitTest("testFirstNamePrefixBLADoubleSalaryForSalaryForFirstName"));
+        suite.addTest(new UpdateAllQueryAdvancedJunitTest("testAssignManagerName"));
+        suite.addTest(new UpdateAllQueryAdvancedJunitTest("testAssignNullToAddress"));
+        suite.addTest(new UpdateAllQueryAdvancedJunitTest("testAssignObjectToAddress"));
+        suite.addTest(new UpdateAllQueryAdvancedJunitTest("testAssignExpressionToAddress"));
+        suite.addTest(new UpdateAllQueryAdvancedJunitTest("testAggregate"));
 
-            @Override
-            protected void tearDown() {
-                new UpdateAllQueryAdvancedJunitTest().clearCache();
-            }
-        };
+        return suite;
     }
 
-    public static void testFirstNamePrefixBLAForAll() {
+    /**
+     * The setup is done as a test, both to record its failure, and to allow execution in the server.
+     */
+    public void testSetup() {
+        new AdvancedTableCreator().replaceTables(JUnitTestCase.getServerSession());
+        clearCache();
+    }
+
+    @Override
+    public void tearDown() {
+        new UpdateAllQueryAdvancedJunitTest().clearCache();
+    }
+
+    public void testFirstNamePrefixBLAForAll() {
         ExpressionBuilder builder = new ExpressionBuilder();
         UpdateAllQuery updateQuery = new UpdateAllQuery(Employee.class);
         updateQuery.addUpdate("firstName", Expression.fromLiteral("'BLA'", null).concat(builder.get("firstName")));
         updateAllQueryInternal(updateQuery);
     }
 
-    public static void testFirstNamePrefixBLAForSalary() {
+    public void testFirstNamePrefixBLAForSalary() {
         ExpressionBuilder builder = new ExpressionBuilder();
         Expression selectionExpression = builder.get("salary").lessThan(20000);
         UpdateAllQuery updateQuery = new UpdateAllQuery(Employee.class, selectionExpression);
@@ -142,14 +159,14 @@ public class UpdateAllQueryAdvancedJunitTest extends JUnitTestCase {
         updateAllQueryInternal(updateQuery);
     }
 
-    public static void testDoubleSalaryForAll() {
+    public void testDoubleSalaryForAll() {
         ExpressionBuilder builder = new ExpressionBuilder();
         UpdateAllQuery updateQuery = new UpdateAllQuery(Employee.class);
         updateQuery.addUpdate("salary", ExpressionMath.multiply(builder.get("salary"), Integer.valueOf(2)));
         updateAllQueryInternal(updateQuery);
     }
 
-    public static void testDoubleSalaryForSalary() {
+    public void testDoubleSalaryForSalary() {
         ExpressionBuilder builder = new ExpressionBuilder();
         Expression selectionExpression = builder.get("salary").lessThan(20000);
         UpdateAllQuery updateQuery = new UpdateAllQuery(Employee.class, selectionExpression);
@@ -157,7 +174,7 @@ public class UpdateAllQueryAdvancedJunitTest extends JUnitTestCase {
         updateAllQueryInternal(updateQuery);
     }
 
-    public static void testFirstNamePrefixBLADoubleSalaryForAll() {
+    public void testFirstNamePrefixBLADoubleSalaryForAll() {
         ExpressionBuilder builder = new ExpressionBuilder();
         UpdateAllQuery updateQuery = new UpdateAllQuery(Employee.class);
         updateQuery.addUpdate("firstName", Expression.fromLiteral("'BLA'", null).concat(builder.get("firstName")));
@@ -165,7 +182,7 @@ public class UpdateAllQueryAdvancedJunitTest extends JUnitTestCase {
         updateAllQueryInternal(updateQuery);
     }
 
-    public static void testFirstNamePrefixBLADoubleSalaryForSalary() {
+    public void testFirstNamePrefixBLADoubleSalaryForSalary() {
         ExpressionBuilder builder = new ExpressionBuilder();
         Expression selectionExpression = builder.get("salary").lessThan(20000);
         UpdateAllQuery updateQuery = new UpdateAllQuery(Employee.class, selectionExpression);
@@ -174,7 +191,7 @@ public class UpdateAllQueryAdvancedJunitTest extends JUnitTestCase {
         updateAllQueryInternal(updateQuery);
     }
 
-    public static void testFirstNamePrefixBLADoubleSalaryForSalaryForFirstName() {
+    public void testFirstNamePrefixBLADoubleSalaryForSalaryForFirstName() {
         ExpressionBuilder builder = new ExpressionBuilder();
         Expression selectionExpression = builder.get("salary").lessThan(20000).and(builder.get("firstName").like("J%"));
         UpdateAllQuery updateQuery = new UpdateAllQuery(Employee.class, selectionExpression);
@@ -183,7 +200,7 @@ public class UpdateAllQueryAdvancedJunitTest extends JUnitTestCase {
         updateAllQueryInternal(updateQuery);
     }
 
-    public static void testAssignManagerName() {
+    public void testAssignManagerName() {
         ExpressionBuilder builder = new ExpressionBuilder();
         Expression selectionExpression = builder.get("manager").notNull();
         UpdateAllQuery updateQuery = new UpdateAllQuery(Employee.class, selectionExpression);
@@ -191,13 +208,13 @@ public class UpdateAllQueryAdvancedJunitTest extends JUnitTestCase {
         updateAllQueryInternal(updateQuery);
     }
 
-    public static void testAssignNullToAddress() {
+    public void testAssignNullToAddress() {
         UpdateAllQuery updateQuery = new UpdateAllQuery(Employee.class);
         updateQuery.addUpdate("address", null);
         updateAllQueryInternal(updateQuery);
     }
 
-    public static void testAssignObjectToAddress() {
+    public void testAssignObjectToAddress() {
         Address address = new Address();
         address.setCountry("Canada");
         address.setProvince("Ontario");
@@ -211,7 +228,7 @@ public class UpdateAllQueryAdvancedJunitTest extends JUnitTestCase {
         updateAllQueryInternal(updateQuery);
     }
 
-    public static void testAssignExpressionToAddress() {
+    public void testAssignExpressionToAddress() {
         ExpressionBuilder builder = new ExpressionBuilder();
         Expression selectionExpression = builder.get("manager").notNull();
         UpdateAllQuery updateQuery = new UpdateAllQuery(Employee.class, selectionExpression);
@@ -219,7 +236,7 @@ public class UpdateAllQueryAdvancedJunitTest extends JUnitTestCase {
         updateAllQueryInternal(updateQuery);
     }
 
-    public static void testAggregate() {
+    public void testAggregate() {
         ExpressionBuilder builder = new ExpressionBuilder();
         Expression selectionExpression = builder.get("manager").notNull();
         UpdateAllQuery updateQuery = new UpdateAllQuery(Employee.class, selectionExpression);
@@ -246,7 +263,9 @@ public class UpdateAllQueryAdvancedJunitTest extends JUnitTestCase {
                     + "Symfoware doesn't support UpdateAll/DeleteAll on multi-table objects (see rfe 298193).");
             return;
         }
+        getServerSession().beginTransaction();
         String errorMsg = UpdateAllQueryTestHelper.execute(getDbSession(), uq);
+        getServerSession().commitTransaction();
         if(errorMsg != null) {
             fail(errorMsg);
         }

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced/src/test/java/org/eclipse/persistence/testing/tests/jpa/advanced/concurrency/LifecycleJUnitTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced/src/test/java/org/eclipse/persistence/testing/tests/jpa/advanced/concurrency/LifecycleJUnitTest.java
@@ -204,7 +204,7 @@ public class LifecycleJUnitTest extends JUnitTestCase {
         EntityManager em = emf.createEntityManager();
         Department dept = null;
         try {
-            em.getTransaction().begin();
+            beginTransaction(em);
             dept = new Department();
             // A merge will not populate the @Id field
             // A persist will populate the @Id field
@@ -221,7 +221,7 @@ public class LifecycleJUnitTest extends JUnitTestCase {
             int lifecycleAfter = uow.getLifecycle();
             assertEquals("Birth state 0 is not set after a clear on state Birth  ", 0, lifecycleAfter);
 
-            em.getTransaction().commit();
+            commitTransaction(em);
 
             // clear em
             em.clear();
@@ -244,7 +244,7 @@ public class LifecycleJUnitTest extends JUnitTestCase {
         EntityManager em = emf.createEntityManager();
         Department dept = null;
         try {
-            em.getTransaction().begin();
+            beginTransaction(em);
             dept = new Department();
             // A merge will not populate the @Id field and will result in a PK null exception in any find later
             // A persist will populate the @Id field
@@ -261,7 +261,7 @@ public class LifecycleJUnitTest extends JUnitTestCase {
             int lifecycleAfter = uow.getLifecycle();
             assertEquals("Birth state 0 is not set after a clear on state Birth  ", 0, lifecycleAfter);
 
-            em.getTransaction().commit();
+            commitTransaction(em);
 
             // don't clear em - leave following line commented
             //em.clear();
@@ -285,7 +285,7 @@ public class LifecycleJUnitTest extends JUnitTestCase {
         EntityManager em = emf.createEntityManager();
         Department dept = null;
         try {
-            em.getTransaction().begin();
+            beginTransaction(em);
             dept = new Department();
             em.persist(dept);
 
@@ -300,7 +300,7 @@ public class LifecycleJUnitTest extends JUnitTestCase {
             int lifecycleAfter = uow.getLifecycle();
             assertEquals("Birth state 0 is not set after a clear on state Birth  ", 0, lifecycleAfter);
 
-            em.getTransaction().commit();
+            commitTransaction(em);
 
             em.clear();
             int lifecycleAfterCommit = uow.getLifecycle();

--- a/jpa/eclipselink.jpa.testapps/jpa.test.composite.advanced/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.composite.advanced/pom.xml
@@ -144,4 +144,26 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>weblogic</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <!--Disabled in WebLogic seems, that EntityManager and EntityManagerFactory JNDI publishing by ejb-jar.xml doesn't work-->
+                            <!--TODO inspect and enable later-->
+                            <execution>
+                                <id>server-test</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.ddlgeneration/src/test/java/org/eclipse/persistence/testing/tests/jpa/ddlgeneration/DDLGenerationExtendTablesTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.ddlgeneration/src/test/java/org/eclipse/persistence/testing/tests/jpa/ddlgeneration/DDLGenerationExtendTablesTest.java
@@ -122,10 +122,7 @@ public class DDLGenerationExtendTablesTest extends  DDLGenerationTest {
         properties.put(PersistenceUnitProperties.DDL_GENERATION_MODE, PersistenceUnitProperties.DDL_DATABASE_GENERATION);
         //this causes DDL generation to occur on refreshMetadata rather than wait until an em is obtained
         properties.put(PersistenceUnitProperties.DEPLOY_ON_STARTUP, "true");
-        // JEE requires a transaction to keep the em open.
-        beginTransaction(em);
         JpaHelper.getEntityManagerFactory(em).refreshMetadata(properties);
-        commitTransaction(em);
         closeEntityManager(em);
         clearCache();
     }

--- a/jpa/eclipselink.jpa.testapps/jpa.test.diagnostic/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.diagnostic/pom.xml
@@ -28,6 +28,8 @@
     <name>Test - diagnostic</name>
 
     <properties>
+        <!--Disabled as multiple transactions in one test method are needed, but it's wrapped in CMP Session EJB-->
+        <server.test.skip>true</server.test.skip>
         <argLine/>
     </properties>
 

--- a/jpa/eclipselink.jpa.testapps/jpa.test.sessionbean.ha/src/test/java/org/eclipse/persistence/testing/tests/jpa/sessionbean/ha/SessionBeanTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.sessionbean.ha/src/test/java/org/eclipse/persistence/testing/tests/jpa/sessionbean/ha/SessionBeanTest.java
@@ -88,7 +88,7 @@ public class SessionBeanTest extends JUnitTestCase {
     "java:comp/env/ejb/EmployeeService", "ejb/EmployeeService",
     // WLS
     "EmployeeService#org.eclipse.persistence.testing.models.jpa.sessionbean.ha.EmployeeService",
-    // WLS 15
+    // WLS 15.1.1
     "java:global.org.eclipse.persistence.jpa.testapps.sessionbean.ha.org.eclipse.persistence.jpa.testapps.sessionbean.ha_ejb.EmployeeServiceBean!org.eclipse.persistence.testing.models.jpa.sessionbean.ha/EmployeeService",
     // WAS
     "org.eclipse.persistence.testing.models.jpa.sessionbean.ha.EmployeeService",

--- a/jpa/eclipselink.jpa.testapps/jpa.test.weaving/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.weaving/pom.xml
@@ -28,6 +28,7 @@
     <name>Test - weaving</name>
 
     <properties>
+        <server.test.skip>true</server.test.skip>
         <argLine/>
     </properties>
 
@@ -101,10 +102,6 @@
                                 <eclipselink.asm.service>eclipselink</eclipselink.asm.service>
                             </systemPropertyVariables>
                         </configuration>
-                    </execution>
-                    <execution>
-                        <id>server-test</id>
-                        <phase>none</phase>
                     </execution>
                 </executions>
             </plugin>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.weaving/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.weaving/pom.xml
@@ -79,12 +79,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <argLine>-javaagent:${org.eclipse.persistence:org.eclipse.persistence.jpa:jar} @{argLine}</argLine>
-                </configuration>
                 <executions>
                     <execution>
                         <id>default-test</id>
+                        <configuration>
+                            <argLine>-javaagent:${org.eclipse.persistence:org.eclipse.persistence.jpa:jar} @{argLine}</argLine>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>asm-eclipselink-test</id>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/member_1/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/member_1/pom.xml
@@ -72,4 +72,13 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>weblogic</id>
+            <properties>
+                <persistence-unit.data-source-name>jdbc/EclipseLinkDS</persistence-unit.data-source-name>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/pom.xml
@@ -150,4 +150,27 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>weblogic</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <!--Disabled in WebLogic seems, that EntityManager and EntityManagerFactory JNDI publishing by ejb-jar.xml doesn't work-->
+                            <!--Same case as org.eclipse.persistence.jpa.testapps.composite.advanced-->
+                            <!--TODO inspect and enable later-->
+                            <execution>
+                                <id>server-test</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/src/main/resources-ejb/META-INF/ejb-jar.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/src/main/resources-ejb/META-INF/ejb-jar.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2022, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -20,6 +20,22 @@
     <enterprise-beans>
         <session>
             <ejb-name>SingleUnitTestRunner</ejb-name>
+            <env-entry>
+                <env-entry-name>ejbLookup</env-entry-name>
+                <env-entry-type>java.lang.Boolean</env-entry-type>
+                <env-entry-value>true</env-entry-value>
+            </env-entry>
+            <persistence-context-ref>
+                <persistence-context-ref-name>persistence/xml-composite-advanced/entity-manager</persistence-context-ref-name>
+                <persistence-unit-name>xml-composite-advanced</persistence-unit-name>
+            </persistence-context-ref>
+            <persistence-unit-ref>
+                <persistence-unit-ref-name>persistence/xml-composite-advanced/factory</persistence-unit-ref-name>
+                <persistence-unit-name>xml-composite-advanced</persistence-unit-name>
+            </persistence-unit-ref>
+        </session>
+        <session>
+            <ejb-name>GenericTestRunner</ejb-name>
             <env-entry>
                 <env-entry-name>ejbLookup</env-entry-name>
                 <env-entry-type>java.lang.Boolean</env-entry-type>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/src/main/resources-ejb/META-INF/persistence.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/src/main/resources-ejb/META-INF/persistence.xml
@@ -20,6 +20,7 @@
         <jar-file>org.eclipse.persistence.jpa.testapps.xml.composite.advanced.member_3_ejb.jar</jar-file>
         <properties>
             <property name="eclipselink.target-server" value="@server-platform@"/>
+            <property name="eclipselink.target-database" value="@database-platform@"/>
             <property name="eclipselink.composite-unit" value="true"/>
             <property name="eclipselink.logging.logger" value="DefaultLogger"/>
             <property name="eclipselink.logging.level" value="${eclipselink.logging.level}"/>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended.composite.advanced/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended.composite.advanced/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2022, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -147,4 +147,27 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>weblogic</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <!--Disabled in WebLogic seems, that EntityManager and EntityManagerFactory JNDI publishing by ejb-jar.xml doesn't work-->
+                            <!--Same case as org.eclipse.persistence.jpa.testapps.composite.advanced-->
+                            <!--TODO inspect and enable later-->
+                            <execution>
+                                <id>server-test</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.advanced/src/test/java/org/eclipse/persistence/testing/tests/jpa/xml/extended/advanced/XmlExtendedAdvancedTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.advanced/src/test/java/org/eclipse/persistence/testing/tests/jpa/xml/extended/advanced/XmlExtendedAdvancedTest.java
@@ -769,7 +769,9 @@ public class XmlExtendedAdvancedTest extends XmlAdvancedTest {
         // clean up
         beginTransaction(em);
         try {
-            employee = em.find(Employee.class, employee.getId());
+            if (isOnServer()) {
+                employee = em.find(Employee.class, employee.getId());
+            }
             em.remove(employee);
             commitTransaction(em);
         } finally {
@@ -802,7 +804,9 @@ public class XmlExtendedAdvancedTest extends XmlAdvancedTest {
         assertTrue("Did not correctly persist a mapping using a class-instance converter", (add.getType() instanceof Bungalow));
 
         beginTransaction(em);
-        add = em.find(Address.class, assignedSequenceNumber);
+        if (isOnServer()) {
+            add = em.find(Address.class, assignedSequenceNumber);
+        }
         em.remove(add);
         commitTransaction(em);
     }

--- a/jpa/eclipselink.jpa.testapps/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/pom.xml
@@ -704,7 +704,7 @@
                 <server.jndi.factory>${server.initialCtxFactory}</server.jndi.factory>
                 <server.remote.url>${server.rmi.protocol}://${server.host}:${server.rmi.port}</server.remote.url>
                 <server.test.runner.context>java:global.${project.build.finalName}.${project.build.finalName}_ejb</server.test.runner.context>
-                <!--TODO RFELCMAN Change later-->
+                <!--TODO Change later-->
                 <weblogic.domainHome>/usr/local/oracle/wls_domains/test_domain151100</weblogic.domainHome>
             </properties>
             <dependencyManagement>

--- a/jpa/eclipselink.jpa.testapps/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/pom.xml
@@ -497,6 +497,8 @@
                                     <server.run>TRUE</server.run>
                                     <is.JTA>true</is.JTA>
                                     <server.url>${server.remote.url}</server.url>
+                                    <server.usr>${server.usr}</server.usr>
+                                    <server.pwd>${server.pwd}</server.pwd>
                                     <server.testrunner.context>${server.test.runner.context}</server.testrunner.context>
                                 </systemPropertyVariables>
                                 <testFailureIgnore>${ignore.server.failures}</testFailureIgnore>
@@ -677,6 +679,104 @@
                                 <phase>post-integration-test</phase>
                                 <goals>
                                     <goal>undeploy</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>server-test</id>
+                                <phase>integration-test</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>weblogic</id>
+            <properties>
+                <se.test.skip>true</se.test.skip>
+                <server.jndi.factory>${server.initialCtxFactory}</server.jndi.factory>
+                <server.remote.url>${server.rmi.protocol}://${server.host}:${server.rmi.port}</server.remote.url>
+                <server.test.runner.context>java:global.${project.build.finalName}.${project.build.finalName}_ejb</server.test.runner.context>
+                <!--TODO RFELCMAN Change later-->
+                <weblogic.domainHome>/usr/local/oracle/wls_domains/test_domain151100</weblogic.domainHome>
+            </properties>
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.oracle.weblogic</groupId>
+                        <artifactId>wlthint3client</artifactId>
+                        <version>${weblogic.version}</version>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
+            <dependencies>
+                <dependency>
+                    <groupId>com.oracle.weblogic</groupId>
+                    <artifactId>wlthint3client</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>com.oracle.weblogic</groupId>
+                            <artifactId>weblogic-maven-plugin</artifactId>
+                            <version>15.1.1-0-0</version>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+                <plugins>
+                    <plugin>
+                        <groupId>com.oracle.weblogic</groupId>
+                        <artifactId>weblogic-maven-plugin</artifactId>
+                        <configuration>
+                            <domainHome>${weblogic.domainHome}</domainHome>
+                            <user>${server.usr}</user>
+                            <password>${server.pwd}</password>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>weblogic-start-server</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>start-server</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>weblogic-deploy-application</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>deploy</goal>
+                                </goals>
+                                <configuration>
+                                    <source>${project.build.directory}/${project.build.finalName}.ear</source>
+                                    <failOnError>false</failOnError>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>weblogic-undeploy-application</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>undeploy</goal>
+                                </goals>
+                                <configuration>
+                                    <name>${project.build.finalName}</name>
+                                    <failOnError>false</failOnError>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>weblogic-stop-server</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>stop-server</goal>
                                 </goals>
                             </execution>
                         </executions>

--- a/jpa/org.eclipse.persistence.jpa.test.framework/src/main/java/org/eclipse/persistence/testing/framework/jpa/junit/JUnitTestCase.java
+++ b/jpa/org.eclipse.persistence.jpa.test.framework/src/main/java/org/eclipse/persistence/testing/framework/jpa/junit/JUnitTestCase.java
@@ -733,7 +733,10 @@ public abstract class JUnitTestCase extends TestCase {
                 final NameClassPair pair = ctx.next();
                 final String clsName = pair.getClassName();
                 final String name = pair.getName();
-                if (name.contains("framework") && name.contains("TestRunner") || (clsName.contains("framework") && clsName.contains("TestRunner"))) {
+                if (name.contains("framework") && name.contains("TestRunner") ||
+                   (clsName.contains("framework") && clsName.contains("TestRunner")) ||
+                   (name.contains("TestRunner") && isTestRunnerInstance(context, testrunnerCtx, name))
+                ) {
                     testRunners.add(name);
                 }
             }
@@ -759,6 +762,15 @@ public abstract class JUnitTestCase extends TestCase {
             }
         } else {
             fail("System property 'server.testrunner.context' must be set.");
+        }
+    }
+
+    private boolean isTestRunnerInstance(Context context, String testRunnerCtxName, String nodeName) {
+        try {
+            return context.lookup(testRunnerCtxName + "/" + nodeName) instanceof TestRunner;
+        }
+        catch (Exception e) {
+            return false;
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -1771,6 +1771,7 @@
         <profile>
             <id>weblogic</id>
             <properties>
+                <weblogic.version>15.1.1.0.0</weblogic.version>
                 <testjee.properties.file>${user.home}/${testjee.weblogic.properties.file}</testjee.properties.file>
                 <testjee.properties.fileName>${testjee.weblogic.properties.file}</testjee.properties.fileName>
                 <jee.client.groupId>com.oracle.weblogic</jee.client.groupId>


### PR DESCRIPTION
This PR contains various fixes related with testing in JEE environment (server side tests) when JPA test modules are wrapped, deployed and called as EJB in selected application server.
There are following test fixes:

- `jpa.testapps.nosql.mongo`				Fixed pom.xml (additional libs added to EAR, MongoDB stop after tests)
- `jpa.testapps.advanced`					Some code fixes in		`org.eclipse.persistence.testing.tests.jpa.advanced.concurrency.LifecycleJUnitTest`
`org.eclipse.persistence.testing.tests.jpa.advanced.NamedQueryJUnitTest` (ensure, that removed entity is managed)	`org.eclipse.persistence.testing.tests.jpa.advanced.PersistenceUnitProcessorTest` (required constructors)
`org.eclipse.persistence.testing.tests.jpa.advanced.UpdateAllQueryAdvancedJunitTest` (test method signatures refactor)
- `jpa.testapps.advanced.multitenant`		Fix in _resources-ejb/META-INF/persistence.xml_ (duplicated `eclipselink.logging.level` property in `multi-tenant-schema-per-tenant`)
- jpa.testapps.composite.advanced			Disabled in WebLogic seems, that `EntityManager` and `EntityManagerFactory` JNDI publishing by ejb-jar.xml doesn't work
- `jpa.testapps.ddlgeneration`                    `org.eclipse.persistence.testing.tests.jpa.ddlgeneration.DDLGenerationExtendTablesTest`
														transaction arround `JpaHelper.getEntityManagerFactory(em).refreshMetadata(properties);` removed as nested transaction in JEE can't be 
- `jpa.testapps.delimited`					for `<property name="eclipselink.ddl-generation" value="drop-and-create-tables"/>` NON XA driver is needed in jdbc/EclipseLinkDS
					NOTE: file a bug for "<property name="eclipselink.ddl-generation" value="drop-and-create-tables"/>" and XA driver
- `jpa.testapps.diagnostic`	TODO - Server side test can not pass as beanmanaged transaction scope is needed as multiple transactions are started and commited in single test
						NOTE: Maybe redesing later. Based on PR #1762
- `jpa.testapps.fieldaccess.advanced`		just works sometimes take same time
- `jpa.testapps.metamodel`		just works sometimes take same time (so many tests in one suite)
- `jpa.testapps.xml.composite.advanced`		Ensure, the same DBPLatformm is specified in all members
													WLS needs non-XA driver in DataSource due DB tables drop/creation
													TODO STILL DISABLED
- `jpa.testapps.oracle.customfeatures`		Fix for DOM Document DB call (INSERT) in `org.eclipse.persistence.internal.databaseaccess.DatabasePlatform#setParameterValueInDatabaseCall`					
- `jpa.testapps.oracle.plsql`				Oracle21PLatform and extended condition for `org.eclipse.persistence.platform.database.oracle.plsql.PLSQLStoredProcedureCall#assignIndices` for boolean
													Struct WebLogic datatype wrapper DataSource->Configuration->Connection Pool->Advanced->Wrap Data Types

**NOTE:**
All `*.composite.*` are currently disabled for server side testing (WebLogic) as it seems, that EntityManager and EntityManagerFactory JNDI publishing by ejb-jar.xml doesn't work or there is some application issue which needs deeper investigation.