### PR TITLE
Issue #2414: Fixed mapping resolution for @Embeddable in ObjectExpression

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/DataExpression.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/DataExpression.java
@@ -269,7 +269,9 @@ public abstract class DataExpression extends BaseExpression {
     private DatabaseMapping getAggregateMapping(String name) {
         List<Expression> derivedExpressions = ((ObjectExpression)baseExpression).derivedExpressions;
         if (derivedExpressions.size() > 1) {
-            if (derivedExpressions.get(derivedExpressions.size() - 2) instanceof ObjectExpression objectExpression) {
+            Expression derivedExpression = derivedExpressions.get(derivedExpressions.size() - 2);
+            if (derivedExpression.isObjectExpression()) {
+                ObjectExpression objectExpression = (ObjectExpression) derivedExpression;
                 DatabaseMapping parentMapping = null;
                 if (objectExpression.baseExpression != null) {
                     ClassDescriptor parentDescriptor = ((DataExpression) this.baseExpression).getDescriptor();

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/FunctionExpression.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/FunctionExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, 2024 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -796,7 +796,10 @@ public class FunctionExpression extends BaseExpression {
                 // now need to find out if it is a direct to field or something else.
                 ClassDescriptor descriptor = null;
                 if (query == null) {
-                    descriptor = ((QueryKeyExpression) baseExp).getDescriptor();
+                    // Trigger aggregate descriptors to be resolved for ReportQuery.
+                    // Unfortunately this ReadQuery is not visible from QueryKeyExpression,
+                    // that would make the solution more simple.
+                    descriptor = ((QueryKeyExpression) baseExp).getDescriptor(isAggregateReportQuery(normalizer));
                 } else {
                     descriptor = query.getDescriptor();
                 }
@@ -919,6 +922,16 @@ public class FunctionExpression extends BaseExpression {
                 }
             }
         }
+    }
+
+    // Check whether ReadQuery in the ExpressionNormalizer is ReportQuery
+    // and contains an aggregate descriptor.
+    private static boolean isAggregateReportQuery(ExpressionNormalizer normalizer) {
+        ReadQuery normalizerQuery = normalizer.getStatement() != null
+                ? normalizer.getStatement().getQuery()
+                : null;
+        return normalizerQuery != null && normalizerQuery.isReportQuery()
+                && normalizerQuery.getDescriptor().isAggregateDescriptor();
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/ObjectExpression.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/ObjectExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -447,9 +447,27 @@ public abstract class ObjectExpression extends DataExpression {
         return new ClassTypeExpression(this);
     }
 
+    /**
+     * INTERNAL:
+     * Get persistence class descriptor of this expression.
+     * Aggregate mapping will not be resolved.
+     *
+     * @return the persistence class descriptor
+     */
     @Override
     public ClassDescriptor getDescriptor() {
-        if (isAttribute()) {
+        return getDescriptor(false);
+    }
+
+    // Package local only, should not be exposed as API.
+    /**
+     * Get persistence class descriptor of this expression.
+     *
+     * @param resolveAggregate trigger resolution of aggregate mapping
+     * @return the persistence class descriptor
+     */
+    ClassDescriptor getDescriptor(boolean resolveAggregate) {
+        if (isAttribute(resolveAggregate)) {
             return null;
         }
         if (descriptor == null) {
@@ -460,7 +478,7 @@ public abstract class ObjectExpression extends DataExpression {
                 descriptor = convertToCastDescriptor(getSession().getDescriptor(queryKey.getReferenceClass()), getSession());
                 return descriptor;
             }
-            if (getMapping() == null) {
+            if (getMapping(resolveAggregate) == null) {
                 throw QueryException.invalidQueryKeyInExpression(this);
             }
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/QueryKeyExpression.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/QueryKeyExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -464,12 +464,17 @@ public class QueryKeyExpression extends ObjectExpression {
 
     @Override
     public DatabaseMapping getMapping() {
+        return getMapping(false);
+    }
+
+    @Override
+    DatabaseMapping getMapping(boolean resolveAggregate) {
         if (!hasMapping) {
             return null;
         }
 
         if (mapping == null) {
-            mapping = super.getMapping();
+            mapping = super.getMapping(resolveAggregate);
             if (mapping == null) {
                 hasMapping = false;
             }
@@ -615,10 +620,27 @@ public class QueryKeyExpression extends ObjectExpression {
 
     /**
      * INTERNAL:
-     * Return if the expression is for a direct mapped attribute.
+     * Check whether the expression is for a direct mapped attribute.
+     * Aggregate mapping will not be resolved.
+     *
+     * @return value of {@code true} when the expression is for a direct mapped attribute
+     *         or {@code false} otherwise
      */
     @Override
     public boolean isAttribute() {
+        return isAttribute(false);
+    }
+
+    // Package local only, should not be exposed as API.
+    /**
+     * Check whether the expression is for a direct mapped attribute.
+     *
+     * @param resolveAggregate trigger resolution of aggregate mapping
+     * @return value of {@code true} when the expression is for a direct mapped attribute
+     *         or {@code false} otherwise
+     */
+    @Override
+    boolean isAttribute(boolean resolveAggregate) {
         if (isAttributeExpression == null) {
             if (getSession() == null) {
                 // We can't tell, so say no.
@@ -628,7 +650,7 @@ public class QueryKeyExpression extends ObjectExpression {
             if (queryKey != null) {
                 isAttributeExpression = queryKey.isDirectQueryKey();
             } else {
-                DatabaseMapping mapping = getMapping();
+                DatabaseMapping mapping = getMapping(true);
                 if (mapping != null) {
                     if (mapping.isVariableOneToOneMapping()) {
                         throw QueryException.cannotQueryAcrossAVariableOneToOneMapping(mapping, mapping.getDescriptor());

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/ReportQuery.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/ReportQuery.java
@@ -1339,11 +1339,6 @@ public class ReportQuery extends ReadAllQuery {
 
         checkDescriptor(getSession());
 
-        if (descriptor.isAggregateDescriptor()) {
-            // Not allowed
-            throw QueryException.aggregateObjectCannotBeDeletedOrWritten(descriptor, this);
-        }
-
         try {
             for (ReportItem item : getItems()) {
                 item.initialize(this);

--- a/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/main/resources/META-INF/persistence.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/main/resources/META-INF/persistence.xml
@@ -162,6 +162,8 @@
         <class>org.eclipse.persistence.testing.models.jpa.relationships.OrderLabel</class>
         <class>org.eclipse.persistence.testing.models.jpa.relationships.SalesPerson</class>
         <class>org.eclipse.persistence.testing.models.jpa.relationships.ServiceCall</class>
+        <class>org.eclipse.persistence.testing.models.jpa.relationships.StreetAddress</class>
+        <class>org.eclipse.persistence.testing.models.jpa.relationships.ShippingAddress</class>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="jakarta.persistence.schema-generation.database.action" value="drop-and-create"/>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpql/relationships/AdvancedQueryTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpql/relationships/AdvancedQueryTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 1998, 2024 IBM Corporation. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -82,6 +82,8 @@ public class AdvancedQueryTest extends JUnitTestCase {
         suite.addTest(new AdvancedQueryTest("testMapJoinFetching"));
         suite.addTest(new AdvancedQueryTest("testLoadGroup"));
         suite.addTest(new AdvancedQueryTest("testConcurrentLoadGroup"));
+        suite.addTest(new AdvancedQueryTest("testSelectOnNames"));
+        suite.addTest(new AdvancedQueryTest("testSelectOnRecipientInfo"));
         suite.addTest(new AdvancedQueryTest("testTearDown"));
         return suite;
     }
@@ -269,4 +271,29 @@ public class AdvancedQueryTest extends JUnitTestCase {
             }
         }
     }
+
+    // Issue #2414 test: IS NOT EMPTY on @ElementCollection of @Entity class
+    public void testSelectOnNames() {
+        EntityManager em = createEntityManager();
+        try {
+            List<?> result = em.createQuery("SELECT o FROM ShippingAddress o WHERE (o.names IS NOT EMPTY)")
+                    .getResultList();
+            assertEquals(1, result.size());
+        } finally {
+            closeEntityManager(em);
+        }
+    }
+
+    // Issue #2414 test: IS NOT EMPTY on @ElementCollection of @Embeddable class
+    public void testSelectOnRecipientInfo() {
+        EntityManager em = createEntityManager();
+        try {
+            List<?> result = em.createQuery("SELECT o FROM ShippingAddress o WHERE (o.streetAddress.recipientInfo IS NOT EMPTY)")
+                    .getResultList();
+            assertEquals(1, result.size());
+        } finally {
+            closeEntityManager(em);
+        }
+    }
+
 }

--- a/jpa/eclipselink.jpa.testapps/jpa.test.relationships/src/main/java/org/eclipse/persistence/testing/models/jpa/relationships/RelationshipsExamples.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.relationships/src/main/java/org/eclipse/persistence/testing/models/jpa/relationships/RelationshipsExamples.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -69,6 +70,8 @@ public class RelationshipsExamples {
         customerExample4.setOrders(ordersList);
         orderExample2.setSalesPerson(salesPerson2);
 
+        ShippingAddress shippingAddressExample1 = shippingAddressExample1();
+
         allObjects.add(customerExample1);
         allObjects.add(customerExample2);
         allObjects.add(orderExample1);
@@ -90,6 +93,8 @@ public class RelationshipsExamples {
         allObjects.add(call2);
         allObjects.add(rep);
         allObjects.add(rep2);
+
+        allObjects.add(shippingAddressExample1);
 
         UnitOfWork unitOfWork = session.acquireUnitOfWork();
         unitOfWork.registerAllObjects(allObjects);
@@ -191,4 +196,16 @@ public class RelationshipsExamples {
         salesPerson.setName("Sales Person 2");
         return salesPerson;
     }
+
+    public static ShippingAddress shippingAddressExample1() {
+        return new ShippingAddress(1001L,
+                                   "Rochester",
+                                   "Minnesota",
+                                   55901,
+                                   List.of("Peter", "Parker"),
+                                   new StreetAddress(2800,
+                                                     "37th St NW",
+                                                     List.of("Receiving Dock", "Building 040-1")));
+    }
+
 }

--- a/jpa/eclipselink.jpa.testapps/jpa.test.relationships/src/main/java/org/eclipse/persistence/testing/models/jpa/relationships/ShippingAddress.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.relationships/src/main/java/org/eclipse/persistence/testing/models/jpa/relationships/ShippingAddress.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025 IBM Corporation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.persistence.testing.models.jpa.relationships;
+
+import java.util.List;
+
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+// Issue #2414 test model.
+/**
+ * Shipping address.
+ * {@link Entity} class with {@link Embedded} attribute.
+ * {@link Embedded} attribute contains {@link ElementCollection} attribute.
+ */
+@Entity
+public class ShippingAddress {
+
+    @Id private Long id;
+
+    private String city;
+
+    private String state;
+
+    @ElementCollection
+    private List<String> names;
+
+    @Embedded
+    private StreetAddress streetAddress;
+
+    private int zipCode;
+
+    public ShippingAddress() {
+        this(-1L, null, null, -1, List.of(), null);
+    }
+
+    public ShippingAddress(Long id,
+                           String city,
+                           String state,
+                           int zipCode,
+                           List<String> names,
+                           StreetAddress streetAddress) {
+        this.id = id;
+        this.city = city;
+        this.state = state;
+        this.zipCode = zipCode;
+        this.names = names;
+        this.streetAddress = streetAddress;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    public List<String> getNames() {
+        return names;
+    }
+
+    public void setNames(List<String> names) {
+        this.names = names;
+    }
+
+    public StreetAddress getStreetAddress() {
+        return streetAddress;
+    }
+
+    public void setStreetAddress(StreetAddress streetAddress) {
+        this.streetAddress = streetAddress;
+    }
+
+    public int getZipCode() {
+        return zipCode;
+    }
+
+    public void setZipCode(int zipCode) {
+        this.zipCode = zipCode;
+    }
+
+}

--- a/jpa/eclipselink.jpa.testapps/jpa.test.relationships/src/main/java/org/eclipse/persistence/testing/models/jpa/relationships/StreetAddress.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.relationships/src/main/java/org/eclipse/persistence/testing/models/jpa/relationships/StreetAddress.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025 IBM Corporation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.persistence.testing.models.jpa.relationships;
+
+import java.util.List;
+
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Embeddable;
+
+// Issue #2414 test model.
+/**
+ * Street address.
+ * {@link Embeddable} class with {@link ElementCollection} attribute.
+ */
+@Embeddable
+public class StreetAddress {
+
+    private int houseNumber;
+
+    private String streetName;
+
+    @ElementCollection
+    private List<String> recipientInfo;
+
+    public StreetAddress() {
+        this(-1, null, List.of());
+    }
+
+    public StreetAddress(int houseNumber, String streetName, List<String> recipientInfo) {
+        this.houseNumber = houseNumber;
+        this.streetName = streetName;
+        this.recipientInfo = recipientInfo;
+    }
+
+    public int getHouseNumber() {
+        return houseNumber;
+    }
+
+    public void setHouseNumber(int houseNumber) {
+        this.houseNumber = houseNumber;
+    }
+
+    public String getStreetName() {
+        return streetName;
+    }
+
+    public void setStreetName(String streetName) {
+        this.streetName = streetName;
+    }
+
+    public List<String> getRecipientInfo() {
+        return recipientInfo;
+    }
+
+    public void setRecipientInfo(List<String> recipientInfo) {
+        this.recipientInfo = recipientInfo;
+    }
+
+}


### PR DESCRIPTION
Attmepts to resolve mapping using before last item in derivedExpressions, which should contain proper descriptor of `@Embeddable` class.

`descriptor.isAggregateDescriptor()` check was deleted in `ReportQuery#prepareSubSelect(AbstractSession,  AbstractRecord, Map<Expression, Expression>)` but I'm not sure whether it's OK to turn it off completely.
Anyway, the exception says _"Aggregate object cannot be deleted or written"_, but this is sub SELECT preparation code, not DML.