### PR TITLE
[4.0] Issue 2423: Fix ClassCastException in OracleChangeNotificationListener.remove() method (#2427) - backport from master

### DIFF
--- a/foundation/org.eclipse.persistence.oracle/src/main/java/org/eclipse/persistence/platform/database/oracle/dcn/OracleChangeNotificationListener.java
+++ b/foundation/org.eclipse.persistence.oracle/src/main/java/org/eclipse/persistence/platform/database/oracle/dcn/OracleChangeNotificationListener.java
@@ -248,13 +248,15 @@ public class OracleChangeNotificationListener implements DatabaseEventListener {
         Accessor accessor = databaseSession.getAccessor();
         accessor.incrementCallCount(databaseSession);
         try {
-            OracleConnection connection = (OracleConnection)databaseSession.getServerPlatform().unwrapConnection(accessor.getConnection());
+            OracleConnection connection = databaseSession.getServerPlatform().unwrapConnection(accessor.getConnection()).unwrap(OracleConnection.class);
             databaseSession.log(SessionLog.FINEST, SessionLog.CONNECTION, "dcn_unregister");
             try {
                 connection.unregisterDatabaseChangeNotification(this.register);
             } catch (SQLException exception) {
                 throw DatabaseException.sqlException(exception, databaseSession.getAccessor(), databaseSession, false);
             }
+        } catch (SQLException e) {
+            throw DatabaseException.sqlException(e, databaseSession.getAccessor(), databaseSession, false);
         } finally {
             accessor.decrementCallCount();
         }


### PR DESCRIPTION
- use unwrap to get the underlying OracleConnection
- Fixes #2423

(cherry picked from commit e62e78aa709b0e1779922eb3bf39fc5f9d557f99)