### PR TITLE
[4.0] New eclipselink dead lock scenario ... enhancement and unit test - backport from master

### DIFF
--- a/docs/docs.jpa/src/main/asciidoc/persistenceproperties_ref.adoc
+++ b/docs/docs.jpa/src/main/asciidoc/persistenceproperties_ref.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2022, 2024 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2022, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -213,6 +213,7 @@ EclipseLink includes the following persistence property extensions for
 concurrency management:
 
 * link:#concurrency-manager-allow-concurrencyexception[`concurrency.manager.allow.concurrencyexception`]
+* link:#concurrency-manager-allow-getcachekeyformerge-mode[`concurrency.manager.allow.getcachekeyformerge.mode`]
 * link:#concurrency-manager-allow-interruptedexception[`concurrency.manager.allow.interruptedexception`]
 * link:#concurrency-manager-allow-readlockstacktrace[`concurrency.manager.allow.readlockstacktrace`]
 * link:#concurrency-manager-build-object-complete-waittime[`concurrency.manager.build.object.complete.waittime`]
@@ -286,6 +287,7 @@ The following lists the EclipseLink persistence property
 * link:#compositeunitmember[`composite-unit.member`]
 * link:#compositeunitproperties[`composite-unit.properties`]
 * link:#concurrency-manager-allow-concurrencyexception[`concurrency.manager.allow.concurrencyexception`]
+* link:#concurrency-manager-allow-getcachekeyformerge-mode[`concurrency.manager.allow.getcachekeyformerge.mode`]
 * link:#concurrency-manager-allow-interruptedexception[`concurrency.manager.allow.interruptedexception`]
 * link:#concurrency-manager-allow-readlockstacktrace[`concurrency.manager.allow.readlockstacktrace`]
 * link:#concurrency-manager-build-object-complete-waittime[`concurrency.manager.build.object.complete.waittime`]
@@ -3099,6 +3101,55 @@ persistence.xml_*
 ----
 <property name="eclipselink.concurrency.manager.allow.interruptedexception" value="true" />
             
+----
+
+'''''
+
+=== concurrency.manager.allow.getcachekeyformerge.mode
+
+This property control in `org.eclipse.persistence.internal.sessions.AbstractSession#getCacheKeyFromTargetSessionForMerge(java.lang.Object, org.eclipse.persistence.internal.descriptors.ObjectBuilder, org.eclipse.persistence.descriptors.ClassDescriptor, org.eclipse.persistence.internal.sessions.MergeManager)`
+strategy how `org.eclipse.persistence.internal.identitymaps.CacheKey` will be fetched from shared cache.
+
+
+*Values*
+
+link:#concurrency.manager.allow.getcachekeyformerge.mode[Table 5-30]
+describes this persistence property's values.
+
+[[concurrency.manager.allow.getcachekeyformerge.mode]]
+
+*_Table 5-30 Valid Values for
+concurrency.manager.allow.getcachekeyformerge.mode_*
+
+|=======================================================================
+|*Value* |*Description*
+|ORIGIN |(Default) There is infinite `java.lang.Object.wait()` call in case
+of some conditions during time when object/entity referred from
+`org.eclipse.persistence.internal.identitymaps.CacheKey` is locked
+and modified by another thread. In some cases it should leads into deadlock.
+
+|WAITLOOP |Merge manager will try in the loop with timeout wait `cacheKey.wait(ConcurrencyUtil.SINGLETON.getAcquireWaitTime());`
+fetch object/entity from `org.eclipse.persistence.internal.identitymaps.CacheKey`.
+If fetch will be successful object/entity loop finish and continue with remaining code.
+If not `java.lang.InterruptedException` is thrown and caught and used `org.eclipse.persistence.internal.identitymaps.CacheKey`
+instance status is set into invalidation state. This strategy avoid deadlock issue,
+but there should be impact to the performance.
+|=======================================================================
+
+*Examples*
+
+link:#concurrency.manager.allow.getcachekeyformerge.mode[Example
+5-24] shows how to use this property in the `persistence.xml` file.
+
+[[concurrency.manager.allow.getcachekeyformerge.mode]]
+
+*_Example 5-24 Using concurrency.manager.allow.getcachekeyformerge.mode in
+persistence.xml_*
+
+[source,oac_no_warn]
+----
+<property name="eclipselink.concurrency.manager.allow.getcachekeyformerge.mode" value="WAITLOOP" />
+
 ----
 
 '''''

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/MergeManagerOperationMode.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/MergeManagerOperationMode.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.config;
+
+/**
+ * INTERNAL:
+ * <p>
+ * <b>Purpose</b>: It is data model behind {@linkplain  org.eclipse.persistence.config.SystemProperties#CONCURRENCY_MANAGER_ALLOW_GET_CACHE_KEY_FOR_MERGE_MODE}
+ * or {@linkplain  org.eclipse.persistence.config.PersistenceUnitProperties#CONCURRENCY_MANAGER_ALLOW_GET_CACHE_KEY_FOR_MERGE_MODE}.
+ */
+public final class MergeManagerOperationMode {
+
+    /**
+     * {@code ORIGIN} (DEFAULT) - There is infinite {@linkplain java.lang.Object#wait()} call in case of some conditions during time when object/entity referred from
+     * {@code org.eclipse.persistence.internal.identitymaps.CacheKey} is locked and modified by another thread. In some cases it should leads into deadlock.
+     */
+    public static final String ORIGIN = "ORIGIN";
+
+    /**
+     * {@code WAITLOOP} - Merge manager will try in the loop with timeout wait {@code cacheKey.wait(ConcurrencyUtil.SINGLETON.getAcquireWaitTime());}
+     * fetch object/entity from {@linkplain org.eclipse.persistence.internal.identitymaps.CacheKey}. If fetch will be successful object/entity loop finish and continue
+     * with remaining code. If not @{code java.lang.InterruptedException} is thrown and caught and used {@linkplain org.eclipse.persistence.internal.identitymaps.CacheKey} instance
+     * status is set into invalidation state. This strategy avoid deadlock issue, but there should be impact to the performance.
+     */
+    public static final String WAITLOOP = "WAITLOOP";
+
+    private MergeManagerOperationMode() {
+        // no instance please
+    }
+}

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/PersistenceUnitProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/PersistenceUnitProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2024 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -4044,6 +4044,23 @@ public class PersistenceUnitProperties {
      * </ul>
      */
     public static final String CONCURRENCY_MANAGER_ALLOW_INTERRUPTED_EXCEPTION  = "eclipselink.concurrency.manager.allow.interruptedexception";
+
+    /**
+     * <p>
+     * This property control in {@link org.eclipse.persistence.internal.sessions.AbstractSession#getCacheKeyFromTargetSessionForMerge(java.lang.Object, org.eclipse.persistence.internal.descriptors.ObjectBuilder, org.eclipse.persistence.descriptors.ClassDescriptor, org.eclipse.persistence.internal.sessions.MergeManager)}
+     * strategy how {@code org.eclipse.persistence.internal.identitymaps.CacheKey} will be fetched from shared cache.
+     * <p>
+     * <b>Allowed Values</b> (case-sensitive String)<b>:</b>
+     * <ul>
+     * <li>{@code ORIGIN} (DEFAULT) - There is infinite {@linkplain java.lang.Object#wait()} call in case of some conditions during time when object/entity referred from
+     * {@code org.eclipse.persistence.internal.identitymaps.CacheKey} is locked and modified by another thread. In some cases it should leads into deadlock.
+     * <li>{@code WAITLOOP} - Merge manager will try in the loop with timeout wait {@code cacheKey.wait(ConcurrencyUtil.SINGLETON.getAcquireWaitTime());}
+     * fetch object/entity from {@linkplain org.eclipse.persistence.internal.identitymaps.CacheKey}. If fetch will be successful object/entity loop finish and continue
+     * with remaining code. If not @{code java.lang.InterruptedException} is thrown and caught and used {@linkplain org.eclipse.persistence.internal.identitymaps.CacheKey} instance
+     * status is set into invalidation state. This strategy avoid deadlock issue, but there should be impact to the performance.
+     * </ul>
+     */
+    public static final String CONCURRENCY_MANAGER_ALLOW_GET_CACHE_KEY_FOR_MERGE_MODE  = "eclipselink.concurrency.manager.allow.getcachekeyformerge.mode";
 
     /**
      * <p>

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/SystemProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/SystemProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2024 Contributors to the Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -157,6 +157,23 @@ public class SystemProperties {
      * </ul>
      */
     public static final String CONCURRENCY_MANAGER_ALLOW_INTERRUPTED_EXCEPTION  = "eclipselink.concurrency.manager.allow.interruptedexception";
+
+    /**
+     * <p>
+     * This property control in {@link org.eclipse.persistence.internal.sessions.AbstractSession#getCacheKeyFromTargetSessionForMerge(java.lang.Object, org.eclipse.persistence.internal.descriptors.ObjectBuilder, org.eclipse.persistence.descriptors.ClassDescriptor, org.eclipse.persistence.internal.sessions.MergeManager)}
+     * strategy how {@code org.eclipse.persistence.internal.identitymaps.CacheKey} will be fetched from shared cache.
+     * <p>
+     * <b>Allowed Values</b> (case-sensitive String)<b>:</b>
+     * <ul>
+     * <li>{@code ORIGIN} (DEFAULT) - There is infinite {@linkplain java.lang.Object#wait()} call in case of some conditions during time when object/entity referred from
+     * {@code org.eclipse.persistence.internal.identitymaps.CacheKey} is locked and modified by another thread. In some cases it should leads into deadlock.
+     * <li>{@code WAITLOOP} - Merge manager will try in the loop with timeout wait {@code cacheKey.wait(ConcurrencyUtil.SINGLETON.getAcquireWaitTime());}
+     * fetch object/entity from {@linkplain org.eclipse.persistence.internal.identitymaps.CacheKey}. If fetch will be successful object/entity loop finish and continue
+     * with remaining code. If not @{code java.lang.InterruptedException} is thrown and caught and used {@linkplain org.eclipse.persistence.internal.identitymaps.CacheKey} instance
+     * status is set into invalidation state. This strategy avoid deadlock issue, but there should be impact to the performance.
+     * </ul>
+     */
+    public static final String CONCURRENCY_MANAGER_ALLOW_GET_CACHE_KEY_FOR_MERGE_MODE  = "eclipselink.concurrency.manager.allow.getcachekeyformerge.mode";
 
     /**
      * <p>

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ConcurrencyUtil.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ConcurrencyUtil.java
@@ -15,6 +15,19 @@
 //     IBM - ConcurrencyUtil call of ThreadMXBean.getThreadInfo() needs doPriv
 package org.eclipse.persistence.internal.helper;
 
+import org.eclipse.persistence.config.MergeManagerOperationMode;
+import org.eclipse.persistence.config.SystemProperties;
+import org.eclipse.persistence.internal.helper.type.CacheKeyToThreadRelationships;
+import org.eclipse.persistence.internal.helper.type.ConcurrencyManagerState;
+import org.eclipse.persistence.internal.helper.type.DeadLockComponent;
+import org.eclipse.persistence.internal.helper.type.ReadLockAcquisitionMetadata;
+import org.eclipse.persistence.internal.identitymaps.CacheKey;
+import org.eclipse.persistence.internal.localization.TraceLocalization;
+import org.eclipse.persistence.internal.security.PrivilegedAccessHelper;
+import org.eclipse.persistence.internal.sessions.AbstractSession;
+import org.eclipse.persistence.logging.AbstractSessionLog;
+import org.eclipse.persistence.logging.SessionLog;
+
 import java.io.StringWriter;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
@@ -29,17 +42,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Vector;
 import java.util.concurrent.atomic.AtomicLong;
-
-import org.eclipse.persistence.config.SystemProperties;
-import org.eclipse.persistence.internal.helper.type.CacheKeyToThreadRelationships;
-import org.eclipse.persistence.internal.helper.type.ConcurrencyManagerState;
-import org.eclipse.persistence.internal.helper.type.DeadLockComponent;
-import org.eclipse.persistence.internal.helper.type.ReadLockAcquisitionMetadata;
-import org.eclipse.persistence.internal.identitymaps.CacheKey;
-import org.eclipse.persistence.internal.localization.TraceLocalization;
-import org.eclipse.persistence.internal.security.PrivilegedAccessHelper;
-import org.eclipse.persistence.logging.AbstractSessionLog;
-import org.eclipse.persistence.logging.SessionLog;
 
 public class ConcurrencyUtil {
 
@@ -73,6 +75,7 @@ public class ConcurrencyUtil {
     private boolean useSemaphoreToLimitConcurrencyOnWriteLockManagerAcquireRequiredLocks  = getBooleanProperty(SystemProperties.CONCURRENCY_MANAGER_USE_SEMAPHORE_TO_SLOW_DOWN_WRITE_LOCK_MANAGER_ACQUIRE_REQUIRED_LOCKS, DEFAULT_USE_SEMAPHORE_TO_SLOW_DOWN_WRITE_LOCK_MANAGER_ACQUIRE_REQUIRED_LOCKS);
     private int noOfThreadsAllowedToObjectBuildInParallel = getIntProperty(SystemProperties.CONCURRENCY_MANAGER_OBJECT_BUILDING_NO_THREADS, DEFAULT_CONCURRENCY_MANAGER_OBJECT_BUILDING_NO_THREADS);
     private int noOfThreadsAllowedToDoWriteLockManagerAcquireRequiredLocksInParallel = getIntProperty(SystemProperties.CONCURRENCY_MANAGER_WRITE_LOCK_MANAGER_ACQUIRE_REQUIRED_LOCKS_NO_THREADS, DEFAULT_CONCURRENCY_MANAGER_WRITE_LOCK_MANAGER_ACQUIRE_REQUIRED_LOCKS_NO_THREADS);
+    private String concurrencyManagerAllowGetCacheKeyForMergeMode = getStringProperty(SystemProperties.CONCURRENCY_MANAGER_ALLOW_GET_CACHE_KEY_FOR_MERGE_MODE, MergeManagerOperationMode.ORIGIN);
     private long concurrencySemaphoreMaxTimePermit = getLongProperty(SystemProperties.CONCURRENCY_SEMAPHORE_MAX_TIME_PERMIT, DEFAULT_CONCURRENCY_SEMAPHORE_MAX_TIME_PERMIT);
     private long concurrencySemaphoreLogTimeout = getLongProperty(SystemProperties.CONCURRENCY_SEMAPHORE_LOG_TIMEOUT, DEFAULT_CONCURRENCY_SEMAPHORE_LOG_TIMEOUT);
 
@@ -126,11 +129,15 @@ public class ConcurrencyUtil {
      *            is most likely too dangerous and possibly the eclipselink code is not robust enough to code with such
      *            scenarios We do not care so much about blowing up exception during object building but during
      *            committing of transactions we are very afraid
+     * @return Returns a boolean value if the code believes that it is stuck. {@code true} means the code ended up either logging
+     *  a tiny Dump message or the massive dump message.
+     *  {@code false} means that the code did not do any logging and just quickly returned. This boolean flag is especially
+     *  meaningful if we have the  interrupt exceptions disabled and so the method is not being caused to blow up.
+     *  In that case there is still a way to know if we believe to be stuck.
      * @throws InterruptedException
-     *             we fire an interrupted exception to ensure that the code blows up and releases all of the locks it
-     *             had.
+     *             it fires an interrupted exception to ensure that the code blows up and releases all the locks it had.
      */
-    public void determineIfReleaseDeferredLockAppearsToBeDeadLocked(ConcurrencyManager concurrencyManager,
+    public boolean determineIfReleaseDeferredLockAppearsToBeDeadLocked(ConcurrencyManager concurrencyManager,
                                                                     final long whileStartTimeMillis, DeferredLockManager lockManager, ReadLockManager readLockManager,
                                                                     boolean callerIsWillingToAllowInterruptedExceptionToBeFiredUpIfNecessary)
             throws InterruptedException {
@@ -143,7 +150,7 @@ public class ConcurrencyUtil {
         if (!tooMuchTimeHasElapsed) {
             // this thread is not stuck for that long let us allow the code to continue waiting for the lock to be acquired
             // or for the deferred locks to be considered as finished
-            return;
+            return false;
         }
 
         // (b) We believe this is a dead lock
@@ -160,7 +167,7 @@ public class ConcurrencyUtil {
             // this thread has recently logged a small message about the fact that it is stuck
             // no point in logging another message like that for some time
             // let us allow for this thread to silently continue stuck without logging anything
-            return ;
+            return true;
         }
 
         // (c) This thread it is dead lock since the whileStartDate indicates a dead lock and
@@ -202,6 +209,7 @@ public class ConcurrencyUtil {
         } else {
             AbstractSessionLog.getLog().log(SessionLog.SEVERE, SessionLog.CACHE,"concurrency_manager_allow_concurrency_exception_fired_up");
         }
+        return true;
     }
 
     /**
@@ -260,7 +268,7 @@ public class ConcurrencyUtil {
      * a minute) the logic complaining that the thread is stuck and going nowhere logs a very big dump message where the
      * FULL concurrency manager state is explained. So that we can (manually) try to understand the dead lock based on
      * the dumped information
-     *
+     * <p>
      * See also {@link #dateWhenLastConcurrencyManagerStateFullDumpWasPerformed}.
      */
     public long getMaxAllowedFrequencyToProduceMassiveDumpLogMessage() {
@@ -330,6 +338,14 @@ public class ConcurrencyUtil {
 
     public void setNoOfThreadsAllowedToDoWriteLockManagerAcquireRequiredLocksInParallel(int noOfThreadsAllowedToDoWriteLockManagerAcquireRequiredLocksInParallel) {
         this.noOfThreadsAllowedToDoWriteLockManagerAcquireRequiredLocksInParallel = noOfThreadsAllowedToDoWriteLockManagerAcquireRequiredLocksInParallel;
+    }
+
+    public String getConcurrencyManagerAllowGetCacheKeyForMergeMode() {
+        return concurrencyManagerAllowGetCacheKeyForMergeMode;
+    }
+
+    public void setConcurrencyManagerAllowGetCacheKeyForMergeMode(String concurrencyManagerAllowGetCacheKeyForMergeMode) {
+        this.concurrencyManagerAllowGetCacheKeyForMergeMode = concurrencyManagerAllowGetCacheKeyForMergeMode;
     }
 
     public long getConcurrencySemaphoreMaxTimePermit() {
@@ -438,10 +454,10 @@ public class ConcurrencyUtil {
     }
 
     /**
-     * Invoke the {@link #dumpConcurrencyManagerInformationStep01(Map, Map, Map, Map, Map, Map, Map, Set, Map, Map)} if sufficient time has passed.
+     * Invoke the {@link #dumpConcurrencyManagerInformationStep01(Map, Map, Map, Map, Map, Map, Map, Set, Map, Map, Map)} if sufficient time has passed.
      * This log message will potentially create a massive dump in the server log file. So we need to check when was the
      * last time that the masive dump was produced and decide if we can log again the state of the concurrency manager.
-     *
+     * <p>
      * The access to dateWhenLastConcurrencyManagerStateFullDumpWasPerformedLock is synchronized, because we do not want
      * two threads in parallel to star deciding to dump the complete state of the concurrency manager at the same time.
      * Only one thread should succeed in producing the massive dump in a given time window.
@@ -480,6 +496,7 @@ public class ConcurrencyUtil {
         Set<Thread> setThreadWaitingToReleaseDeferredLocksOriginal = ConcurrencyManager.getThreadsWaitingToReleaseDeferredLocksSnapshot();
         Map<Thread, String> mapThreadsThatAreCurrentlyWaitingToReleaseDeferredLocksJustificationClone = ConcurrencyManager.getThreadsWaitingToReleaseDeferredLocksJustificationSnapshot();
         Map<Thread, Set<Object>> mapThreadToObjectIdWithWriteLockManagerChangesOriginal = WriteLockManager.getMapWriteLockManagerThreadToObjectIdsWithChangeSetSnapshot();
+        Map<Thread, String> mapThreadsToWaitMergeManagerWaitingDeferredCacheKeys = AbstractSession.getThreadsToWaitMergeManagerWaitingDeferredCacheKeysSnapshot();
         dumpConcurrencyManagerInformationStep01(
                 deferredLockManagers,
                 readLockManagersOriginal,
@@ -490,14 +507,15 @@ public class ConcurrencyUtil {
                 mapThreadToWaitOnAcquireReadLockMethodNameOriginal,
                 setThreadWaitingToReleaseDeferredLocksOriginal,
                 mapThreadsThatAreCurrentlyWaitingToReleaseDeferredLocksJustificationClone,
-                mapThreadToObjectIdWithWriteLockManagerChangesOriginal);
+                mapThreadToObjectIdWithWriteLockManagerChangesOriginal,
+                mapThreadsToWaitMergeManagerWaitingDeferredCacheKeys);
     }
 
     /**
      * The current working thread is having problems. It seems to not go forward being stuck either trying to acquire a
      * cache key for writing, as a deferred cache key or it is at the end of the process and it is waiting for some
      * other thread to finish building some objects it needed to defer.
-     *
+     * <p>
      * Now that the system is frozen we want to start spamming into the server log file the state of the concurrency
      * manager since this might help us understand the situation of the system.
      *
@@ -544,7 +562,8 @@ public class ConcurrencyUtil {
                                                            Map<Thread, String> mapThreadToWaitOnAcquireReadLockMethodNameOriginal,
                                                            Set<Thread> setThreadWaitingToReleaseDeferredLocksOriginal,
                                                            Map<Thread, String> mapThreadsThatAreCurrentlyWaitingToReleaseDeferredLocksJustificationClone,
-                                                           Map<Thread, Set<Object>> mapThreadToObjectIdWithWriteLockManagerChangesOriginal) {
+                                                           Map<Thread, Set<Object>> mapThreadToObjectIdWithWriteLockManagerChangesOriginal,
+                                                           Map<Thread, String> mapThreadsToWaitMergeManagerWaitingDeferredCacheKeys) {
 
         // (a) create object to represent our cache state.
         ConcurrencyManagerState concurrencyManagerState = createConcurrencyManagerState(
@@ -557,7 +576,8 @@ public class ConcurrencyUtil {
                 mapThreadToWaitOnAcquireReadLockMethodNameOriginal,
                 setThreadWaitingToReleaseDeferredLocksOriginal,
                 mapThreadsThatAreCurrentlyWaitingToReleaseDeferredLocksJustificationClone,
-                mapThreadToObjectIdWithWriteLockManagerChangesOriginal);
+                mapThreadToObjectIdWithWriteLockManagerChangesOriginal,
+                mapThreadsToWaitMergeManagerWaitingDeferredCacheKeys);
         dumpConcurrencyManagerInformationStep02(concurrencyManagerState);
     }
 
@@ -602,6 +622,13 @@ public class ConcurrencyUtil {
         // with the number of readers increased
         String deadLockExplanation = dumpDeadLockExplanationIfPossible(concurrencyManagerState);
         writer.write(deadLockExplanation);
+        // (g) PAGE 08 - threads that have commited and are facing difficulties
+        // merging the clone changes to the shared cache
+        // relates to:
+        // https://github.com/eclipse-ee4j/eclipselink/issues/2094
+        String threadStuckInMergeManagerProcess = createInformationAboutThreadsHavingDifficultyGettingCacheKeysWithObjectDifferentThanNullDuringMergeClonesToCacheAfterTransactionCommit(
+                concurrencyManagerState.getMapThreadsToWaitMergeManagerWaitingDeferredCacheKeys());
+        writer.write(threadStuckInMergeManagerProcess);
         // (g) Final header
         writer.write(TraceLocalization.buildMessage("concurrency_util_dump_concurrency_manager_information_step02_02", new Object[] {messageNumber}));
         // there should be no risk that the string is simply to big. the max string size in java is 2pow31 chars
@@ -677,6 +704,42 @@ public class ConcurrencyUtil {
     }
 
     /**
+     * A string describing threads that are likely facing the deadlock <a href="https://github.com/eclipse-ee4j/eclipselink/issues/2094">issue 2094</a>.
+     * @param mapThreadsToWaitMergeManagerWaitingDeferredCacheKeys
+     *            This parameter is related to the
+     *            {@link AbstractSession#THREADS_TO_WAIT_MERGE_MANAGER_WAITING_DEFERRED_CACHE_KEYS}
+     *            and to the <a href="https://github.com/eclipse-ee4j/eclipselink/issues/2094">issue 2094</a> it allows check
+     *            threads that are at post-commit phase and are trying to merge their change set into the original
+     *            objects in the cache. When this is taking place some of the cache keys that the merge manager is
+     *            needing might be locked by other threads. This can lead to deadlocks, if our merge manager thread
+     *            happens to be the owner of cache keys that matter to the owner of the cache keys the merge manager
+     *            will need to acquire.
+     * @return A string describing all threads that are stuck in the
+     *         {@code org.eclipse.persistence.internal.sessions.AbstractSession.getCacheKeyFromTargetSessionForMergeScenarioMergeManagerNotNullAndCacheKeyOriginalStillNull(CacheKey, Object, ObjectBuilder, ClassDescriptor, MergeManager) }
+     *         logic. There is thread that want to return to the merge manage a cacheKey where the cacheKey object is no
+     *         longer null. The threads are stuck because the cache key object is still null and the cache key is
+     *         acquired most likely by some random thread doing object building. Deadlocks may be occurring between the
+     *         merge manager and the object building threads.
+     */
+    private String createInformationAboutThreadsHavingDifficultyGettingCacheKeysWithObjectDifferentThanNullDuringMergeClonesToCacheAfterTransactionCommit(
+            Map<Thread, String> mapThreadsToWaitMergeManagerWaitingDeferredCacheKeys) {
+        // (a) Create a header string of information
+        StringWriter writer = new StringWriter();
+        writer.write(TraceLocalization.buildMessage("concurrency_util_threads_having_difficulty_getting_cache_keys_with_object_different_than_null_during_merge_clones_to_cache_after_transaction_commit_page_header"
+                , new Object[] {mapThreadsToWaitMergeManagerWaitingDeferredCacheKeys.size()}));
+        int currentThreadNumber = 0;
+        for (Map.Entry<Thread, String> currentEntry : mapThreadsToWaitMergeManagerWaitingDeferredCacheKeys.entrySet()) {
+            currentThreadNumber++;
+            Thread thread = currentEntry.getKey();
+            String justification = currentEntry.getValue();
+            writer.write(TraceLocalization.buildMessage("concurrency_util_threads_having_difficulty_getting_cache_keys_with_object_different_than_null_during_merge_clones_to_cache_after_transaction_commit_body",
+                    new Object[] {currentThreadNumber, thread.getName(), justification}));
+        }
+        writer.write(TraceLocalization.buildMessage("concurrency_util_threads_having_difficulty_getting_cache_keys_with_object_different_than_null_during_merge_clones_to_cache_after_transaction_commit_page_end"));
+        return writer.toString();
+    }
+
+    /**
      * create a DTO that tries to represent the current snapshot of the concurrency manager and write lock manager cache
      * state
      */
@@ -690,7 +753,8 @@ public class ConcurrencyUtil {
             Map<Thread, String> mapThreadToWaitOnAcquireReadLockMethodNameOriginal,
             Set<Thread> setThreadWaitingToReleaseDeferredLocksOriginal,
             Map<Thread, String> mapThreadsThatAreCurrentlyWaitingToReleaseDeferredLocksJustificationClone,
-            Map<Thread, Set<Object>> mapThreadToObjectIdWithWriteLockManagerChangesOriginal) {
+            Map<Thread, Set<Object>> mapThreadToObjectIdWithWriteLockManagerChangesOriginal,
+            Map<Thread, String> mapThreadsToWaitMergeManagerWaitingDeferredCacheKeys) {
         // (a) As a first step we want to clone-copy the two maps
         // once we start working with the maps and using them to do dead lock detection
         // or simply print the state of the system we do not want the maps to continue changing as the threads referenced in the maps
@@ -747,7 +811,8 @@ public class ConcurrencyUtil {
                 readLockManagerMapClone, deferredLockManagerMapClone, unifiedMapOfThreadsStuckTryingToAcquireWriteLock,
                 mapThreadToWaitOnAcquireMethodNameClone, mapThreadToWaitOnAcquireReadLockClone, mapThreadToWaitOnAcquireReadLockMethodNameClone,
                 setThreadWaitingToReleaseDeferredLocksClone, mapThreadsThatAreCurrentlyWaitingToReleaseDeferredLocksJustificationClone,
-                mapOfCacheKeyToDtosExplainingThreadExpectationsOnCacheKey, mapThreadToObjectIdWithWriteLockManagerChangesClone);
+                mapOfCacheKeyToDtosExplainingThreadExpectationsOnCacheKey, mapThreadToObjectIdWithWriteLockManagerChangesClone,
+                mapThreadsToWaitMergeManagerWaitingDeferredCacheKeys);
     }
 
     /**
@@ -921,7 +986,7 @@ public class ConcurrencyUtil {
      *
      * <P>
      * NOTE: This approach can be easily tested in a basic unit test.
-     *
+     * <p>
      *
      * <a href="https://crunchify.com/how-to-generate-java-thread-dump-programmatically/">Original source of code</a>
      *
@@ -1209,7 +1274,7 @@ public class ConcurrencyUtil {
         writer.write(createStringWithSummaryOfDeferredLocksOnThread(lockManager, threadName));
         // (d) On the topic of the defferred locks we can also try to do better and explain why the algorithm
         // keeps returning false that the build object is not yet complete
-        if (waitingToReleaseDeferredLocksJustification != null && waitingToReleaseDeferredLocksJustification.length() > 0) {
+        if (waitingToReleaseDeferredLocksJustification != null && !waitingToReleaseDeferredLocksJustification.isEmpty()) {
             writer.write(TraceLocalization.buildMessage("concurrency_util_create_information_all_resources_acquired_deferred_8", new Object[] {waitingToReleaseDeferredLocksJustification}));
         } else {
             writer.write(TraceLocalization.buildMessage("concurrency_util_create_information_all_resources_acquired_deferred_9"));
@@ -1677,6 +1742,20 @@ public class ConcurrencyUtil {
         if (value != null) {
             try {
                 return Boolean.parseBoolean(value.trim());
+            } catch (Exception ignoreE) {
+                return defaultValue;
+            }
+        }
+        return defaultValue;
+    }
+
+    private String getStringProperty(final String key, final String defaultValue) {
+        final String value = PrivilegedAccessHelper.callDoPrivileged(
+                () -> System.getProperty(key, String.valueOf(defaultValue))
+        );
+        if (value != null) {
+            try {
+                return value.trim();
             } catch (Exception ignoreE) {
                 return defaultValue;
             }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/type/ConcurrencyManagerState.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/type/ConcurrencyManagerState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -83,6 +83,17 @@ public class ConcurrencyManagerState {
     private final Map<Thread, Set<Object>> mapThreadToObjectIdWithWriteLockManagerChangesClone;
 
     /**
+     * This field is related to the
+     * {@link org.eclipse.persistence.internal.sessions.AbstractSession#THREADS_TO_WAIT_MERGE_MANAGER_WAITING_DEFERRED_CACHE_KEYS}
+     * and to the bug https://github.com/eclipse-ee4j/eclipselink/issues/2094 it allows to monitor on threads
+     * that are at post-commit phase and are trying to merge their change set into the original objects in the cache.
+     * When this is taking place some of the cache keys that the merge manager is needing might be locked by other
+     * threads. This can lead to deadlocks, if our merge manager thread happens to be the owner of cache keys that
+     * matter to the owner of the cache keys the merge manager will need to acquire.
+     */
+    private final Map<Thread, String> mapThreadsToWaitMergeManagerWaitingDeferredCacheKeys;
+
+    /**
      * Create a new ConcurrencyManagerState.
      *
      */
@@ -96,7 +107,8 @@ public class ConcurrencyManagerState {
             Set<Thread> setThreadWaitingToReleaseDeferredLocksClone,
             Map<Thread, String> mapThreadsThatAreCurrentlyWaitingToReleaseDeferredLocksJustificationClone,
             Map<ConcurrencyManager, CacheKeyToThreadRelationships> mapOfCacheKeyToDtosExplainingThreadExpectationsOnCacheKey,
-            Map<Thread, Set<Object>> mapThreadToObjectIdWithWriteLockManagerChangesClone) {
+            Map<Thread, Set<Object>> mapThreadToObjectIdWithWriteLockManagerChangesClone,
+            Map<Thread, String> mapThreadsToWaitMergeManagerWaitingDeferredCacheKeys) {
         super();
         this.readLockManagerMapClone = readLockManagerMapClone;
         this.deferredLockManagerMapClone = deferredLockManagerMapClone;
@@ -108,6 +120,7 @@ public class ConcurrencyManagerState {
         this.mapThreadsThatAreCurrentlyWaitingToReleaseDeferredLocksJustificationClone = mapThreadsThatAreCurrentlyWaitingToReleaseDeferredLocksJustificationClone;
         this.mapOfCacheKeyToDtosExplainingThreadExpectationsOnCacheKey = mapOfCacheKeyToDtosExplainingThreadExpectationsOnCacheKey;
         this.mapThreadToObjectIdWithWriteLockManagerChangesClone = mapThreadToObjectIdWithWriteLockManagerChangesClone;
+        this.mapThreadsToWaitMergeManagerWaitingDeferredCacheKeys = mapThreadsToWaitMergeManagerWaitingDeferredCacheKeys;
     }
 
     /** Getter for {@link #readLockManagerMapClone} */
@@ -158,5 +171,10 @@ public class ConcurrencyManagerState {
     /** Getter for {@link #mapThreadToWaitOnAcquireReadLockCloneMethodName} */
     public Map<Thread, String> getMapThreadToWaitOnAcquireReadLockCloneMethodName() {
         return unmodifiableMap(mapThreadToWaitOnAcquireReadLockCloneMethodName);
+    }
+
+    /** Getter for {@link #mapThreadsToWaitMergeManagerWaitingDeferredCacheKeys} */
+    public Map<Thread, String> getMapThreadsToWaitMergeManagerWaitingDeferredCacheKeys() {
+        return unmodifiableMap(mapThreadsToWaitMergeManagerWaitingDeferredCacheKeys);
     }
 }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/ExceptionLocalizationResource.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/ExceptionLocalizationResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2018 IBM Corporation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -262,7 +262,8 @@ public class ExceptionLocalizationResource extends ListResourceBundle {
                                            { "json_pgsql_pgobject_conversion", "Database PGobject conversion failed."},
                                            { "json_pgsql_unknown_type", "Unknown JSON type returned from database."},
                                            { "json_ora21c_jsonvalue_to_oraclevalue", "Could not convert JsonValue to OracleJsonValue."},
-                                           { "json_ora21c_resultset_to_jsonvalue", "Could not convert JDBC ResultSet type to JsonValue."}
+                                           { "json_ora21c_resultset_to_jsonvalue", "Could not convert JDBC ResultSet type to JsonValue."},
+                                           { "missing_jpql_parser_class", "Could not load the JPQL parser class."}
                                         };
     /**
      * Return the lookup table.

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/TraceLocalizationResource.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/TraceLocalizationResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2017, 2022 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -269,7 +269,24 @@ public class TraceLocalizationResource extends ListResourceBundle {
                 + " stopping the candidate thread to make progress... We expect this code spot to never be invoked. "
                 + " Either this thread made progress or if it continues to be stuck in the releaseDeferredLock "
                 + " we most likely have an implementation bug somewhere. "},
-
+        { "concurrency_util_threads_having_difficulty_getting_cache_keys_with_object_different_than_null_during_merge_clones_to_cache_after_transaction_commit_justification",
+                " Merge manager logic is currently stuck in the process of trying to return the cache key: {0}  \n"
+                + " this cache key is currently acquired by a competing thread: {1} . \n"
+                + " This cache key has the problem that its original object is still set to NULL. \n"
+                + "  The operation of this current thread is that by waiting for some time the current owner of the cache key will finish object building and release the cache key. \n"
+                + " Note: There is real risk that we are in a deadlock. The daedlock exists if the current thread: {2} \n"
+                + " is owning other cache key resources as a writer. Any lock acquired by the current thread might be needed by competing threads. \n"
+                + " Much in the same manner that our current thread is stuck hoping to see this specific cache key being released. \n"},
+        { "concurrency_util_threads_having_difficulty_getting_cache_keys_with_object_different_than_null_during_merge_clones_to_cache_after_transaction_commit_page_header"
+                , "Concurrency manager - Page 08 start - Threads in MergeManager Acquiring Cache Keys for Clones to be merged into eclipselink server session cache of originals"
+                + "\n This section provides information about threads within the MergeManager that require cache keys for merging clones with changes."
+                + "\n Specifically, it focuses on the threads working in the context of an ObjectChangeSet where the server session CacheKey is found to still have CacheKy.object null,"
+                + "\n and the CacheKey is acquired by a competing thread (typically an ObjectBuilder thread)."
+                + "\nTotal number of threads waiting to see lock being released: {0}\n\n"},
+        { "concurrency_util_threads_having_difficulty_getting_cache_keys_with_object_different_than_null_during_merge_clones_to_cache_after_transaction_commit_body"
+                , "[currentThreadNumber: {0}] [ThreadName: {1}]:  Justification for being stuck: {2}\n"},
+        { "concurrency_util_threads_having_difficulty_getting_cache_keys_with_object_different_than_null_during_merge_clones_to_cache_after_transaction_commit_page_end"
+                , "Concurrency manager - Page 08 end - Threads in MergeManager Acquiring Cache Keys for Clones to be merged into eclipselink server session cache of originals\n"},
         { "XML_call", "XML call" },
         { "XML_data_call", "XML data call" },
         { "XML_data_delete", "XML data delete" },

--- a/jpa/eclipselink.jpa.testapps/jpa.test.diagnostic.deadlock/src/main/resources/META-INF/persistence.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.diagnostic.deadlock/src/main/resources/META-INF/persistence.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2024, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -29,6 +29,24 @@
             <property name="eclipselink.concurrency.manager.allow.readlockstacktrace" value="true"/>
             <property name="eclipselink.concurrency.manager.allow.concurrencyexception" value="true"/>
             <property name="eclipselink.concurrency.manager.allow.interruptedexception" value="true"/>
+        </properties>
+    </persistence-unit>
+
+    <persistence-unit name="cachedeadlockdetection-loopwait-pu" transaction-type="RESOURCE_LOCAL">
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+        <class>org.eclipse.persistence.testing.models.jpa.deadlock.diagnostic.CacheDeadLockDetectionMaster</class>
+        <class>org.eclipse.persistence.testing.models.jpa.deadlock.diagnostic.CacheDeadLockDetectionDetail</class>
+        <exclude-unlisted-classes>true</exclude-unlisted-classes>
+        <properties>
+            <property name="eclipselink.concurrency.manager.waittime" value="1"/>
+            <property name="eclipselink.concurrency.manager.maxsleeptime" value="2"/>
+            <property name="eclipselink.concurrency.manager.maxfrequencytodumptinymessage" value="800"/>
+            <property name="eclipselink.concurrency.manager.maxfrequencytodumpmassivemessage" value="1000"/>
+            <property name="eclipselink.concurrency.manager.build.object.complete.waittime" value="5"/>
+            <property name="eclipselink.concurrency.manager.allow.readlockstacktrace" value="true"/>
+            <property name="eclipselink.concurrency.manager.allow.concurrencyexception" value="true"/>
+            <property name="eclipselink.concurrency.manager.allow.interruptedexception" value="true"/>
+            <property name="eclipselink.concurrency.manager.allow.getcachekeyformerge.mode" value="WAITLOOP"/>
         </properties>
     </persistence-unit>
 

--- a/jpa/eclipselink.jpa.testapps/jpa.test.diagnostic.deadlock/src/test/java/org/eclipse/persistence/testing/tests/jpa/deadlock/diagnostic/CacheDeadLockDetectionTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.diagnostic.deadlock/src/test/java/org/eclipse/persistence/testing/tests/jpa/deadlock/diagnostic/CacheDeadLockDetectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -29,11 +29,12 @@ import junit.framework.Test;
 import junit.framework.TestSuite;
 import org.junit.Assert;
 
+import org.eclipse.persistence.config.MergeManagerOperationMode;
+import org.eclipse.persistence.internal.helper.ConcurrencyUtil;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
 import org.eclipse.persistence.jpa.JpaEntityManager;
 import org.eclipse.persistence.logging.AbstractSessionLog;
 
-import org.eclipse.persistence.internal.helper.ConcurrencyUtil;
 import org.eclipse.persistence.testing.framework.jpa.junit.JUnitTestCase;
 import org.eclipse.persistence.testing.framework.junit.JUnitTestCaseHelper;
 import org.eclipse.persistence.testing.models.jpa.deadlock.diagnostic.CacheDeadLockDetectionDetail;
@@ -125,7 +126,7 @@ public class CacheDeadLockDetectionTest extends JUnitTestCase {
         }
         //Check if at least one log message is generated
         assertTrue(logWrapper.getMessageCount("Stuck thread problem: unique tiny message number") > 0);
-        assertTrue(logWrapper.getMessageCount("Start full concurrency manager state \\(massive\\) dump No") > 0);
+        assertTrue(logWrapper.getMessageCount("Start full concurrency manager state (massive) dump No") > 0);
     }
 
     public void testVerifySemaphorePersistenceProperties() {
@@ -184,6 +185,8 @@ public class CacheDeadLockDetectionTest extends JUnitTestCase {
         Assert.assertEquals(800L, ConcurrencyUtil.SINGLETON.getMaxAllowedFrequencyToProduceTinyDumpLogMessage());
         Assert.assertEquals(1000L, ConcurrencyUtil.SINGLETON.getMaxAllowedFrequencyToProduceMassiveDumpLogMessage());
         Assert.assertEquals(5L, ConcurrencyUtil.SINGLETON.getBuildObjectCompleteWaitTime());
+        //MergeManagerOperationMode.ORIGIN is default value not explicitly specified in persistence.xml
+        Assert.assertEquals(MergeManagerOperationMode.ORIGIN, ConcurrencyUtil.SINGLETON.getConcurrencyManagerAllowGetCacheKeyForMergeMode());
         Assert.assertTrue(ConcurrencyUtil.SINGLETON.isAllowTakingStackTraceDuringReadLockAcquisition());
         Assert.assertTrue(ConcurrencyUtil.SINGLETON.isAllowConcurrencyExceptionToBeFiredUp());
         Assert.assertTrue(ConcurrencyUtil.SINGLETON.isAllowInterruptedExceptionFired());

--- a/jpa/eclipselink.jpa.testapps/jpa.test.diagnostic.deadlock/src/test/java/org/eclipse/persistence/testing/tests/jpa/deadlock/diagnostic/CacheDeadLockManagersTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.diagnostic.deadlock/src/test/java/org/eclipse/persistence/testing/tests/jpa/deadlock/diagnostic/CacheDeadLockManagersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,18 +14,25 @@
 //     Oracle - initial API and implementation
 package org.eclipse.persistence.testing.tests.jpa.deadlock.diagnostic;
 
+import java.util.Map;
+import java.util.concurrent.Semaphore;
+
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.Persistence;
 import jakarta.persistence.Query;
+
 import junit.framework.Test;
 import junit.framework.TestSuite;
+
+import org.eclipse.persistence.config.MergeManagerOperationMode;
 import org.eclipse.persistence.descriptors.ClassDescriptor;
 import org.eclipse.persistence.internal.helper.ConcurrencyUtil;
 import org.eclipse.persistence.internal.helper.WriteLockManager;
 import org.eclipse.persistence.internal.identitymaps.CacheKey;
 import org.eclipse.persistence.internal.jpa.EJBQueryImpl;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
+import org.eclipse.persistence.internal.sessions.IdentityMapAccessor;
 import org.eclipse.persistence.jpa.JpaEntityManager;
 import org.eclipse.persistence.logging.AbstractSessionLog;
 import org.eclipse.persistence.queries.ObjectBuildingQuery;
@@ -34,8 +41,6 @@ import org.eclipse.persistence.testing.framework.junit.JUnitTestCaseHelper;
 import org.eclipse.persistence.testing.models.jpa.deadlock.diagnostic.CacheDeadLockDetectionDetail;
 import org.eclipse.persistence.testing.models.jpa.deadlock.diagnostic.CacheDeadLockDetectionMaster;
 import org.eclipse.persistence.testing.models.jpa.deadlock.diagnostic.DeadLockDiagnosticTableCreator;
-
-import java.util.Map;
 
 public class CacheDeadLockManagersTest extends JUnitTestCase {
 
@@ -54,6 +59,8 @@ public class CacheDeadLockManagersTest extends JUnitTestCase {
         suite.setName("CacheDeadLockDetectionTest");
         suite.addTest(new CacheDeadLockManagersTest("testSetup"));
         suite.addTest(new CacheDeadLockManagersTest("testWriteLockManagerAcquireLocksForClone"));
+        suite.addTest(new CacheDeadLockManagersTest("testAbstractSessionCacheKeyFromTargetSessionForMerge"));
+        suite.addTest(new CacheDeadLockManagersTest("testAbstractSessionCacheKeyFromTargetSessionForMergeWithLockedCacheKey"));
         return suite;
     }
 
@@ -62,10 +69,12 @@ public class CacheDeadLockManagersTest extends JUnitTestCase {
      * execution in the server.
      */
     public void testSetup() {
-        EntityManagerFactory emf = Persistence.createEntityManagerFactory("cachedeadlockdetection-pu", JUnitTestCaseHelper.getDatabaseProperties());
+        final String PU_NAME = "cachedeadlockdetection-pu";
+
+        EntityManagerFactory emf = Persistence.createEntityManagerFactory(PU_NAME, JUnitTestCaseHelper.getDatabaseProperties());
         EntityManager em = emf.createEntityManager();
         new DeadLockDiagnosticTableCreator().replaceTables(((JpaEntityManager)em).getServerSession());
-        clearCache("cachedeadlockdetection-pu");
+        clearCache(PU_NAME);
         try {
             em.getTransaction().begin();
             initData(em);
@@ -87,7 +96,9 @@ public class CacheDeadLockManagersTest extends JUnitTestCase {
     }
 
     public void testWriteLockManagerAcquireLocksForClone() {
-        EntityManagerFactory emf = Persistence.createEntityManagerFactory("cachedeadlockdetection-pu", JUnitTestCaseHelper.getDatabaseProperties());
+        final String PU_NAME = "cachedeadlockdetection-pu";
+
+        EntityManagerFactory emf = Persistence.createEntityManagerFactory(PU_NAME, JUnitTestCaseHelper.getDatabaseProperties());
         EntityManager em = emf.createEntityManager();
         AbstractSession serverSession = ((JpaEntityManager)em).getServerSession();
         LogWrapper logWrapper = new LogWrapper();
@@ -113,6 +124,146 @@ public class CacheDeadLockManagersTest extends JUnitTestCase {
                 if (em.isOpen()) {
                     em.close();
                 }
+            }
+        }
+    }
+
+    public void testAbstractSessionCacheKeyFromTargetSessionForMerge() {
+        final String PU_NAME = "cachedeadlockdetection-loopwait-pu";
+        final long MASTER_ID = 1000L;
+        final long DETAIL_ID_1 = 1111L;
+        final long DETAIL_ID_2 = 1112L;
+
+        EntityManagerFactory emf = Persistence.createEntityManagerFactory(PU_NAME, JUnitTestCaseHelper.getDatabaseProperties());
+        EntityManager em = emf.createEntityManager();
+        assertEquals(MergeManagerOperationMode.WAITLOOP, ConcurrencyUtil.SINGLETON.getConcurrencyManagerAllowGetCacheKeyForMergeMode());
+        clearCache(PU_NAME);
+        try {
+            em.getTransaction().begin();
+            CacheDeadLockDetectionMaster cacheDeadLockDetectionMaster = new CacheDeadLockDetectionMaster(MASTER_ID, "M1000");
+            CacheDeadLockDetectionDetail cacheDeadLockDetectionDetail1 = new CacheDeadLockDetectionDetail(DETAIL_ID_1, "D1111");
+            cacheDeadLockDetectionDetail1.setMaster(cacheDeadLockDetectionMaster);
+            em.persist(cacheDeadLockDetectionMaster);
+            em.persist(cacheDeadLockDetectionDetail1);
+            em.getTransaction().commit();
+
+            IdentityMapAccessor identityMapAccessor = (IdentityMapAccessor) ((JpaEntityManager)em).getServerSession().getIdentityMapAccessor();
+            CacheKey cacheKey = identityMapAccessor.getCacheKeyForObject(cacheDeadLockDetectionMaster);
+            Semaphore semaphore = new Semaphore(1);
+            semaphore.acquire();
+            Object backupObject = cacheKey.getObject();
+            //Lock existing cache key by another thread
+            Thread thread = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        cacheKey.acquire(true);
+                        cacheKey.setObject(null);
+                        semaphore.acquire();
+                        cacheKey.setObject(backupObject);
+                        cacheKey.release();
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            });
+            thread.start();
+
+            em.getTransaction().begin();
+            CacheDeadLockDetectionDetail cacheDeadLockDetectionDetail2 = new CacheDeadLockDetectionDetail(DETAIL_ID_2, "D1112");
+            cacheDeadLockDetectionDetail2.setMaster(cacheDeadLockDetectionMaster);
+            em.persist(cacheDeadLockDetectionDetail2);
+            //Release semaphore which block second thread and unlock cacheKey to allow process next piece of code without any issue.
+            semaphore.release();
+            em.getTransaction().commit();
+            CacheDeadLockDetectionDetail findResult = em.find(CacheDeadLockDetectionDetail.class, DETAIL_ID_2);
+            assertEquals(DETAIL_ID_2, findResult.getId());
+            assertEquals("D1112", findResult.getName());
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException();
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if (em.isOpen()) {
+                em.close();
+            }
+            if (emf.isOpen()) {
+                emf.close();
+            }
+        }
+    }
+
+    public void testAbstractSessionCacheKeyFromTargetSessionForMergeWithLockedCacheKey() {
+        final String PU_NAME = "cachedeadlockdetection-loopwait-pu";
+        final long MASTER_ID = 2000L;
+        final long DETAIL_ID_1 = 2111L;
+        final long DETAIL_ID_2 = 2222L;
+
+        EntityManagerFactory emf = Persistence.createEntityManagerFactory(PU_NAME, JUnitTestCaseHelper.getDatabaseProperties());
+        EntityManager em = emf.createEntityManager();
+        AbstractSession serverSession = ((JpaEntityManager)em).getServerSession();
+        LogWrapper logWrapper = new LogWrapper();
+        serverSession.setSessionLog(logWrapper);
+        AbstractSessionLog.setLog(logWrapper);
+        assertEquals(MergeManagerOperationMode.WAITLOOP, ConcurrencyUtil.SINGLETON.getConcurrencyManagerAllowGetCacheKeyForMergeMode());
+        clearCache(PU_NAME);
+        try {
+            em.getTransaction().begin();
+            CacheDeadLockDetectionMaster cacheDeadLockDetectionMaster = new CacheDeadLockDetectionMaster(MASTER_ID, "M2000");
+            CacheDeadLockDetectionDetail cacheDeadLockDetectionDetail1 = new CacheDeadLockDetectionDetail(DETAIL_ID_1, "D2111");
+            cacheDeadLockDetectionDetail1.setMaster(cacheDeadLockDetectionMaster);
+            em.persist(cacheDeadLockDetectionMaster);
+            em.persist(cacheDeadLockDetectionDetail1);
+            em.getTransaction().commit();
+
+            IdentityMapAccessor identityMapAccessor = (IdentityMapAccessor) ((JpaEntityManager)em).getServerSession().getIdentityMapAccessor();
+            CacheKey cacheKey = identityMapAccessor.getCacheKeyForObject(cacheDeadLockDetectionMaster);
+            Semaphore semaphore = new Semaphore(1);
+            semaphore.acquire();
+            Object backupObject = cacheKey.getObject();
+            //Lock existing cache key by another thread
+            Thread thread = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        cacheKey.acquire(true);
+                        cacheKey.setObject(null);
+                        semaphore.acquire();
+                        cacheKey.setObject(backupObject);
+                        cacheKey.release();
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            });
+            thread.start();
+
+            em.getTransaction().begin();
+            CacheDeadLockDetectionDetail cacheDeadLockDetectionDetail2 = new CacheDeadLockDetectionDetail(DETAIL_ID_2, "D2222");
+            cacheDeadLockDetectionDetail2.setMaster(cacheDeadLockDetectionMaster);
+            em.persist(cacheDeadLockDetectionDetail2);
+            //Sleep is there to simulate, that main thread is doing some more time consuming operations and allow dead lock detection -> log messages.
+            Thread.sleep(1000);
+            em.getTransaction().commit();
+            CacheDeadLockDetectionDetail findResult = em.find(CacheDeadLockDetectionDetail.class, DETAIL_ID_2);
+            assertEquals(DETAIL_ID_2, findResult.getId());
+            assertEquals("D2222", findResult.getName());
+            assertEquals(1, logWrapper.getMessageCount("Page 08 start"));
+            assertEquals(1, logWrapper.getMessageCount("competing thread: " + thread));
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException();
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if (em.isOpen()) {
+                em.close();
+            }
+            if (emf.isOpen()) {
+                emf.close();
             }
         }
     }

--- a/jpa/eclipselink.jpa.testapps/jpa.test.diagnostic.deadlock/src/test/java/org/eclipse/persistence/testing/tests/jpa/deadlock/diagnostic/LogWrapper.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.diagnostic.deadlock/src/test/java/org/eclipse/persistence/testing/tests/jpa/deadlock/diagnostic/LogWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -42,7 +42,7 @@ public class LogWrapper extends DefaultSessionLog {
 
     public long getMessageCount(String checkedMessage) {
         String logOutput = sw.toString();
-        return Pattern.compile(checkedMessage)
+        return Pattern.compile(checkedMessage, Pattern.LITERAL)
                 .matcher(logOutput)
                 .results()
                 .count();

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
@@ -507,7 +507,7 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
             sessionName = (String)puInfo.getProperties().get(PersistenceUnitProperties.SESSION_NAME);
         }
         // Specifying empty String in properties allows to remove SESSION_NAME specified in puInfo properties.
-        if(sessionName != null && sessionName.length() > 0) {
+        if(sessionName != null && !sessionName.isEmpty()) {
             return sessionName;
         }
 
@@ -566,7 +566,7 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
                     }
                 }
                 // don't set an empty String
-                if (strValue.length() > 0) {
+                if (!strValue.isEmpty()) {
                     suffix.append("_").append(Helper.getShortClassName(name)).append("=").append(strValue);
                 }
             }
@@ -606,15 +606,15 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
 
     /**
      * Deploy a persistence session and return an EntityManagerFactory.
-     *
+     * <p>
      * Deployment takes a session that was partially created in the predeploy call and makes it whole.
-     *
+     * <p>
      * This means doing any configuration that requires the real class definitions for the entities.  In
      * the predeploy phase we were in a stage where we were not let allowed to load the real classes.
-     *
+     * <p>
      * Deploy could be called several times - but only the first call does the actual deploying -
      * additional calls allow to update session properties (in case the session is not connected).
-     *
+     * <p>
      * Note that there is no need to synchronize deploy method - it doesn't alter factoryCount
      * and while deploy is executed no other method can alter the current state
      * (predeploy call would just increment factoryCount; undeploy call would not drop factoryCount to 0).
@@ -748,7 +748,7 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
                         this.session.setProperties(deployProperties);
                         updateSession(deployProperties, classLoaderToUse);
                         if (isValidationOnly(deployProperties, false)) {
-                            /**
+                            /*
                              * for 324213 we could add a session.loginAndDetectDatasource() call
                              * before calling initializeDescriptors when validation-only is True
                              * to avoid a native sequence exception on a generic DatabasePlatform
@@ -1273,7 +1273,7 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
         // Set logging file.
         String loggingFileString = (String)persistenceProperties.get(PersistenceUnitProperties.LOGGING_FILE);
         if (loggingFileString != null) {
-            if (!loggingFileString.trim().equals("")) {
+            if (!loggingFileString.trim().isEmpty()) {
                 try {
                     if (sessionLog!=null){
                         if (sessionLog instanceof AbstractSessionLog) {
@@ -1719,16 +1719,16 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
     /**
      * Perform any steps necessary prior to actual deployment.  This includes any steps in the session
      * creation that do not require the real loaded domain classes.
-     *
+     * <p>
      * The first call to this method caches persistenceUnitInfo which is reused in the following calls.
-     *
+     * <p>
      * Note that in JSE case factoryCount is NOT incremented on the very first call
      * (by JavaSECMPInitializer.callPredeploy, typically in preMain).
      * That provides 1 to 1 correspondence between factoryCount and the number of open factories.
-     *
+     * <p>
      * In case factoryCount &gt; 0 the method just increments factoryCount.
      * factory == 0 triggers creation of a new session.
-     *
+     * <p>
      * This method and undeploy - the only methods altering factoryCount - should be synchronized.
      *
      * @return A transformer (which may be null) that should be plugged into the proper
@@ -2146,7 +2146,7 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
                     String message = LoggingLocalization.buildMessage("predeploy_end", new Object[]{getPersistenceUnitInfo().getPersistenceUnitName(), "N/A", state, factoryCount});
                     try {
                         logWriter.write(message);
-                        logWriter.write(Helper.cr());
+                        logWriter.write(System.lineSeparator());
                     } catch (IOException ioex) {
                         // Ignore IOException
                     }
@@ -2372,7 +2372,7 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
     protected void updateSerializer(Map m, ClassLoader loader) {
         String serializer = getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.SERIALIZER, m, this.session);
         if (serializer != null) {
-            if (serializer.length() > 0) {
+            if (!serializer.isEmpty()) {
                 try {
                     Class<?> transportClass = findClassForProperty(serializer, PersistenceUnitProperties.SERIALIZER, loader);
                     this.session.setSerializer((Serializer)transportClass.getConstructor().newInstance());
@@ -2539,7 +2539,7 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
         PersistenceUnitTransactionType transactionType = this.persistenceUnitInfo.getTransactionType();
         //bug 5867753: find and override the transaction type using properties
         String transTypeString = getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.TRANSACTION_TYPE, m, this.session);
-        if (transTypeString != null && transTypeString.length() > 0) {
+        if (transTypeString != null && !transTypeString.isEmpty()) {
             transactionType = PersistenceUnitTransactionType.valueOf(transTypeString);
         }
         //find the jta datasource
@@ -2626,7 +2626,7 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
             return defaultDataSource;
         }
         if ( datasource instanceof String){
-            if(((String)datasource).length() > 0) {
+            if(!((String) datasource).isEmpty()) {
                 // Create a dummy DataSource that will throw an exception on access
                 return new DataSourceImpl((String)datasource, null, null, null);
             } else {
@@ -2940,6 +2940,7 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
             updateConcurrencyManagerAllowInterruptedExceptionFired(m);
             updateConcurrencyManagerAllowConcurrencyExceptionToBeFiredUp(m);
             updateConcurrencyManagerAllowTakingStackTraceDuringReadLockAcquisition(m);
+            updateAbstractSessionModeOfOperationOfMergeManagerGetCacheKey(m);
             updateConcurrencyManagerUseObjectBuildingSemaphore(m);
             updateConcurrencyManagerUseWriteLockManagerSemaphore(m);
             updateConcurrencyManagerNoOfThreadsAllowedToObjectBuildInParallel(m);
@@ -3456,8 +3457,6 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
         if (parser != null) {
             if (parser.equalsIgnoreCase(ParserType.Hermes)) {
                 parser = "org.eclipse.persistence.internal.jpa.jpql.HermesParser";
-            } else if (parser.equalsIgnoreCase(ParserType.ANTLR)) {
-                parser = "org.eclipse.persistence.queries.ANTLRQueryBuilder";
             }
             this.session.setProperty(PersistenceUnitProperties.JPQL_PARSER, parser);
         }
@@ -3655,7 +3654,7 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
      */
     protected void updateTableCreationSettings(Map m) {
         String tableCreationSuffix = EntityManagerFactoryProvider.getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.TABLE_CREATION_SUFFIX, m, session);
-        if (tableCreationSuffix != null && tableCreationSuffix.length()>0) {
+        if (tableCreationSuffix != null && !tableCreationSuffix.isEmpty()) {
             session.getPlatform().setTableCreationSuffix(tableCreationSuffix);
         }
     }
@@ -3665,7 +3664,7 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
      */
     protected void updateIndexForeignKeys(Map m) {
         String indexForeignKeys = EntityManagerFactoryProvider.getConfigPropertyAsStringLogDebug(PersistenceUnitProperties.DDL_GENERATION_INDEX_FOREIGN_KEYS, m, this.session);
-        if (indexForeignKeys != null && (indexForeignKeys.length() > 0)) {
+        if (indexForeignKeys != null && (!indexForeignKeys.isEmpty())) {
             if (indexForeignKeys.equalsIgnoreCase("true") ){
                 this.session.getProject().getLogin().setShouldCreateIndicesOnForeignKeys(true);
             } else if (indexForeignKeys.equalsIgnoreCase("false")){
@@ -3863,6 +3862,21 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
             }
         } catch (NumberFormatException exception) {
             this.session.handleException(ValidationException.invalidValueForProperty(allowTakingStackTraceDuringReadLockAcquisition, PersistenceUnitProperties.CONCURRENCY_MANAGER_ALLOW_STACK_TRACE_READ_LOCK, exception));
+        }
+    }
+
+    /**
+     * Related to <a href="https://github.com/eclipse-ee4j/eclipselink/issues/2094">issue 2094</a>
+     * Setup of mode how {@code org.eclipse.persistence.internal.sessions.AbstractSession.getCacheKeyFromTargetSessionForMerge(Object, ObjectBuilder, ClassDescriptor, MergeManager)}
+     * get {@code org.eclipse.persistence.internal.identitymaps.CacheKey} and related object.
+     */
+    private void updateAbstractSessionModeOfOperationOfMergeManagerGetCacheKey(Map persistenceProperties) {
+        String abstractSessionModeOfOperationOfMergeManagerGetCacheKey = EntityManagerFactoryProvider
+                .getConfigPropertyAsStringLogDebug(
+                        PersistenceUnitProperties.CONCURRENCY_MANAGER_ALLOW_GET_CACHE_KEY_FOR_MERGE_MODE,
+                        persistenceProperties, session);
+        if (abstractSessionModeOfOperationOfMergeManagerGetCacheKey != null) {
+            ConcurrencyUtil.SINGLETON.setConcurrencyManagerAllowGetCacheKeyForMergeMode(abstractSessionModeOfOperationOfMergeManagerGetCacheKey.trim());
         }
     }
 
@@ -4511,7 +4525,7 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
     /**
      * Create a new version of this EntityManagerSetupImpl and cache it.  Prepare "this" EntityManagerSetupImpl
      * for garbage collection.
-     *
+     * <p>
      * This call will mean any users of this EntityManagerSetupImpl will get the new version the next time
      * they look it up (for instance and EntityManager creation time)
      */


### PR DESCRIPTION
Fixes #2094 
This is enhancement for case of possible deadlock which should happens in `org.eclipse.persistence.internal.sessions.AbstractSession#getCacheKeyFromTargetSessionForMerge` method if used `org.eclipse.persistence.internal.identitymaps.CacheKey` instance is locked by another thread.
There is new system or persistence property `eclipselink.concurrency.manager.allow.getcachekeyformerge.mode` which can control `org.eclipse.persistence.internal.sessions.AbstractSession#getCacheKeyFromTargetSessionForMerge` logic to get `org.eclipse.persistence.internal.identitymaps.CacheKey` instance and object value behind this.
There are two allowed values:

- `ORIGIN` (DEFAULT) - There is infinite `java.lang.Object.wait()` call in case of some conditions during time when object/entity referred from `org.eclipse.persistence.internal.identitymaps.CacheKey` is locked and modified by another thread. In some cases it should leads into deadlock.
- `WAITLOOP` - Merge manager will try in the loop with timeout wait `cacheKey.wait(ConcurrencyUtil.SINGLETON.getAcquireWaitTime());` fetch object/entity from `org.eclipse.persistence.internal.identitymaps.CacheKey`. If fetch will be successful object/entity loop finish and continue
 with remaining code. If not `java.lang.InterruptedException` is thrown and caught and used `org.eclipse.persistence.internal.identitymaps.CacheKey` instance status is set into invalidation state. This strategy avoid deadlock issue, but there should be impact to the performance.

(cherry picked from commit dd6124725b06563c42ef60581788b8f26eaef54a)