### PR TITLE
[3.0] New eclipselink dead lock scenario ... enhancement and unit test - backport from master

### DIFF
--- a/docs/docs.jpa/src/main/asciidoc/persistenceproperties_ref.adoc
+++ b/docs/docs.jpa/src/main/asciidoc/persistenceproperties_ref.adoc
@@ -208,6 +208,7 @@ concurrency management:
 * link:#concurrencymanagermaxfrequencytodumpmassivemessage[`concurrency.manager.maxfrequencytodumpmassivemessage`]
 * link:#concurrencymanagerallowinterruptedexception[`concurrency.manager.allow.interruptedexception`]
 * link:#concurrencymanagerallowconcurrencyexception[`concurrency.manager.allow.concurrencyexception`]
+* link:#concurrencymanagerallowgetcachekeyformergemode[`concurrency.manager.allow.getcachekeyformerge.mode`]
 * link:#concurrencymanagerallowreadlockstacktrace[`concurrency.manager.allow.readlockstacktrace`]
 
 [[CACBGBJG2]][[TLJPA1055]]
@@ -250,6 +251,7 @@ The following lists the EclipseLink persistence property
 * link:#concurrencymanagermaxfrequencytodumpmassivemessage[`concurrency.manager.maxfrequencytodumpmassivemessage`]
 * link:#concurrencymanagerallowinterruptedexception[`concurrency.manager.allow.interruptedexception`]
 * link:#concurrencymanagerallowconcurrencyexception[`concurrency.manager.allow.concurrencyexception`]
+* link:#concurrencymanagerallowgetcachekeyformergemode[`concurrency.manager.allow.getcachekeyformerge.mode`]
 * link:#concurrencymanagerallowreadlockstacktrace[`concurrency.manager.allow.readlockstacktrace`]
 * link:#connectionpool[`connection-pool`]
 * link:#connectionpoolread[`connection-pool.read`]
@@ -2504,6 +2506,56 @@ persistence.xml_*
 ----
 <property name="eclipselink.concurrency.manager.allow.interruptedexception" value="true" />
             
+----
+
+[[concurrencymanagerallowgetcachekeyformergemode]]
+
+'''''
+
+=== concurrency.manager.allow.getcachekeyformerge.mode
+
+This property control in `org.eclipse.persistence.internal.sessions.AbstractSession#getCacheKeyFromTargetSessionForMerge(java.lang.Object, org.eclipse.persistence.internal.descriptors.ObjectBuilder, org.eclipse.persistence.descriptors.ClassDescriptor, org.eclipse.persistence.internal.sessions.MergeManager)`
+strategy how `org.eclipse.persistence.internal.identitymaps.CacheKey` will be fetched from shared cache.
+
+
+*Values*
+
+link:#concurrency.manager.allow.getcachekeyformerge.mode[Table 5-30]
+describes this persistence property's values.
+
+[[concurrency.manager.allow.getcachekeyformerge.mode]]
+
+*_Table 5-30 Valid Values for
+concurrency.manager.allow.getcachekeyformerge.mode_*
+
+|=======================================================================
+|*Value* |*Description*
+|ORIGIN |(Default) There is infinite `java.lang.Object.wait()` call in case
+of some conditions during time when object/entity referred from
+`org.eclipse.persistence.internal.identitymaps.CacheKey` is locked
+and modified by another thread. In some cases it should leads into deadlock.
+|WAITLOOP |Merge manager will try in the loop with timeout wait `cacheKey.wait(ConcurrencyUtil.SINGLETON.getAcquireWaitTime());`
+fetch object/entity from `org.eclipse.persistence.internal.identitymaps.CacheKey`.
+If fetch will be successful object/entity loop finish and continue with remaining code.
+If not `java.lang.InterruptedException` is thrown and caught and used `org.eclipse.persistence.internal.identitymaps.CacheKey`
+instance status is set into invalidation state. This strategy avoid deadlock issue,
+but there should be impact to the performance.
+|=======================================================================
+
+*Examples*
+
+link:#concurrency.manager.allow.getcachekeyformerge.mode[Example
+5-24] shows how to use this property in the `persistence.xml` file.
+
+[[concurrency.manager.allow.getcachekeyformerge.mode]]
+
+*_Example 5-24 Using concurrency.manager.allow.getcachekeyformerge.mode in
+persistence.xml_*
+
+[source,oac_no_warn]
+----
+<property name="eclipselink.concurrency.manager.allow.getcachekeyformerge.mode" value="WAITLOOP" />
+
 ----
 
 [[concurrencymanagerallowconcurrencyexception]]

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/MergeManagerOperationMode.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/MergeManagerOperationMode.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.config;
+
+/**
+ * INTERNAL:
+ * <p>
+ * <b>Purpose</b>: It is data model behind {@linkplain  org.eclipse.persistence.config.SystemProperties#CONCURRENCY_MANAGER_ALLOW_GET_CACHE_KEY_FOR_MERGE_MODE}
+ * or {@linkplain  org.eclipse.persistence.config.PersistenceUnitProperties#CONCURRENCY_MANAGER_ALLOW_GET_CACHE_KEY_FOR_MERGE_MODE}.
+ */
+public final class MergeManagerOperationMode {
+
+    /**
+     * {@code ORIGIN} (DEFAULT) - There is infinite {@linkplain java.lang.Object#wait()} call in case of some conditions during time when object/entity referred from
+     * {@code org.eclipse.persistence.internal.identitymaps.CacheKey} is locked and modified by another thread. In some cases it should leads into deadlock.
+     */
+    public static final String ORIGIN = "ORIGIN";
+
+    /**
+     * {@code WAITLOOP} - Merge manager will try in the loop with timeout wait {@code cacheKey.wait(ConcurrencyUtil.SINGLETON.getAcquireWaitTime());}
+     * fetch object/entity from {@linkplain org.eclipse.persistence.internal.identitymaps.CacheKey}. If fetch will be successful object/entity loop finish and continue
+     * with remaining code. If not @{code java.lang.InterruptedException} is thrown and caught and used {@linkplain org.eclipse.persistence.internal.identitymaps.CacheKey} instance
+     * status is set into invalidation state. This strategy avoid deadlock issue, but there should be impact to the performance.
+     */
+    public static final String WAITLOOP = "WAITLOOP";
+
+    private MergeManagerOperationMode() {
+        // no instance please
+    }
+}

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/PersistenceUnitProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/PersistenceUnitProperties.java
@@ -1016,11 +1016,11 @@ public class PersistenceUnitProperties {
     public static final String PARTITIONING_CALLBACK = "eclipselink.partitioning.callback";
 
     /**
-     * Property "<code>eclipselink.jdbc.bind-parameters</code>" configures whether parameter binding 
+     * Property "<code>eclipselink.jdbc.bind-parameters</code>" configures whether parameter binding
      * should be used in the creation of JDBC prepared statements.
      * <p>
-     * Usage of parameter binding is generally a performance optimization; 
-     * allowing for SQL and prepared statement caching, as well as usage of batch writing. 
+     * Usage of parameter binding is generally a performance optimization;
+     * allowing for SQL and prepared statement caching, as well as usage of batch writing.
      * <p>
      * <b>Allowed Values:</b>
      * <ul>
@@ -1031,7 +1031,7 @@ public class PersistenceUnitProperties {
     public static final String JDBC_BIND_PARAMETERS = "eclipselink.jdbc.bind-parameters";
 
     /**
-     * Property "<code>eclipselink.jdbc.allow-partial-bind-parameters</code>" configures whether 
+     * Property "<code>eclipselink.jdbc.allow-partial-bind-parameters</code>" configures whether
      * partial parameter binding should be allowed in the creation of JDBC prepared statements.
      * <p>
      * EclipseLink determines binding behavior based on the database platform's support for binding.
@@ -1039,8 +1039,8 @@ public class PersistenceUnitProperties {
      * all binding for the whole query. Setting this property to 'true' will allow EclipseLink to bind
      * per expression, instead of per query.
      * <p>
-     * Usage of parameter binding is generally a performance optimization; 
-     * allowing for SQL and prepared statement caching, as well as usage of batch writing. 
+     * Usage of parameter binding is generally a performance optimization;
+     * allowing for SQL and prepared statement caching, as well as usage of batch writing.
      * <p>
      * <b>Allowed Values:</b>
      * <ul>
@@ -1582,7 +1582,7 @@ public class PersistenceUnitProperties {
 
     /**
      * The "<code>eclipselink.logging.level</code>" property allows the default logging levels to be specified.
-     * <p>
+     *
      * <table>
      * <caption>Logging Levels:</caption>
      * <tr><td>{@link SessionLog#ALL_LABEL}</td><td>&nbsp;</td><td>ALL</td></tr>
@@ -1893,7 +1893,7 @@ public class PersistenceUnitProperties {
      * <b> Example 2 : </b> To change the value of
      * DatabasePlatform.supportsReturnGeneratedKeys via configuration, provide the
      * following :<br><br>
-     * 
+     *
      * {@code
      *  <property name="eclipselink.target-database-properties" value="supportsReturnGeneratedKeys=true"/>}
      * @see TargetDatabase
@@ -4044,6 +4044,23 @@ public class PersistenceUnitProperties {
      * </ul>
      */
     public static final String CONCURRENCY_MANAGER_ALLOW_INTERRUPTED_EXCEPTION  = "eclipselink.concurrency.manager.allow.interruptedexception";
+
+    /**
+     * <p>
+     * This property control in {@link org.eclipse.persistence.internal.sessions.AbstractSession#getCacheKeyFromTargetSessionForMerge(java.lang.Object, org.eclipse.persistence.internal.descriptors.ObjectBuilder, org.eclipse.persistence.descriptors.ClassDescriptor, org.eclipse.persistence.internal.sessions.MergeManager)}
+     * strategy how {@code org.eclipse.persistence.internal.identitymaps.CacheKey} will be fetched from shared cache.
+     * <p>
+     * <b>Allowed Values</b> (case-sensitive String)<b>:</b>
+     * <ul>
+     * <li>{@code ORIGIN} (DEFAULT) - There is infinite {@linkplain java.lang.Object#wait()} call in case of some conditions during time when object/entity referred from
+     * {@code org.eclipse.persistence.internal.identitymaps.CacheKey} is locked and modified by another thread. In some cases it should leads into deadlock.
+     * <li>{@code WAITLOOP} - Merge manager will try in the loop with timeout wait {@code cacheKey.wait(ConcurrencyUtil.SINGLETON.getAcquireWaitTime());}
+     * fetch object/entity from {@linkplain org.eclipse.persistence.internal.identitymaps.CacheKey}. If fetch will be successful object/entity loop finish and continue
+     * with remaining code. If not @{code java.lang.InterruptedException} is thrown and caught and used {@linkplain org.eclipse.persistence.internal.identitymaps.CacheKey} instance
+     * status is set into invalidation state. This strategy avoid deadlock issue, but there should be impact to the performance.
+     * </ul>
+     */
+    public static final String CONCURRENCY_MANAGER_ALLOW_GET_CACHE_KEY_FOR_MERGE_MODE  = "eclipselink.concurrency.manager.allow.getcachekeyformerge.mode";
 
     /**
      * <p>

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/SystemProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/SystemProperties.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -84,15 +85,15 @@ public class SystemProperties {
      * LocalDateTime, OffsetDateTime, and OffsetTime types.
      */
     public static final String CONVERSION_USE_TIMEZONE = "org.eclipse.persistence.conversion.useTimeZone";
-    
+
     /**
-     * This system property can be set to restore ConversionManager behavior with converting 
+     * This system property can be set to restore ConversionManager behavior with converting
      * LocalDateTime, OffsetDateTime, and OffsetTime types back to using the JVM's default time zone instead
      * of UTC.  This restores behavior prior to fixing Bug 538296.  This property is ignored if the
      * System Property CONVERSION_USE_TIMEZONE has been set.
      */
     public static final String CONVERSION_USE_DEFAULT_TIMEZONE = "org.eclipse.persistence.conversion.useDefaultTimeZoneForJavaTime";
-    
+
     /**
      * This property can be set to <code>false</code> to enable UPDATE call to set
      * foreign key value in the target row in unidirectional 1-Many mapping
@@ -156,6 +157,23 @@ public class SystemProperties {
      * </ul>
      */
     public static final String CONCURRENCY_MANAGER_ALLOW_INTERRUPTED_EXCEPTION  = "eclipselink.concurrency.manager.allow.interruptedexception";
+
+    /**
+     * <p>
+     * This property control in {@link org.eclipse.persistence.internal.sessions.AbstractSession#getCacheKeyFromTargetSessionForMerge(java.lang.Object, org.eclipse.persistence.internal.descriptors.ObjectBuilder, org.eclipse.persistence.descriptors.ClassDescriptor, org.eclipse.persistence.internal.sessions.MergeManager)}
+     * strategy how {@code org.eclipse.persistence.internal.identitymaps.CacheKey} will be fetched from shared cache.
+     * <p>
+     * <b>Allowed Values</b> (case-sensitive String)<b>:</b>
+     * <ul>
+     * <li>{@code ORIGIN} (DEFAULT) - There is infinite {@linkplain java.lang.Object#wait()} call in case of some conditions during time when object/entity referred from
+     * {@code org.eclipse.persistence.internal.identitymaps.CacheKey} is locked and modified by another thread. In some cases it should leads into deadlock.
+     * <li>{@code WAITLOOP} - Merge manager will try in the loop with timeout wait {@code cacheKey.wait(ConcurrencyUtil.SINGLETON.getAcquireWaitTime());}
+     * fetch object/entity from {@linkplain org.eclipse.persistence.internal.identitymaps.CacheKey}. If fetch will be successful object/entity loop finish and continue
+     * with remaining code. If not @{code java.lang.InterruptedException} is thrown and caught and used {@linkplain org.eclipse.persistence.internal.identitymaps.CacheKey} instance
+     * status is set into invalidation state. This strategy avoid deadlock issue, but there should be impact to the performance.
+     * </ul>
+     */
+    public static final String CONCURRENCY_MANAGER_ALLOW_GET_CACHE_KEY_FOR_MERGE_MODE  = "eclipselink.concurrency.manager.allow.getcachekeyformerge.mode";
 
     /**
      * <p>

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ConcurrencyManager.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ConcurrencyManager.java
@@ -26,8 +26,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Vector;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.eclipse.persistence.config.SystemProperties;
 import org.eclipse.persistence.exceptions.ConcurrencyException;
@@ -81,6 +85,9 @@ public class ConcurrencyManager implements Serializable {
      // was set to 0. It should happen if an entity being shared by two threads.
     private final AtomicLong totalNumberOfKeysReleasedForReadingBlewUpExceptionDueToCacheKeyHavingReachedCounterZero = new AtomicLong(0);
 
+    private final Lock instanceLock  = new ReentrantLock();
+    private final Condition instanceLockCondition = instanceLock.newCondition();
+
     private static final Map<Thread, ConcurrencyManager> THREADS_TO_WAIT_ON_ACQUIRE_READ_LOCK = new ConcurrentHashMap<>();
     private static final Map<Thread, String> THREADS_TO_WAIT_ON_ACQUIRE_READ_LOCK_NAME_OF_METHOD_CREATING_TRACE = new ConcurrentHashMap<>();
     private static final Map<Thread, ConcurrencyManager> THREADS_TO_WAIT_ON_ACQUIRE = new ConcurrentHashMap<>();
@@ -121,55 +128,60 @@ public class ConcurrencyManager implements Serializable {
      * This should be called before entering a critical section.
      * called with true from the merge process, if true then the refresh will not refresh the object
      */
-    public synchronized void acquire(boolean forMerge) throws ConcurrencyException {
-        //Flag the time when we start the while loop
-        final long whileStartTimeMillis = System.currentTimeMillis();
-        Thread currentThread = Thread.currentThread();
-        DeferredLockManager lockManager = getDeferredLockManager(currentThread);
-        ReadLockManager readLockManager = getReadLockManager(currentThread);
+    public void acquire(boolean forMerge) throws ConcurrencyException {
+        instanceLock.lock();
+        try {
+            //Flag the time when we start the while loop
+            final long whileStartTimeMillis = System.currentTimeMillis();
+            Thread currentThread = Thread.currentThread();
+            DeferredLockManager lockManager = getDeferredLockManager(currentThread);
+            ReadLockManager readLockManager = getReadLockManager(currentThread);
 
-        // Waiting to acquire cache key will now start on the while loop
-        // NOTE: this step bares no influence in acquiring or not acquiring locks
-        // is just storing debug metadata that we can use when we detect the system is frozen in a dead lock
-        final boolean currentThreadWillEnterTheWhileWait = ((this.activeThread != null) || (this.numberOfReaders.get() > 0)) && (this.activeThread != currentThread);
-        if(currentThreadWillEnterTheWhileWait) {
-            putThreadAsWaitingToAcquireLockForWriting(currentThread, ACQUIRE_METHOD_NAME);
-        }
-        while (((this.activeThread != null) || (this.numberOfReaders.get() > 0)) && (this.activeThread != Thread.currentThread())) {
-            // This must be in a while as multiple threads may be released, or another thread may rush the acquire after one is released.
-            try {
-                this.numberOfWritersWaiting.incrementAndGet();
-                wait(ConcurrencyUtil.SINGLETON.getAcquireWaitTime());
-                // Run a method that will fire up an exception if we having been sleeping for too long
-                ConcurrencyUtil.SINGLETON.determineIfReleaseDeferredLockAppearsToBeDeadLocked(this, whileStartTimeMillis, lockManager, readLockManager, ConcurrencyUtil.SINGLETON.isAllowInterruptedExceptionFired());
-            } catch (InterruptedException exception) {
-                // If the thread is interrupted we want to make sure we release all of the locks the thread was owning
-                releaseAllLocksAcquiredByThread(lockManager);
-                // Improve concurrency manager metadata
-                // Waiting to acquire cache key is is over
-                if (currentThreadWillEnterTheWhileWait) {
-                    removeThreadNoLongerWaitingToAcquireLockForWriting(currentThread);
+            // Waiting to acquire cache key will now start on the while loop
+            // NOTE: this step bares no influence in acquiring or not acquiring locks
+            // is just storing debug metadata that we can use when we detect the system is frozen in a dead lock
+            final boolean currentThreadWillEnterTheWhileWait = ((this.activeThread != null) || (this.numberOfReaders.get() > 0)) && (this.activeThread != currentThread);
+            if (currentThreadWillEnterTheWhileWait) {
+                putThreadAsWaitingToAcquireLockForWriting(currentThread, ACQUIRE_METHOD_NAME);
+            }
+            while (((this.activeThread != null) || (this.numberOfReaders.get() > 0)) && (this.activeThread != Thread.currentThread())) {
+                // This must be in a while as multiple threads may be released, or another thread may rush the acquire after one is released.
+                try {
+                    this.numberOfWritersWaiting.incrementAndGet();
+                    wait(ConcurrencyUtil.SINGLETON.getAcquireWaitTime());
+                    // Run a method that will fire up an exception if we having been sleeping for too long
+                    ConcurrencyUtil.SINGLETON.determineIfReleaseDeferredLockAppearsToBeDeadLocked(this, whileStartTimeMillis, lockManager, readLockManager, ConcurrencyUtil.SINGLETON.isAllowInterruptedExceptionFired());
+                } catch (InterruptedException exception) {
+                    // If the thread is interrupted we want to make sure we release all of the locks the thread was owning
+                    releaseAllLocksAcquiredByThread(lockManager);
+                    // Improve concurrency manager metadata
+                    // Waiting to acquire cache key is is over
+                    if (currentThreadWillEnterTheWhileWait) {
+                        removeThreadNoLongerWaitingToAcquireLockForWriting(currentThread);
+                    }
+                    throw ConcurrencyException.waitWasInterrupted(exception.getMessage());
+                } finally {
+                    // Since above we increments the number of writers
+                    // whether or not the thread is exploded by an interrupt
+                    // we need to make sure we decrement the number of writer to not allow the code to be corrupted
+                    this.numberOfWritersWaiting.decrementAndGet();
                 }
-                throw ConcurrencyException.waitWasInterrupted(exception.getMessage());
-            } finally {
-                // Since above we increments the number of writers
-                // whether or not the thread is exploded by an interrupt
-                // we need to make sure we decrement the number of writer to not allow the code to be corrupted
-                this.numberOfWritersWaiting.decrementAndGet();
+            } // end of while loop
+            // Waiting to acquire cahe key is is over
+            if (currentThreadWillEnterTheWhileWait) {
+                removeThreadNoLongerWaitingToAcquireLockForWriting(currentThread);
             }
-        } // end of while loop
-        // Waiting to acquire cahe key is is over
-        if(currentThreadWillEnterTheWhileWait) {
-            removeThreadNoLongerWaitingToAcquireLockForWriting(currentThread);
-        }
-        if (this.activeThread == null) {
-            this.activeThread = Thread.currentThread();
-            if (shouldTrackStack){
-                this.stack = new Exception();
+            if (this.activeThread == null) {
+                this.activeThread = Thread.currentThread();
+                if (shouldTrackStack) {
+                    this.stack = new Exception();
+                }
             }
+            this.lockedByMergeManager = forMerge;
+            this.depth.incrementAndGet();
+        } finally {
+            instanceLock.unlock();
         }
-        this.lockedByMergeManager = forMerge;
-        this.depth.incrementAndGet();
     }
 
     /**
@@ -187,13 +199,18 @@ public class ConcurrencyManager implements Serializable {
      * Added for CR 2317
      * called with true from the merge process, if true then the refresh will not refresh the object
      */
-    public synchronized boolean acquireNoWait(boolean forMerge) throws ConcurrencyException {
-        if ((this.activeThread == null && this.numberOfReaders.get() == 0) || (this.activeThread == Thread.currentThread())) {
-            //if I own the lock increment depth
-            acquire(forMerge);
-            return true;
-        } else {
-            return false;
+    public boolean acquireNoWait(boolean forMerge) throws ConcurrencyException {
+        instanceLock.lock();
+        try {
+            if ((this.activeThread == null && this.numberOfReaders.get() == 0) || (this.activeThread == Thread.currentThread())) {
+                //if I own the lock increment depth
+                acquire(forMerge);
+                return true;
+            } else {
+                return false;
+            }
+        } finally {
+            instanceLock.unlock();
         }
     }
 
@@ -203,27 +220,32 @@ public class ConcurrencyManager implements Serializable {
      * Added for CR 2317
      * called with true from the merge process, if true then the refresh will not refresh the object
      */
-    public synchronized boolean acquireWithWait(boolean forMerge, int wait) throws ConcurrencyException {
-        final Thread currentThread = Thread.currentThread();
-        if ((this.activeThread == null && this.numberOfReaders.get() == 0) || (this.activeThread == currentThread)) {
-            // if I own the lock increment depth
-            acquire(forMerge);
-            return true;
-        } else {
-            try {
-                putThreadAsWaitingToAcquireLockForWriting(currentThread, ACQUIRE_WITH_WAIT_METHOD_NAME);
-                wait(wait);
-            } catch (InterruptedException e) {
-                return false;
-            } finally {
-                removeThreadNoLongerWaitingToAcquireLockForWriting(currentThread);
-            }
-            if ((this.activeThread == null && this.numberOfReaders.get() == 0)
-                    || (this.activeThread == currentThread)) {
+    public boolean acquireWithWait(boolean forMerge, int wait) throws ConcurrencyException {
+        instanceLock.lock();
+        try {
+            final Thread currentThread = Thread.currentThread();
+            if ((this.activeThread == null && this.numberOfReaders.get() == 0) || (this.activeThread == currentThread)) {
+                // if I own the lock increment depth
                 acquire(forMerge);
                 return true;
+            } else {
+                try {
+                    putThreadAsWaitingToAcquireLockForWriting(currentThread, ACQUIRE_WITH_WAIT_METHOD_NAME);
+                    instanceLockCondition.await(wait, TimeUnit.MILLISECONDS);
+                } catch (InterruptedException e) {
+                    return false;
+                } finally {
+                    removeThreadNoLongerWaitingToAcquireLockForWriting(currentThread);
+                }
+                if ((this.activeThread == null && this.numberOfReaders.get() == 0)
+                        || (this.activeThread == currentThread)) {
+                    acquire(forMerge);
+                    return true;
+                }
+                return false;
             }
-            return false;
+        } finally {
+            instanceLock.unlock();
         }
     }
 
@@ -233,14 +255,19 @@ public class ConcurrencyManager implements Serializable {
      * Added for Bug 5840635
      * Call with true from the merge process, if true then the refresh will not refresh the object.
      */
-    public synchronized boolean acquireIfUnownedNoWait(boolean forMerge) throws ConcurrencyException {
-        // Only acquire lock if active thread is null. Do not check current thread.
-        if (this.activeThread == null && this.numberOfReaders.get() == 0) {
-             // if lock is unowned increment depth
-            acquire(forMerge);
-            return true;
-        } else {
-            return false;
+    public boolean acquireIfUnownedNoWait(boolean forMerge) throws ConcurrencyException {
+        instanceLock.lock();
+        try {
+            // Only acquire lock if active thread is null. Do not check current thread.
+            if (this.activeThread == null && this.numberOfReaders.get() == 0) {
+                // if lock is unowned increment depth
+                acquire(forMerge);
+                return true;
+            } else {
+                return false;
+            }
+        } finally {
+            instanceLock.unlock();
         }
     }
 
@@ -256,7 +283,8 @@ public class ConcurrencyManager implements Serializable {
             putDeferredLock(currentThread, lockManager);
         }
         lockManager.incrementDepth();
-        synchronized (this) {
+        instanceLock.lock();
+        try {
             final long whileStartTimeMillis = System.currentTimeMillis();
             final boolean currentThreadWillEnterTheWhileWait = this.numberOfReaders.get() != 0;
             if(currentThreadWillEnterTheWhileWait) {
@@ -271,7 +299,7 @@ public class ConcurrencyManager implements Serializable {
                 //the object is not being built.
                 try {
                     this.numberOfWritersWaiting.incrementAndGet();
-                    wait(ConcurrencyUtil.SINGLETON.getAcquireWaitTime());
+                    instanceLockCondition.await(ConcurrencyUtil.SINGLETON.getAcquireWaitTime(), TimeUnit.MILLISECONDS);
                     ConcurrencyUtil.SINGLETON.determineIfReleaseDeferredLockAppearsToBeDeadLocked(this, whileStartTimeMillis, lockManager, readLockManager, ConcurrencyUtil.SINGLETON.isAllowInterruptedExceptionFired());
                 } catch (InterruptedException exception) {
                     // If the thread is interrupted we want to make sure we release all of the locks the thread was owning
@@ -296,6 +324,8 @@ public class ConcurrencyManager implements Serializable {
                     AbstractSessionLog.getLog().log(SessionLog.FINER, SessionLog.CACHE, "acquiring_deferred_lock", ((CacheKey)this).getObject(), currentThread.getName());
                 }
             }
+        } finally {
+            instanceLock.unlock();
         }
     }
 
@@ -329,48 +359,58 @@ public class ConcurrencyManager implements Serializable {
      * Wait on any writer.
      * Allow concurrent reads.
      */
-    public synchronized void acquireReadLock() throws ConcurrencyException {
-        final Thread currentThread = Thread.currentThread();
-        final long whileStartTimeMillis = System.currentTimeMillis();
-        DeferredLockManager lockManager = getDeferredLockManager(currentThread);
-        ReadLockManager readLockManager = getReadLockManager(currentThread);
-        final boolean currentThreadWillEnterTheWhileWait = (this.activeThread != null) && (this.activeThread != currentThread);
-        if (currentThreadWillEnterTheWhileWait) {
-            putThreadAsWaitingToAcquireLockForReading(currentThread, ACQUIRE_READ_LOCK_METHOD_NAME);
-        }
-        // Cannot check for starving writers as will lead to deadlocks.
-        while ((this.activeThread != null) && (this.activeThread != Thread.currentThread())) {
-            try {
-                wait(ConcurrencyUtil.SINGLETON.getAcquireWaitTime());
-                ConcurrencyUtil.SINGLETON.determineIfReleaseDeferredLockAppearsToBeDeadLocked(this, whileStartTimeMillis, lockManager, readLockManager, ConcurrencyUtil.SINGLETON.isAllowInterruptedExceptionFired());
-            } catch (InterruptedException exception) {
-                releaseAllLocksAcquiredByThread(lockManager);
-                if (currentThreadWillEnterTheWhileWait) {
-                    removeThreadNoLongerWaitingToAcquireLockForReading(currentThread);
-                }
-                throw ConcurrencyException.waitWasInterrupted(exception.getMessage());
-            }
-        }
-        if (currentThreadWillEnterTheWhileWait) {
-            removeThreadNoLongerWaitingToAcquireLockForReading(currentThread);
-        }
+    public void acquireReadLock() throws ConcurrencyException {
+        instanceLock.lock();
         try {
-            addReadLockToReadLockManager();
+            final Thread currentThread = Thread.currentThread();
+            final long whileStartTimeMillis = System.currentTimeMillis();
+            DeferredLockManager lockManager = getDeferredLockManager(currentThread);
+            ReadLockManager readLockManager = getReadLockManager(currentThread);
+            final boolean currentThreadWillEnterTheWhileWait = (this.activeThread != null) && (this.activeThread != currentThread);
+            if (currentThreadWillEnterTheWhileWait) {
+                putThreadAsWaitingToAcquireLockForReading(currentThread, ACQUIRE_READ_LOCK_METHOD_NAME);
+            }
+            // Cannot check for starving writers as will lead to deadlocks.
+            while ((this.activeThread != null) && (this.activeThread != Thread.currentThread())) {
+                try {
+                    instanceLockCondition.await(ConcurrencyUtil.SINGLETON.getAcquireWaitTime(), TimeUnit.MILLISECONDS);
+                    ConcurrencyUtil.SINGLETON.determineIfReleaseDeferredLockAppearsToBeDeadLocked(this, whileStartTimeMillis, lockManager, readLockManager, ConcurrencyUtil.SINGLETON.isAllowInterruptedExceptionFired());
+                } catch (InterruptedException exception) {
+                    releaseAllLocksAcquiredByThread(lockManager);
+                    if (currentThreadWillEnterTheWhileWait) {
+                        removeThreadNoLongerWaitingToAcquireLockForReading(currentThread);
+                    }
+                    throw ConcurrencyException.waitWasInterrupted(exception.getMessage());
+                }
+            }
+            if (currentThreadWillEnterTheWhileWait) {
+                removeThreadNoLongerWaitingToAcquireLockForReading(currentThread);
+            }
+            try {
+                addReadLockToReadLockManager();
+            } finally {
+                this.numberOfReaders.incrementAndGet();
+                this.totalNumberOfKeysAcquiredForReading.incrementAndGet();
+            }
         } finally {
-            this.numberOfReaders.incrementAndGet();
-            this.totalNumberOfKeysAcquiredForReading.incrementAndGet();
+            instanceLock.unlock();
         }
     }
 
     /**
      * If this is acquired return false otherwise acquire readlock and return true
      */
-    public synchronized boolean acquireReadLockNoWait() {
-        if ((this.activeThread == null) || (this.activeThread == Thread.currentThread())) {
-            acquireReadLock();
-            return true;
-        } else {
-            return false;
+    public boolean acquireReadLockNoWait() {
+        instanceLock.lock();
+        try {
+            if ((this.activeThread == null) || (this.activeThread == Thread.currentThread())) {
+                acquireReadLock();
+                return true;
+            } else {
+                return false;
+            }
+        } finally {
+            instanceLock.unlock();
         }
     }
 
@@ -591,19 +631,24 @@ public class ConcurrencyManager implements Serializable {
      * The notify will release the first thread waiting on the object,
      * if no threads are waiting it will do nothing.
      */
-    public synchronized void release() throws ConcurrencyException {
-        if (this.depth.get() == 0) {
-            throw ConcurrencyException.signalAttemptedBeforeWait();
-        } else {
-            this.depth.decrementAndGet();
-        }
-        if (this.depth.get() == 0) {
-            this.activeThread = null;
-            if (shouldTrackStack){
-                this.stack = null;
+    public void release() throws ConcurrencyException {
+        instanceLock.lock();
+        try {
+            if (this.depth.get() == 0) {
+                throw ConcurrencyException.signalAttemptedBeforeWait();
+            } else {
+                this.depth.decrementAndGet();
             }
-            this.lockedByMergeManager = false;
-            notifyAll();
+            if (this.depth.get() == 0) {
+                this.activeThread = null;
+                if (shouldTrackStack) {
+                    this.stack = null;
+                }
+                this.lockedByMergeManager = false;
+                instanceLockCondition.signalAll();
+            }
+        } finally {
+            instanceLock.unlock();
         }
     }
 
@@ -695,25 +740,30 @@ public class ConcurrencyManager implements Serializable {
     /**
      * Decrement the number of readers. Used to allow concurrent reads.
      */
-    public synchronized void releaseReadLock() throws ConcurrencyException {
-        if (this.numberOfReaders.get() == 0) {
-            this.totalNumberOfKeysReleasedForReadingBlewUpExceptionDueToCacheKeyHavingReachedCounterZero.incrementAndGet();
-            try {
-                removeReadLockFromReadLockManager();
-            } catch (Exception e) {
-                AbstractSessionLog.getLog().logThrowable(SessionLog.SEVERE, SessionLog.CACHE, e);
+    public void releaseReadLock() throws ConcurrencyException {
+        instanceLock.lock();
+        try {
+            if (this.numberOfReaders.get() == 0) {
+                this.totalNumberOfKeysReleasedForReadingBlewUpExceptionDueToCacheKeyHavingReachedCounterZero.incrementAndGet();
+                try {
+                    removeReadLockFromReadLockManager();
+                } catch (Exception e) {
+                    AbstractSessionLog.getLog().logThrowable(SessionLog.SEVERE, SessionLog.CACHE, e);
+                }
+                throw ConcurrencyException.signalAttemptedBeforeWait();
+            } else {
+                try {
+                    removeReadLockFromReadLockManager();
+                } finally {
+                    this.numberOfReaders.decrementAndGet();
+                    this.totalNumberOfKeysReleasedForReading.incrementAndGet();
+                }
             }
-            throw ConcurrencyException.signalAttemptedBeforeWait();
-        } else {
-            try {
-                removeReadLockFromReadLockManager();
-            } finally {
-                this.numberOfReaders.decrementAndGet();
-                this.totalNumberOfKeysReleasedForReading.incrementAndGet();
+            if (this.numberOfReaders.get() == 0) {
+                instanceLockCondition.signalAll();
             }
-        }
-        if (this.numberOfReaders.get() == 0) {
-            notifyAll();
+        } finally {
+            instanceLock.unlock();
         }
     }
 
@@ -762,15 +812,20 @@ public class ConcurrencyManager implements Serializable {
         this.numberOfWritersWaiting.set(numberOfWritersWaiting);
     }
 
-    public synchronized void transitionToDeferredLock() {
-        Thread currentThread = Thread.currentThread();
-        DeferredLockManager lockManager = getDeferredLockManager(currentThread);
-        if (lockManager == null) {
-            lockManager = new DeferredLockManager();
-            putDeferredLock(currentThread, lockManager);
+    public void transitionToDeferredLock() {
+        instanceLock.lock();
+        try {
+            Thread currentThread = Thread.currentThread();
+            DeferredLockManager lockManager = getDeferredLockManager(currentThread);
+            if (lockManager == null) {
+                lockManager = new DeferredLockManager();
+                putDeferredLock(currentThread, lockManager);
+            }
+            lockManager.incrementDepth();
+            lockManager.addActiveLock(this);
+        } finally {
+            instanceLock.unlock();
         }
-        lockManager.incrementDepth();
-        lockManager.addActiveLock(this);
     }
 
     /**
@@ -807,7 +862,7 @@ public class ConcurrencyManager implements Serializable {
      * @return Never null if the read lock manager does not yet exist for the current thread. otherwise its read log
      *         manager is returned.
      */
-    protected static ReadLockManager getReadLockManager(Thread thread) {
+    public static ReadLockManager getReadLockManager(Thread thread) {
         Map<Thread, ReadLockManager> readLockManagers = getReadLockManagers();
         return readLockManagers.get(thread);
     }
@@ -1057,5 +1112,37 @@ public class ConcurrencyManager implements Serializable {
      */
     public static void setJustificationWhyMethodIsBuildingObjectCompleteReturnsFalse(String justification) {
         THREADS_WAITING_TO_RELEASE_DEFERRED_LOCKS_BUILD_OBJECT_COMPLETE_GOES_NOWHERE.put(Thread.currentThread(), justification);
+    }
+
+    public Lock getInstanceLock() {
+        return this.instanceLock;
+    }
+
+    public Condition getInstanceLockCondition() {
+        return this.instanceLockCondition;
+    }
+
+    /**
+     * Check if {@code org.eclipse.persistence.internal.helper.ConcurrencyManager} or child like {@code org.eclipse.persistence.internal.identitymaps.CacheKey} is currently being owned for writing
+     * and if that owning thread happens to be the current thread doing the check.
+     *
+     * @return {@code false} means either the thread is currently not owned by any other thread for writing purposes. Or otherwise if is owned by some thread
+     * but the thread is not the current thread. {@code false} is returned if and only if instance is being owned by some thread
+     * and that thread is not the current thread, it is some other competing thread.
+     */
+    public boolean isAcquiredForWritingAndOwnedByDifferentThread() {
+        instanceLock.lock();
+        try {
+            if (!this.isAcquired()) {
+                return false;
+            }
+            if (this.activeThread == null) {
+                return false;
+            }
+            Thread currentThread = Thread.currentThread();
+            return this.activeThread != currentThread;
+        } finally {
+            instanceLock.unlock();
+        }
     }
 }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ConcurrencyManager.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ConcurrencyManager.java
@@ -148,7 +148,7 @@ public class ConcurrencyManager implements Serializable {
                 // This must be in a while as multiple threads may be released, or another thread may rush the acquire after one is released.
                 try {
                     this.numberOfWritersWaiting.incrementAndGet();
-                    wait(ConcurrencyUtil.SINGLETON.getAcquireWaitTime());
+                    instanceLockCondition.await(ConcurrencyUtil.SINGLETON.getAcquireWaitTime(), TimeUnit.MILLISECONDS);
                     // Run a method that will fire up an exception if we having been sleeping for too long
                     ConcurrencyUtil.SINGLETON.determineIfReleaseDeferredLockAppearsToBeDeadLocked(this, whileStartTimeMillis, lockManager, readLockManager, ConcurrencyUtil.SINGLETON.isAllowInterruptedExceptionFired());
                 } catch (InterruptedException exception) {

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ConcurrencyUtil.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ConcurrencyUtil.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.Vector;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.eclipse.persistence.config.MergeManagerOperationMode;
 import org.eclipse.persistence.config.SystemProperties;
 import org.eclipse.persistence.internal.helper.type.CacheKeyToThreadRelationships;
 import org.eclipse.persistence.internal.helper.type.ConcurrencyManagerState;
@@ -38,6 +39,7 @@ import org.eclipse.persistence.internal.helper.type.ReadLockAcquisitionMetadata;
 import org.eclipse.persistence.internal.identitymaps.CacheKey;
 import org.eclipse.persistence.internal.localization.TraceLocalization;
 import org.eclipse.persistence.internal.security.PrivilegedAccessHelper;
+import org.eclipse.persistence.internal.sessions.AbstractSession;
 import org.eclipse.persistence.logging.AbstractSessionLog;
 import org.eclipse.persistence.logging.SessionLog;
 
@@ -73,6 +75,7 @@ public class ConcurrencyUtil {
     private boolean useSemaphoreToLimitConcurrencyOnWriteLockManagerAcquireRequiredLocks  = getBooleanProperty(SystemProperties.CONCURRENCY_MANAGER_USE_SEMAPHORE_TO_SLOW_DOWN_WRITE_LOCK_MANAGER_ACQUIRE_REQUIRED_LOCKS, DEFAULT_USE_SEMAPHORE_TO_SLOW_DOWN_WRITE_LOCK_MANAGER_ACQUIRE_REQUIRED_LOCKS);
     private int noOfThreadsAllowedToObjectBuildInParallel = getIntProperty(SystemProperties.CONCURRENCY_MANAGER_OBJECT_BUILDING_NO_THREADS, DEFAULT_CONCURRENCY_MANAGER_OBJECT_BUILDING_NO_THREADS);
     private int noOfThreadsAllowedToDoWriteLockManagerAcquireRequiredLocksInParallel = getIntProperty(SystemProperties.CONCURRENCY_MANAGER_WRITE_LOCK_MANAGER_ACQUIRE_REQUIRED_LOCKS_NO_THREADS, DEFAULT_CONCURRENCY_MANAGER_WRITE_LOCK_MANAGER_ACQUIRE_REQUIRED_LOCKS_NO_THREADS);
+    private String concurrencyManagerAllowGetCacheKeyForMergeMode = getStringProperty(SystemProperties.CONCURRENCY_MANAGER_ALLOW_GET_CACHE_KEY_FOR_MERGE_MODE, MergeManagerOperationMode.ORIGIN);
     private long concurrencySemaphoreMaxTimePermit = getLongProperty(SystemProperties.CONCURRENCY_SEMAPHORE_MAX_TIME_PERMIT, DEFAULT_CONCURRENCY_SEMAPHORE_MAX_TIME_PERMIT);
     private long concurrencySemaphoreLogTimeout = getLongProperty(SystemProperties.CONCURRENCY_SEMAPHORE_LOG_TIMEOUT, DEFAULT_CONCURRENCY_SEMAPHORE_LOG_TIMEOUT);
 
@@ -126,11 +129,15 @@ public class ConcurrencyUtil {
      *            is most likely too dangerous and possibly the eclipselink code is not robust enough to code with such
      *            scenarios We do not care so much about blowing up exception during object building but during
      *            committing of transactions we are very afraid
+     * @return Returns a boolean value if the code believes that it is stuck. {@code true} means the code ended up either logging
+     *  a tiny Dump message or the massive dump message.
+     *  {@code false} means that the code did not do any logging and just quickly returned. This boolean flag is especially
+     *  meaningful if we have the  interrupt exceptions disabled and so the method is not being caused to blow up.
+     *  In that case there is still a way to know if we believe to be stuck.
      * @throws InterruptedException
-     *             we fire an interrupted exception to ensure that the code blows up and releases all of the locks it
-     *             had.
+     *             it fires an interrupted exception to ensure that the code blows up and releases all the locks it had.
      */
-    public void determineIfReleaseDeferredLockAppearsToBeDeadLocked(ConcurrencyManager concurrencyManager,
+    public boolean determineIfReleaseDeferredLockAppearsToBeDeadLocked(ConcurrencyManager concurrencyManager,
                                                                     final long whileStartTimeMillis, DeferredLockManager lockManager, ReadLockManager readLockManager,
                                                                     boolean callerIsWillingToAllowInterruptedExceptionToBeFiredUpIfNecessary)
             throws InterruptedException {
@@ -143,7 +150,7 @@ public class ConcurrencyUtil {
         if (!tooMuchTimeHasElapsed) {
             // this thread is not stuck for that long let us allow the code to continue waiting for the lock to be acquired
             // or for the deferred locks to be considered as finished
-            return;
+            return false;
         }
 
         // (b) We believe this is a dead lock
@@ -160,7 +167,7 @@ public class ConcurrencyUtil {
             // this thread has recently logged a small message about the fact that it is stuck
             // no point in logging another message like that for some time
             // let us allow for this thread to silently continue stuck without logging anything
-            return ;
+            return true;
         }
 
         // (c) This thread it is dead lock since the whileStartDate indicates a dead lock and
@@ -202,6 +209,7 @@ public class ConcurrencyUtil {
         } else {
             AbstractSessionLog.getLog().log(SessionLog.SEVERE, SessionLog.CACHE,"concurrency_manager_allow_concurrency_exception_fired_up");
         }
+        return true;
     }
 
     /**
@@ -260,7 +268,7 @@ public class ConcurrencyUtil {
      * a minute) the logic complaining that the thread is stuck and going nowhere logs a very big dump message where the
      * FULL concurrency manager state is explained. So that we can (manually) try to understand the dead lock based on
      * the dumped information
-     *
+     * <p>
      * See also {@link #dateWhenLastConcurrencyManagerStateFullDumpWasPerformed}.
      */
     public long getMaxAllowedFrequencyToProduceMassiveDumpLogMessage() {
@@ -330,6 +338,14 @@ public class ConcurrencyUtil {
 
     public void setNoOfThreadsAllowedToDoWriteLockManagerAcquireRequiredLocksInParallel(int noOfThreadsAllowedToDoWriteLockManagerAcquireRequiredLocksInParallel) {
         this.noOfThreadsAllowedToDoWriteLockManagerAcquireRequiredLocksInParallel = noOfThreadsAllowedToDoWriteLockManagerAcquireRequiredLocksInParallel;
+    }
+
+    public String getConcurrencyManagerAllowGetCacheKeyForMergeMode() {
+        return concurrencyManagerAllowGetCacheKeyForMergeMode;
+    }
+
+    public void setConcurrencyManagerAllowGetCacheKeyForMergeMode(String concurrencyManagerAllowGetCacheKeyForMergeMode) {
+        this.concurrencyManagerAllowGetCacheKeyForMergeMode = concurrencyManagerAllowGetCacheKeyForMergeMode;
     }
 
     public long getConcurrencySemaphoreMaxTimePermit() {
@@ -438,10 +454,10 @@ public class ConcurrencyUtil {
     }
 
     /**
-     * Invoke the {@link #dumpConcurrencyManagerInformationStep01(Map, Map, Map, Map, Map, Map, Map, Set, Map, Map)} if sufficient time has passed.
+     * Invoke the {@link #dumpConcurrencyManagerInformationStep01(Map, Map, Map, Map, Map, Map, Map, Set, Map, Map, Map)} if sufficient time has passed.
      * This log message will potentially create a massive dump in the server log file. So we need to check when was the
      * last time that the masive dump was produced and decide if we can log again the state of the concurrency manager.
-     *
+     * <p>
      * The access to dateWhenLastConcurrencyManagerStateFullDumpWasPerformedLock is synchronized, because we do not want
      * two threads in parallel to star deciding to dump the complete state of the concurrency manager at the same time.
      * Only one thread should succeed in producing the massive dump in a given time window.
@@ -480,6 +496,7 @@ public class ConcurrencyUtil {
         Set<Thread> setThreadWaitingToReleaseDeferredLocksOriginal = ConcurrencyManager.getThreadsWaitingToReleaseDeferredLocksSnapshot();
         Map<Thread, String> mapThreadsThatAreCurrentlyWaitingToReleaseDeferredLocksJustificationClone = ConcurrencyManager.getThreadsWaitingToReleaseDeferredLocksJustificationSnapshot();
         Map<Thread, Set<Object>> mapThreadToObjectIdWithWriteLockManagerChangesOriginal = WriteLockManager.getMapWriteLockManagerThreadToObjectIdsWithChangeSetSnapshot();
+        Map<Thread, String> mapThreadsToWaitMergeManagerWaitingDeferredCacheKeys = AbstractSession.getThreadsToWaitMergeManagerWaitingDeferredCacheKeysSnapshot();
         dumpConcurrencyManagerInformationStep01(
                 deferredLockManagers,
                 readLockManagersOriginal,
@@ -490,14 +507,15 @@ public class ConcurrencyUtil {
                 mapThreadToWaitOnAcquireReadLockMethodNameOriginal,
                 setThreadWaitingToReleaseDeferredLocksOriginal,
                 mapThreadsThatAreCurrentlyWaitingToReleaseDeferredLocksJustificationClone,
-                mapThreadToObjectIdWithWriteLockManagerChangesOriginal);
+                mapThreadToObjectIdWithWriteLockManagerChangesOriginal,
+                mapThreadsToWaitMergeManagerWaitingDeferredCacheKeys);
     }
 
     /**
      * The current working thread is having problems. It seems to not go forward being stuck either trying to acquire a
      * cache key for writing, as a deferred cache key or it is at the end of the process and it is waiting for some
      * other thread to finish building some objects it needed to defer.
-     *
+     * <p>
      * Now that the system is frozen we want to start spamming into the server log file the state of the concurrency
      * manager since this might help us understand the situation of the system.
      *
@@ -544,7 +562,8 @@ public class ConcurrencyUtil {
                                                            Map<Thread, String> mapThreadToWaitOnAcquireReadLockMethodNameOriginal,
                                                            Set<Thread> setThreadWaitingToReleaseDeferredLocksOriginal,
                                                            Map<Thread, String> mapThreadsThatAreCurrentlyWaitingToReleaseDeferredLocksJustificationClone,
-                                                           Map<Thread, Set<Object>> mapThreadToObjectIdWithWriteLockManagerChangesOriginal) {
+                                                           Map<Thread, Set<Object>> mapThreadToObjectIdWithWriteLockManagerChangesOriginal,
+                                                           Map<Thread, String> mapThreadsToWaitMergeManagerWaitingDeferredCacheKeys) {
 
         // (a) create object to represent our cache state.
         ConcurrencyManagerState concurrencyManagerState = createConcurrencyManagerState(
@@ -557,7 +576,8 @@ public class ConcurrencyUtil {
                 mapThreadToWaitOnAcquireReadLockMethodNameOriginal,
                 setThreadWaitingToReleaseDeferredLocksOriginal,
                 mapThreadsThatAreCurrentlyWaitingToReleaseDeferredLocksJustificationClone,
-                mapThreadToObjectIdWithWriteLockManagerChangesOriginal);
+                mapThreadToObjectIdWithWriteLockManagerChangesOriginal,
+                mapThreadsToWaitMergeManagerWaitingDeferredCacheKeys);
         dumpConcurrencyManagerInformationStep02(concurrencyManagerState);
     }
 
@@ -602,6 +622,13 @@ public class ConcurrencyUtil {
         // with the number of readers increased
         String deadLockExplanation = dumpDeadLockExplanationIfPossible(concurrencyManagerState);
         writer.write(deadLockExplanation);
+        // (g) PAGE 08 - threads that have commited and are facing difficulties
+        // merging the clone changes to the shared cache
+        // relates to:
+        // https://github.com/eclipse-ee4j/eclipselink/issues/2094
+        String threadStuckInMergeManagerProcess = createInformationAboutThreadsHavingDifficultyGettingCacheKeysWithObjectDifferentThanNullDuringMergeClonesToCacheAfterTransactionCommit(
+                concurrencyManagerState.getMapThreadsToWaitMergeManagerWaitingDeferredCacheKeys());
+        writer.write(threadStuckInMergeManagerProcess);
         // (g) Final header
         writer.write(TraceLocalization.buildMessage("concurrency_util_dump_concurrency_manager_information_step02_02", new Object[] {messageNumber}));
         // there should be no risk that the string is simply to big. the max string size in java is 2pow31 chars
@@ -677,6 +704,42 @@ public class ConcurrencyUtil {
     }
 
     /**
+     * A string describing threads that are likely facing the deadlock <a href="https://github.com/eclipse-ee4j/eclipselink/issues/2094">issue 2094</a>.
+     * @param mapThreadsToWaitMergeManagerWaitingDeferredCacheKeys
+     *            This parameter is related to the
+     *            {@link AbstractSession#THREADS_TO_WAIT_MERGE_MANAGER_WAITING_DEFERRED_CACHE_KEYS}
+     *            and to the <a href="https://github.com/eclipse-ee4j/eclipselink/issues/2094">issue 2094</a> it allows check
+     *            threads that are at post-commit phase and are trying to merge their change set into the original
+     *            objects in the cache. When this is taking place some of the cache keys that the merge manager is
+     *            needing might be locked by other threads. This can lead to deadlocks, if our merge manager thread
+     *            happens to be the owner of cache keys that matter to the owner of the cache keys the merge manager
+     *            will need to acquire.
+     * @return A string describing all threads that are stuck in the
+     *         {@code org.eclipse.persistence.internal.sessions.AbstractSession.getCacheKeyFromTargetSessionForMergeScenarioMergeManagerNotNullAndCacheKeyOriginalStillNull(CacheKey, Object, ObjectBuilder, ClassDescriptor, MergeManager) }
+     *         logic. There is thread that want to return to the merge manage a cacheKey where the cacheKey object is no
+     *         longer null. The threads are stuck because the cache key object is still null and the cache key is
+     *         acquired most likely by some random thread doing object building. Deadlocks may be occurring between the
+     *         merge manager and the object building threads.
+     */
+    private String createInformationAboutThreadsHavingDifficultyGettingCacheKeysWithObjectDifferentThanNullDuringMergeClonesToCacheAfterTransactionCommit(
+            Map<Thread, String> mapThreadsToWaitMergeManagerWaitingDeferredCacheKeys) {
+        // (a) Create a header string of information
+        StringWriter writer = new StringWriter();
+        writer.write(TraceLocalization.buildMessage("concurrency_util_threads_having_difficulty_getting_cache_keys_with_object_different_than_null_during_merge_clones_to_cache_after_transaction_commit_page_header"
+                , new Object[] {mapThreadsToWaitMergeManagerWaitingDeferredCacheKeys.size()}));
+        int currentThreadNumber = 0;
+        for (Map.Entry<Thread, String> currentEntry : mapThreadsToWaitMergeManagerWaitingDeferredCacheKeys.entrySet()) {
+            currentThreadNumber++;
+            Thread thread = currentEntry.getKey();
+            String justification = currentEntry.getValue();
+            writer.write(TraceLocalization.buildMessage("concurrency_util_threads_having_difficulty_getting_cache_keys_with_object_different_than_null_during_merge_clones_to_cache_after_transaction_commit_body",
+                    new Object[] {currentThreadNumber, thread.getName(), justification}));
+        }
+        writer.write(TraceLocalization.buildMessage("concurrency_util_threads_having_difficulty_getting_cache_keys_with_object_different_than_null_during_merge_clones_to_cache_after_transaction_commit_page_end"));
+        return writer.toString();
+    }
+
+    /**
      * create a DTO that tries to represent the current snapshot of the concurrency manager and write lock manager cache
      * state
      */
@@ -690,7 +753,8 @@ public class ConcurrencyUtil {
             Map<Thread, String> mapThreadToWaitOnAcquireReadLockMethodNameOriginal,
             Set<Thread> setThreadWaitingToReleaseDeferredLocksOriginal,
             Map<Thread, String> mapThreadsThatAreCurrentlyWaitingToReleaseDeferredLocksJustificationClone,
-            Map<Thread, Set<Object>> mapThreadToObjectIdWithWriteLockManagerChangesOriginal) {
+            Map<Thread, Set<Object>> mapThreadToObjectIdWithWriteLockManagerChangesOriginal,
+            Map<Thread, String> mapThreadsToWaitMergeManagerWaitingDeferredCacheKeys) {
         // (a) As a first step we want to clone-copy the two maps
         // once we start working with the maps and using them to do dead lock detection
         // or simply print the state of the system we do not want the maps to continue changing as the threads referenced in the maps
@@ -747,7 +811,8 @@ public class ConcurrencyUtil {
                 readLockManagerMapClone, deferredLockManagerMapClone, unifiedMapOfThreadsStuckTryingToAcquireWriteLock,
                 mapThreadToWaitOnAcquireMethodNameClone, mapThreadToWaitOnAcquireReadLockClone, mapThreadToWaitOnAcquireReadLockMethodNameClone,
                 setThreadWaitingToReleaseDeferredLocksClone, mapThreadsThatAreCurrentlyWaitingToReleaseDeferredLocksJustificationClone,
-                mapOfCacheKeyToDtosExplainingThreadExpectationsOnCacheKey, mapThreadToObjectIdWithWriteLockManagerChangesClone);
+                mapOfCacheKeyToDtosExplainingThreadExpectationsOnCacheKey, mapThreadToObjectIdWithWriteLockManagerChangesClone,
+                mapThreadsToWaitMergeManagerWaitingDeferredCacheKeys);
     }
 
     /**
@@ -924,7 +989,7 @@ public class ConcurrencyUtil {
      *
      * <P>
      * NOTE: This approach can be easily tested in a basic unit test.
-     *
+     * <p>
      *
      * <a href="https://crunchify.com/how-to-generate-java-thread-dump-programmatically/">Original source of code</a>
      *
@@ -1212,7 +1277,7 @@ public class ConcurrencyUtil {
         writer.write(createStringWithSummaryOfDeferredLocksOnThread(lockManager, threadName));
         // (d) On the topic of the defferred locks we can also try to do better and explain why the algorithm
         // keeps returning false that the build object is not yet complete
-        if (waitingToReleaseDeferredLocksJustification != null && waitingToReleaseDeferredLocksJustification.length() > 0) {
+        if (waitingToReleaseDeferredLocksJustification != null && !waitingToReleaseDeferredLocksJustification.isEmpty()) {
             writer.write(TraceLocalization.buildMessage("concurrency_util_create_information_all_resources_acquired_deferred_8", new Object[] {waitingToReleaseDeferredLocksJustification}));
         } else {
             writer.write(TraceLocalization.buildMessage("concurrency_util_create_information_all_resources_acquired_deferred_9"));
@@ -1681,6 +1746,20 @@ public class ConcurrencyUtil {
         if (value != null) {
             try {
                 return Boolean.parseBoolean(value.trim());
+            } catch (Exception ignoreE) {
+                return defaultValue;
+            }
+        }
+        return defaultValue;
+    }
+
+    private String getStringProperty(final String key, final String defaultValue) {
+        final String value = PrivilegedAccessHelper.callDoPrivileged(
+                () -> System.getProperty(key, String.valueOf(defaultValue))
+        );
+        if (value != null) {
+            try {
+                return value.trim();
             } catch (Exception ignoreE) {
                 return defaultValue;
             }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/type/ConcurrencyManagerState.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/type/ConcurrencyManagerState.java
@@ -1,5 +1,6 @@
-/*******************************************************************************
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+/*
+ * Copyright (c) 2020, 2025 Oracle and/or its affiliates. All rights reserved.
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -9,7 +10,7 @@
  *
  * Contributors:
  *     Oracle - initial API and implementation from Oracle TopLink
- ******************************************************************************/
+ */
 package org.eclipse.persistence.internal.helper.type;
 
 import org.eclipse.persistence.internal.helper.ConcurrencyManager;
@@ -83,6 +84,17 @@ public class ConcurrencyManagerState {
     private final Map<Thread, Set<Object>> mapThreadToObjectIdWithWriteLockManagerChangesClone;
 
     /**
+     * This field is related to the
+     * {@link org.eclipse.persistence.internal.sessions.AbstractSession#THREADS_TO_WAIT_MERGE_MANAGER_WAITING_DEFERRED_CACHE_KEYS}
+     * and to the bug https://github.com/eclipse-ee4j/eclipselink/issues/2094 it allows to monitor on threads
+     * that are at post-commit phase and are trying to merge their change set into the original objects in the cache.
+     * When this is taking place some of the cache keys that the merge manager is needing might be locked by other
+     * threads. This can lead to deadlocks, if our merge manager thread happens to be the owner of cache keys that
+     * matter to the owner of the cache keys the merge manager will need to acquire.
+     */
+    private final Map<Thread, String> mapThreadsToWaitMergeManagerWaitingDeferredCacheKeys;
+
+    /**
      * Create a new ConcurrencyManagerState.
      *
      * @param readLockManagerMapClone
@@ -106,7 +118,8 @@ public class ConcurrencyManagerState {
             Set<Thread> setThreadWaitingToReleaseDeferredLocksClone,
             Map<Thread, String> mapThreadsThatAreCurrentlyWaitingToReleaseDeferredLocksJustificationClone,
             Map<ConcurrencyManager, CacheKeyToThreadRelationships> mapOfCacheKeyToDtosExplainingThreadExpectationsOnCacheKey,
-            Map<Thread, Set<Object>> mapThreadToObjectIdWithWriteLockManagerChangesClone) {
+            Map<Thread, Set<Object>> mapThreadToObjectIdWithWriteLockManagerChangesClone,
+            Map<Thread, String> mapThreadsToWaitMergeManagerWaitingDeferredCacheKeys) {
         super();
         this.readLockManagerMapClone = readLockManagerMapClone;
         this.deferredLockManagerMapClone = deferredLockManagerMapClone;
@@ -118,6 +131,7 @@ public class ConcurrencyManagerState {
         this.mapThreadsThatAreCurrentlyWaitingToReleaseDeferredLocksJustificationClone = mapThreadsThatAreCurrentlyWaitingToReleaseDeferredLocksJustificationClone;
         this.mapOfCacheKeyToDtosExplainingThreadExpectationsOnCacheKey = mapOfCacheKeyToDtosExplainingThreadExpectationsOnCacheKey;
         this.mapThreadToObjectIdWithWriteLockManagerChangesClone = mapThreadToObjectIdWithWriteLockManagerChangesClone;
+        this.mapThreadsToWaitMergeManagerWaitingDeferredCacheKeys = mapThreadsToWaitMergeManagerWaitingDeferredCacheKeys;
     }
 
     /** Getter for {@link #readLockManagerMapClone} */
@@ -168,5 +182,10 @@ public class ConcurrencyManagerState {
     /** Getter for {@link #mapThreadToWaitOnAcquireReadLockCloneMethodName} */
     public Map<Thread, String> getMapThreadToWaitOnAcquireReadLockCloneMethodName() {
         return unmodifiableMap(mapThreadToWaitOnAcquireReadLockCloneMethodName);
+    }
+
+    /** Getter for {@link #mapThreadsToWaitMergeManagerWaitingDeferredCacheKeys} */
+    public Map<Thread, String> getMapThreadsToWaitMergeManagerWaitingDeferredCacheKeys() {
+        return unmodifiableMap(mapThreadsToWaitMergeManagerWaitingDeferredCacheKeys);
     }
 }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/ExceptionLocalizationResource.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/ExceptionLocalizationResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2018 IBM Corporation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -255,7 +255,8 @@ public class ExceptionLocalizationResource extends ListResourceBundle {
                                            { "wrap_convert_exception", "An exception occurred while calling {0} on converter class {1} with value {2}"},
                                            { "ora_pessimistic_locking_with_rownum", "Pessimistic locking with query row limits is not supported."},
                                            { "bean_validation_constraint_violated", "One or more Bean Validation constraints were violated while executing Automatic Bean Validation on callback event: {0} for class: {1}. Please refer to the embedded constraint violations for details."},
-                                           { "unsupported_classfile_version", "The {0} class was compiled with an unsupported JDK. Report this error to the EclipseLink open source project."}
+                                           { "unsupported_classfile_version", "The {0} class was compiled with an unsupported JDK. Report this error to the EclipseLink open source project."},
+                                           { "missing_jpql_parser_class", "Could not load the JPQL parser class."}
 
                                         };
     /**

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/TraceLocalizationResource.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/TraceLocalizationResource.java
@@ -269,7 +269,24 @@ public class TraceLocalizationResource extends ListResourceBundle {
                 + " stopping the candidate thread to make progress... We expect this code spot to never be invoked. "
                 + " Either this thread made progress or if it continues to be stuck in the releaseDeferredLock "
                 + " we most likely have an implementation bug somewhere. "},
-
+        { "concurrency_util_threads_having_difficulty_getting_cache_keys_with_object_different_than_null_during_merge_clones_to_cache_after_transaction_commit_justification",
+                " Merge manager logic is currently stuck in the process of trying to return the cache key: {0}  \n"
+                + " this cache key is currently acquired by a competing thread: {1} . \n"
+                + " This cache key has the problem that its original object is still set to NULL. \n"
+                + "  The operation of this current thread is that by waiting for some time the current owner of the cache key will finish object building and release the cache key. \n"
+                + " Note: There is real risk that we are in a deadlock. The daedlock exists if the current thread: {2} \n"
+                + " is owning other cache key resources as a writer. Any lock acquired by the current thread might be needed by competing threads. \n"
+                + " Much in the same manner that our current thread is stuck hoping to see this specific cache key being released. \n"},
+        { "concurrency_util_threads_having_difficulty_getting_cache_keys_with_object_different_than_null_during_merge_clones_to_cache_after_transaction_commit_page_header"
+                , "Concurrency manager - Page 08 start - Threads in MergeManager Acquiring Cache Keys for Clones to be merged into eclipselink server session cache of originals"
+                + "\n This section provides information about threads within the MergeManager that require cache keys for merging clones with changes."
+                + "\n Specifically, it focuses on the threads working in the context of an ObjectChangeSet where the server session CacheKey is found to still have CacheKy.object null,"
+                + "\n and the CacheKey is acquired by a competing thread (typically an ObjectBuilder thread)."
+                + "\nTotal number of threads waiting to see lock being released: {0}\n\n"},
+        { "concurrency_util_threads_having_difficulty_getting_cache_keys_with_object_different_than_null_during_merge_clones_to_cache_after_transaction_commit_body"
+                , "[currentThreadNumber: {0}] [ThreadName: {1}]:  Justification for being stuck: {2}\n"},
+        { "concurrency_util_threads_having_difficulty_getting_cache_keys_with_object_different_than_null_during_merge_clones_to_cache_after_transaction_commit_page_end"
+                , "Concurrency manager - Page 08 end - Threads in MergeManager Acquiring Cache Keys for Clones to be merged into eclipselink server session cache of originals\n"},
         { "XML_call", "XML call" },
         { "XML_data_call", "XML data call" },
         { "XML_data_delete", "XML data delete" },

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/IsolatedClientSessionIdentityMapAccessor.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/IsolatedClientSessionIdentityMapAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -264,7 +264,8 @@ public class IsolatedClientSessionIdentityMapAccessor extends org.eclipse.persis
         // in which GC could remove the object and we would end up with a null pointer
         // as well we must inspect the cacheKey without locking on it.
         if ((cacheKey != null) && (shouldReturnInvalidatedObjects || !descriptor.getCacheInvalidationPolicy().isInvalidated(cacheKey))) {
-            synchronized (cacheKey) {
+            cacheKey.getInstanceLock().lock();
+            try {
                 //if the object in the cachekey is null but the key is acquired then
                 //someone must be rebuilding it or creating a new one.  Sleep until
                 // it's finished. A plain wait here would be more efficient but we may not
@@ -280,6 +281,8 @@ public class IsolatedClientSessionIdentityMapAccessor extends org.eclipse.persis
                 if (objectFromCache == null) {
                     return null;
                 }
+            } finally {
+                cacheKey.getInstanceLock().unlock();
             }
         } else {
             return null;

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/ObjectChangeSet.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/ObjectChangeSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -533,7 +533,8 @@ public class ObjectChangeSet implements Serializable, Comparable<ObjectChangeSet
                         session.getParent().log(SessionLog.SEVERE, SessionLog.CACHE, "entity_not_available_during_merge", new Object[]{descriptor.getJavaClassName(), cacheKey.getKey(), Thread.currentThread().getName(), cacheKey.getActiveThread()});
                         break;
                     }
-                    synchronized (cacheKey) {
+                    cacheKey.getInstanceLock().lock();
+                    try {
                         if (cacheKey.isAcquired()) {
                             try {
                                 cacheKey.wait(10);
@@ -542,6 +543,8 @@ public class ObjectChangeSet implements Serializable, Comparable<ObjectChangeSet
                             }
                         }
                         domainObject = cacheKey.getObject();
+                    } finally {
+                        cacheKey.getInstanceLock().unlock();
                     }
                 }
                 cacheKey.releaseDeferredLock();

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkIdentityMapAccessor.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkIdentityMapAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -172,7 +172,8 @@ public class UnitOfWorkIdentityMapAccessor extends IdentityMapAccessor {
         // in which GC could remove the object and we would end up with a null pointer
         // as well we must inspect the cacheKey without locking on it.
         if ((cacheKey != null) && (shouldReturnInvalidatedObjects || !descriptor.getCacheInvalidationPolicy().isInvalidated(cacheKey))) {
-            synchronized (cacheKey) {
+            cacheKey.getInstanceLock().lock();
+            try {
                 //if the object in the cachekey is null but the key is acquired then
                 //someone must be rebuilding it or creating a new one.  Sleep until
                 // it's finished. A plain wait here would be more efficient but we may not
@@ -185,8 +186,9 @@ public class UnitOfWorkIdentityMapAccessor extends IdentityMapAccessor {
                     }
                 } catch (InterruptedException ex) {
                 }
+            } finally {
+                cacheKey.getInstanceLock().unlock();
             }
-
             // check for inheritance.
             objectFromCache = checkForInheritance(objectFromCache, theClass, descriptor);
             if (objectFromCache == null) {

--- a/jpa/eclipselink.jpa.testapps/jpa.test.diagnostic.deadlock/src/main/resources/META-INF/persistence.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.diagnostic.deadlock/src/main/resources/META-INF/persistence.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2024, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -29,6 +29,24 @@
             <property name="eclipselink.concurrency.manager.allow.readlockstacktrace" value="true"/>
             <property name="eclipselink.concurrency.manager.allow.concurrencyexception" value="true"/>
             <property name="eclipselink.concurrency.manager.allow.interruptedexception" value="true"/>
+        </properties>
+    </persistence-unit>
+
+    <persistence-unit name="cachedeadlockdetection-loopwait-pu" transaction-type="RESOURCE_LOCAL">
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+        <class>org.eclipse.persistence.testing.models.jpa.deadlock.diagnostic.CacheDeadLockDetectionMaster</class>
+        <class>org.eclipse.persistence.testing.models.jpa.deadlock.diagnostic.CacheDeadLockDetectionDetail</class>
+        <exclude-unlisted-classes>true</exclude-unlisted-classes>
+        <properties>
+            <property name="eclipselink.concurrency.manager.waittime" value="1"/>
+            <property name="eclipselink.concurrency.manager.maxsleeptime" value="2"/>
+            <property name="eclipselink.concurrency.manager.maxfrequencytodumptinymessage" value="800"/>
+            <property name="eclipselink.concurrency.manager.maxfrequencytodumpmassivemessage" value="1000"/>
+            <property name="eclipselink.concurrency.manager.build.object.complete.waittime" value="5"/>
+            <property name="eclipselink.concurrency.manager.allow.readlockstacktrace" value="true"/>
+            <property name="eclipselink.concurrency.manager.allow.concurrencyexception" value="true"/>
+            <property name="eclipselink.concurrency.manager.allow.interruptedexception" value="true"/>
+            <property name="eclipselink.concurrency.manager.allow.getcachekeyformerge.mode" value="WAITLOOP"/>
         </properties>
     </persistence-unit>
 

--- a/jpa/eclipselink.jpa.testapps/jpa.test.diagnostic.deadlock/src/test/java/org/eclipse/persistence/testing/tests/jpa/deadlock/diagnostic/CacheDeadLockDetectionTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.diagnostic.deadlock/src/test/java/org/eclipse/persistence/testing/tests/jpa/deadlock/diagnostic/CacheDeadLockDetectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -29,11 +29,12 @@ import junit.framework.Test;
 import junit.framework.TestSuite;
 import org.junit.Assert;
 
+import org.eclipse.persistence.config.MergeManagerOperationMode;
+import org.eclipse.persistence.internal.helper.ConcurrencyUtil;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
 import org.eclipse.persistence.jpa.JpaEntityManager;
 import org.eclipse.persistence.logging.AbstractSessionLog;
 
-import org.eclipse.persistence.internal.helper.ConcurrencyUtil;
 import org.eclipse.persistence.testing.framework.jpa.junit.JUnitTestCase;
 import org.eclipse.persistence.testing.framework.junit.JUnitTestCaseHelper;
 import org.eclipse.persistence.testing.models.jpa.deadlock.diagnostic.CacheDeadLockDetectionDetail;
@@ -184,6 +185,8 @@ public class CacheDeadLockDetectionTest extends JUnitTestCase {
         Assert.assertEquals(800L, ConcurrencyUtil.SINGLETON.getMaxAllowedFrequencyToProduceTinyDumpLogMessage());
         Assert.assertEquals(1000L, ConcurrencyUtil.SINGLETON.getMaxAllowedFrequencyToProduceMassiveDumpLogMessage());
         Assert.assertEquals(5L, ConcurrencyUtil.SINGLETON.getBuildObjectCompleteWaitTime());
+        //MergeManagerOperationMode.ORIGIN is default value not explicitly specified in persistence.xml
+        Assert.assertEquals(MergeManagerOperationMode.ORIGIN, ConcurrencyUtil.SINGLETON.getConcurrencyManagerAllowGetCacheKeyForMergeMode());
         Assert.assertTrue(ConcurrencyUtil.SINGLETON.isAllowTakingStackTraceDuringReadLockAcquisition());
         Assert.assertTrue(ConcurrencyUtil.SINGLETON.isAllowConcurrencyExceptionToBeFiredUp());
         Assert.assertTrue(ConcurrencyUtil.SINGLETON.isAllowInterruptedExceptionFired());

--- a/jpa/eclipselink.jpa.testapps/jpa.test.diagnostic.deadlock/src/test/java/org/eclipse/persistence/testing/tests/jpa/deadlock/diagnostic/CacheDeadLockManagersTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.diagnostic.deadlock/src/test/java/org/eclipse/persistence/testing/tests/jpa/deadlock/diagnostic/CacheDeadLockManagersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,18 +14,25 @@
 //     Oracle - initial API and implementation
 package org.eclipse.persistence.testing.tests.jpa.deadlock.diagnostic;
 
+import java.util.Map;
+import java.util.concurrent.Semaphore;
+
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.Persistence;
 import jakarta.persistence.Query;
+
 import junit.framework.Test;
 import junit.framework.TestSuite;
+
+import org.eclipse.persistence.config.MergeManagerOperationMode;
 import org.eclipse.persistence.descriptors.ClassDescriptor;
 import org.eclipse.persistence.internal.helper.ConcurrencyUtil;
 import org.eclipse.persistence.internal.helper.WriteLockManager;
 import org.eclipse.persistence.internal.identitymaps.CacheKey;
 import org.eclipse.persistence.internal.jpa.EJBQueryImpl;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
+import org.eclipse.persistence.internal.sessions.IdentityMapAccessor;
 import org.eclipse.persistence.jpa.JpaEntityManager;
 import org.eclipse.persistence.logging.AbstractSessionLog;
 import org.eclipse.persistence.queries.ObjectBuildingQuery;
@@ -34,8 +41,6 @@ import org.eclipse.persistence.testing.framework.junit.JUnitTestCaseHelper;
 import org.eclipse.persistence.testing.models.jpa.deadlock.diagnostic.CacheDeadLockDetectionDetail;
 import org.eclipse.persistence.testing.models.jpa.deadlock.diagnostic.CacheDeadLockDetectionMaster;
 import org.eclipse.persistence.testing.models.jpa.deadlock.diagnostic.DeadLockDiagnosticTableCreator;
-
-import java.util.Map;
 
 public class CacheDeadLockManagersTest extends JUnitTestCase {
 
@@ -54,6 +59,8 @@ public class CacheDeadLockManagersTest extends JUnitTestCase {
         suite.setName("CacheDeadLockDetectionTest");
         suite.addTest(new CacheDeadLockManagersTest("testSetup"));
         suite.addTest(new CacheDeadLockManagersTest("testWriteLockManagerAcquireLocksForClone"));
+        suite.addTest(new CacheDeadLockManagersTest("testAbstractSessionCacheKeyFromTargetSessionForMerge"));
+        suite.addTest(new CacheDeadLockManagersTest("testAbstractSessionCacheKeyFromTargetSessionForMergeWithLockedCacheKey"));
         return suite;
     }
 
@@ -62,10 +69,12 @@ public class CacheDeadLockManagersTest extends JUnitTestCase {
      * execution in the server.
      */
     public void testSetup() {
-        EntityManagerFactory emf = Persistence.createEntityManagerFactory("cachedeadlockdetection-pu", JUnitTestCaseHelper.getDatabaseProperties());
+        final String PU_NAME = "cachedeadlockdetection-pu";
+
+        EntityManagerFactory emf = Persistence.createEntityManagerFactory(PU_NAME, JUnitTestCaseHelper.getDatabaseProperties());
         EntityManager em = emf.createEntityManager();
         new DeadLockDiagnosticTableCreator().replaceTables(((JpaEntityManager)em).getServerSession());
-        clearCache("cachedeadlockdetection-pu");
+        clearCache(PU_NAME);
         try {
             em.getTransaction().begin();
             initData(em);
@@ -87,7 +96,9 @@ public class CacheDeadLockManagersTest extends JUnitTestCase {
     }
 
     public void testWriteLockManagerAcquireLocksForClone() {
-        EntityManagerFactory emf = Persistence.createEntityManagerFactory("cachedeadlockdetection-pu", JUnitTestCaseHelper.getDatabaseProperties());
+        final String PU_NAME = "cachedeadlockdetection-pu";
+
+        EntityManagerFactory emf = Persistence.createEntityManagerFactory(PU_NAME, JUnitTestCaseHelper.getDatabaseProperties());
         EntityManager em = emf.createEntityManager();
         AbstractSession serverSession = ((JpaEntityManager)em).getServerSession();
         LogWrapper logWrapper = new LogWrapper();
@@ -113,6 +124,146 @@ public class CacheDeadLockManagersTest extends JUnitTestCase {
                 if (em.isOpen()) {
                     em.close();
                 }
+            }
+        }
+    }
+
+    public void testAbstractSessionCacheKeyFromTargetSessionForMerge() {
+        final String PU_NAME = "cachedeadlockdetection-loopwait-pu";
+        final long MASTER_ID = 1000L;
+        final long DETAIL_ID_1 = 1111L;
+        final long DETAIL_ID_2 = 1112L;
+
+        EntityManagerFactory emf = Persistence.createEntityManagerFactory(PU_NAME, JUnitTestCaseHelper.getDatabaseProperties());
+        EntityManager em = emf.createEntityManager();
+        assertEquals(MergeManagerOperationMode.WAITLOOP, ConcurrencyUtil.SINGLETON.getConcurrencyManagerAllowGetCacheKeyForMergeMode());
+        clearCache(PU_NAME);
+        try {
+            em.getTransaction().begin();
+            CacheDeadLockDetectionMaster cacheDeadLockDetectionMaster = new CacheDeadLockDetectionMaster(MASTER_ID, "M1000");
+            CacheDeadLockDetectionDetail cacheDeadLockDetectionDetail1 = new CacheDeadLockDetectionDetail(DETAIL_ID_1, "D1111");
+            cacheDeadLockDetectionDetail1.setMaster(cacheDeadLockDetectionMaster);
+            em.persist(cacheDeadLockDetectionMaster);
+            em.persist(cacheDeadLockDetectionDetail1);
+            em.getTransaction().commit();
+
+            IdentityMapAccessor identityMapAccessor = (IdentityMapAccessor) ((JpaEntityManager)em).getServerSession().getIdentityMapAccessor();
+            CacheKey cacheKey = identityMapAccessor.getCacheKeyForObject(cacheDeadLockDetectionMaster);
+            Semaphore semaphore = new Semaphore(1);
+            semaphore.acquire();
+            Object backupObject = cacheKey.getObject();
+            //Lock existing cache key by another thread
+            Thread thread = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        cacheKey.acquire(true);
+                        cacheKey.setObject(null);
+                        semaphore.acquire();
+                        cacheKey.setObject(backupObject);
+                        cacheKey.release();
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            });
+            thread.start();
+
+            em.getTransaction().begin();
+            CacheDeadLockDetectionDetail cacheDeadLockDetectionDetail2 = new CacheDeadLockDetectionDetail(DETAIL_ID_2, "D1112");
+            cacheDeadLockDetectionDetail2.setMaster(cacheDeadLockDetectionMaster);
+            em.persist(cacheDeadLockDetectionDetail2);
+            //Release semaphore which block second thread and unlock cacheKey to allow process next piece of code without any issue.
+            semaphore.release();
+            em.getTransaction().commit();
+            CacheDeadLockDetectionDetail findResult = em.find(CacheDeadLockDetectionDetail.class, DETAIL_ID_2);
+            assertEquals(DETAIL_ID_2, findResult.getId());
+            assertEquals("D1112", findResult.getName());
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException();
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if (em.isOpen()) {
+                em.close();
+            }
+            if (emf.isOpen()) {
+                emf.close();
+            }
+        }
+    }
+
+    public void testAbstractSessionCacheKeyFromTargetSessionForMergeWithLockedCacheKey() {
+        final String PU_NAME = "cachedeadlockdetection-loopwait-pu";
+        final long MASTER_ID = 2000L;
+        final long DETAIL_ID_1 = 2111L;
+        final long DETAIL_ID_2 = 2222L;
+
+        EntityManagerFactory emf = Persistence.createEntityManagerFactory(PU_NAME, JUnitTestCaseHelper.getDatabaseProperties());
+        EntityManager em = emf.createEntityManager();
+        AbstractSession serverSession = ((JpaEntityManager)em).getServerSession();
+        LogWrapper logWrapper = new LogWrapper();
+        serverSession.setSessionLog(logWrapper);
+        AbstractSessionLog.setLog(logWrapper);
+        assertEquals(MergeManagerOperationMode.WAITLOOP, ConcurrencyUtil.SINGLETON.getConcurrencyManagerAllowGetCacheKeyForMergeMode());
+        clearCache(PU_NAME);
+        try {
+            em.getTransaction().begin();
+            CacheDeadLockDetectionMaster cacheDeadLockDetectionMaster = new CacheDeadLockDetectionMaster(MASTER_ID, "M2000");
+            CacheDeadLockDetectionDetail cacheDeadLockDetectionDetail1 = new CacheDeadLockDetectionDetail(DETAIL_ID_1, "D2111");
+            cacheDeadLockDetectionDetail1.setMaster(cacheDeadLockDetectionMaster);
+            em.persist(cacheDeadLockDetectionMaster);
+            em.persist(cacheDeadLockDetectionDetail1);
+            em.getTransaction().commit();
+
+            IdentityMapAccessor identityMapAccessor = (IdentityMapAccessor) ((JpaEntityManager)em).getServerSession().getIdentityMapAccessor();
+            CacheKey cacheKey = identityMapAccessor.getCacheKeyForObject(cacheDeadLockDetectionMaster);
+            Semaphore semaphore = new Semaphore(1);
+            semaphore.acquire();
+            Object backupObject = cacheKey.getObject();
+            //Lock existing cache key by another thread
+            Thread thread = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        cacheKey.acquire(true);
+                        cacheKey.setObject(null);
+                        semaphore.acquire();
+                        cacheKey.setObject(backupObject);
+                        cacheKey.release();
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            });
+            thread.start();
+
+            em.getTransaction().begin();
+            CacheDeadLockDetectionDetail cacheDeadLockDetectionDetail2 = new CacheDeadLockDetectionDetail(DETAIL_ID_2, "D2222");
+            cacheDeadLockDetectionDetail2.setMaster(cacheDeadLockDetectionMaster);
+            em.persist(cacheDeadLockDetectionDetail2);
+            //Sleep is there to simulate, that main thread is doing some more time consuming operations and allow dead lock detection -> log messages.
+            Thread.sleep(1000);
+            em.getTransaction().commit();
+            CacheDeadLockDetectionDetail findResult = em.find(CacheDeadLockDetectionDetail.class, DETAIL_ID_2);
+            assertEquals(DETAIL_ID_2, findResult.getId());
+            assertEquals("D2222", findResult.getName());
+            assertEquals(1, logWrapper.getMessageCount("Page 08 start"));
+            assertEquals(1, logWrapper.getMessageCount("competing thread: " + thread));
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException();
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if (em.isOpen()) {
+                em.close();
+            }
+            if (emf.isOpen()) {
+                emf.close();
             }
         }
     }


### PR DESCRIPTION
Fixes #2094 
This is enhancement for case of possible deadlock which should happens in `org.eclipse.persistence.internal.sessions.AbstractSession#getCacheKeyFromTargetSessionForMerge` method if used `org.eclipse.persistence.internal.identitymaps.CacheKey` instance is locked by another thread.
There is new system or persistence property `eclipselink.concurrency.manager.allow.getcachekeyformerge.mode` which can control `org.eclipse.persistence.internal.sessions.AbstractSession#getCacheKeyFromTargetSessionForMerge` logic to get `org.eclipse.persistence.internal.identitymaps.CacheKey` instance and object value behind this.
There are two allowed values:

- `ORIGIN` (DEFAULT) - There is infinite `java.lang.Object.wait()` call in case of some conditions during time when object/entity referred from `org.eclipse.persistence.internal.identitymaps.CacheKey` is locked and modified by another thread. In some cases it should leads into deadlock.
- `WAITLOOP` - Merge manager will try in the loop with timeout wait `cacheKey.wait(ConcurrencyUtil.SINGLETON.getAcquireWaitTime());` fetch object/entity from `org.eclipse.persistence.internal.identitymaps.CacheKey`. If fetch will be successful object/entity loop finish and continue
 with remaining code. If not `java.lang.InterruptedException` is thrown and caught and used `org.eclipse.persistence.internal.identitymaps.CacheKey` instance status is set into invalidation state. This strategy avoid deadlock issue, but there should be impact to the performance.

(cherry picked from commit dd6124725b06563c42ef60581788b8f26eaef54a)