### PR TITLE
[4.0] Oracle 21C and 23AI platform fixes

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/core/databaseaccess/CorePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/core/databaseaccess/CorePlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,6 +16,7 @@ package org.eclipse.persistence.internal.core.databaseaccess;
 
 import org.eclipse.persistence.exceptions.ConversionException;
 import org.eclipse.persistence.internal.core.helper.CoreConversionManager;
+import org.eclipse.persistence.internal.sessions.AbstractSession;
 
 public interface CorePlatform<CONVERSION_MANAGER extends CoreConversionManager> {
 
@@ -28,6 +29,17 @@ public interface CorePlatform<CONVERSION_MANAGER extends CoreConversionManager> 
      * @return the newly converted object
      */
     <T> T convertObject(Object sourceObject, Class<T> javaClass);
+
+    /**
+     * Convert the object to the appropriate type by invoking the appropriate
+     * ConversionManager method.
+     * @param sourceObject the object that must be converted
+     * @param javaClass the class that the object must be converted to
+     * @param session current database session
+     * @exception ConversionException all exceptions will be thrown as this type.
+     * @return the newly converted object
+     */
+    <T> T convertObject(Object sourceObject, Class<T> javaClass, AbstractSession session) throws ConversionException;
 
     /**
      * The platform hold its own instance of conversion manager to allow customization.

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatasourcePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatasourcePlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, 2022 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -249,6 +249,20 @@ public class DatasourcePlatform implements Platform {
     @Override
     public <T> T convertObject(Object sourceObject, Class<T> javaClass) throws ConversionException {
         return getConversionManager().convertObject(sourceObject, javaClass);
+    }
+
+    /**
+     * Convert the object to the appropriate type by invoking the appropriate
+     * ConversionManager method.
+     * @param sourceObject the object that must be converted
+     * @param javaClass the class that the object must be converted to
+     * @param session current database session
+     * @exception ConversionException all exceptions will be thrown as this type.
+     * @return the newly converted object
+     */
+    @Override
+    public <T> T convertObject(Object sourceObject, Class<T> javaClass, AbstractSession session) throws ConversionException {
+        return convertObject(sourceObject, javaClass);
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/mappings/converters/TypeConversionConverter.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/mappings/converters/TypeConversionConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -25,6 +25,7 @@ import org.eclipse.persistence.exceptions.ValidationException;
 import org.eclipse.persistence.internal.descriptors.ClassNameConversionRequired;
 import org.eclipse.persistence.internal.security.PrivilegedAccessHelper;
 import org.eclipse.persistence.internal.security.PrivilegedClassForName;
+import org.eclipse.persistence.internal.sessions.AbstractSession;
 import org.eclipse.persistence.mappings.DatabaseMapping;
 import org.eclipse.persistence.mappings.DirectCollectionMapping;
 import org.eclipse.persistence.mappings.foundation.AbstractDirectMapping;
@@ -209,7 +210,12 @@ public class TypeConversionConverter implements Converter, ClassNameConversionRe
     @Override
     public Object convertObjectValueToDataValue(Object attributeValue, Session session) {
         try {
-            return session.getDatasourcePlatform().convertObject(attributeValue, getDataClass());
+            if (session.isConnected()) {
+                //Should handle conversions where DB connection is needed like String -> java.sql.Clob
+                return session.getDatasourcePlatform().convertObject(attributeValue, getDataClass(), (AbstractSession)session);
+            } else {
+                return session.getDatasourcePlatform().convertObject(attributeValue, getDataClass());
+            }
         } catch (ConversionException e) {
             throw ConversionException.couldNotBeConverted(mapping, mapping.getDescriptor(), e);
         }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/Oracle21Platform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/Oracle21Platform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,8 +14,50 @@
 //     13/01/2022-4.0.0 Tomas Kraus - 1391: JSON support in JPA
 package org.eclipse.persistence.platform.database;
 
+import org.eclipse.persistence.exceptions.ConversionException;
+import org.eclipse.persistence.exceptions.DatabaseException;
+import org.eclipse.persistence.internal.databaseaccess.FieldTypeDefinition;
+import org.eclipse.persistence.internal.helper.ClassConstants;
+import org.eclipse.persistence.internal.sessions.AbstractSession;
+
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Hashtable;
+
+import static org.eclipse.persistence.internal.helper.StringHelper.EMPTY_STRING;
+
 public class Oracle21Platform extends Oracle19Platform {
     public Oracle21Platform() {
         super();
+    }
+
+    @Override
+    protected Hashtable<Class<?>, FieldTypeDefinition> buildFieldTypes() {
+        Hashtable<Class<?>, FieldTypeDefinition> fieldTypes = super.buildFieldTypes();
+        fieldTypes.put(java.time.LocalDateTime.class, new FieldTypeDefinition("TIMESTAMP", 9));
+        fieldTypes.put(java.time.LocalTime.class, new FieldTypeDefinition("TIMESTAMP", 9));
+        return fieldTypes;
+    }
+
+        /**
+     * INTERNAL:
+     * Allow for conversion from the Oracle type to the Java type. Used in cases when DB connection is needed like BLOB, CLOB.
+     */
+    @Override
+    public <T> T convertObject(Object sourceObject, Class<T> javaClass, AbstractSession session) throws ConversionException, DatabaseException {
+        //Handle special case when empty String ("") is passed from the entity into CLOB type column
+        if (ClassConstants.CLOB.equals(javaClass) && sourceObject instanceof String && EMPTY_STRING.equals(sourceObject)) {
+            Connection connection = session.getAccessor().getConnection();
+            Clob clob = null;
+            try {
+                clob = connection.createClob();
+                clob.setString(1, (String)sourceObject);
+            } catch (SQLException e) {
+                throw ConversionException.couldNotBeConvertedToClass(sourceObject, ClassConstants.CLOB, e);
+            }
+            return (T) clob;
+        }
+        return super.convertObject(sourceObject, javaClass);
     }
 }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/Oracle23Platform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/Oracle23Platform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,7 +15,19 @@
 package org.eclipse.persistence.platform.database;
 
 public class Oracle23Platform extends Oracle21Platform {
+
     public Oracle23Platform() {
         super();
+    }
+
+    /**
+     * INTERNAL:
+     * Check whether current platform is Oracle 23c or later.
+     * @return Always returns {@code true} for instances of Oracle 23c platform.
+     * @since 4.0.2
+     */
+    @Override
+    public boolean isOracle23() {
+        return true;
     }
 }

--- a/foundation/org.eclipse.persistence.oracle/src/main/java/module-info.java
+++ b/foundation/org.eclipse.persistence.oracle/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -18,6 +18,7 @@ module org.eclipse.persistence.oracle {
     requires transitive jakarta.json;
     requires transitive com.oracle.database.jdbc;
     requires com.oracle.database.ucp;
+    requires java.sql;
 
     exports org.eclipse.persistence.platform.database.oracle;
     exports org.eclipse.persistence.platform.database.oracle.converters;

--- a/foundation/org.eclipse.persistence.oracle/src/main/java/org/eclipse/persistence/platform/database/oracle/Oracle21Platform.java
+++ b/foundation/org.eclipse.persistence.oracle/src/main/java/org/eclipse/persistence/platform/database/oracle/Oracle21Platform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,6 +15,8 @@
 package org.eclipse.persistence.platform.database.oracle;
 
 import java.sql.CallableStatement;
+import java.sql.Clob;
+import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Hashtable;
@@ -22,8 +24,13 @@ import java.util.Map;
 
 import oracle.jdbc.OracleType;
 import oracle.sql.json.OracleJsonValue;
+import org.eclipse.persistence.exceptions.ConversionException;
+import org.eclipse.persistence.exceptions.DatabaseException;
 import org.eclipse.persistence.internal.databaseaccess.FieldTypeDefinition;
+import org.eclipse.persistence.internal.helper.ClassConstants;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
+
+import static org.eclipse.persistence.internal.helper.StringHelper.EMPTY_STRING;
 
 /**
  * <p><b>Purpose:</b>
@@ -60,10 +67,33 @@ public class Oracle21Platform extends Oracle19Platform {
      */
     @Override
     protected Hashtable<Class<?>, FieldTypeDefinition> buildFieldTypes() {
-        final Hashtable<Class<?>, FieldTypeDefinition>fieldTypeMapping = super.buildFieldTypes();
+        Hashtable<Class<?>, FieldTypeDefinition>fieldTypeMapping = super.buildFieldTypes();
+        fieldTypeMapping.put(java.time.LocalDateTime.class, new FieldTypeDefinition("TIMESTAMP", 9));
+        fieldTypeMapping.put(java.time.LocalTime.class, new FieldTypeDefinition("TIMESTAMP", 9));
         // Mapping for JSON type.
         getJsonPlatform().updateFieldTypes(fieldTypeMapping);
         return fieldTypeMapping;
+    }
+
+    /**
+     * INTERNAL:
+     * Allow for conversion from the Oracle type to the Java type. Used in cases when DB connection is needed like BLOB, CLOB.
+     */
+    @Override
+    public <T> T convertObject(Object sourceObject, Class<T> javaClass, AbstractSession session) throws ConversionException, DatabaseException {
+        //Handle special case when empty String ("") is passed from the entity into CLOB type column
+        if (ClassConstants.CLOB.equals(javaClass) && sourceObject instanceof String && EMPTY_STRING.equals(sourceObject)) {
+            Connection connection = session.getAccessor().getConnection();
+            Clob clob = null;
+            try {
+                clob = connection.createClob();
+                clob.setString(1, (String)sourceObject);
+            } catch (SQLException e) {
+                throw ConversionException.couldNotBeConvertedToClass(sourceObject, ClassConstants.CLOB, e);
+            }
+            return (T) clob;
+        }
+        return super.convertObject(sourceObject, javaClass);
     }
 
     /**

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/json/TestJson.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/json/TestJson.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -236,17 +236,21 @@ public class TestJson implements JsonTestConverter.ConverterStatus {
                 .add("id", "1006")
                 .build();
         try {
-            em.getTransaction().begin();
-            JsonEntity e = new JsonEntity(1006, value);
-            em.persist(e);
-            em.flush();
-            em.getTransaction().commit();
-            em.clear();
-            JsonEntity dbValue = em.createQuery(
-                    "SELECT v FROM JsonEntity v WHERE v.value = :value", JsonEntity.class)
-                    .setParameter("value", value)
-                    .getSingleResult();
-            Assert.assertEquals(value, dbValue.getValue());
+            //TODO this test can't pass in Oracle DB as JSON DB instance can't be compared by operators such as = and >
+            //query normalizer should convert this query in Oracle platform part into e.g. .....WHERE JSON_EQUAL(VALUE, '{"id":"1007"}')
+            if (!emf.unwrap(Session.class).getPlatform().isOracle()) {
+                em.getTransaction().begin();
+                JsonEntity e = new JsonEntity(1006, value);
+                em.persist(e);
+                em.flush();
+                em.getTransaction().commit();
+                em.clear();
+                JsonEntity dbValue = em.createQuery(
+                                "SELECT v FROM JsonEntity v WHERE v.value = :value", JsonEntity.class)
+                        .setParameter("value", value)
+                        .getSingleResult();
+                Assert.assertEquals(value, dbValue.getValue());
+            }
         } finally {
             if (em.getTransaction().isActive()) {
                 em.getTransaction().rollback();

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/oraclefeatures/TestOracleLOBLocatorFeature.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/oraclefeatures/TestOracleLOBLocatorFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -157,12 +157,16 @@ public class TestOracleLOBLocatorFeature {
         // After Oracle 11, the lob locator is disabled by default (requiring a Session Customizer to reenable it)
         // So the test should fail because Eclipselink will try store a null value instead of an empty_blob()/empty_clob()
         // and violate the NOT NULL constraint.
+        // In Oracle21Platform, Oracle23Platform case when empty String ("") is stored into CLOB column is handled by java.sql.Clob and
+        // test will not throw expected exception.
         Set<String> notAllowedPlatforms = new HashSet<String>();
         notAllowedPlatforms.add("org.eclipse.persistence.platform.database.Oracle8Platform");
         notAllowedPlatforms.add("org.eclipse.persistence.platform.database.Oracle9Platform");
         notAllowedPlatforms.add("org.eclipse.persistence.platform.database.Oracle10Platform");
-        
-        
+        notAllowedPlatforms.add("org.eclipse.persistence.platform.database.Oracle21Platform");
+        notAllowedPlatforms.add("org.eclipse.persistence.platform.database.oracle.Oracle21Platform");
+        notAllowedPlatforms.add("org.eclipse.persistence.platform.database.Oracle23Platform");
+        notAllowedPlatforms.add("org.eclipse.persistence.platform.database.oracle.Oracle23Platform");
         if (!checkIsOracle() || notAllowedPlatforms.contains(getPlatform(emfNoSessionCustomizer).getClass().getName())) {
             // Skip if not testing against Oracle
             return;

--- a/jpa/eclipselink.jpa.testapps/jpa.test.beanvalidation/src/test/java/org/eclipse/persistence/testing/tests/jpa/beanvalidation/BeanValidationJunitTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.beanvalidation/src/test/java/org/eclipse/persistence/testing/tests/jpa/beanvalidation/BeanValidationJunitTest.java
@@ -432,10 +432,11 @@ public class BeanValidationJunitTest extends JUnitTestCase {
             assertEquals(1, resultSet.size());
             
             final DatabaseRecord dr = resultSet.firstElement();
-            assertEquals(900L, dr.get("ID"));
-            assertEquals(2L, dr.get("VERSION")); // should be incremented by the pessimistic lock
+            //To avoid platform dependent result types in dr.get(...) Integer, Long, BigDecimal.... values are converted to String
+            assertEquals( "900", dr.get("ID").toString());
+            assertEquals("2", dr.get("VERSION").toString()); // should be incremented by the pessimistic lock
             assertNull(dr.get("NAME")); // should be unchanged
-            assertEquals(1L, dr.get("PRIORITY")); // should be unchanged
+            assertEquals("1", dr.get("PRIORITY").toString()); // should be unchanged
             
         } catch (RuntimeException ex) {
             if (isTransactionActive(em)) {
@@ -497,10 +498,11 @@ public class BeanValidationJunitTest extends JUnitTestCase {
         assertEquals(1, resultSet.size());
         
         final DatabaseRecord dr = (DatabaseRecord) resultSet.firstElement();
-        assertEquals(901L, dr.get("ID"));
-        assertEquals(1L, dr.get("VERSION")); // should be unchanged
+        //To avoid platform dependent result types in dr.get(...) Integer, Long, BigDecimal.... values are converted to String
+        assertEquals("901", dr.get("ID").toString());
+        assertEquals("1", dr.get("VERSION").toString()); // should be unchanged
         assertNull(dr.get("NAME")); // should be unchanged
-        assertEquals(1L, dr.get("PRIORITY")); // should be unchanged
+        assertEquals("1", dr.get("PRIORITY").toString()); // should be unchanged
     }
 
     /**
@@ -547,10 +549,11 @@ public class BeanValidationJunitTest extends JUnitTestCase {
         assertEquals(1, resultSet.size());
         
         final DatabaseRecord dr = (DatabaseRecord) resultSet.firstElement();
-        assertEquals(902L, dr.get("ID"));
-        assertEquals(2L, dr.get("VERSION")); // should be incremented by the pessimistic lock
+        //To avoid platform dependent result types in dr.get(...) Integer, Long, BigDecimal.... values are converted to String
+        assertEquals("902", dr.get("ID").toString());
+        assertEquals("2", dr.get("VERSION").toString()); // should be incremented by the pessimistic lock
         assertEquals("Do some work", dr.get("NAME")); // new value
-        assertEquals(2L, dr.get("PRIORITY")); // new value
+        assertEquals("2", dr.get("PRIORITY").toString()); // new value
     }
 
     //--------------------Helper Methods ---------------//

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/converters/LobMetadata.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/converters/LobMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -120,10 +120,14 @@ public class LobMetadata extends MetadataConverter {
         // referenceClass type.
         if (isValidClobType(referenceClass)) {
             setFieldClassification(mapping, java.sql.Clob.class, isForMapKey);
-            setConverter(mapping, new TypeConversionConverter(mapping), isForMapKey);
+            TypeConversionConverter typeConversionConverter = new TypeConversionConverter(mapping);
+            typeConversionConverter.setDataClass(java.sql.Clob.class);
+            setConverter(mapping, typeConversionConverter, isForMapKey);
         } else if (isValidBlobType(referenceClass)) {
             setFieldClassification(mapping, java.sql.Blob.class, isForMapKey);
-            setConverter(mapping, new TypeConversionConverter(mapping), isForMapKey);
+            TypeConversionConverter typeConversionConverter = new TypeConversionConverter(mapping);
+            typeConversionConverter.setDataClass(java.sql.Blob.class);
+            setConverter(mapping, typeConversionConverter, isForMapKey);
         } else if (referenceClass.extendsInterface(Serializable.class)) {
             setFieldClassification(mapping, java.sql.Blob.class, isForMapKey);
             setConverter(mapping, new SerializedObjectConverter(mapping), isForMapKey);


### PR DESCRIPTION
This fixes following two issues related with Oracle23c:

- when empty String (`""`) is inserted into table column like `...CLOBDATA CLOB NOT NULL...` Solution is based on conversion into `java.sql.Clob`, because solution based on `SimpleAppendCallCustomParameter("empty_clob()")` and `DatabasePlatform.appendParameter()` leads into another test failures.
- loss of precision if DB table is automatically created if entity using `java.time.LocalDateTime`, `java.time.LocalTime`
- JSON test with query like `SELECT v FROM JsonEntity v WHERE v.value = :value` where `v.value` and `:value` is disabled on Oracle platform as this DB can't compare by `=` or `<` two JSON object types.
- BeanValidationJunitTest fix to avoid platform dependent result types in dr.get(...) Integer, Long, BigDecimal.... values are converted to String