### PR TITLE
[4.0] JPA Server side test fixes - part 1 (backport from 3.0 #2401)

### DIFF
--- a/jpa/eclipselink.jpa.testapps/README.md
+++ b/jpa/eclipselink.jpa.testapps/README.md
@@ -38,7 +38,7 @@ if no customized descriptor is provided in `src/main/resources-ejb/META-INF/pers
 * `src/main/resources-ejb` optional directory for ejb jar specific resources for server-side testing, packaged into `test-app_ejb.jar`
 * `src/main/resources-ear` optional directory for ear specific resources for server-side testing, packaged into `test-app.ear`
 * `src/test/java` contains actual tests
-* EJB/EAR archives are produced by the [eclipselink-testbuild-plugin](https://github.com/lukasj/eclipselink-build-support)
+* EJB/EAR archives are produced by the [eclipselink-testbuild-plugin](https://github.com/eclipse-ee4j/eclipselink-build-support)
 * `pom.xml` reference:
 ```xml
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced2/src/test/java/org/eclipse/persistence/testing/tests/advanced2/weave/WeaveVersionTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced2/src/test/java/org/eclipse/persistence/testing/tests/advanced2/weave/WeaveVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -174,7 +174,7 @@ public class WeaveVersionTest extends JUnitTestCase {
 
     public void cleanup() {
         EntityManager em = createEntityManager();
-        em.getTransaction().begin();
+        beginTransaction(em);
         try {
             em.createQuery("delete from IsolatedEntity s").executeUpdate();
             em.createQuery("delete from Order t").executeUpdate();
@@ -191,7 +191,7 @@ public class WeaveVersionTest extends JUnitTestCase {
     @Override
     public void tearDown() {
         EntityManager em = createEntityManager();
-        em.getTransaction().begin();
+        beginTransaction(em);
         try {
             em.createQuery("delete from Location l").executeUpdate();
             em.createQuery("delete from Order t").executeUpdate();

--- a/jpa/eclipselink.jpa.testapps/jpa.test.diagnostic/src/test/java/org/eclipse/persistence/testing/tests/jpa/diagnostic/DiagnosticTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.diagnostic/src/test/java/org/eclipse/persistence/testing/tests/jpa/diagnostic/DiagnosticTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -65,7 +65,7 @@ public class DiagnosticTest extends JUnitTestCase {
         final int BRANCHB_ID = 11;
 
         EntityManager em = createEntityManager("diagnostic-with-property-test-pu");
-        Session serverSession  = ((JpaEntityManager) em).getServerSession();
+        Session serverSession  = em.unwrap(JpaEntityManager.class).getServerSession();
         LogWrapper logWrapper = new LogWrapper("corrupt_object_referenced_through_mapping");
         serverSession.setSessionLog(logWrapper);
 
@@ -84,7 +84,7 @@ public class DiagnosticTest extends JUnitTestCase {
         commitTransaction(em);
 
         //Simulate business transaction where we do work with Entity removed
-        em.getTransaction().begin();
+        beginTransaction(em);
         if (branchADiagnostic.getBranchBs().contains(branchBDiagnostic)) {
             branchADiagnostic.getBranchBs().remove(branchBDiagnostic);
         }
@@ -97,7 +97,7 @@ public class DiagnosticTest extends JUnitTestCase {
         //Simulation of code logical error to mix into same object tree attached and detached entities
         //Add already removed (detached) entity back to the object tree
         //Required prerequisite are: caching enabled
-        em.getTransaction().begin();
+        beginTransaction(em);
         branchADiagnostic.getBranchBs().add(branchBDiagnostic);
         branchBDiagnostic.setBranchA(branchADiagnostic);
         //Detached entity (branchBDiagnostic) is not persisted again - logical error
@@ -118,7 +118,7 @@ public class DiagnosticTest extends JUnitTestCase {
         final int BRANCHB_ID = 22;
 
         EntityManager em = createEntityManager("diagnostic-test-pu");
-        Session serverSession  = ((JpaEntityManager) em).getServerSession();
+        Session serverSession  = em.unwrap(JpaEntityManager.class).getServerSession();
         LogWrapper logWrapper = new LogWrapper("corrupt_object_referenced_through_mapping");
         serverSession.setSessionLog(logWrapper);
 
@@ -137,7 +137,7 @@ public class DiagnosticTest extends JUnitTestCase {
         commitTransaction(em);
 
         //Simulate business transaction where we do work with Entity removed
-        em.getTransaction().begin();
+        beginTransaction(em);
         if (branchADiagnostic.getBranchBs().contains(branchBDiagnostic)) {
             branchADiagnostic.getBranchBs().remove(branchBDiagnostic);
         }
@@ -150,7 +150,7 @@ public class DiagnosticTest extends JUnitTestCase {
         //Simulation of code logical error to mix into same object tree attached and detached entities
         //Add already removed (detached) entity back to the object tree
         //Required prerequisite are: caching enabled
-        em.getTransaction().begin();
+        beginTransaction(em);
         branchADiagnostic.getBranchBs().add(branchBDiagnostic);
         branchBDiagnostic.setBranchA(branchADiagnostic);
         //Detached entity (branchBDiagnostic) is not persisted again - logical error

--- a/jpa/eclipselink.jpa.testapps/jpa.test.jpaadvancedproperties/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpaadvancedproperties/JPAAdvPropertiesTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.jpaadvancedproperties/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpaadvancedproperties/JPAAdvPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -302,27 +302,30 @@ public class JPAAdvPropertiesTest extends JUnitTestCase {
     }
 
     public void testLoginEncryptorProperty() {
-        EntityManager em = createEntityManager();
-        try {
-            //Create new customer
-            beginTransaction(em);
-            Customer customer = ModelExamples.customerExample1();
-            em.persist(customer);
-            em.flush();
-            Integer customerId = customer.getCustomerId();
-            commitTransaction(em);
+        //This test is valid for JSE environment
+        if (! isOnServer()) {
+            EntityManager em = createEntityManager();
+            try {
+                //Create new customer
+                beginTransaction(em);
+                Customer customer = ModelExamples.customerExample1();
+                em.persist(customer);
+                em.flush();
+                Integer customerId = customer.getCustomerId();
+                commitTransaction(em);
 
-            customer = em.find(org.eclipse.persistence.testing.models.jpa.jpaadvancedproperties.Customer.class, customerId);
-            //Purge it
-            beginTransaction(em);
-            em.remove(customer);
-            commitTransaction(em);
+                //Purge it
+                beginTransaction(em);
+                customer = em.find(org.eclipse.persistence.testing.models.jpa.jpaadvancedproperties.Customer.class, customerId);
+                em.remove(customer);
+                commitTransaction(em);
 
-            assertNotNull(customer);
-            assertTrue("CustomizedEncryptor.encryptPassword() method wasn't called.", CustomizedEncryptor.encryptPasswordCounter > 0);
-            assertTrue("CustomizedEncryptor.decryptPassword() method wasn't called.", CustomizedEncryptor.decryptPasswordCounter > 0);
-        } finally {
-            closeEntityManager(em);
+                assertNotNull(customer);
+                assertTrue("CustomizedEncryptor.encryptPassword() method wasn't called.", CustomizedEncryptor.encryptPasswordCounter > 0);
+                assertTrue("CustomizedEncryptor.decryptPassword() method wasn't called.", CustomizedEncryptor.decryptPasswordCounter > 0);
+            } finally {
+                closeEntityManager(em);
+            }
         }
     }
 }

--- a/jpa/eclipselink.jpa.testapps/jpa.test.metamodel.apectj/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.metamodel.apectj/pom.xml
@@ -71,6 +71,26 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>eclipselink-testbuild-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>package-server-tests</id>
+                        <goals>
+                            <goal>package-testapp</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <mode>EAR</mode>
+                            <libs>
+                                <lib>org.aspectj:aspectjrt</lib>
+                                <lib>org.aspectj:aspectjweaver</lib>
+                            </libs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.carlspring.maven</groupId>
                 <artifactId>derby-maven-plugin</artifactId>
                 <executions>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.metamodel.apectj/src/test/java/org/eclipse/persistence/testing/tests/jpa/weaving/aspectj/MetamodelAspectJTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.metamodel.apectj/src/test/java/org/eclipse/persistence/testing/tests/jpa/weaving/aspectj/MetamodelAspectJTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -80,30 +80,30 @@ public class MetamodelAspectJTest extends JUnitTestCase {
         EntityManager em = entityManagerFactory.createEntityManager();
 
         try {
-            em.getTransaction().begin();
+            beginTransaction(em);
             ItemAspectJ entity = new ItemAspectJ(ID, "aaaa");
             em.persist(entity);
-            em.getTransaction().commit();
-            em.getTransaction().begin();
+            commitTransaction(em);
+            beginTransaction(em);
             entity.setName(NAME);
             em.merge(entity);
-            em.getTransaction().commit();
+            commitTransaction(em);
             ItemAspectJ entity1 = em.find(ItemAspectJ.class, ID);
             assertNotNull(entity1);
             assertEquals(ID, entity1.getId());
             assertEquals(NAME, entity1.getName());
-            em.getTransaction().begin();
+            beginTransaction(em);
             em.remove(entity);
-            em.getTransaction().commit();
+            commitTransaction(em);
         } catch (Exception e) {
             e.printStackTrace();
             throw new RuntimeException();
         }
         finally {
-            if (em.getTransaction().isActive()) {
-                em.getTransaction().rollback();
+            if (isTransactionActive(em)) {
+                rollbackTransaction(em);
             }
-            em.close();
+            closeEntityManager(em);
         }
     }
 }

--- a/jpa/eclipselink.jpa.testapps/jpa.test.sessionbean.ha/src/test/java/org/eclipse/persistence/testing/tests/jpa/sessionbean/ha/SessionBeanTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.sessionbean.ha/src/test/java/org/eclipse/persistence/testing/tests/jpa/sessionbean/ha/SessionBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -88,6 +88,8 @@ public class SessionBeanTest extends JUnitTestCase {
     "java:comp/env/ejb/EmployeeService", "ejb/EmployeeService",
     // WLS
     "EmployeeService#org.eclipse.persistence.testing.models.jpa.sessionbean.ha.EmployeeService",
+    // WLS 15
+    "java:global.org.eclipse.persistence.jpa.testapps.sessionbean.ha.org.eclipse.persistence.jpa.testapps.sessionbean.ha_ejb.EmployeeServiceBean!org.eclipse.persistence.testing.models.jpa.sessionbean.ha/EmployeeService",
     // WAS
     "org.eclipse.persistence.testing.models.jpa.sessionbean.ha.EmployeeService",
     // jboss

--- a/jpa/eclipselink.jpa.testapps/jpa.test.weaving/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.weaving/pom.xml
@@ -116,6 +116,10 @@
                             </classpathDependencyExcludes>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>server-test</id>
+                        <phase>none</phase>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.advanced/src/test/java/org/eclipse/persistence/testing/tests/jpa/xml/extended/advanced/XmlExtendedAdvancedTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.advanced/src/test/java/org/eclipse/persistence/testing/tests/jpa/xml/extended/advanced/XmlExtendedAdvancedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -40,7 +40,6 @@ import org.eclipse.persistence.internal.descriptors.OptimisticLockingPolicy;
 import org.eclipse.persistence.internal.helper.ClassConstants;
 import org.eclipse.persistence.internal.helper.DatabaseField;
 import org.eclipse.persistence.internal.helper.Helper;
-import org.eclipse.persistence.internal.jpa.EntityManagerImpl;
 import org.eclipse.persistence.mappings.DatabaseMapping;
 import org.eclipse.persistence.mappings.DirectToFieldMapping;
 import org.eclipse.persistence.mappings.ForeignReferenceMapping;
@@ -83,6 +82,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * JUnit test case(s) for the TopLink EntityMappingsXMLProcessor.
@@ -769,6 +769,7 @@ public class XmlExtendedAdvancedTest extends XmlAdvancedTest {
         // clean up
         beginTransaction(em);
         try {
+            employee = em.find(Employee.class, employee.getId());
             em.remove(employee);
             commitTransaction(em);
         } finally {
@@ -801,6 +802,7 @@ public class XmlExtendedAdvancedTest extends XmlAdvancedTest {
         assertTrue("Did not correctly persist a mapping using a class-instance converter", (add.getType() instanceof Bungalow));
 
         beginTransaction(em);
+        add = em.find(Address.class, assignedSequenceNumber);
         em.remove(add);
         commitTransaction(em);
     }
@@ -811,9 +813,9 @@ public class XmlExtendedAdvancedTest extends XmlAdvancedTest {
      */
     public void testProperty() {
         EntityManager em = createEntityManager();
-        ClassDescriptor descriptor = ((EntityManagerImpl) em).getServerSession().getDescriptorForAlias("XMLEmployee");
-        ClassDescriptor aggregateDescriptor = ((EntityManagerImpl) em).getServerSession().getDescriptor(EmploymentPeriod.class);
-        em.close();
+        ClassDescriptor descriptor = (em.unwrap(org.eclipse.persistence.sessions.Session.class)).getDescriptorForAlias("XMLEmployee");
+        ClassDescriptor aggregateDescriptor = (em.unwrap(org.eclipse.persistence.sessions.Session.class)).getDescriptor(EmploymentPeriod.class);
+        closeEntityManager(em);
 
         String errorMsg = "";
 
@@ -1084,8 +1086,8 @@ public class XmlExtendedAdvancedTest extends XmlAdvancedTest {
             // Do an update
             beginTransaction(em);
 
-            em.merge(refreshedShovel);
             refreshedShovel.setMy("cost", 7.99);
+            em.merge(refreshedShovel);
 
             commitTransaction(em);
 
@@ -1093,11 +1095,11 @@ public class XmlExtendedAdvancedTest extends XmlAdvancedTest {
             em.clear();
 
             Shovel refreshedUpdatedShovel = em.find(Shovel.class, shovelId);
-            assertTrue("Shovel didn't match after update", getPersistenceUnitServerSession().compareObjects(refreshedShovel, refreshedUpdatedShovel));
+            assertTrue("Shovel didn't match after update", equalsShovelBasic(refreshedShovel, refreshedUpdatedShovel));
 
             // Now delete it
             beginTransaction(em);
-            em.merge(refreshedUpdatedShovel);
+            refreshedUpdatedShovel = em.merge(refreshedUpdatedShovel);
             em.remove(refreshedUpdatedShovel);
             commitTransaction(em);
 
@@ -1117,6 +1119,18 @@ public class XmlExtendedAdvancedTest extends XmlAdvancedTest {
         } finally {
             closeEntityManager(em);
         }
+    }
+
+    private boolean equalsShovelBasic(Shovel shovel1, Shovel shovel2) {
+        return Objects.equals(shovel1.getMy("id"), shovel2.getMy("id"))
+                && equalsShovelSections((ShovelSections)shovel1.getMy("sections"), (ShovelSections)shovel2.getMy("sections"))
+                && Objects.equals(shovel1.getMy("cost"), shovel2.getMy("cost"));
+    }
+
+    private boolean equalsShovelSections(ShovelSections shovelSections1, ShovelSections shovelSections2) {
+        return Objects.equals(shovelSections1.getMaterial("handle"), shovelSections2.getMaterial("handle"))
+                && Objects.equals(shovelSections1.getMaterial("shaft"), shovelSections2.getMaterial("shaft"))
+                && Objects.equals(shovelSections1.getMaterial("scoop"), shovelSections2.getMaterial("scoop"));
     }
 
     /**

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.advanced/src/test/java/org/eclipse/persistence/testing/tests/jpa/xml/advanced/XmlAdvancedJunitTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.advanced/src/test/java/org/eclipse/persistence/testing/tests/jpa/xml/advanced/XmlAdvancedJunitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -72,30 +72,33 @@ public class XmlAdvancedJunitTest extends JUnitTestCase {
     }*/
 
     public void testEL254937(){
-        EntityManager em = createEntityManager();
-        beginTransaction(em);
-        LargeProject lp1 = new LargeProject();
-        lp1.setName("one");
-        em.persist(lp1);
-        commitTransaction(em);
-        em = createEntityManager();
-        beginTransaction(em);
-        em.remove(em.find(LargeProject.class, lp1.getId()));
-        em.flush();
-        JpaEntityManager eclipselinkEm = (JpaEntityManager)em.getDelegate();
-        RepeatableWriteUnitOfWork uow =
-            (RepeatableWriteUnitOfWork)eclipselinkEm.getActiveSession();
-        //duplicate the beforeCompletion call
-        uow.issueSQLbeforeCompletion();
-        //commit the transaction
-        uow.setShouldTerminateTransaction(true);
-        uow.commitTransaction();
-        //duplicate the AfterCompletion call.  This should merge, removing the LargeProject from the shared cache
-        uow.mergeClonesAfterCompletion();
-        em = createEntityManager();
-        LargeProject cachedLargeProject = em.find(LargeProject.class, lp1.getId());
-        closeEntityManager(em);
-        assertNull("Entity removed during flush was not removed from the shared cache on commit", cachedLargeProject);
+        // Should not run in the server - bug 264589
+        if (! isOnServer()) {
+            EntityManager em = createEntityManager();
+            beginTransaction(em);
+            LargeProject lp1 = new LargeProject();
+            lp1.setName("one");
+            em.persist(lp1);
+            commitTransaction(em);
+            em = createEntityManager();
+            beginTransaction(em);
+            em.remove(em.find(LargeProject.class, lp1.getId()));
+            em.flush();
+            JpaEntityManager eclipselinkEm = (JpaEntityManager) em.getDelegate();
+            RepeatableWriteUnitOfWork uow =
+                    (RepeatableWriteUnitOfWork) eclipselinkEm.getActiveSession();
+            //duplicate the beforeCompletion call
+            uow.issueSQLbeforeCompletion();
+            //commit the transaction
+            uow.setShouldTerminateTransaction(true);
+            uow.commitTransaction();
+            //duplicate the AfterCompletion call.  This should merge, removing the LargeProject from the shared cache
+            uow.mergeClonesAfterCompletion();
+            em = createEntityManager();
+            LargeProject cachedLargeProject = em.find(LargeProject.class, lp1.getId());
+            closeEntityManager(em);
+            assertNull("Entity removed during flush was not removed from the shared cache on commit", cachedLargeProject);
+        }
     }
 
     public void testGF1894() {

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.advanced/src/test/java/org/eclipse/persistence/testing/tests/jpa/xml/advanced/compositepk/XmlAdvancedCompositePKTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.advanced/src/test/java/org/eclipse/persistence/testing/tests/jpa/xml/advanced/compositepk/XmlAdvancedCompositePKTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -223,7 +223,6 @@ public class XmlAdvancedCompositePKTest extends JUnitTestCase {
 
             em.persist(depAdmin);
             commitTransaction(em);
-            org.eclipse.persistence.internal.jpa.EntityManagerImpl emImpl = (org.eclipse.persistence.internal.jpa.EntityManagerImpl) em;
             DepartmentAdminRolePK depAdminPk= new DepartmentAdminRolePK(depName, depRole, location, adminEmp.getEmployee().getId());
 
             DepartmentAdminRole cacheObject = em.find(DepartmentAdminRole.class, depAdminPk);

--- a/jpa/eclipselink.jpa.testapps/nativeapi/src/main/resources-ejb/META-INF/sessions.xml
+++ b/jpa/eclipselink.jpa.testapps/nativeapi/src/main/resources-ejb/META-INF/sessions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="US-ASCII"?>
 <!--
 
-    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,7 +16,7 @@
 <sessions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="file://xsd/eclipselink_sessions_1.0.xsd" version="1.0">
     <session xsi:type="server-session">
         <name>NativeAPITest</name>
-        <server-platform xsi:type="@server-platform-class@"/>
+        <server-platform xsi:type="@server.platform.class@"/>
         <event-listener-classes/>
         <logging xsi:type="eclipselink-log">
             <log-level>@eclipselink.logging.level@</log-level>

--- a/jpa/org.eclipse.persistence.jpa.test.framework/src/main/java/org/eclipse/persistence/testing/framework/jpa/junit/JUnitTestCase.java
+++ b/jpa/org.eclipse.persistence.jpa.test.framework/src/main/java/org/eclipse/persistence/testing/framework/jpa/junit/JUnitTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -31,6 +31,7 @@ import org.eclipse.persistence.internal.databaseaccess.Platform;
 import org.eclipse.persistence.internal.jpa.EntityManagerFactoryImpl;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
 import org.eclipse.persistence.internal.sessions.DatabaseSessionImpl;
+import org.eclipse.persistence.jpa.JpaEntityManager;
 import org.eclipse.persistence.logging.AbstractSessionLog;
 import org.eclipse.persistence.logging.DefaultSessionLog;
 import org.eclipse.persistence.logging.SessionLog;
@@ -538,31 +539,31 @@ public abstract class JUnitTestCase extends TestCase {
     }
 
     public DatabaseSessionImpl getDatabaseSession() {
-        return ((org.eclipse.persistence.jpa.JpaEntityManager)getEntityManagerFactory().createEntityManager()).getDatabaseSession();
+        return getEntityManagerFactory().createEntityManager().unwrap(JpaEntityManager.class).getDatabaseSession();
     }
 
     public static DatabaseSessionImpl getDatabaseSession(String persistenceUnitName) {
-        return ((org.eclipse.persistence.jpa.JpaEntityManager)getEntityManagerFactory(persistenceUnitName).createEntityManager()).getDatabaseSession();
+        return getEntityManagerFactory(persistenceUnitName).createEntityManager().unwrap(JpaEntityManager.class).getDatabaseSession();
     }
 
     public SessionBroker getSessionBroker() {
-        return ((org.eclipse.persistence.jpa.JpaEntityManager)getEntityManagerFactory().createEntityManager()).getSessionBroker();
+        return getEntityManagerFactory().createEntityManager().unwrap(JpaEntityManager.class).getSessionBroker();
     }
 
     public static SessionBroker getSessionBroker(String persistenceUnitName) {
-        return ((org.eclipse.persistence.jpa.JpaEntityManager)getEntityManagerFactory(persistenceUnitName).createEntityManager()).getSessionBroker();
+        return getEntityManagerFactory(persistenceUnitName).createEntityManager().unwrap(JpaEntityManager.class).getSessionBroker();
     }
 
     public static ServerSession getServerSession() {
-        return ((org.eclipse.persistence.jpa.JpaEntityManager)getEntityManagerFactory("default").createEntityManager()).getServerSession();
+        return getEntityManagerFactory("default").createEntityManager().unwrap(JpaEntityManager.class).getServerSession();
     }
 
     public static ServerSession getServerSession(String persistenceUnitName) {
-        return ((org.eclipse.persistence.jpa.JpaEntityManager)getEntityManagerFactory(persistenceUnitName).createEntityManager()).getServerSession();
+        return getEntityManagerFactory(persistenceUnitName).createEntityManager().unwrap(JpaEntityManager.class).getServerSession();
     }
 
     public static ServerSession getServerSession(String persistenceUnitName, Map properties) {
-        return ((org.eclipse.persistence.jpa.JpaEntityManager)getEntityManagerFactory(persistenceUnitName, properties).createEntityManager()).getServerSession();
+        return getEntityManagerFactory(persistenceUnitName, properties).createEntityManager().unwrap(JpaEntityManager.class).getServerSession();
     }
 
     public ServerSession getPersistenceUnitServerSession() {
@@ -712,7 +713,15 @@ public abstract class JUnitTestCase extends TestCase {
         if (url == null) {
             fail("System property 'server.url' must be set.");
         }
-        properties.put("java.naming.provider.url", url);
+        properties.put(Context.PROVIDER_URL, url);
+        String tmpUsr = System.getProperty("server.usr");
+        if (tmpUsr != null && !tmpUsr.isEmpty()) {
+            properties.put(Context.SECURITY_PRINCIPAL, tmpUsr);
+        }
+        String tmpPwd = System.getProperty("server.pwd");
+        if (tmpPwd != null && !tmpPwd.isEmpty()) {
+            properties.put(Context.SECURITY_CREDENTIALS, tmpPwd);
+        }
         Context context = new InitialContext(properties);
 
         String testrunnerCtx = System.getProperty("server.testrunner.context");

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/jpa/JpaEntityManager.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/jpa/JpaEntityManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/pom.xml
+++ b/pom.xml
@@ -254,7 +254,6 @@
         <springboot.version>3.5.0</springboot.version>
         <!-- CQ #23233 -->
         <weld-se.version>5.1.0.Final</weld-se.version>
-        <weblogic.version>12.2.1-3</weblogic.version>
         <wildfly.version>27.0.0.Final</wildfly.version>
         <wsdl4j.version>1.6.3</wsdl4j.version>
 


### PR DESCRIPTION
* JPA Server side test fixes - part 1 This is first part of the fix for JPA test apps executed in JEE server environment. Main changes there:
- `(JpaEntityManager)entityManager` -> `entityManager.unwrap(JpaEntityManager)` as server should provide proxy class
- `em.getTransaction().begin()` -> `beginTransaction(em)` to allow JPA test FW identify if test is executed in JSE or JEE environment and call proper code