### PR TITLE
JPA Server side test fixes - part 4

### DIFF
--- a/jpa/eclipselink.jpa.testapps/jpa.test.diagnostic.deadlock/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.diagnostic.deadlock/pom.xml
@@ -28,6 +28,7 @@
     <name>Test - deadlock diagnostic framework</name>
 
     <properties>
+        <server.test.skip>true</server.test.skip>
         <argLine/>
     </properties>
 


### PR DESCRIPTION
Main changes there:
- `testapps.deadlock.diagnostic` server side tests disabled due dependencies on Weld, CDI and JSE thread management (create additional threads to simulate deadlock)