### PR TITLE
[4.0] JPA Server side test fixes - part 5

### DIFF
--- a/bundles/eclipselink/src/main/java/module-info.java
+++ b/bundles/eclipselink/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -173,6 +173,8 @@ module eclipselink {
     exports org.eclipse.persistence.jaxb.metadata;
     exports org.eclipse.persistence.jaxb.plugins;
     exports org.eclipse.persistence.jaxb.rs;
+    exports org.eclipse.persistence.jpa.rs.util;
+    exports org.eclipse.persistence.jpa.rs.logging;
     exports org.eclipse.persistence.jaxb.xmlmodel;
 
     exports org.eclipse.persistence.jaxb.xjc;

--- a/jpa/eclipselink.jpa.testapps/jpa.test.jta/src/main/resources-ejb/META-INF/persistence.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.jta/src/main/resources-ejb/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,11 +13,14 @@
 -->
 
 <persistence xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence persistence_1_0.xsd" version="1.0">
-    <persistence-unit name="JTA" transaction-type="JTA">
+    <persistence-unit name="JTA" transaction-type="@transaction-type@">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+        <@datasource-type@>@data-source-name@</@datasource-type@>
         <class>org.eclipse.persistence.testing.models.jpa22.jta.Animal</class>
         <exclude-unlisted-classes>true</exclude-unlisted-classes>
         <properties>
+            <property name="eclipselink.target-server" value="@server-platform@" />
+            <property name="eclipselink.target-database" value="@database-platform@"/>
             <property name="eclipselink.session-name" value="default-jta-session"/>
             <property name="eclipselink.orm.validate.schema" value="true"/>
             <property name="eclipselink.jdbc.uppercase-columns" value="true"/>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.sessionbean.ha/src/main/resources-ejb/META-INF/persistence.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.sessionbean.ha/src/main/resources-ejb/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -25,7 +25,9 @@
         <class>org.eclipse.persistence.testing.models.jpa.fieldaccess.advanced.Address</class>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-<!--            <property name="eclipselink.ddl-generation" value="drop-and-create-tables"/>-->
+            <property name="eclipselink.target-server" value="@server-platform@" />
+            <property name="eclipselink.target-database" value="@database-platform@"/>
+            <property name="eclipselink.ddl-generation" value="drop-and-create-tables"/>
             <property name="eclipselink.logging.level" value="${eclipselink.logging.level}"/>
             <property name="eclipselink.logging.level.sql" value="${eclipselink.logging.sql.level}"/>
             <property name="eclipselink.logging.parameters" value="${eclipselink.logging.parameters}"/>

--- a/jpa/org.eclipse.persistence.jpars.server/src/main/java/module-info.java
+++ b/jpa/org.eclipse.persistence.jpars.server/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -30,8 +30,10 @@ module org.eclipse.persistence.jpars.server {
     exports org.eclipse.persistence.jpa.rs.features.core.selflinks;
     exports org.eclipse.persistence.jpa.rs.features.fieldsfiltering;
     exports org.eclipse.persistence.jpa.rs.features.paging;
+    exports org.eclipse.persistence.jpa.rs.logging;
     exports org.eclipse.persistence.jpa.rs.resources;
     exports org.eclipse.persistence.jpa.rs.resources.common;
+    exports org.eclipse.persistence.jpa.rs.util;
     exports org.eclipse.persistence.jpa.rs.util.list;
 
     //exported through PUBLIC API (for XML Binding)

--- a/pom.xml
+++ b/pom.xml
@@ -2159,5 +2159,31 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>all-sources</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>all-sources</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                                <inherited>false</inherited>
+                                <configuration>
+                                    <descriptors>
+                                        <descriptor>src/main/assembly/all-sources.xml</descriptor>
+                                    </descriptors>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/src/main/assembly/all-sources.xml
+++ b/src/main/assembly/all-sources.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0,
+    or the Eclipse Distribution License v. 1.0 which is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+
+    SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+-->
+
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+    <id>all-sources</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>${project.basedir}</directory>
+            <includes>
+                <include>**/**</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+</assembly>


### PR DESCRIPTION
Main changes there:
- new Maven profile `all-sources` and assembly config due a Toplink
- _eclipselink.jar_ new exports due a Toplink
- `jpa.testapps.jta` server platform, database platform substitution strings in _resources-ejb/META-INF/persistence.xml_
- `jpa.testapps.sessionbean.ha` server platform, database platform substitution strings in _resources-ejb/META-INF/persistence.xml_