### PR TITLE
[master] Jakarta Persistence 3.2 new feature - add entities(), classes() and columns() to NamedNativeQuery

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/exceptions/ValidationException.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/exceptions/ValidationException.java
@@ -474,6 +474,7 @@ public class ValidationException extends EclipseLinkException {
     public static final int INVALID_PERSISTENCE_ROOT_URL = 7357;
     public static final int INCORRECT_ASM_SERVICE_PROVIDED = 7358;
     public static final int NOT_AVAILABLE_ASM_SERVICE = 7359;
+    public static final int DUPLICIT_RESULT_SET_MAPPING_IN_NATIVE_QUERY = 7364;
 
     /* Code values in range <7500;7599> reserved for {@link org.eclipse.persistence.exceptions.BeanValidationException}. */
 
@@ -2669,6 +2670,13 @@ public class ValidationException extends EclipseLinkException {
         Object[] args = { specifiedBooleanValue };
         ValidationException validationException = new ValidationException(ExceptionMessageGenerator.buildMessage(ValidationException.class, INVALID_BOOLEAN_VALUE_FOR_SETTING_ALLOW_NATIVESQL_QUERIES, args));
         validationException.setErrorCode(INVALID_BOOLEAN_VALUE_FOR_SETTING_ALLOW_NATIVESQL_QUERIES);
+        return validationException;
+    }
+
+    public static ValidationException duplicitResultSetMappingInNativeQuery(String entityName, String queryName) {
+        Object[] args = { entityName, queryName };
+        ValidationException validationException = new ValidationException(ExceptionMessageGenerator.buildMessage(ValidationException.class, DUPLICIT_RESULT_SET_MAPPING_IN_NATIVE_QUERY, args));
+        validationException.setErrorCode(DUPLICIT_RESULT_SET_MAPPING_IN_NATIVE_QUERY);
         return validationException;
     }
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/exceptions/i18n/ValidationExceptionResource.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/exceptions/i18n/ValidationExceptionResource.java
@@ -374,7 +374,8 @@ public final class ValidationExceptionResource extends ListResourceBundle {
                                            { "7357", "The \"[{0}]\" URL for the \"[{1}]\" resource does not belong to a valid persistence root, as defined by the Jakarta Persistence specification." },
                                            { "7358", "Incorrect ASM service name provided."},
                                            { "7359", "No any ASM service available."},
-                                           { "7360", "Database password was encrypted by deprecated algorithm. Reencrypt it by `passwordUpdate.sh` from eclipselink.zip bundle."}
+                                           { "7360", "Database password was encrypted by deprecated algorithm. Reencrypt it by `passwordUpdate.sh` from eclipselink.zip bundle."},
+                                           { "7364", "In the entity [{0}] in NamedNativeQuery [{1}] is implicit SqlResultSetMapping (\"entities\" or \"classes\" or \"columns\" attribute) used together with external SqlResultSetMapping referred by \"resultSetMapping\" attribute. This is not allowed."},
  };
 
     /**

--- a/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/pom.xml
@@ -83,7 +83,6 @@
                             </includes>
                         </configuration>
                     </execution>
-
                 </executions>
             </plugin>
             <plugin>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/main/java/org/eclipse/persistence/testing/models/jpa/persistence32/Pokemon.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/main/java/org/eclipse/persistence/testing/models/jpa/persistence32/Pokemon.java
@@ -15,7 +15,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
 
+import jakarta.persistence.ColumnResult;
+import jakarta.persistence.ConstructorResult;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityResult;
+import jakarta.persistence.FieldResult;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
@@ -26,26 +30,72 @@ import jakarta.persistence.NamedEntityGraph;
 import jakarta.persistence.NamedNativeQuery;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.NamedSubgraph;
+import jakarta.persistence.SqlResultSetMapping;
+import jakarta.persistence.SqlResultSetMappings;
 import jakarta.persistence.Table;
 import org.eclipse.persistence.annotations.FetchAttribute;
 import org.eclipse.persistence.annotations.FetchGroup;
 import org.eclipse.persistence.annotations.FetchGroups;
 
 @Entity
-@Table(name="PERSISTENCE32_POKEMON")
-@NamedQuery(name="Pokemon.get", query="SELECT p FROM Pokemon p WHERE p.id = :id")
-@NamedNativeQuery(name="Pokemon.deleteAllTypes", query="DELETE FROM PERSISTENCE32_POKEMON_TYPE")
-@NamedNativeQuery(name="Pokemon.deleteAll", query="DELETE FROM PERSISTENCE32_POKEMON")
+@Table(name = "PERSISTENCE32_POKEMON")
+@NamedQuery(name = "Pokemon.get", query = "SELECT p FROM Pokemon p WHERE p.id = :id")
+@NamedNativeQuery(name = "Pokemon.deleteAllTypes", query = "DELETE FROM PERSISTENCE32_POKEMON_TYPE")
+@NamedNativeQuery(name = "Pokemon.deleteAll", query = "DELETE FROM PERSISTENCE32_POKEMON")
+@NamedNativeQuery(name = "Pokemon.selectByIdResultSetMapping", query = "SELECT * FROM PERSISTENCE32_POKEMON WHERE ID=?",
+        resultSetMapping = "pokemon-map"
+)
+@NamedNativeQuery(name = "Pokemon.selectByIdEntitiesProperty", query = "SELECT * FROM PERSISTENCE32_POKEMON WHERE ID=?",
+        entities = {
+                @EntityResult(
+                        entityClass = Pokemon.class,
+                        fields = {
+                                @FieldResult(name = "ID", column = "id"),
+                                @FieldResult(name = "NAME", column = "name")
+                        }
+                )}
+)
+@NamedNativeQuery(name = "Pokemon.selectByIdColumnsProperty", query = "SELECT * FROM PERSISTENCE32_POKEMON WHERE ID=?",
+        columns = {
+                @ColumnResult(name = "id"),
+                @ColumnResult(name = "name")
+        }
+)
+@NamedNativeQuery(name = "Pokemon.selectByIdClassesProperty", query = "SELECT * FROM PERSISTENCE32_POKEMON WHERE ID=?",
+        classes = {
+                @ConstructorResult(
+                        targetClass = Pokemon.class,
+                        columns = {
+                                @ColumnResult(name = "id", type = Integer.class),
+                                @ColumnResult(name = "name", type = String.class),
+                        }
+                )
+        }
+)
+@SqlResultSetMappings({
+        @SqlResultSetMapping(
+                name = "pokemon-map",
+                entities = {
+                        @EntityResult(
+                                entityClass = Pokemon.class,
+                                fields = {
+                                        @FieldResult(name = "ID", column = "id"),
+                                        @FieldResult(name = "NAME", column = "name")
+                                }
+                        )
+                }
+        )
+})
 @FetchGroups({
         @FetchGroup(name = "FetchTypes", attributes = {@FetchAttribute(name = "types")})
 })
 @NamedEntityGraph(name = "Pokemon.fetchGraph",
-                  attributeNodes = {
-                        @NamedAttributeNode("name"),
-                        @NamedAttributeNode(value = "types", subgraph = "types")
-                  },
-                  subgraphs = @NamedSubgraph(name = "types",
-                                             attributeNodes = @NamedAttributeNode("name"))
+        attributeNodes = {
+                @NamedAttributeNode("name"),
+                @NamedAttributeNode(value = "types", subgraph = "types")
+        },
+        subgraphs = @NamedSubgraph(name = "types",
+                attributeNodes = @NamedAttributeNode("name"))
 )
 public class Pokemon {
 
@@ -61,14 +111,14 @@ public class Pokemon {
 
     @ManyToMany
     @JoinTable(name = "PERSISTENCE32_POKEMON_TYPE",
-               joinColumns = @JoinColumn(
-                       name = "POKEMON_ID",
-                       referencedColumnName = "ID"
-               ),
-               inverseJoinColumns = @JoinColumn(
-                       name = "TYPE_ID",
-                       referencedColumnName = "ID"
-               ))
+            joinColumns = @JoinColumn(
+                    name = "POKEMON_ID",
+                    referencedColumnName = "ID"
+            ),
+            inverseJoinColumns = @JoinColumn(
+                    name = "TYPE_ID",
+                    referencedColumnName = "ID"
+            ))
     private Collection<Type> types;
 
     public Pokemon() {

--- a/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/test/java/org/eclipse/persistence/testing/tests/jpa/persistence32/NamedNativeQueryTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/test/java/org/eclipse/persistence/testing/tests/jpa/persistence32/NamedNativeQueryTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.persistence.testing.tests.jpa.persistence32;
+
+import junit.framework.Test;
+import org.eclipse.persistence.testing.models.jpa.persistence32.Pokemon;
+import org.junit.Assert;
+
+import java.util.List;
+
+/**
+ * Verify jakarta.persistence 3.2 API changes in queries.
+ */
+public class NamedNativeQueryTest extends AbstractPokemonSuite {
+
+    // Pokemons. Array index is ID value.
+    // Value of ID = 0 does not exist so it's array instance is set to null.
+    static final Pokemon[] POKEMONS = new Pokemon[]{
+            null, // Skip array index 0
+            new Pokemon(1, "Pidgey", List.of(TYPES[1], TYPES[3])),
+            new Pokemon(2, "Beedrill", List.of(TYPES[7], TYPES[4])),
+            new Pokemon(3, "Squirtle", List.of(TYPES[11])),
+            new Pokemon(4, "Caterpie", List.of(TYPES[7]))
+    };
+
+    public static Test suite() {
+        return suite(
+                "QueryTest",
+                new NamedNativeQueryTest("testNamedNativeQueryExternalResultSetMapping"),
+                new NamedNativeQueryTest("testNamedNativeQueryInternalEntitiesProperty"),
+                new NamedNativeQueryTest("testNamedNativeQueryInternalColumnsProperty"),
+                new NamedNativeQueryTest("testNamedNativeQueryInternalClassesProperty")
+        );
+    }
+
+    public NamedNativeQueryTest() {
+    }
+
+    public NamedNativeQueryTest(String name) {
+        super(name);
+        setPuName(getPersistenceUnitName());
+    }
+
+    @Override
+    public String getPersistenceUnitName() {
+        return "persistence32";
+    }
+
+    // Initialize data
+    @Override
+    protected void suiteSetUp() {
+        super.suiteSetUp();
+        emf.runInTransaction(em -> {
+            for (int i = 1; i < POKEMONS.length; i++) {
+                em.persist(POKEMONS[i]);
+            }
+        });
+    }
+
+    public void testNamedNativeQueryExternalResultSetMapping() {
+        Pokemon pokemon = (Pokemon) emf.callInTransaction(em -> em
+                .createNamedQuery("Pokemon.selectByIdResultSetMapping")
+                .setParameter(1, POKEMONS[1].getId())
+                .getSingleResult());
+        Assert.assertEquals(POKEMONS[1], pokemon);
+    }
+
+    public void testNamedNativeQueryInternalEntitiesProperty() {
+        Pokemon pokemon = (Pokemon) emf.callInTransaction(em -> em
+                .createNamedQuery("Pokemon.selectByIdEntitiesProperty")
+                .setParameter(1, POKEMONS[1].getId())
+                .getSingleResult());
+        Assert.assertEquals(POKEMONS[1], pokemon);
+    }
+
+    public void testNamedNativeQueryInternalColumnsProperty() {
+        Object[] results = (Object[]) emf.callInTransaction(em -> em
+                .createNamedQuery("Pokemon.selectByIdColumnsProperty")
+                .setParameter(1, POKEMONS[1].getId())
+                .getSingleResult());
+        //Converted to String as various databases should return int, long or BigDecimal or other numeric types
+        Assert.assertEquals(String.valueOf(POKEMONS[1].getId()), results[0].toString());
+        Assert.assertEquals(POKEMONS[1].getName(), results[1]);
+    }
+
+    public void testNamedNativeQueryInternalClassesProperty() {
+        Pokemon pokemon = (Pokemon) emf.callInTransaction(em -> em
+                .createNamedQuery("Pokemon.selectByIdClassesProperty")
+                .setParameter(1, POKEMONS[1].getId())
+                .getSingleResult());
+        Assert.assertEquals(POKEMONS[1].getId(), pokemon.getId());
+        Assert.assertEquals(POKEMONS[1].getName(), pokemon.getName());
+    }
+}

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/queries/SQLResultSetMappingMetadata.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/queries/SQLResultSetMappingMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -26,6 +26,7 @@ package org.eclipse.persistence.internal.jpa.metadata.queries;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.persistence.internal.jpa.metadata.MetadataProject;
 import org.eclipse.persistence.internal.jpa.metadata.ORMetadata;
@@ -59,6 +60,7 @@ public class SQLResultSetMappingMetadata extends ORMetadata {
     private List<ConstructorResultMetadata> m_constructorResults = new ArrayList<>();
     private List<EntityResultMetadata> m_entityResults = new ArrayList<>();
     private String m_name;
+    private static final AtomicInteger defaultNameCounter = new AtomicInteger();
 
     /**
      * INTERNAL:
@@ -101,6 +103,18 @@ public class SQLResultSetMappingMetadata extends ORMetadata {
         // class name.
         m_name = entityClass.getName();
         m_entityResults.add(new EntityResultMetadata(entityClass, accessibleObject));
+    }
+
+    /**
+     * INTERNAL:
+     * Used for annotation specified as a part of @NamedNativeQuery.
+     */
+    public SQLResultSetMappingMetadata(MetadataAnnotation sqlResultSetMapping, MetadataAccessor accessor, List<EntityResultMetadata> entityResults, List<ConstructorResultMetadata> constructorResults,  List<ColumnResultMetadata> columnResults) {
+        super(sqlResultSetMapping, accessor);
+        m_name = "_default_" + defaultNameCounter.getAndIncrement();
+        m_entityResults = entityResults;
+        m_constructorResults = constructorResults;
+        m_columnResults = columnResults;
     }
 
     /**


### PR DESCRIPTION
Add new `entities()`, `classes()` and `columns()` methods/properties to `@NamedNativeQuery` implementation https://jakarta.ee/specifications/persistence/3.2/jakarta-persistence-spec-3.2#namednativequery-annotation

Implementation plus unit tests.