### PR TITLE
[4.0] Fix for #2366 which caused statements to stay open after usage

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/queries/DatabaseQueryMechanism.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/queries/DatabaseQueryMechanism.java
@@ -24,6 +24,7 @@ package org.eclipse.persistence.internal.queries;
 import java.io.Serializable;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -923,7 +924,12 @@ public abstract class DatabaseQueryMechanism implements Cloneable, Serializable 
         } finally {
             try {
                 if (resultSet != null) {
+                    Statement statement = resultSet.getStatement();
                     resultSet.close();
+
+                    if (statement != null && !statement.isClosed()) {
+                        statement.close();
+                    }
                 }
             } catch (SQLException cleanupSQLException) {
                 if (!exceptionOccured) {


### PR DESCRIPTION
This particularly concerned usage with the DB2 driver, which doesn't support closing the associated statement from a resultset obtained from getGeneratedKeys.

Cherry pick from master branch.