### PR TITLE
[master] Jakarta Persistence 3.2 - Makes the name member of TableGenerator and SequenceGenerator optional (implementation and unit test)

### DIFF
--- a/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/main/java/org/eclipse/persistence/testing/models/jpa/persistence32/SequenceGeneratorEntity.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/main/java/org/eclipse/persistence/testing/models/jpa/persistence32/SequenceGeneratorEntity.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.persistence.testing.models.jpa.persistence32;
+
+import jakarta.persistence.Cacheable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+
+import java.util.Objects;
+
+@Entity
+@Table(name = "PERSISTENCE32_SEQUENCE_GEN_ENTITY")
+@Cacheable(false)
+public class SequenceGeneratorEntity {
+
+    private int id;
+    private String name;
+
+    @Id
+    @GeneratedValue
+    @SequenceGenerator(sequenceName = "PERSISTENCE32_SEQUENCE_GENERATOR", allocationSize = 1)
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        SequenceGeneratorEntity that = (SequenceGeneratorEntity) o;
+        return id == that.id && Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+}

--- a/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/main/java/org/eclipse/persistence/testing/models/jpa/persistence32/TableGeneratorEntity.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/main/java/org/eclipse/persistence/testing/models/jpa/persistence32/TableGeneratorEntity.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.persistence.testing.models.jpa.persistence32;
+
+import jakarta.persistence.Cacheable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.TableGenerator;
+
+import java.util.Objects;
+
+import static jakarta.persistence.GenerationType.TABLE;
+
+@Entity
+@Table(name = "PERSISTENCE32_TABLE_GEN_ENTITY")
+@Cacheable(false)
+public class TableGeneratorEntity {
+
+    private int id;
+    private String name;
+
+    @Id
+    @GeneratedValue(strategy=TABLE)
+    @TableGenerator(
+            table="PERSISTENCE32_TABLE_GENERATOR",
+            pkColumnName="SEQ_NAME",
+            valueColumnName="SEQ_COUNT"
+    )
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        TableGeneratorEntity that = (TableGeneratorEntity) o;
+        return id == that.id && Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+}

--- a/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/main/resources/META-INF/persistence.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/main/resources/META-INF/persistence.xml
@@ -28,6 +28,8 @@
         <class>org.eclipse.persistence.testing.models.jpa.persistence32.SyntaxEntity</class>
         <class>org.eclipse.persistence.testing.models.jpa.persistence32.VersionEntity</class>
         <class>org.eclipse.persistence.testing.models.jpa.persistence32.InnerEntitiesContainer$InnerTeamEntity</class>
+        <class>org.eclipse.persistence.testing.models.jpa.persistence32.TableGeneratorEntity</class>
+        <class>org.eclipse.persistence.testing.models.jpa.persistence32.SequenceGeneratorEntity</class>
         <exclude-unlisted-classes>true</exclude-unlisted-classes>
         <properties>
             <property name="jakarta.persistence.schema-generation.scripts.action" value="none"/>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/test/java/org/eclipse/persistence/testing/tests/jpa/persistence32/SchemaManagerValidateOnMissingSchemaTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/test/java/org/eclipse/persistence/testing/tests/jpa/persistence32/SchemaManagerValidateOnMissingSchemaTest.java
@@ -59,7 +59,9 @@ public class SchemaManagerValidateOnMissingSchemaTest extends AbstractSchemaMana
                     "PERSISTENCE32_SYNTAX_ENTITY",
                     "PERSISTENCE32_VERSION_ENTITY",
                     "PERSISTENCE32_SE_COLTABLE",
-                    "PERSISTENCE32_INNER_TEAM"
+                    "PERSISTENCE32_INNER_TEAM",
+                    "PERSISTENCE32_SEQUENCE_GEN_ENTITY",
+                    "PERSISTENCE32_TABLE_GEN_ENTITY"
             };
             Set<String> missingTablesSet = new HashSet<>(Arrays.asList(missingTables));
             Set<String> initialMissingTablesSet = Set.copyOf(missingTablesSet);

--- a/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/test/java/org/eclipse/persistence/testing/tests/jpa/persistence32/TableSequenceGeneratorTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/test/java/org/eclipse/persistence/testing/tests/jpa/persistence32/TableSequenceGeneratorTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.persistence.testing.tests.jpa.persistence32;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityTransaction;
+import junit.framework.Test;
+import org.eclipse.persistence.testing.models.jpa.persistence32.SequenceGeneratorEntity;
+import org.eclipse.persistence.testing.models.jpa.persistence32.TableGeneratorEntity;
+
+
+public class TableSequenceGeneratorTest extends AbstractSuite {
+
+    private final String NAME = "abcde";
+
+    public static Test suite() {
+        return suite(
+                "StaticInnerEntitiesTest",
+                new TableSequenceGeneratorTest("testTableGeneratorWithoutName"),
+                new TableSequenceGeneratorTest("testSequenceGeneratorWithoutName")
+        );
+    }
+
+    public TableSequenceGeneratorTest() {
+    }
+
+    public TableSequenceGeneratorTest(String name) {
+        super(name);
+        setPuName(getPersistenceUnitName());
+    }
+
+    @Override
+    public String getPersistenceUnitName() {
+        return "persistence32";
+    }
+
+    @Override
+    protected void suiteSetUp() {
+        super.suiteSetUp();
+    }
+
+    public void testTableGeneratorWithoutName() {
+        try (EntityManager em = emf.createEntityManager()) {
+            EntityTransaction et = em.getTransaction();
+            try {
+                et.begin();
+                TableGeneratorEntity entity = new TableGeneratorEntity();
+                entity.setName(NAME);
+                em.persist(entity);
+                et.commit();
+                em.clear();
+                TableGeneratorEntity fetchedEntity = em.find(TableGeneratorEntity.class, entity.getId());
+                assertEquals(entity, fetchedEntity);
+            } catch (Exception e) {
+                et.rollback();
+                throw e;
+            }
+        }
+    }
+
+    public void testSequenceGeneratorWithoutName() {
+        try (EntityManager em = emf.createEntityManager()) {
+            EntityTransaction et = em.getTransaction();
+            try {
+                et.begin();
+                SequenceGeneratorEntity entity = new SequenceGeneratorEntity();
+                entity.setName(NAME);
+                em.persist(entity);
+                et.commit();
+                em.clear();
+                SequenceGeneratorEntity fetchedEntity = em.find(SequenceGeneratorEntity.class, entity.getId());
+                assertEquals(entity, fetchedEntity);
+            } catch (Exception e) {
+                et.rollback();
+                throw e;
+            }
+        }
+    }
+}

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/accessors/classes/MappedSuperclassAccessor.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/accessors/classes/MappedSuperclassAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -1550,20 +1550,20 @@ public class MappedSuperclassAccessor extends ClassAccessor {
     protected void processSequenceGenerator() {
         // Process the xml defined sequence generator first.
         if (m_sequenceGenerator != null) {
-            getProject().addSequenceGenerator(m_sequenceGenerator, getDescriptor().getDefaultCatalog(), getDescriptor().getDefaultSchema());
+            getProject().addSequenceGenerator(m_sequenceGenerator, getDescriptor().getDefaultCatalog(), getDescriptor().getDefaultSchema(), null);
         }
 
         MetadataAnnotation sequenceGenerators = getAnnotation(JPA_SEQUENCE_GENERATORS);
         if (sequenceGenerators != null) {
             for (Object sequenceGenerator : sequenceGenerators.getAttributeArray("value")) {
                 // Ask the common processor to process what we found.
-                getProject().addSequenceGenerator(new SequenceGeneratorMetadata((MetadataAnnotation) sequenceGenerator, this), getDescriptor().getDefaultCatalog(), getDescriptor().getDefaultSchema());
+                getProject().addSequenceGenerator(new SequenceGeneratorMetadata((MetadataAnnotation) sequenceGenerator, this), getDescriptor().getDefaultCatalog(), getDescriptor().getDefaultSchema(), null);
             }
         }
 
         if (isAnnotationPresent(JPA_SEQUENCE_GENERATOR)) {
             // Ask the common processor to process what we found.
-            getProject().addSequenceGenerator(new SequenceGeneratorMetadata(getAnnotation(JPA_SEQUENCE_GENERATOR), this), getDescriptor().getDefaultCatalog(), getDescriptor().getDefaultSchema());
+            getProject().addSequenceGenerator(new SequenceGeneratorMetadata(getAnnotation(JPA_SEQUENCE_GENERATOR), this), getDescriptor().getDefaultCatalog(), getDescriptor().getDefaultSchema(), null);
         }
     }
 
@@ -1622,19 +1622,19 @@ public class MappedSuperclassAccessor extends ClassAccessor {
     protected void processTableGenerator() {
         // Process the xml defined table generator first.
         if (m_tableGenerator != null) {
-            getProject().addTableGenerator(m_tableGenerator, getDescriptor().getDefaultCatalog(), getDescriptor().getDefaultSchema());
+            getProject().addTableGenerator(m_tableGenerator, getDescriptor().getDefaultCatalog(), getDescriptor().getDefaultSchema(), null);
         }
 
         MetadataAnnotation tableGenerators = getAnnotation(JPA_TABLE_GENERATORS);
         if (tableGenerators != null) {
             for (Object tableGenerator : tableGenerators.getAttributeArray("value")) {
                 // Ask the common processor to process what we found.
-                getProject().addTableGenerator(new TableGeneratorMetadata((MetadataAnnotation) tableGenerator, this), getDescriptor().getDefaultCatalog(), getDescriptor().getDefaultSchema());
+                getProject().addTableGenerator(new TableGeneratorMetadata((MetadataAnnotation) tableGenerator, this), getDescriptor().getDefaultCatalog(), getDescriptor().getDefaultSchema(), null);
             }
         }
 
         if (isAnnotationPresent(JPA_TABLE_GENERATOR)) {
-            getProject().addTableGenerator(new TableGeneratorMetadata(getAnnotation(JPA_TABLE_GENERATOR), this), getDescriptor().getDefaultCatalog(), getDescriptor().getDefaultSchema());
+            getProject().addTableGenerator(new TableGeneratorMetadata(getAnnotation(JPA_TABLE_GENERATOR), this), getDescriptor().getDefaultCatalog(), getDescriptor().getDefaultSchema(), null);
         }
     }
 

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/accessors/mappings/BasicAccessor.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/accessors/mappings/BasicAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -65,6 +65,7 @@ import org.eclipse.persistence.internal.jpa.metadata.MetadataDescriptor;
 import org.eclipse.persistence.internal.jpa.metadata.MetadataLogger;
 
 import org.eclipse.persistence.internal.jpa.metadata.accessors.classes.ClassAccessor;
+import org.eclipse.persistence.internal.jpa.metadata.accessors.classes.EntityAccessor;
 import org.eclipse.persistence.internal.jpa.metadata.accessors.objects.MetadataAccessibleObject;
 import org.eclipse.persistence.internal.jpa.metadata.accessors.objects.MetadataAnnotation;
 import org.eclipse.persistence.internal.jpa.metadata.accessors.objects.MetadataClass;
@@ -447,14 +448,19 @@ public class BasicAccessor extends DirectAccessor {
         // Process a generated value setting.
         processGeneratedValue();
 
+        String entityName = null;
+        if (this.getClassAccessor().isEntityAccessor()) {
+            entityName = ((EntityAccessor)this.getClassAccessor()).getEntityName();
+        }
+
         // Add the table generator to the project if one is set.
         if (m_tableGenerator != null) {
-            getProject().addTableGenerator(m_tableGenerator, getDescriptor().getDefaultCatalog(), getDescriptor().getDefaultSchema());
+            getProject().addTableGenerator(m_tableGenerator, getDescriptor().getDefaultCatalog(), getDescriptor().getDefaultSchema(), entityName);
         }
 
         // Add the sequence generator to the project if one is set.
         if (m_sequenceGenerator != null) {
-            getProject().addSequenceGenerator(m_sequenceGenerator, getDescriptor().getDefaultCatalog(), getDescriptor().getDefaultSchema());
+            getProject().addSequenceGenerator(m_sequenceGenerator, getDescriptor().getDefaultCatalog(), getDescriptor().getDefaultSchema(), entityName);
         }
 
         // Add the uuid generator to the project if one is set.

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/sequencing/GeneratedValueMetadata.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/sequencing/GeneratedValueMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024 Oracle, IBM and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle, IBM and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -121,13 +121,13 @@ public class GeneratedValueMetadata extends ORMetadata {
      * INTERNAL:
      */
     public void process(MetadataDescriptor descriptor, Map<String, Sequence> sequences, DatasourceLogin login) {
-        // If the generator value is null then it was loaded from XML (and it
+      // If the generator value is null then it was loaded from XML (and it
         // wasn't specified) so assign it the annotation default of ""
         if (m_generator == null) {
             m_generator = "";
         }
 
-        Sequence sequence = sequences.get(m_generator);
+        Sequence sequence = (sequences.get(m_generator) != null) ? sequences.get(m_generator) : sequences.get(descriptor.getEntityAccessor().getEntityName());
 
         if (sequence == null) {
             // A null strategy will default to AUTO.

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/sequencing/SequenceGeneratorMetadata.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/sequencing/SequenceGeneratorMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -236,16 +236,20 @@ public class SequenceGeneratorMetadata extends ORMetadata {
     /**
      * INTERNAL:
      */
-    public NativeSequence process(MetadataLogger logger) {
+    public NativeSequence process(MetadataLogger logger, String generatedName) {
         NativeSequence sequence = new NativeSequence();
 
         // Process the sequence name.
-        if (m_sequenceName == null || m_sequenceName.isEmpty()) {
-            logger.logConfigMessage(MetadataLogger.SEQUENCE_GENERATOR_SEQUENCE_NAME, m_name, getAccessibleObject(), getLocation());
-            sequence.setName(m_name);
+        String name = null;
+        if (m_sequenceName != null && !m_sequenceName.isEmpty()) {
+            name = m_sequenceName;
+        } else if (m_name != null && !m_name.isEmpty()) {
+            name = m_name;
         } else {
-            sequence.setName(m_sequenceName);
+            name = generatedName;
         }
+        logger.logConfigMessage(MetadataLogger.SEQUENCE_GENERATOR_SEQUENCE_NAME, name, getAccessibleObject(), getLocation());
+        sequence.setName(name);
 
         // Set the should use identity flag.
         sequence.setShouldUseIdentityIfPlatformSupports(m_useIdentityIfPlatformSupports);

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/sequencing/TableGeneratorMetadata.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/sequencing/TableGeneratorMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -231,13 +231,14 @@ public class TableGeneratorMetadata extends TableMetadata {
     /**
      * INTERNAL:
      */
-    public TableSequence process(MetadataLogger logger) {
+    public TableSequence process(MetadataLogger logger, String generatedName) {
         TableSequence sequence = new TableSequence();
+        String name = (m_generatorName != null) ? m_generatorName : generatedName;
 
         // Process the sequence name.
         if (m_pkColumnValue == null || m_pkColumnValue.isEmpty()) {
-            logger.logConfigMessage(MetadataLogger.TABLE_GENERATOR_PK_COLUMN_VALUE, m_generatorName, getAccessibleObject(), getLocation());
-            sequence.setName(m_generatorName);
+            logger.logConfigMessage(MetadataLogger.TABLE_GENERATOR_PK_COLUMN_VALUE, name, getAccessibleObject(), getLocation());
+            sequence.setName(name);
         } else {
             sequence.setName(m_pkColumnValue);
         }

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/xml/XMLEntityMappings.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/xml/XMLEntityMappings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -766,13 +766,13 @@ public class XMLEntityMappings extends ORMetadata {
         // Add the XML table generators to the project.
         for (TableGeneratorMetadata tableGenerator : m_tableGenerators) {
             tableGenerator.initXMLObject(m_file, this);
-            m_project.addTableGenerator(tableGenerator, getDefaultCatalog(), getDefaultSchema());
+            m_project.addTableGenerator(tableGenerator, getDefaultCatalog(), getDefaultSchema(), null);
         }
 
         // Add the XML sequence generators to the project.
         for (SequenceGeneratorMetadata sequenceGenerator : m_sequenceGenerators) {
             sequenceGenerator.initXMLObject(m_file, this);
-            m_project.addSequenceGenerator(sequenceGenerator, getDefaultCatalog(), getDefaultSchema());
+            m_project.addSequenceGenerator(sequenceGenerator, getDefaultCatalog(), getDefaultSchema(), null);
         }
 
         // Add the XML uuid generators to the project.


### PR DESCRIPTION
See
[11.1.52. TableGenerator Annotation](https://jakarta.ee/specifications/persistence/3.2/jakarta-persistence-spec-3.2#a16256)
[11.1.49. SequenceGenerator Annotation](https://jakarta.ee/specifications/persistence/3.2/jakarta-persistence-spec-3.2#a16164)
