### PR TITLE
[master] Maven build - Snapshots publishing change

### DIFF
--- a/etc/jenkins/publish_snapshots.sh
+++ b/etc/jenkins/publish_snapshots.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2025 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -17,7 +17,7 @@ if [ ${CONTINUOUS_BUILD} = "true" ]; then
 else
     echo '-[ EclipseLink Publish to Jakarta Snapshots ]-----------------------------------------------------------'
     mvn --no-transfer-progress -U -C -B -V \
-      -Psnapshots -DskipTests \
+      -Psnapshot-build -DskipTests \
       -Ddoclint=none -Ddeploy \
       deploy
 fi

--- a/pom.xml
+++ b/pom.xml
@@ -1222,6 +1222,11 @@
                     </dependencies>
                 </plugin>
                 <plugin>
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>0.9.0</version>
+                </plugin>
+                <plugin>
                     <groupId>org.wildfly.plugins</groupId>
                     <artifactId>wildfly-maven-plugin</artifactId>
                     <version>5.0.1.Final</version>
@@ -2162,6 +2167,27 @@
                                 </goals>
                             </execution>
                         </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>snapshot-build</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                            <waitUntil>published</waitUntil>
+                            <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots/</centralSnapshotsUrl>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
Snapshots publishing target change from https://jakarta.oss.sonatype.org/content/repositories/snapshots/ into https://central.sonatype.com/repository/maven-snapshots/