### PR TITLE
[master] Implement ClearDatabaseSchema for DB2

### DIFF
--- a/foundation/org.eclipse.persistence.core.test.framework/src/main/java/org/eclipse/persistence/testing/tests/ClearDatabaseSchemaTest.java
+++ b/foundation/org.eclipse.persistence.core.test.framework/src/main/java/org/eclipse/persistence/testing/tests/ClearDatabaseSchemaTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to Eclipse Foundation.
  * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/foundation/org.eclipse.persistence.core.test.framework/src/main/java/org/eclipse/persistence/testing/tests/ClearDatabaseSchemaTest.java
+++ b/foundation/org.eclipse.persistence.core.test.framework/src/main/java/org/eclipse/persistence/testing/tests/ClearDatabaseSchemaTest.java
@@ -23,9 +23,6 @@ import org.eclipse.persistence.logging.AbstractSessionLog;
 import org.eclipse.persistence.sessions.DatabaseLogin;
 import org.eclipse.persistence.testing.framework.TestCase;
 
-import static java.sql.Types.VARCHAR;
-
-import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;


### PR DESCRIPTION
ClearDatabaseSchema wasn't implemented for DB2. This class is used by various tests during the build. When building EclipseLink in DB2 this would therefor always fail.
