### PR TITLE
[3.0] Maven build - Release publishing change - backport from master

### DIFF
--- a/etc/jenkins/release.sh
+++ b/etc/jenkins/release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2020, 2022 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2025 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -48,7 +48,7 @@ if [ ${DRY_RUN} = 'true' ]; then
   MVN_DEPLOY_ARGS='install'
   echo '-[ Skipping GitHub branch and tag checks ]--------------------------------------'
 else
-  MVN_DEPLOY_ARGS='deploy'
+  MVN_DEPLOY_ARGS='install javadoc:jar gpg:sign org.sonatype.central:central-publishing-maven-plugin:0.9.0:publish  '
   GIT_ORIGIN=`git remote`
   echo '-[ Prepare branch ]-------------------------------------------------------------'
   if [[ -n `git branch -r | grep "${GIT_ORIGIN}/${RELEASE_BRANCH}"` ]]; then


### PR DESCRIPTION
Release publishing target change from https://jakarta.oss.sonatype.org/ into https://central.sonatype.com/publishing/deployments by org.sonatype.central:central-publishing-maven-plugin


(cherry picked from commit c8b11c21586d6b592fcc1234d97c17c254f93380)