### PR TITLE
[master] MOXy JPMS/module-info export fix

### DIFF
--- a/bundles/eclipselink/src/main/java/module-info.java
+++ b/bundles/eclipselink/src/main/java/module-info.java
@@ -221,6 +221,7 @@ module eclipselink {
     exports org.eclipse.persistence.internal.identitymaps;
     exports org.eclipse.persistence.internal.indirection;
     exports org.eclipse.persistence.internal.jaxb;
+    exports org.eclipse.persistence.internal.jaxb.many;
     exports org.eclipse.persistence.internal.jpa;
     exports org.eclipse.persistence.internal.jpa.deployment;
     exports org.eclipse.persistence.internal.jpa.metadata.xml;

--- a/moxy/org.eclipse.persistence.moxy/src/main/java/module-info.java
+++ b/moxy/org.eclipse.persistence.moxy/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -47,6 +47,7 @@ module org.eclipse.persistence.moxy {
 
     //exported through MOXy PUBLIC API
     exports org.eclipse.persistence.internal.jaxb;
+    exports org.eclipse.persistence.internal.jaxb.many;
 
     provides jakarta.xml.bind.JAXBContextFactory with org.eclipse.persistence.jaxb.XMLBindingContextFactory;
     provides com.sun.tools.xjc.Plugin with org.eclipse.persistence.jaxb.plugins.BeanValidationPlugin;

--- a/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/jaxbcontext/JaxbContextCreationTests.java
+++ b/moxy/org.eclipse.persistence.moxy/src/test/java/org/eclipse/persistence/testing/jaxb/jaxbcontext/JaxbContextCreationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,6 +13,7 @@
 package org.eclipse.persistence.testing.jaxb.jaxbcontext;
 
 import java.io.InputStream;
+import java.io.StringWriter;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.net.URL;
@@ -203,5 +204,32 @@ public class JaxbContextCreationTests extends junit.framework.TestCase {
         JAXBContext context = JAXBContext.newInstance(this.getClass().getPackage().getName() + ".xlink");
         assertNotNull(context);
     }
+
+    public void testCreateContextWithMultipleOutputDocuments() throws Exception {
+        final StringWriter sw = new StringWriter();
+
+        //Describe types
+        Class<?>[] classes = new Class<?>[2];
+        classes[0] = Collection.class;
+        classes[1] = Employee.class;
+
+        //Prepare data to marshall
+        Employee e1 = new Employee();
+        e1.id = 1;
+        e1.name = "Jeeves Sobs";
+        Employee e2 = new Employee();
+        e2.id = 2;
+        e2.name = "John Smith";
+        Collection<Employee> employeeCollection = new HashSet<>();
+        employeeCollection.add(e1);
+        employeeCollection.add(e2);
+
+        JAXBContext jaxbContext = JAXBContextFactory.createContext(classes, null);
+        Marshaller marshaller = jaxbContext.createMarshaller();
+        marshaller.marshal(employeeCollection, sw);
+        assertTrue(sw.toString().contains("<?xml version=\"1.0\" encoding=\"UTF-8\"?><employee id=\"1\"><name>Jeeves Sobs</name></employee>"));
+        assertTrue(sw.toString().contains("<?xml version=\"1.0\" encoding=\"UTF-8\"?><employee id=\"2\"><name>John Smith</name></employee>"));
+    }
+
 
 }


### PR DESCRIPTION
This is fix for JPMS releated issue discovered by Jersey team when EclipseLink MOXy marshaller will marshal collection/array of objects into multiple XML/JSON documents.
There is some dynamic class generated by MOXy (ASM) which extends `org.eclipse.persistence.internal.jaxb.many.CollectionValue` or other abstract class from `org.eclipse.persistence.internal.jaxb.many` package
