### PR TITLE
[4.x] Accessor and Session removal from Logs.

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/logging/AbstractSessionLog.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/logging/AbstractSessionLog.java
@@ -67,6 +67,8 @@ public abstract class AbstractSessionLog implements SessionLog, java.lang.Clonea
     @Deprecated(forRemoval=true, since="4.0.9")
     protected Session session;
 
+    private String sessionName;
+
     /**
      * Represents prefix to logged severe
      */
@@ -373,7 +375,7 @@ public abstract class AbstractSessionLog implements SessionLog, java.lang.Clonea
      * </p>
      *
      * @return  session
-     * @deprecated {@link Session} instance will be removed
+     * @deprecated Use {@link #getSessionName()} instead
      */
     @Override
     @Deprecated(forRemoval=true, since="4.0.9")
@@ -388,12 +390,24 @@ public abstract class AbstractSessionLog implements SessionLog, java.lang.Clonea
      * </p>
      *
      * @param session  a Session
-     * @deprecated {@link Session} instance will be removed
+     * @deprecated Use {@link #setSessionName(String)} instead
      */
     @Override
     @Deprecated(forRemoval=true, since="4.0.9")
     public void setSession(Session session) {
         this.session = session;
+        // Update sessionName too to keep those two values consistent
+        this.sessionName = session != null ? session.getName() : null;
+    }
+
+    @Override
+    public String getSessionName() {
+        return sessionName;
+    }
+
+    @Override
+    public void setSessionName(String sessionName) {
+        this.sessionName = sessionName;
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/logging/SessionLog.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/logging/SessionLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -818,14 +818,32 @@ public interface SessionLog extends Cloneable {
     /**
      * PUBLIC:
      * Get the session that owns this SessionLog.
+     * @deprecated Use {@link #getSessionName()} instead
      */
+    @Deprecated(forRemoval=true, since="4.0.9")
     Session getSession();
 
     /**
      * PUBLIC:
      * Set the session that owns this SessionLog.
+     * @deprecated Use {@link #setSessionName(String)} instead
      */
+    @Deprecated(forRemoval=true, since="4.0.9")
     void setSession(Session session);
+
+    /**
+     * Return the name of the session.
+     *
+     * @return the name of the session
+     */
+    String getSessionName();
+
+    /**
+     * Set the name of the session.
+     *
+     * @param sessionName the name of the session
+     */
+    void setSessionName(String sessionName);
 
     /**
      * PUBLIC:

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/logging/SessionLogEntry.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/logging/SessionLogEntry.java
@@ -44,17 +44,17 @@ public class SessionLogEntry implements Serializable {
     /**
      * The session that generated the log entry.
      *
-     * @deprecated Use {@link #getConnectionId()} instead, Accessor instance won't be available
+     * @deprecated Use {@link #getSessionId()} instead
      */
     @Deprecated(forRemoval=true, since="4.0.9")
     // Only connection ID will be stored in 5.x, but 4.x must be backward compatible
     protected transient Session session;
-    private final String sessionId;
+    private String sessionId;
     protected transient Thread thread;
     /**
      * The connection that generated the log entry.
      *
-     * @deprecated Use {@link #getConnectionId()} instead, Accessor instance won't be available
+     * @deprecated Use {@link #getConnectionId()} instead
      */
     @Deprecated(forRemoval=true, since="4.0.9")
     // Only connection ID will be stored in 5.x, but 4.x must be backward compatible
@@ -340,6 +340,7 @@ public class SessionLogEntry implements Serializable {
      * Return the session that generated the log entry.
      *
      * @return the session
+     * @deprecated Use {@link #getSessionId()} instead
      */
     public Session getSession() {
         return session;
@@ -475,9 +476,21 @@ public class SessionLogEntry implements Serializable {
      * Set the session that generated the log entry.
      *
      * @param session the session
+     * @deprecated Use {@link #setSessionId(String)} instead
      */
+    @Deprecated(forRemoval=true, since="4.0.9")
     public void setSession(Session session) {
         this.session = session;
+        this.sessionId = session != null ? session.getSessionId() : null;
+    }
+
+    /**
+     * Set the session identifier that generated the log entry.
+     *
+     * @param sessionId the session identifier
+     */
+    public void setSessionId(String sessionId) {
+        this.sessionId = sessionId;
     }
 
     /**


### PR DESCRIPTION
Parts of https://github.com/eclipse-ee4j/eclipselink/pull/2547 PR from master to mark corresponding fields and methods as deprecated.