### PR TITLE
[4.0] Fix NPE when handling empty CLOB values on Oracle 21c/23c

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/Oracle21Platform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/Oracle21Platform.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2022, 2025 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2026 IBM Corporation. All rights reserved.
+ * Copyright (c) 2022, 2026 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at


### PR DESCRIPTION
This PR fixes NPE when handling empty CLOB values on Oracle 21c/23c databases.
Fixes #2601 