### PR TITLE
[master] EclipseLink generates invalid PostgreSQL DDL `(INTEGER SERIAL NOT NULL)` - bugfix

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/PostgreSQLPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/PostgreSQLPlatform.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2019, 2024 IBM Corporation. All rights reserved.
+ * Copyright (c) 2019, 2026 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -629,6 +629,13 @@ public class PostgreSQLPlatform extends DatabasePlatform {
             super.printFieldTypeSize(writer, field, fieldType, shouldPrintFieldIdentityClause);
         }
     }
+    @Override
+    public void printFieldTypeSize(Writer writer, FieldDefinition field, FieldDefinition.DatabaseType databaseType, boolean shouldPrintFieldIdentityClause) throws IOException {
+        if (!shouldPrintFieldIdentityClause) {
+            super.printFieldTypeSize(writer, field, databaseType, shouldPrintFieldIdentityClause);
+        }
+    }
+
 
     @Override
     public void printFieldUnique(Writer writer, boolean shouldPrintFieldIdentityClause) throws IOException {


### PR DESCRIPTION
Fixes #2616 