### PR TITLE
[master] Jakarta Persistence 3.2 Tests (without persistence.xml file)

### DIFF
--- a/jpa/eclipselink.jpa.testapps/jpa.test.persistence32.nofile/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.persistence32.nofile/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0,
+    or the Eclipse Distribution License v. 1.0 which is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+
+    SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
+        <groupId>org.eclipse.persistence</groupId>
+        <version>5.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>org.eclipse.persistence.jpa.testapps.persistence32.nofile</artifactId>
+
+    <name>Test - Jakarta Persistence 3.2 - No persistence.xml</name>
+
+    <properties>
+        <argLine/>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <!--Resolve dependencies into Maven properties like ${org.eclipse.persistence:org.eclipse.persistence.jpa:jar} for JPA module-->
+                    <execution>
+                        <id>get-test-classpath-to-properties</id>
+                        <phase>process-test-classes</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.carlspring.maven</groupId>
+                <artifactId>derby-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>start-derby</id>
+                        <phase>process-test-classes</phase>
+                    </execution>
+                    <execution>
+                        <id>stop-derby</id>
+                        <phase>prepare-package</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <configuration>
+                            <argLine>-javaagent:${org.eclipse.persistence:org.eclipse.persistence.jpa:jar} @{argLine}</argLine>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>eclipselink-testbuild-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>package-server-tests</id>
+                        <!--Server side tests disabled until eclipselink-testbuild-plugin will handle projects without persistence.xml file.-->
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.persistence32.nofile/src/main/java/org/eclipse/persistence/testing/models/jpa/persistence32/nofile/TypeNoFileEntity.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.persistence32.nofile/src/main/java/org/eclipse/persistence/testing/models/jpa/persistence32/nofile/TypeNoFileEntity.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.persistence.testing.models.jpa.persistence32.nofile;
+
+import java.util.Objects;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name="PERSISTENCE32_TYPE_NO_FILE")
+public class TypeNoFileEntity {
+
+    @Id
+    private int id;
+
+    private String name;
+
+    public TypeNoFileEntity() {
+    }
+
+    public TypeNoFileEntity(int id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null || obj.getClass() != this.getClass()) {
+            return false;
+        }
+        return id == ((TypeNoFileEntity) obj).id
+                && Objects.equals(name, ((TypeNoFileEntity) obj).name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("TypeNoFileEntity {id=");
+        sb.append(id);
+        sb.append(", name=");
+        sb.append(name);
+        sb.append("}");
+        return sb.toString();
+    }
+}

--- a/jpa/eclipselink.jpa.testapps/jpa.test.persistence32.nofile/src/test/java/org/eclipse/persistence/testing/tests/jpa/persistence32/nofile/EntityManagerFactoryTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.persistence32.nofile/src/test/java/org/eclipse/persistence/testing/tests/jpa/persistence32/nofile/EntityManagerFactoryTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.persistence.testing.tests.jpa.persistence32.nofile;
+
+import java.util.Map;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityTransaction;
+import jakarta.persistence.Persistence;
+import jakarta.persistence.PersistenceConfiguration;
+import jakarta.persistence.PersistenceUnitTransactionType;
+import org.eclipse.persistence.config.PersistenceUnitProperties;
+import org.eclipse.persistence.testing.framework.jpa.junit.JUnitTestCase;
+import org.eclipse.persistence.testing.models.jpa.persistence32.nofile.TypeNoFileEntity;
+
+/**
+ * Verify jakarta.persistence 3.2 API changes in {@link jakarta.persistence.EntityManagerFactory}
+ * and new {@link jakarta.persistence.PersistenceConfiguration} without any persistence.xml file.
+ */
+public class EntityManagerFactoryTest extends JUnitTestCase {
+
+    // Test Persistence.createEntityManagerFactory(PersistenceConfiguration)
+    public void testCreateCustomEntityManagerFactoryWithoutPersistenceXMLFile() {
+        PersistenceConfiguration configuration = createPersistenceConfiguration("persistence32_nofile");
+        final int ID = 1;
+        TypeNoFileEntity typeNoFileEntity = new TypeNoFileEntity(ID, "Type Name 1");
+        try (EntityManagerFactory emfFromConfig = Persistence.createEntityManagerFactory(configuration)) {
+            try (EntityManager em = emfFromConfig.createEntityManager()) {
+                EntityTransaction et = em.getTransaction();
+                try {
+                    et.begin();
+                    em.persist(typeNoFileEntity);
+                    et.commit();
+                } catch (Exception e) {
+                    et.rollback();
+                    throw e;
+                }
+            }
+            try (EntityManager em = emfFromConfig.createEntityManager()) {
+                TypeNoFileEntity typeNoFileEntityFound = em.find(TypeNoFileEntity.class, ID);
+                assertEquals(typeNoFileEntity, typeNoFileEntityFound);
+            }
+        }
+    }
+
+    private PersistenceConfiguration createPersistenceConfiguration(String puName) {
+        PersistenceConfiguration configuration = new PersistenceConfiguration(puName);
+        Map<String , String> persistenceProperties = this.getPersistenceProperties();
+        persistenceProperties.put(PersistenceUnitProperties.SCHEMA_GENERATION_DATABASE_ACTION, "drop-and-create");
+        configuration.properties(persistenceProperties);
+        configuration.managedClass(org.eclipse.persistence.testing.models.jpa.persistence32.nofile.TypeNoFileEntity.class);
+        configuration.transactionType(PersistenceUnitTransactionType.RESOURCE_LOCAL);
+        configuration.provider("org.eclipse.persistence.jpa.PersistenceProvider");
+        return configuration;
+    }
+}

--- a/jpa/eclipselink.jpa.testapps/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2023, 2026 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -327,6 +327,7 @@
         <module>jpa.test.performance</module>
         <module>jpa.test.performance2</module>
         <module>jpa.test.persistence32</module>
+        <module>jpa.test.persistence32.nofile</module>
         <module>jpa.test.privateowned</module>
         <module>jpa.test.pu with spaces</module>
         <module>jpa.test.relationships</module>


### PR DESCRIPTION
New Maven test module under `org.eclipse.persistence.jpa.testapps` to verify `jakarta.persistence.PersistenceConfiguration` and `jakarta.persistence.Persistence#createEntityManagerFactory(jakarta.persistence.PersistenceConfiguration)` without _persistence.xml_ file in the project.