### PR TITLE
Fix for jmsSubscriberNotClosedOnServerShutDown

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/LoggingLocalizationResource.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/LoggingLocalizationResource.java
@@ -364,7 +364,7 @@ Current thread (id: {3} name: {4}) stack trace:
 
         { "update_all_query_cannot_use_binding_on_this_platform", "UpdateAllQuery cannot use binding on this database platform. Changed query setting to execute without binding." },
 
-        { "exception_thrown_when_attempting_to_close_subscriber", "Warning: {0}: attempt to close subscriber caused exception {1}" },
+        { "broadcast_exception_thrown_when_attempting_to_close_subscriber", "Warning: {0}: attempt to close subscriber caused exception {1}" },
         { "broadcast_exception_thrown_when_attempting_to_close_connection", "Warning: {0}: attempt to close connection caused exception {1}" },
         { "broadcast_connection_already_closed", "Warning: {0}: attempt to close connection which has been already closed. Ignoring." },
         { "broadcast_connection_already_closing", "Warning: {0}: attempt to close connection which is currently closing. Ignoring." },

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/coordination/jms/JMSTopicRemoteConnection.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/coordination/jms/JMSTopicRemoteConnection.java
@@ -272,7 +272,7 @@ public class JMSTopicRemoteConnection extends BroadcastRemoteConnection implemen
                 subscriber.close();
             } catch (JMSException closeException) {
                 Object[] args = { displayString, closeException };
-                rcm.logWarning("exception_thrown_when_attempting_to_close_subscriber", args);
+                rcm.logWarning("broadcast_exception_thrown_when_attempting_to_close_subscriber", args);
             }
         }
         //this method should be a no-op now that external connections open/close TopicConnection when needed.  Close on Local


### PR DESCRIPTION
JMS subscribers are not closed when the server is being shut down as it continues to be waiting in the run method due to the blocking receive call

So we have added the fix to close JMS subscribers in the closeInternal method 

Signed-off-by: Vaibhav Vishal <vaibhav.vishal@oracle.com>