### PR TITLE
[MASTER] Pull new way of UUID handling from Derby to DB2 parent

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/DB2Platform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/DB2Platform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2025, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 1998, 2026 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2025 IBM Corporation. All rights reserved.
  *
@@ -1850,6 +1850,7 @@ public class DB2Platform extends DatabasePlatform {
     private static final FieldDefinition.DatabaseType DB2_TYPE_DATE = TYPE_DATE.ofNoSize();
     private static final FieldDefinition.DatabaseType DB2_TYPE_BLOB = TYPE_BLOB.ofSize(64000);
     private static final FieldDefinition.DatabaseType DB2_TYPE_CLOB = TYPE_CLOB.ofSize(64000);
+    private static final FieldDefinition.DatabaseType DB2_TYPE_BINARY = new FieldDefinition.DatabaseType("CHAR", 16, "FOR BIT DATA");
 
     @Override
     protected Map<Class<?>, FieldDefinition.DatabaseType> buildDatabaseTypes() {
@@ -1889,6 +1890,7 @@ public class DB2Platform extends DatabasePlatform {
         fieldTypeMapping.put(java.time.OffsetDateTime.class, TYPE_TIMESTAMP);
         fieldTypeMapping.put(java.time.OffsetTime.class, TYPE_TIMESTAMP);
         fieldTypeMapping.put(java.time.Instant.class, DB2_TYPE_TIMESTAMP);
+        fieldTypeMapping.put(java.util.UUID.class, DB2_TYPE_BINARY);
 
         return fieldTypeMapping;
     }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/DerbyPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/DerbyPlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2025, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2005, 2026 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2005, 2024 IBM Corporation. All rights reserved.
  *
@@ -1004,7 +1004,6 @@ public class DerbyPlatform extends DB2Platform {
     private static final FieldDefinition.DatabaseType DERBY_TYPE_VARCHAR = TYPE_VARCHAR.ofSize(DEFAULT_VARCHAR_SIZE);;
     private static final FieldDefinition.DatabaseType DERBY_TYPE_BLOB = TYPE_BLOB.ofSize(MAX_BLOB);
     private static final FieldDefinition.DatabaseType DERBY_TYPE_CLOB = TYPE_CLOB.ofSize(MAX_CLOB);
-    private static final FieldDefinition.DatabaseType DERBY_TYPE_BINARY = new FieldDefinition.DatabaseType("CHAR", 16, "FOR BIT DATA");
 
     @Override
     protected Map<Class<?>, FieldDefinition.DatabaseType> buildDatabaseTypes() {
@@ -1021,8 +1020,6 @@ public class DerbyPlatform extends DB2Platform {
         fieldTypeMapping.replace(java.sql.Clob.class, DERBY_TYPE_CLOB);
 
         fieldTypeMapping.replace(java.time.LocalTime.class, TYPE_TIME);
-
-        fieldTypeMapping.put(java.util.UUID.class, DERBY_TYPE_BINARY);
 
         return fieldTypeMapping;
     }


### PR DESCRIPTION
After #2611, the DB2Platform wasn't updated, which resulted in many conversion errors when handling UUID.

As DB2 uses the same syntax as Derby and Derby being a sub-class of the DB2 platform, pulled up the adjusted field handling from Derby to DB2.