### PR TITLE
fixes #2636: ModelGen: The getter method on entity class does not have a corresponding setter method defined

### DIFF
--- a/jpa/org.eclipse.persistence.jpa.modelgen/src/main/java/org/eclipse/persistence/internal/jpa/modelgen/visitors/TypeVisitor.java
+++ b/jpa/org.eclipse.persistence.jpa.modelgen/src/main/java/org/eclipse/persistence/internal/jpa/modelgen/visitors/TypeVisitor.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
  * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -157,6 +158,7 @@ public class TypeVisitor<R, P> extends SimpleTypeVisitor14<MetadataAnnotatedElem
         // set method with the boxed class which will not be found. We deal with
         // boxing the type when generating the canonical model.
         annotatedElement.setPrimitiveType(primitiveType);
+        annotatedElement.setType(primitiveType.getKind().toString().toLowerCase());
         return annotatedElement;
     }
 

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/accessors/objects/MetadataAnnotatedElement.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metadata/accessors/objects/MetadataAnnotatedElement.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
  * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -877,7 +878,6 @@ public class MetadataAnnotatedElement extends MetadataAccessibleObject {
      */
     public void setPrimitiveType(Object primitiveType) {
         m_primitiveType = primitiveType;
-        m_type = primitiveType.toString();
     }
 
     /**


### PR DESCRIPTION
caused by the JDK change which added TYPE_USE (and made TypeMirror extend AnnotatedConstruct), so what used to be string name of the return type became a string with annotation and the type and that broke the setter method lookup