### PR TITLE
#2627: Regression in eclipselink 4.0.9 and 5+ for TableGenerator in multitenancy per table

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
  * Copyright (c) 1998, 2026 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, 2024 IBM Corporation. All rights reserved.
  *
@@ -3127,7 +3128,7 @@ public class DatabasePlatform extends DatasourcePlatform implements DDLPlatform 
      * Return the mapping of class types to database types for the schema framework.
      */
     protected Map<Class<?>, FieldDefinition.DatabaseType> buildDatabaseTypes() {
-        Map<Class<?>, FieldDefinition.DatabaseType> fieldTypeMapping = DB_TYPES;
+        Map<Class<?>, FieldDefinition.DatabaseType> fieldTypeMapping = new HashMap<>(DB_TYPES);
         getJsonPlatform().updateFieldTypes(fieldTypeMapping);
         return fieldTypeMapping;
     }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sequencing/TableSequence.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sequencing/TableSequence.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
  * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -165,7 +166,7 @@ public class TableSequence extends QuerySequence {
     }
 
     public String getTableName() {
-        return getTable().getQualifiedName();
+        return getTable().getName();
     }
 
     public String getQualifiedTableName() {

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/sequence/TestTableQualifier.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/sequence/TestTableQualifier.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
  * Copyright (c) 2017, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -47,7 +48,7 @@ public class TestTableQualifier {
         TableSequence tableSequence = (TableSequence) descriptor.getSequence();
         DatabaseTable table = tableSequence.getTable();
 
-        String tableName = table.getName(); // returns fully qualified table name, by design
+        String tableName = table.getName();
         String tableQualifier = table.getTableQualifier();
 
         String tsQualifier = tableSequence.getQualifier();
@@ -59,7 +60,7 @@ public class TestTableQualifier {
         Assert.assertNotNull("Table qualifier should be non-null", tableQualifier);
         Assert.assertTrue("Table qualifier should not be empty", !tableQualifier.isEmpty());
 
-        Assert.assertEquals("Table Sequence : table name (with qualifier) should be equal", (tableQualifier + "." + tableName), tsTableName);
+        Assert.assertEquals("Table Sequence : table name should be equal", tableName, tsTableName);
         Assert.assertEquals("Table Sequence : table qualifier should be equal", tableQualifier, tsQualifier);
         Assert.assertEquals("Table Sequence : qualified table name should be equal", (tableQualifier + "." + tableName), tsQualifiedTableName);
     }


### PR DESCRIPTION
a name should be a name - without a qualifier

fixes #2627 