### PR TITLE
Fix for the DerbyPlatform error SQLDataException:The syntax of the string representation of a date/time value is incorrect

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/mappings/foundation/AbstractDirectMapping.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/mappings/foundation/AbstractDirectMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2024 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -30,6 +30,7 @@ import org.eclipse.persistence.internal.databaseaccess.DatabaseAccessor;
 import org.eclipse.persistence.internal.databaseaccess.DatabasePlatform;
 import org.eclipse.persistence.internal.descriptors.DescriptorIterator;
 import org.eclipse.persistence.internal.expressions.SQLSelectStatement;
+import org.eclipse.persistence.internal.helper.ClassConstants;
 import org.eclipse.persistence.internal.helper.DatabaseField;
 import org.eclipse.persistence.internal.helper.DatabaseTable;
 import org.eclipse.persistence.internal.helper.Helper;
@@ -69,6 +70,7 @@ import java.security.PrivilegedActionException;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -77,6 +79,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Vector;
 
 /**
  * <b>Purpose</b>: Maps an attribute to the corresponding database field type.
@@ -118,6 +121,7 @@ public abstract class AbstractDirectMapping extends AbstractColumnMapping implem
      * some data-types such as Calendar or byte[] or converter types may be desired to be used as mutable.
      */
     protected Boolean isMutable;
+    private static final Map<String, Integer> columnSqlTypeCache = new HashMap<>();
 
     /**
      * Default constructor.
@@ -820,6 +824,12 @@ public abstract class AbstractDirectMapping extends AbstractColumnMapping implem
         if (fieldClassification == null) {
             fieldClassification = getFieldClassification(this.field);
         }
+        // If the mapping is java.util.Date but DB metadata says TIMESTAMP, coerce to Timestamp.
+        // This avoids date-shaped literal rendering on Derby for TIMESTAMP predicates.
+        if ((fieldClassification == ClassConstants.UTILDATE)
+                && shouldUseTimestampFieldClassification(this.field, session)) {
+            fieldClassification = ClassConstants.TIMESTAMP;
+        }
         // PERF: Avoid conversion if not required.
         // EclipseLink bug 240407 - nulls not translated when writing to database
         if ((fieldValue == null) || (fieldClassification != fieldValue.getClass())) {
@@ -832,6 +842,65 @@ public abstract class AbstractDirectMapping extends AbstractColumnMapping implem
             }
         }
         return fieldValue;
+    }
+
+    /**
+     * INTERNAL:
+     * Return whether the field should be treated as {@link java.sql.Timestamp}
+     * for value conversion.
+     * If the field SQL type is unknown, column metadata may be consulted and cached
+     * to determine whether the underlying database type is {@link Types#TIMESTAMP}.
+     */
+    private boolean shouldUseTimestampFieldClassification(DatabaseField dbField, AbstractSession session) {
+        if (dbField == null) {
+            return false;
+        }
+        int sqlType = dbField.getSqlType();
+        Class fieldType = dbField.getType();
+        String typeName = dbField.getTypeName();
+        String columnDefinition = dbField.getColumnDefinition();
+        String qualifiedFieldName = dbField.getQualifiedName();
+        String fieldName = dbField.getName();
+        if (sqlType == DatabaseField.NULL_SQL_TYPE) {
+            if ((session != null) && (session.getAccessor() != null)) {
+                String tableName = dbField.hasTableName() ? dbField.getTableName() : null;
+                String columnName = dbField.getName();
+                if ((tableName != null) && (tableName.length() > 0) && (columnName != null) && (columnName.length() > 0)) {
+                    String cacheKey = tableName.toUpperCase() + "." + columnName.toUpperCase();
+                    Integer metadataSqlType = columnSqlTypeCache.get(cacheKey);
+                    if (metadataSqlType == null) {
+                        Vector columnInfo = session.getAccessor().getColumnInfo(null, null, tableName, columnName, session);
+                        if ((columnInfo != null) && !columnInfo.isEmpty()) {
+                            for (int i = 0; i < columnInfo.size(); i++) {
+                                Object rowObject = columnInfo.elementAt(i);
+                                if (!(rowObject instanceof AbstractRecord)) {
+                                    continue;
+                                }
+                                Object dataType = ((AbstractRecord) rowObject).get("DATA_TYPE");
+                                if (dataType instanceof Number) {
+                                    metadataSqlType = Integer.valueOf(((Number) dataType).intValue());
+                                } else if (dataType != null) {
+                                    metadataSqlType = Integer.valueOf(dataType.toString());
+                                }
+                                if (metadataSqlType != null) {
+                                    columnSqlTypeCache.put(cacheKey, metadataSqlType);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    if (metadataSqlType != null) {
+                        sqlType = metadataSqlType.intValue();
+                        dbField.setSqlType(sqlType);
+                    }
+                }
+            }
+        }
+        if (sqlType == Types.TIMESTAMP) {
+            return true;
+        } else {
+            return false;
+        }
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/DerbyPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/DerbyPlatform.java
@@ -90,6 +90,18 @@ public class DerbyPlatform extends DB2Platform {
     }
 
     /**
+     * Derby error the data type, length or value of arguments 'TIMESTAMP' and 'DATE' is incompatible.
+     * Instead, use a java.sql.Date type for property {d } casting
+     */
+    @Override
+    public Object convertToDatabaseType(Object value) {
+        if (value != null && value.getClass() == CoreClassConstants.UTILDATE) {
+            return Helper.sqlDateFromUtilDate((java.util.Date)value);
+        }
+        return super.convertToDatabaseType(value);
+    }
+
+    /**
      * INTERNAL:
      * This method returns the query to select the timestamp from the server
      * for Derby.

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/criteria/model/CoalesceTimestampEntity.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/criteria/model/CoalesceTimestampEntity.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.persistence.jpa.test.criteria.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class CoalesceTimestampEntity {
+
+    @Id
+    private Integer id;
+
+    private String description;
+
+    private java.util.Date dateValue;
+
+    public CoalesceTimestampEntity() {
+    }
+
+    public CoalesceTimestampEntity(Integer id, String description, java.util.Date dateValue) {
+        this.id = id;
+        this.description = description;
+        this.dateValue = dateValue;
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/property/TestDerbyDateLiteral.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/property/TestDerbyDateLiteral.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.property;
+
+import java.sql.Date;
+import java.sql.Timestamp;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Query;
+import jakarta.persistence.TemporalType;
+
+import org.eclipse.persistence.config.HintValues;
+import org.eclipse.persistence.config.QueryHints;
+import org.eclipse.persistence.internal.helper.DatabaseField;
+import org.eclipse.persistence.internal.jpa.EntityManagerFactoryImpl;
+import org.eclipse.persistence.jpa.test.criteria.model.CoalesceTimestampEntity;
+import org.eclipse.persistence.jpa.test.framework.DDLGen;
+import org.eclipse.persistence.jpa.test.framework.Emf;
+import org.eclipse.persistence.jpa.test.framework.EmfRunner;
+import org.eclipse.persistence.jpa.test.framework.Property;
+import org.eclipse.persistence.mappings.foundation.AbstractDirectMapping;
+import org.eclipse.persistence.platform.database.DatabasePlatform;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(EmfRunner.class)
+public class TestDerbyDateLiteral {
+
+    @Emf(name = "derbyDateLiteralFreshEMF",
+         createTables = DDLGen.DROP_CREATE,
+         classes = { CoalesceTimestampEntity.class },
+         properties = {
+             @Property(name = "eclipselink.jdbc.native-sql", value = "true"),
+             @Property(name = "eclipselink.logging.level", value = "FINE"),
+             @Property(name = "eclipselink.logging.level.sql", value = "FINE"),
+             @Property(name = "eclipselink.logging.parameters", value = "true")
+         })
+    private EntityManagerFactory emf;
+
+    @Test
+    public void testRealLogPathBetweenDateLiteralsCoercesToTimestamp() {
+        DatabasePlatform platform = (DatabasePlatform) emf.unwrap(EntityManagerFactoryImpl.class)
+                .getDatabaseSession().getDatasourcePlatform();
+
+        EntityManager em = emf.createEntityManager();
+        try {
+            em.getTransaction().begin();
+            em.persist(new CoalesceTimestampEntity(1, "r1", Timestamp.valueOf("2026-04-13 17:57:41")));
+            em.persist(new CoalesceTimestampEntity(2, "r2", Timestamp.valueOf("2026-04-14 17:57:41")));
+            em.getTransaction().commit();
+
+            AbstractDirectMapping mapping = (AbstractDirectMapping) emf.unwrap(EntityManagerFactoryImpl.class)
+                    .getDatabaseSession()
+                    .getClassDescriptor(CoalesceTimestampEntity.class)
+                    .getMappingForAttributeName("dateValue");
+            Assert.assertNotNull("Expected dateValue mapping", mapping);
+            Assert.assertNotNull("Expected dateValue mapping field", mapping.getField());
+            mapping.setConverter(null);
+            mapping.getField().setType(null);
+            mapping.getField().setSqlType(DatabaseField.NULL_SQL_TYPE);
+            mapping.getField().setTypeName(null);
+            Assert.assertEquals("Expected NULL_SQL_TYPE precondition",
+                    DatabaseField.NULL_SQL_TYPE, mapping.getField().getSqlType());
+
+            Query query = em.createQuery(
+                    "SELECT e.id FROM CoalesceTimestampEntity e "
+                            + "WHERE (e.dateValue BETWEEN ?1 AND ?2) "
+                            + "ORDER BY e.dateValue DESC");
+            query.setHint(QueryHints.BIND_PARAMETERS, HintValues.FALSE);
+            query.setParameter(1, Date.valueOf("2026-04-13"), TemporalType.DATE);
+            query.setParameter(2, Date.valueOf("2026-04-14"), TemporalType.DATE);
+            query.getResultList();
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            em.close();
+        }
+    }
+}


### PR DESCRIPTION
The org.eclipse.persistence.platform.database.DerbyPlatform#convertToDatabaseType method returns a java.sql.Date which doesn't include the time due to which some applications throws the following exception 

java.sql.SQLDataException: The syntax of the string representation of a date/time value is incorrect.

So a fix has been done to return appropriate and correct values

Signed-off-by: Vaibhav Vishal vaibhav.vishal@oracle.com