### PR TITLE
remove few warnings from the build

### DIFF
--- a/bundles/tests/pom.xml
+++ b/bundles/tests/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
+    Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
     Copyright (c) 2020, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -278,9 +279,9 @@
                                 </goals>
                                 <configuration>
                                     <!--<skip>true</skip>-->
-                                    <systemProperties>
+                                    <systemPropertyVariables>
                                         <plugins.dir>${project.build.directory}/${osgi.test.plugins.dir}</plugins.dir>
-                                    </systemProperties>
+                                    </systemPropertyVariables>
                                     <includes>
                                         <include>org.eclipse.persistence.testing.osgi.beanvalidation.NoBeanValidationTest</include>
                                         <include>org.eclipse.persistence.testing.osgi.beanvalidation.BeanValidationTest</include>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
+    Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
     Copyright (c) 2019, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -684,6 +685,7 @@
                             <goal>timestamp-property</goal>
                         </goals>
                         <configuration>
+                            <locale>en_US</locale>
                             <name>release.date</name>
                             <pattern>MMMM dd, YYYY</pattern>
                         </configuration>
@@ -781,6 +783,9 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
+                    <noWarningProjectTypes>
+                        <noWarningProjectType>pom</noWarningProjectType>
+                    </noWarningProjectTypes>
                     <niceManifest>true</niceManifest>
                     <instructions>
                         <_noextraheaders>true</_noextraheaders>

--- a/sdo/eclipselink.sdo.test.server/pom.xml
+++ b/sdo/eclipselink.sdo.test.server/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
+    Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
     Copyright (c) 2019, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -185,13 +186,13 @@
                     <workingDirectory>${project.build.testOutputDirectory}</workingDirectory>
                     <!--Set system properties required for tests-->
                     <systemPropertiesFile>${testjee.properties.file}</systemPropertiesFile>
-                    <systemProperties>
+                    <systemPropertyVariables>
                         <sessionBean>${ejb-jndi-name}</sessionBean>
                         <securityPrincipal>${server.usr}</securityPrincipal>
                         <securityCredentials>${server.pwd}</securityCredentials>
                         <providerUrl>${server.rmi.protocol}://${server.host}:${server.rmi.port}</providerUrl>
                         <initialCtxFactory>${server.initialCtxFactory}</initialCtxFactory>
-                    </systemProperties>
+                    </systemPropertyVariables>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
* failsafe systemProperties -> systemPropertyVariables
* set locale for timestamp-property
* set pom to not print warning by bundle plugin