### PR TITLE
Fix/2659 null deferred lock manager

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ConcurrencyManager.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ConcurrencyManager.java
@@ -725,7 +725,7 @@ public class ConcurrencyManager implements Serializable {
                         throw ConcurrencyException.waitWasInterrupted(interrupted.getMessage());
                     }
                 }
-            } catch (Error error) {
+            } catch (Error | Exception error) {
                 if (!releaseAllLocksAquiredByThreadAlreadyPerformed) {
                     THREADS_WAITING_TO_RELEASE_DEFERRED_LOCKS.remove(currentThread);
                     AbstractSessionLog.getLog().logThrowable(SessionLog.SEVERE, SessionLog.CACHE, error);

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/WriteLockManager.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/WriteLockManager.java
@@ -553,7 +553,13 @@ public class WriteLockManager {
                 // for others to find an prevent cycles
             }
             if (mergeManager.isTransitionedToDeferredLocks()){
-                ConcurrencyManager.getDeferredLockManager(Thread.currentThread()).getActiveLocks().add(lockedCacheKey);
+                DeferredLockManager deferredLockManager = ConcurrencyManager.getDeferredLockManager(Thread.currentThread());
+                if (deferredLockManager != null) {
+                    deferredLockManager.getActiveLocks().add(lockedCacheKey);
+                } else {
+                    // Fallback to regular lock tracking if DeferredLockManager not available
+                    mergeManager.getAcquiredLocks().add(lockedCacheKey);
+                }
             }else{
                  mergeManager.getAcquiredLocks().add(lockedCacheKey);
             }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/WriteLockManager.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/WriteLockManager.java
@@ -273,8 +273,11 @@ public class WriteLockManager {
             for (CacheKey cacheKey : mergeManager.getAcquiredLocks()){
                 cacheKey.release();
             }
-            ConcurrencyManager.getDeferredLockManager(Thread.currentThread()).setIsThreadComplete(true);
-            ConcurrencyManager.removeDeferredLockManager(Thread.currentThread());
+            DeferredLockManager lockManager = ConcurrencyManager.getDeferredLockManager(Thread.currentThread());
+            if (lockManager != null) {
+                lockManager.setIsThreadComplete(true);
+                ConcurrencyManager.removeDeferredLockManager(Thread.currentThread());
+            }
             mergeManager.getAcquiredLocks().clear();
             throw ex;
         }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/ObjectChangeSet.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/ObjectChangeSet.java
@@ -519,36 +519,44 @@ public class ObjectChangeSet implements Serializable, Comparable<ObjectChangeSet
         CacheKey cacheKey = session.getIdentityMapAccessorInstance().getCacheKeyForObject(primaryKey, descriptor.getJavaClass(), descriptor, true);
         if (cacheKey != null) {
             if (cacheKey.acquireReadLockNoWait()) {
-                domainObject = cacheKey.getObject();
-                cacheKey.releaseReadLock();
+                try {
+                    domainObject = cacheKey.getObject();
+                } finally {
+                    cacheKey.releaseReadLock();
+                }
             } else {
                 if (!mergeManager.isTransitionedToDeferredLocks()) {
                     session.getIdentityMapAccessorInstance().getWriteLockManager().transitionToDeferredLocks(mergeManager);
                 }
                 cacheKey.acquireDeferredLock();
-                domainObject = cacheKey.getObject();
-                int tries = 0;
-                while (domainObject == null) {
-                    ++tries;
-                    if (tries > MAX_TRIES){
-                        session.getParent().log(SessionLog.SEVERE, SessionLog.CACHE, "entity_not_available_during_merge", new Object[]{descriptor.getJavaClassName(), cacheKey.getKey(), Thread.currentThread().getName(), cacheKey.getActiveThread()});
-                        break;
-                    }
-                    cacheKey.getInstanceLock().lock();
-                    try {
-                        if (cacheKey.isAcquired()) {
-                            try {
-                                cacheKey.wait(10);
-                            } catch (InterruptedException e) {
-                                //ignore and return
+                try {
+                    domainObject = cacheKey.getObject();
+                    int tries = 0;
+                    while (domainObject == null) {
+                        ++tries;
+                        if (tries > MAX_TRIES) {
+                            if (session.getParent() != null) {
+                                session.getParent().log(SessionLog.SEVERE, SessionLog.CACHE, "entity_not_available_during_merge", new Object[]{descriptor.getJavaClassName(), cacheKey.getKey(), Thread.currentThread().getName(), cacheKey.getActiveThread()});
                             }
+                            break;
                         }
-                        domainObject = cacheKey.getObject();
-                    } finally {
-                        cacheKey.getInstanceLock().unlock();
+                        cacheKey.getInstanceLock().lock();
+                        try {
+                            if (cacheKey.isAcquired()) {
+                                try {
+                                    cacheKey.wait(10);
+                                } catch (InterruptedException e) {
+                                    //ignore and return
+                                }
+                            }
+                            domainObject = cacheKey.getObject();
+                        } finally {
+                            cacheKey.getInstanceLock().unlock();
+                        }
                     }
+                } finally {
+                    cacheKey.releaseDeferredLock();
                 }
-                cacheKey.releaseDeferredLock();
             }
         } else {
             domainObject = mergeManager.registerExistingObjectOfReadOnlyClassInNestedTransaction(getUnitOfWorkClone(), descriptor, session);

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
@@ -1742,6 +1742,18 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
             verifyMutexThreadIntegrityBeforeRelease();
             // exception occurred during the commit.
             this.parent.getIdentityMapAccessorInstance().getWriteLockManager().releaseAllAcquiredLocks(this.lastUsedMergeManager);
+
+            // Fix for GitHub issue #2376: Release DeferredLockManager locks
+            Thread currentThread = Thread.currentThread();
+            org.eclipse.persistence.internal.helper.DeferredLockManager deferredLockManager =
+                    org.eclipse.persistence.internal.helper.ConcurrencyManager.getDeferredLockManager(currentThread);
+            if (deferredLockManager != null) {
+                if (!deferredLockManager.getActiveLocks().isEmpty()) {
+                    deferredLockManager.releaseActiveLocksOnThread();
+                }
+                org.eclipse.persistence.internal.helper.ConcurrencyManager.removeDeferredLockManager(currentThread);
+            }
+
             this.lastUsedMergeManager = null;
         }
     }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
@@ -1744,11 +1744,18 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
             this.parent.getIdentityMapAccessorInstance().getWriteLockManager().releaseAllAcquiredLocks(this.lastUsedMergeManager);
 
             // Fix for GitHub issue #2376: Release DeferredLockManager locks
+            // Safety-net cleanup for any DeferredLockManager that survived due to an exception during merge.
+            // We must strip locks already released by releaseAllAcquiredLocks() above to prevent double-release:
+            // transitionToDeferredLocks() duplicates getAcquiredLocks() entries into the DLM's activeLocks
+            // without removing them from getAcquiredLocks(), so both lists can contain the same cache keys.
             Thread currentThread = Thread.currentThread();
             org.eclipse.persistence.internal.helper.DeferredLockManager deferredLockManager =
                     org.eclipse.persistence.internal.helper.ConcurrencyManager.getDeferredLockManager(currentThread);
             if (deferredLockManager != null) {
+                // Remove any locks that were already released by releaseAllAcquiredLocks() above.
+                deferredLockManager.getActiveLocks().removeAll(this.lastUsedMergeManager.getAcquiredLocks());
                 if (!deferredLockManager.getActiveLocks().isEmpty()) {
+                    // Release only locks that are exclusively tracked by the DLM (appended after transition).
                     deferredLockManager.releaseActiveLocksOnThread();
                 }
                 org.eclipse.persistence.internal.helper.ConcurrencyManager.removeDeferredLockManager(currentThread);


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                              
  Fixes #2659 — NPE in `WriteLockManager.appendLock` when `isTransitionedToDeferredLocks` is `true` but the `DeferredLockManager` for the current thread has already been removed (e.g. torn down by a concurrent `releaseDeferredLock()` at depth 1 with no  
  deferred locks).                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                              
  Also fixes a related double-release risk in `UnitOfWorkImpl.releaseWriteLocks()`: `transitionToDeferredLocks()` copies (not moves) keys from `mergeManager.getAcquiredLocks()` into `DeferredLockManager.activeLocks`, so calling both                      
  `releaseAllAcquiredLocks()` and `releaseActiveLocksOnThread()` releases the same `CacheKey` objects twice.                                                                                                                                                  
                                                                                                                                                                                                                                                              
  ## Changes                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                              
  - **`WriteLockManager.appendLock`** — null-check `DeferredLockManager` before calling `getActiveLocks().add()`; fall back to `mergeManager.getAcquiredLocks()` if null.                                                                                     
  - **`WriteLockManager.transitionToDeferredLocks` (catch block)** — null-check before calling `setIsThreadComplete(true)` and `removeDeferredLockManager()`.                                                                                                 
  - **`ObjectChangeSet.getTargetVersionOfSourceObject`** — wrap `acquireDeferredLock()` / `releaseDeferredLock()` in try-finally; null-check `session.getParent()` before logging.                                                                            
  - **`UnitOfWorkImpl.releaseWriteLocks`** — after `releaseAllAcquiredLocks()`, strip already-released keys from `DeferredLockManager.activeLocks` before calling `releaseActiveLocksOnThread()` to prevent double-release.                                   
                                                                                                                                                                                                                                                              
  ## Test plan                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                              
  - [ ] Reproduce the deadlock scenario described in #2659 (concurrent merge under L2 cache with `isTransitionedToDeferredLocks=true`) — verify no NPE and no thread hang.                                                                                    
  - [ ] Run existing `ConcurrencyManagerTest`                                                                                                                                                                               
  - [ ] Run JPA LRG against a Payara 6 deployment to confirm no regression.                                                                                                                                                                                   
                                                                                                                                                                                                                                                              
  Reported and diagnosed in: https://github.com/eclipse-ee4j/eclipselink/issues/2659