### PR TITLE
#2600: QueryImpl.setParameterInternal validates parameter type only for first occurrence

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/jpa/jpql/HermesParser.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/jpa/jpql/HermesParser.java
@@ -1,6 +1,6 @@
 /*
+ * Copyright (c) 2024, 2026 Contributors to the Eclipse Foundation. All rights reserved.
  * Copyright (c) 2006, 2025 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2024 Contributors to the Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -109,23 +109,13 @@ public final class HermesParser implements JPAQueryBuilder {
     private void addArguments(JPQLQueryContext queryContext, DatabaseQuery databaseQuery) {
 
         if (queryContext.inputParameters != null) {
-
-            Map<String, ParameterInfo> parameters = new LinkedHashMap<>();
             for (Map.Entry<InputParameter, Expression> entry : queryContext.inputParameters.entrySet()) {
                 ParameterExpression parameter = (ParameterExpression) entry.getValue();
-                String name = parameter.getField().getName();
-                Class<?> type = (Class<?>) parameter.getType();
-                ParameterType parameterType = entry.getKey().isPositional() ? ParameterType.POSITIONAL : ParameterType.NAMED;
-                ParameterInfo info = parameters.get(name);
-                if (info == null) {
-                    parameters.put(name, new ParameterInfo(type, parameterType));
-                } else {
-                    info.merge(type);
-                }
-            }
-            for (Map.Entry<String, ParameterInfo> entry : parameters.entrySet()) {
-                ParameterInfo info = entry.getValue();
-                databaseQuery.addArgument(entry.getKey(), info.type, info.parameterType);
+                databaseQuery.addArgument(
+                        parameter.getField().getName(),
+                        (Class<?>) parameter.getType(),
+                        entry.getKey().isPositional() ? ParameterType.POSITIONAL : ParameterType.NAMED
+                );
             }
         }
     }

--- a/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpql/datetime/JUnitJPQLDateTimeTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.jpql/src/test/java/org/eclipse/persistence/testing/tests/jpa/jpql/datetime/JUnitJPQLDateTimeTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
  * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -14,6 +15,7 @@
 //     Oracle - initial API and implementation from Oracle TopLink
 package org.eclipse.persistence.testing.tests.jpa.jpql.datetime;
 
+import jakarta.persistence.EntityManager;
 import jakarta.persistence.TemporalType;
 import junit.framework.Test;
 import junit.framework.TestSuite;
@@ -24,6 +26,7 @@ import org.eclipse.persistence.testing.models.jpa.datetime.DateTimeTableCreator;
 import java.time.Instant;
 import java.time.Year;
 import java.util.Calendar;
+import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
 
@@ -55,6 +58,7 @@ public class JUnitJPQLDateTimeTest extends JUnitTestCase {
         suite.addTest(new JUnitJPQLDateTimeTest("testTimestampToDate"));
         suite.addTest(new JUnitJPQLDateTimeTest("testTimestampToTime"));
         suite.addTest(new JUnitJPQLDateTimeTest("testUtilDate"));
+        suite.addTest(new JUnitJPQLDateTimeTest("testAssignWrongType"));
         suite.addTest(new JUnitJPQLDateTimeTest("testCalendarWithUtilDate"));
         suite.addTest(new JUnitJPQLDateTimeTest("testSqlDateWithCal"));
         suite.addTest(new JUnitJPQLDateTimeTest("testTimeWithCal"));
@@ -174,6 +178,23 @@ public class JUnitJPQLDateTimeTest extends JUnitTestCase {
             getResultList();
 
        assertEquals("There should be one result", 1, result.size());
+    }
+
+   public void testAssignWrongType() {
+       Date now = new Date();
+       try (EntityManager em = createEntityManager();) {
+           List<?> result = em.createQuery("SELECT o FROM DateTime o WHERE o.utilDate = :utilDate AND o.localDate = :utilDate").
+                   setParameter("utilDate", now).
+                   getResultList();
+           fail("parameter value assignment should fail on o.localDate");
+       } catch (Exception e) {}
+
+       try (EntityManager em = createEntityManager();) {
+           List<?> result = em.createQuery("SELECT o FROM DateTime o WHERE o.localDate = :utilDate AND o.utilDate = :utilDate ").
+                   setParameter("utilDate", now).
+                   getResultList();
+           fail("parameter value assignment should fail on o.localDate");
+       } catch (Exception e) {}
     }
 
     public void testCalendarWithUtilDate() {


### PR DESCRIPTION
fixes #2600 

rollbacks code changes introduced by a change for #2632, marks test to be ignored 