### PR TITLE
#2632: keep specific field type for null parameter binding

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabaseCall.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/databaseaccess/DatabaseCall.java
@@ -1161,7 +1161,8 @@ public abstract class DatabaseCall extends DatasourceCall {
                         // If the value is null, the field is passed as the value so the type can be obtained from the field.
                         if ((translatedValue == null) && (field != null)) {
                             if (!this.query.hasNullableArguments() || !this.query.getNullableArguments().contains(field)) {
-                                translatedValue = translationRow.getField(field);
+                                DatabaseField fieldFromRow = translationRow.getField(field);
+                                translatedValue = chooseMostSpecificFieldForNullBinding(field, fieldFromRow);
                                 // The field from the row is used, as the calls field may not have the type,
                                 // but if the field is missing the calls field may also have the type.
                                 if (translatedValue == null) {
@@ -1205,6 +1206,35 @@ public abstract class DatabaseCall extends DatasourceCall {
         } else {
             translateQueryString(translationRow, modifyRow, session);
         }
+    }
+
+    /**
+     * For null bind values, prefer the field instance that carries more specific SQL/Java type metadata.
+     * This avoids order-dependent type loss when equivalent fields collapse in translation rows.
+     */
+    private static DatabaseField chooseMostSpecificFieldForNullBinding(DatabaseField parameterField, DatabaseField rowField) {
+        if (parameterField == null) {
+            return rowField;
+        }
+        if (rowField == null) {
+            return parameterField;
+        }
+        if (nullBindingTypeScore(parameterField) > nullBindingTypeScore(rowField)) {
+            return parameterField;
+        }
+        return rowField;
+    }
+
+    private static int nullBindingTypeScore(DatabaseField field) {
+        int score = 0;
+        if (field.getSqlType() != DatabaseField.NULL_SQL_TYPE) {
+            score += 2;
+        }
+        Class<?> type = field.getType();
+        if ((type != null) && (type != Object.class)) {
+            score += 2;
+        }
+        return score;
     }
 
     /**

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/TestNullParameterTypeInference.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/query/TestNullParameterTypeInference.java
@@ -24,12 +24,10 @@ import org.eclipse.persistence.jpa.test.framework.EmfRunner;
 import org.eclipse.persistence.jpa.test.query.model.QuerySyntaxEntity;
 import org.eclipse.persistence.platform.database.DatabasePlatform;
 import org.junit.Assume;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(EmfRunner.class)
-@Ignore()
 public class TestNullParameterTypeInference {
 
     @Emf(name = "defaultEMF",


### PR DESCRIPTION
This PR proposes a narrow fix for #2632.

- Keep HermesParser/argument inference behavior unchanged.
- In DatabaseCall null-binding path, choose the DatabaseField instance with more specific type metadata (sqlType/non-Object Java type) between parameter field and translation-row field.
- This avoids type degradation to VARCHAR in PostgreSQL for reused parameters in OR + IS NULL forms.
- Unignore TestNullParameterTypeInference to keep the regression covered.

Local verification:
- TestNullParameterTypeInference passes against PostgreSQL with db properties overridden for local user.