### PR TITLE
cyclonedx.skipNotDeployed property no longer needed,

### DIFF
--- a/boms/bom/pom.xml
+++ b/boms/bom/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
+    Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
     Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -26,7 +27,6 @@
     </parent>
 
     <artifactId>org.eclipse.persistence.bom</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>EclipseLink BOM</name>

--- a/boms/dependencies/pom.xml
+++ b/boms/dependencies/pom.xml
@@ -27,7 +27,6 @@
     </parent>
 
     <artifactId>org.eclipse.persistence.dependencies</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>EclipseLink Dependencies</name>

--- a/boms/parent/pom.xml
+++ b/boms/parent/pom.xml
@@ -81,11 +81,6 @@
         <url>https://github.com/eclipse-ee4j/eclipselink/issues</url>
     </issueManagement>
 
-    <properties>
-        <!-- see https://github.com/eclipse-ee4j/ee4j/issues/116 -->
-        <cyclonedx.skipNotDeployed>false</cyclonedx.skipNotDeployed>
-    </properties>
-
     <build>
         <pluginManagement>
             <plugins>

--- a/boms/tests/pom.xml
+++ b/boms/tests/pom.xml
@@ -27,7 +27,6 @@
     </parent>
 
     <artifactId>org.eclipse.persistence.tests.bom</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>EclipseLink BOM (Tests)</name>

--- a/docs/docs.concepts/pom.xml
+++ b/docs/docs.concepts/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
  
+    Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
     Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
  
     This program and the accompanying materials are made available under the
@@ -23,7 +24,6 @@
     <name>Documentation - Concepts</name>
     <description>EclipseLink Documentation for the WebSite - Concepts</description>
     <artifactId>org.eclipse.persistence.documentation.concepts</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>

--- a/docs/docs.dbws/pom.xml
+++ b/docs/docs.dbws/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
  
+    Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
     Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
  
     This program and the accompanying materials are made available under the
@@ -23,7 +24,6 @@
     <name>Documentation - DBWS</name>
     <description>EclipseLink Documentation for the WebSite - DBWS</description>
     <artifactId>org.eclipse.persistence.documentation.dbws</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>

--- a/docs/docs.jpa/pom.xml
+++ b/docs/docs.jpa/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
  
+    Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
     Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
  
     This program and the accompanying materials are made available under the
@@ -23,7 +24,6 @@
     <name>Documentation - JPA Extensions</name>
     <description>EclipseLink Documentation for the WebSite - JPA Extensions</description>
     <artifactId>org.eclipse.persistence.documentation.jpaextensions</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>

--- a/docs/docs.moxy/pom.xml
+++ b/docs/docs.moxy/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
  
+    Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
     Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
  
     This program and the accompanying materials are made available under the
@@ -23,7 +24,6 @@
     <name>Documentation - MOXy</name>
     <description>EclipseLink Documentation for the WebSite - MOXy</description>
     <artifactId>org.eclipse.persistence.documentation.moxy</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>

--- a/docs/docs.solutions/pom.xml
+++ b/docs/docs.solutions/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
  
+    Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
     Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
  
     This program and the accompanying materials are made available under the
@@ -23,7 +24,6 @@
     <name>Documentation - Solutions</name>
     <description>EclipseLink Documentation for the WebSite - Solutions</description>
     <artifactId>org.eclipse.persistence.documentation.solutions</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>

--- a/docs/docs.ug/pom.xml
+++ b/docs/docs.ug/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
+    Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
     Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -23,7 +24,6 @@
     <name>Documentation - Solutions</name>
     <description>Documentation - User Guide (Old)</description>
     <artifactId>org.eclipse.persistence.documentation.userguide</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
+    Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
     Copyright (c) 2022, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -23,7 +24,6 @@
     <name>Documentation</name>
     <description>EclipseLink Documentation for the WebSite</description>
     <artifactId>org.eclipse.persistence.documentation</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,6 @@
     </parent>
 
     <artifactId>org.eclipse.persistence.project</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>EclipseLink Project</name>


### PR DESCRIPTION
removed redundant version from poms