### PR TITLE
Fix: Change retryQuery comparison from <= to < for correct retry count

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/sessions/AbstractSession.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/sessions/AbstractSession.java
@@ -1920,7 +1920,7 @@ public abstract class AbstractSession extends CoreAbstractSession<ClassDescripto
     public Object retryQuery(DatabaseQuery query, AbstractRecord row, DatabaseException databaseException, int retryCount, AbstractSession executionSession) {
         DatabaseException exception = databaseException;
         //retry
-        if (retryCount <= getLogin().getQueryRetryAttemptCount()) {
+        if (retryCount < getLogin().getQueryRetryAttemptCount()) {
             try {
                 // attempt to reconnect for a certain number of times.
                 // servers may take some time to recover.


### PR DESCRIPTION
## Description

Fix inconsistency between documentation and implementation for `queryRetryAttemptCount=0` setting.

## Problem

According to the [DatabaseLogin JavaDoc](https://javadoc.io/doc/org.eclipse.persistence/eclipselink/2.6.9/org/eclipse/persistence/sessions/DatabaseLogin.html#setQueryRetryAttemptCount-int-):

> "by setting this value to 0 EclipseLink will not retry queries"

However, the actual implementation allows **one retry attempt** when `queryRetryAttemptCount=0`, contradicting the documentation.

### Current Behavior
- `queryRetryAttemptCount=0` → **1 retry occurs** ❌
- `queryRetryAttemptCount=3` → 3 retries occur ✓

### Expected Behavior  
- `queryRetryAttemptCount=0` → **0 retries** ✓
- `queryRetryAttemptCount=3` → 3 retries occur ✓

## Root Cause

In `AbstractSession.retryQuery()` at line 1923:
```java
if (retryCount <= getLogin().getQueryRetryAttemptCount())
