### PR TITLE
Fix SchemaManager.truncate() to drop FK constraints before truncation

### DIFF
--- a/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/test/java/org/eclipse/persistence/testing/tests/jpa/persistence32/SchemaManagerTruncateOnExistingTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/test/java/org/eclipse/persistence/testing/tests/jpa/persistence32/SchemaManagerTruncateOnExistingTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
  * Copyright (c) 2023, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -10,6 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
 package org.eclipse.persistence.testing.tests.jpa.persistence32;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Locale;
+import java.util.Set;
+import java.util.TreeSet;
 
 import jakarta.persistence.SchemaManager;
 import junit.framework.Test;
@@ -23,6 +32,9 @@ import static org.eclipse.persistence.testing.tests.jpa.persistence32.AbstractPo
  * Test {@link SchemaManager#truncate()} method on database with already existing schema and data.
  */
 public class SchemaManagerTruncateOnExistingTest extends AbstractSchemaManager {
+
+    // Common prefix of all the tables of the persistence unit under test
+    private static final String TABLE_NAME_PREFIX = "PERSISTENCE32_";
 
     public static Test suite() {
         return suite(
@@ -53,22 +65,73 @@ public class SchemaManagerTruncateOnExistingTest extends AbstractSchemaManager {
                 em.persist(TYPES[i]);
             }
         });
+        // Foreign key constraints of the schema before the truncation
+        Set<String> foreignKeysBeforeTruncate = foreignKeys();
         // Truncate the schema
         SchemaManager schemaManager = emf.getSchemaManager();
         schemaManager.truncate();
         // Verify that tables still exist but are empty
-        // - Team count shall be 0
-        int teamCount = emf.callInTransaction(
-                em -> em.createQuery("SELECT count(t) FROM Team t", Integer.class).getFirstResult());
-        assertEquals(teamCount, 0);
-        // - Trainer count shall be 0
-        int trainerCount = emf.callInTransaction(
-                em -> em.createQuery("SELECT count(t) FROM Trainer t", Integer.class).getFirstResult());
-        assertEquals(trainerCount, 0);
-        // - Type count shall be 0
-        int typeCount = emf.callInTransaction(
-                em -> em.createQuery("SELECT count(t) FROM Type t", Integer.class).getFirstResult());
-        assertEquals(typeCount, 0);
+        // Team is referenced by a foreign key from Trainer, so truncating it requires
+        // the constraint to be dropped first on databases that enforce this
+        assertEquals("Team table shall be empty after truncate()", 0L, count("Team"));
+        assertEquals("Trainer table shall be empty after truncate()", 0L, count("Trainer"));
+        assertEquals("Type table shall be empty after truncate()", 0L, count("Type"));
+        // Verify that the schema was left as it was found: constraints dropped to allow
+        // the truncation must be restored
+        assertEquals("Foreign key constraints shall not be modified by truncate()",
+                     foreignKeysBeforeTruncate,
+                     foreignKeys());
+    }
+
+    // Count of the entity instances stored in the database
+    private long count(String entityName) {
+        return emf.callInTransaction(
+                em -> em.createQuery(String.format("SELECT count(e) FROM %s e", entityName), Long.class)
+                        .getSingleResult());
+    }
+
+    // Foreign key constraints of the tables of the persistence unit under test as
+    // "FK_TABLE.FK_COLUMN -> PK_TABLE.PK_COLUMN" values. Generated constraint names are
+    // not part of the values, only the relationships that the constraints define.
+    private Set<String> foreignKeys() {
+        return emf.callInTransaction(em -> {
+            Connection connection = em.unwrap(Connection.class);
+            assertNotNull("Could not access the database connection", connection);
+            try {
+                DatabaseMetaData metaData = connection.getMetaData();
+                String catalog = connection.getCatalog();
+                Set<String> foreignKeys = new TreeSet<>();
+                for (String table : tables(metaData, catalog)) {
+                    try (ResultSet keys = metaData.getImportedKeys(catalog, null, table)) {
+                        while (keys.next()) {
+                            foreignKeys.add(String.format("%s.%s -> %s.%s",
+                                                          keys.getString("FKTABLE_NAME"),
+                                                          keys.getString("FKCOLUMN_NAME"),
+                                                          keys.getString("PKTABLE_NAME"),
+                                                          keys.getString("PKCOLUMN_NAME")));
+                        }
+                    }
+                }
+                return foreignKeys;
+            } catch (SQLException e) {
+                throw new RuntimeException("Could not read the foreign key constraints", e);
+            }
+        });
+    }
+
+    // Names of the tables of the persistence unit under test. Names are read from the database
+    // metadata to match the identifier case used by the database.
+    private static Set<String> tables(DatabaseMetaData metaData, String catalog) throws SQLException {
+        Set<String> tables = new TreeSet<>();
+        try (ResultSet result = metaData.getTables(catalog, null, "%", new String[] {"TABLE"})) {
+            while (result.next()) {
+                String table = result.getString("TABLE_NAME");
+                if (table != null && table.toUpperCase(Locale.ROOT).startsWith(TABLE_NAME_PREFIX)) {
+                    tables.add(table);
+                }
+            }
+        }
+        return tables;
     }
 
 }

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/SchemaManagerImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/SchemaManagerImpl.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 1998, 2026 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2024 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/SchemaManagerImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/SchemaManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2024 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -78,7 +78,15 @@ class SchemaManagerImpl implements SchemaManager {
     @Override
     public void truncate() {
         try {
-            schemaManager.truncateDefaultTables(false);
+            // Generate the foreign key constraint metadata (true) so that the
+            // constraints are dropped before each table is truncated and
+            // recreated afterwards. Without it the constraint drop/recreate that
+            // wraps the truncation is a no-op and TRUNCATE fails on databases
+            // that reject truncating a table referenced by a foreign key
+            // (e.g. PostgreSQL). This also keeps truncate() consistent with
+            // create(), drop() and validate(), which all operate with the
+            // foreign-key-aware table model.
+            schemaManager.truncateDefaultTables(true);
         } catch (EclipseLinkException ex) {
             throw new PersistenceException(ex.getMessage(), ex);
         }


### PR DESCRIPTION
## Problem

`EntityManagerFactory.getSchemaManager().truncate()` (Jakarta Persistence 3.2 `SchemaManager` API) fails when the schema contains foreign-key relationships, on databases that reject truncating a referenced table:

```
org.postgresql.util.PSQLException: ERROR: cannot truncate a table referenced in a foreign key constraint
  Detail: Table "cargos" references "handling_events".
  Hint: Truncate table "cargos" at the same time, or use TRUNCATE ... CASCADE.
Call: TRUNCATE TABLE handling_events
```

## Root cause

`SchemaManagerImpl.truncate()` called `schemaManager.truncateDefaultTables(false)`. The `false` (`generateFKConstraints`) makes `getDefaultTableCreator` build the `TableDefinition` model **without** any `ForeignKeyConstraint` objects. As a result the `dropConstraints(...)` step that wraps the truncation inside `TableCreator.truncateTables(...)` iterates over tables that carry no constraint metadata and drops nothing. The real FK constraints created at DDL/deploy time stay live, so the subsequent `TRUNCATE TABLE` is rejected by FK-enforcing databases (e.g. PostgreSQL).

This is also inconsistent with the sibling operations in the same class: `create()` uses `createDefaultTables(true)`, `drop()` uses the FK-aware `dropDefaultTables()`, and `validate()` passes `true` — only `truncate()` passed `false`.

## Fix

Pass `true` so the FK-aware table model is used: the constraints are genuinely dropped before each `TRUNCATE` and recreated afterwards. Because `create()`/`drop()`/`validate()` already use the FK-aware model, this also keeps the cached `defaultTableCreator` consistent across the `SchemaManager` lifecycle.

## Test

`SchemaManagerTruncateOnExistingTest` already exercised the truncate path on a model with a `Trainer -> Team` foreign key, but it could not fail:

- its assertions read `Query.getFirstResult()`, which returns the paging offset (always 0) rather than the count, so all three of them passed unconditionally;
- `getDefaultTableCreator()` sets `setIgnoreDatabaseException(true)`, so the `DatabaseException` raised by the rejected `TRUNCATE` is swallowed and the table simply keeps its rows.

The test now counts with `getSingleResult()` on a `Long` typed query, and additionally asserts that the foreign keys reported by `DatabaseMetaData.getImportedKeys` are identical before and after `truncate()`, i.e. that the constraints dropped to allow the truncation are restored.

`PERSISTENCE32_TEAM` is a referenced table, so the corrected test fails without the fix on any database that rejects truncating such a table. Verified against H2:

- without the fix: `Team table shall be empty after truncate() expected:<0> but was:<1>`
- with the fix: passes

The CI database (MySQL/InnoDB) enforces the same rule as PostgreSQL, so the corrected test covers the fix on CI as well.

## Notes

- Fixes #2759 (originally reported downstream as eclipse-ee4j/glassfish#25668).
