### PR TITLE
[master] Do not calculate changes for aggregates registered in the UnitOfWork

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
@@ -719,6 +719,18 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
 
             ClassDescriptor descriptor = getDescriptor(object);
 
+            // Aggregates (embeddables) have no identity of their own and must never be change-tracked as
+            // roots: their changes are calculated by the owning AggregateObjectMapping /
+            // AggregateCollectionMapping, which uses its own initialized *clone* of the aggregate
+            // descriptor. The descriptor returned here is the prototype registered on the session; its
+            // mappings are never initialized, so the attribute accessors have no reflective Method/Field
+            // and comparing the object throws a NullPointerException wrapped in DescriptorException.
+            // Aggregates can reach the clone mapping through ObjectBuilder.buildWorkingCopyCloneFromRow,
+            // which bypasses the cannotRegisterAggregateObjectInUnitOfWork guards of the register methods.
+            if (descriptor.isDescriptorTypeAggregate()) {
+                continue;
+            }
+
             // Update any derived id's.
             updateDerivedIds(object, descriptor);
 

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/mapping/TestAggregateChangeCalculation.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/mapping/TestAggregateChangeCalculation.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     07/23/2026 - Andreas Lemmer
+//       - 1455: Do not calculate changes for aggregates registered in the UnitOfWork
+package org.eclipse.persistence.jpa.test.mapping;
+
+import java.util.List;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.LockModeType;
+
+import org.eclipse.persistence.jpa.test.framework.DDLGen;
+import org.eclipse.persistence.jpa.test.framework.Emf;
+import org.eclipse.persistence.jpa.test.framework.EmfRunner;
+import org.eclipse.persistence.jpa.test.mapping.model.AggregateChangeEmbeddable;
+import org.eclipse.persistence.jpa.test.mapping.model.AggregateChangeEntity;
+import org.eclipse.persistence.jpa.test.mapping.model.BatchFetchAggregateChangeEntity;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Aggregates (embeddables) have no identity of their own, so they must never be change-tracked as
+ * roots of the UnitOfWork. They can nevertheless end up in the UnitOfWork's clone mapping, because
+ * ObjectBuilder.buildWorkingCopyCloneFromRow bypasses the guards of the register methods whenever
+ * the aggregate rows are built by an ObjectLevelReadQuery of their own.
+ * <p>
+ * Committing such a UnitOfWork used to fail with a DescriptorException wrapping a
+ * NullPointerException, because the descriptor UnitOfWorkImpl.calculateChanges resolves for the
+ * aggregate is the uninitialized prototype registered on the session rather than the initialized
+ * clone held by the owning mapping.
+ */
+@RunWith(EmfRunner.class)
+public class TestAggregateChangeCalculation {
+
+    @Emf(name = "aggregateChangeEMF", createTables = DDLGen.DROP_CREATE,
+            classes = { AggregateChangeEntity.class, AggregateChangeEmbeddable.class })
+    private EntityManagerFactory emf;
+
+    @Emf(name = "batchFetchAggregateChangeEMF", createTables = DDLGen.DROP_CREATE,
+            classes = { BatchFetchAggregateChangeEntity.class, AggregateChangeEmbeddable.class })
+    private EntityManagerFactory batchFetchEmf;
+
+    /**
+     * Selecting the embeddables of an element collection directly registers them in the UnitOfWork.
+     * The following commit must not try to calculate their changes. See issue #1455.
+     */
+    @Test
+    public void testCommitAfterSelectingEmbeddables() {
+        EntityManager em = emf.createEntityManager();
+        try {
+            em.getTransaction().begin();
+            AggregateChangeEntity entity = new AggregateChangeEntity(1);
+            entity.getEmbeds().add(new AggregateChangeEmbeddable("one"));
+            entity.getEmbeds().add(new AggregateChangeEmbeddable("two"));
+            em.persist(entity);
+            em.getTransaction().commit();
+            em.clear();
+
+            List<AggregateChangeEmbeddable> embeds = em.createQuery(
+                    "SELECT y FROM AggregateChangeEntity x JOIN x.embeds y", AggregateChangeEmbeddable.class)
+                    .getResultList();
+            Assert.assertEquals(2, embeds.size());
+
+            // Used to throw: A NullPointerException was thrown while extracting a value from the
+            // instance variable [value] in the object [AggregateChangeEmbeddable].
+            em.getTransaction().begin();
+            em.getTransaction().commit();
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if (em.isOpen()) {
+                em.close();
+            }
+        }
+    }
+
+    /**
+     * Batch fetching an element collection of embeddables runs a ReadAllQuery on the aggregate
+     * descriptor, which registers the embeddables in the UnitOfWork. Reading the owning entities
+     * under a pessimistic lock makes them be built in the UnitOfWork rather than in the shared
+     * cache, so the batch query is executed against the UnitOfWork. The following commit must not
+     * try to calculate the changes of the batch fetched embeddables.
+     */
+    @Test
+    public void testCommitAfterBatchFetchingEmbeddablesWithPessimisticLock() {
+        EntityManager em = batchFetchEmf.createEntityManager();
+        try {
+            em.getTransaction().begin();
+            for (int id = 1; id <= 2; id++) {
+                BatchFetchAggregateChangeEntity entity = new BatchFetchAggregateChangeEntity(id);
+                entity.getEmbeds().add(new AggregateChangeEmbeddable("one-" + id));
+                entity.getEmbeds().add(new AggregateChangeEmbeddable("two-" + id));
+                em.persist(entity);
+            }
+            em.getTransaction().commit();
+            em.clear();
+
+            em.getTransaction().begin();
+            List<BatchFetchAggregateChangeEntity> entities = em.createQuery(
+                    "SELECT x FROM BatchFetchAggregateChangeEntity x", BatchFetchAggregateChangeEntity.class)
+                    .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+                    .getResultList();
+            Assert.assertEquals(2, entities.size());
+
+            // Trigger the batch query for the element collection.
+            for (BatchFetchAggregateChangeEntity entity : entities) {
+                Assert.assertEquals(2, entity.getEmbeds().size());
+            }
+
+            // Used to throw: A NullPointerException was thrown while extracting a value from the
+            // instance variable [value] in the object [AggregateChangeEmbeddable].
+            em.getTransaction().commit();
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            if (em.isOpen()) {
+                em.close();
+            }
+        }
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/mapping/model/AggregateChangeEmbeddable.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/mapping/model/AggregateChangeEmbeddable.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     07/23/2026 - Andreas Lemmer
+//       - 1455: Do not calculate changes for aggregates registered in the UnitOfWork
+package org.eclipse.persistence.jpa.test.mapping.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class AggregateChangeEmbeddable {
+
+    @Column(name = "EMBEDDED_VALUE")
+    private String value;
+
+    public AggregateChangeEmbeddable() { }
+
+    public AggregateChangeEmbeddable(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public int hashCode() {
+        return (value == null) ? 0 : value.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof AggregateChangeEmbeddable)) {
+            return false;
+        }
+        AggregateChangeEmbeddable other = (AggregateChangeEmbeddable) obj;
+        return (value == null) ? (other.value == null) : value.equals(other.value);
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/mapping/model/AggregateChangeEntity.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/mapping/model/AggregateChangeEntity.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     07/23/2026 - Andreas Lemmer
+//       - 1455: Do not calculate changes for aggregates registered in the UnitOfWork
+package org.eclipse.persistence.jpa.test.mapping.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+
+@Entity
+public class AggregateChangeEntity {
+
+    @Id
+    private int id;
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "AGG_CHANGE_EMBEDS", joinColumns = @JoinColumn(name = "ENTITY_ID"))
+    private List<AggregateChangeEmbeddable> embeds = new ArrayList<>();
+
+    public AggregateChangeEntity() { }
+
+    public AggregateChangeEntity(int id) {
+        this.id = id;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public List<AggregateChangeEmbeddable> getEmbeds() {
+        return embeds;
+    }
+
+    public void setEmbeds(List<AggregateChangeEmbeddable> embeds) {
+        this.embeds = embeds;
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/mapping/model/BatchFetchAggregateChangeEntity.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/mapping/model/BatchFetchAggregateChangeEntity.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     07/23/2026 - Andreas Lemmer
+//       - 1455: Do not calculate changes for aggregates registered in the UnitOfWork
+package org.eclipse.persistence.jpa.test.mapping.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+
+import org.eclipse.persistence.annotations.BatchFetch;
+import org.eclipse.persistence.annotations.BatchFetchType;
+
+@Entity
+public class BatchFetchAggregateChangeEntity {
+
+    @Id
+    private int id;
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @BatchFetch(BatchFetchType.EXISTS)
+    @CollectionTable(name = "BATCH_AGG_CHANGE_EMBEDS", joinColumns = @JoinColumn(name = "ENTITY_ID"))
+    private List<AggregateChangeEmbeddable> embeds = new ArrayList<>();
+
+    public BatchFetchAggregateChangeEntity() { }
+
+    public BatchFetchAggregateChangeEntity(int id) {
+        this.id = id;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public List<AggregateChangeEmbeddable> getEmbeds() {
+        return embeds;
+    }
+
+    public void setEmbeds(List<AggregateChangeEmbeddable> embeds) {
+        this.embeds = embeds;
+    }
+}


### PR DESCRIPTION
Fixes #1455. Related: #921, #1465 (and the approach previously attempted in #2269).

### Symptom

Committing a UnitOfWork fails with:

```
Exception [EclipseLink-70] (Eclipse Persistence Services)
org.eclipse.persistence.exceptions.DescriptorException
Exception Description: A NullPointerException was thrown while extracting a value
through the method [getX] in the object [SomeEmbeddable].
Internal Exception: java.lang.NullPointerException
Mapping: org.eclipse.persistence.mappings.DirectToFieldMapping[x-->X]
Descriptor: RelationalDescriptor(SomeEmbeddable --> [])
```

from `UnitOfWorkImpl.calculateChanges`, whenever an `@Embeddable` instance ends up in the
UnitOfWork's clone mapping. Note the empty table list in the descriptor — that is the tell.

### Analysis

Aggregates have no identity of their own, and EclipseLink deliberately refuses to register
them: `internalRegisterObject`, `registerNewObject` and `registerExistingObject` all throw
`cannotRegisterAggregateObjectInUnitOfWork` when `descriptor.isDescriptorTypeAggregate()`.

The read path bypasses those guards. `ObjectBuilder.buildWorkingCopyCloneFromRow` writes the
clone straight into `unitOfWork.getCloneMapping()`, and it is reached for an aggregate whenever
the aggregate rows are built by an `ObjectLevelReadQuery` of their own. Two routes:

* **`@BatchFetch` on an `@ElementCollection` of an `@Embeddable`.** When the owning entity is
  built from a `ReadAllQuery` row, `ForeignReferenceMapping.valueFromRow` takes the batch branch,
  `CollectionMapping.executeBatchQuery` runs a `ReadAllQuery` whose descriptor is the aggregate
  descriptor, and `ReadAllQuery.registerResultInUnitOfWork` registers the embeddables. Reproduces
  reliably when the owner is read into the UnitOfWork rather than the shared cache — e.g. under
  `LockModeType.PESSIMISTIC_WRITE`, which begins the transaction early and isolates the read.
* **Selecting the embeddable directly**, as in #1455 (`SELECT y FROM Entity x JOIN x.embeds y`),
  or a `LEFT JOIN FETCH` on an embeddable element collection (#921, #1465).

Once such an object is in the clone mapping, `calculateChanges` resolves its descriptor via
`getDescriptor(object)`. That returns the **prototype** aggregate descriptor held by the session —
not the per-mapping clone that `AggregateCollectionMapping.initializeReferenceDescriptor` builds
and initializes. The prototype is never initialized, so its mappings' attribute accessors have no
reflective `Method`/`Field`, and comparing the object throws.

### Fix

Skip aggregates in that loop. Their changes are computed by the owning `AggregateObjectMapping` /
`AggregateCollectionMapping` against the initialized descriptor clone, so calculating them again
from the root loop is both wrong and redundant.

### Note on scope

This guard stops the aggregate from being change-tracked, but leaves it in the clone mapping.
The other iterations over that map are `basicPrintRegisteredObjects()` (debug output),
`revertAndResume()` and `validateObjectSpace()` — the latter two would still trip over an
aggregate, though neither is called internally by EclipseLink or the JPA layer. A deeper fix
would keep aggregates out of `cloneMapping` in `ObjectBuilder.buildWorkingCopyCloneFromRow`
altogether; happy to take that route instead if maintainers prefer it.

### Testing

Verified against a local application: the reproducer above fails without the patch and passes with it, and a full run of 92 test tasks shows no regressions. No test is included here — glad to add one to the JPA suite if you'd
like, with a pointer to where it best belongs.