### PR TITLE
fix Firebird type mappings for character LOBs and add time zone columns

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/FirebirdPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/FirebirdPlatform.java
@@ -59,11 +59,11 @@ public class FirebirdPlatform extends DatabasePlatform {
         fieldTypeMapping.put(Character.class, new FieldDefinition.DatabaseType("VARCHAR", 1));
 
         fieldTypeMapping.put(Byte[].class, TYPE_BLOB);
-        fieldTypeMapping.put(Character[].class, new FieldDefinition.DatabaseType("VARCHAR", 32000));
+        fieldTypeMapping.put(Character[].class, new FieldDefinition.DatabaseType("BLOB SUB_TYPE TEXT", false));
         fieldTypeMapping.put(byte[].class, TYPE_BLOB);
-        fieldTypeMapping.put(char[].class, new FieldDefinition.DatabaseType("VARCHAR", 32000));
+        fieldTypeMapping.put(char[].class, new FieldDefinition.DatabaseType("BLOB SUB_TYPE TEXT", false));
         fieldTypeMapping.put(java.sql.Blob.class, TYPE_BLOB);
-        fieldTypeMapping.put(java.sql.Clob.class, new FieldDefinition.DatabaseType("VARCHAR", 32000));
+        fieldTypeMapping.put(java.sql.Clob.class, new FieldDefinition.DatabaseType("BLOB SUB_TYPE TEXT", false));
 
         fieldTypeMapping.put(java.sql.Date.class, new FieldDefinition.DatabaseType("DATE", false));
         fieldTypeMapping.put(java.sql.Timestamp.class, new FieldDefinition.DatabaseType("TIMESTAMP", false));

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/FirebirdPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/FirebirdPlatform.java
@@ -70,6 +70,8 @@ public class FirebirdPlatform extends DatabasePlatform {
         fieldTypeMapping.put(java.sql.Time.class, new FieldDefinition.DatabaseType("TIME", false));
         fieldTypeMapping.put(java.util.Calendar.class, new FieldDefinition.DatabaseType("TIMESTAMP", false));
         fieldTypeMapping.put(java.util.Date.class, new FieldDefinition.DatabaseType("TIMESTAMP", false));
+        fieldTypeMapping.put(java.time.OffsetDateTime.class, new FieldDefinition.DatabaseType("TIMESTAMP WITH TIME ZONE", false));
+        fieldTypeMapping.put(java.time.OffsetTime.class, new FieldDefinition.DatabaseType("TIME WITH TIME ZONE", false));
 
         return fieldTypeMapping;
     }


### PR DESCRIPTION
Fixes #2788
Fixes #2789

Two related fixes in `FirebirdPlatform.buildDatabaseTypes()`, kept as separate
commits:

**1. Character LOBs (#2788).** `java.sql.Clob`, `char[]` and `Character[]` were
mapped to `VARCHAR(32000)`. Firebird limits VARCHAR to 32765 bytes, so on UTF8
databases `CREATE TABLE` fails "Implementation limit exceeded"

**2. Time zone types (#2789).** There was no mapping for
`java.time.OffsetDateTime` / `OffsetTime`, so such attributes fell back to plain
`TIMESTAMP` / `TIME` columns and lost the zone offset. They are now mapped to
`TIMESTAMP WITH TIME ZONE` / `TIME WITH TIME ZONE`