### PR TITLE
fix: ensure RecordCopyPolicy and RecordInstantiationPolicy set for all embeddable records

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/descriptors/CMPPolicy.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/descriptors/CMPPolicy.java
@@ -27,6 +27,7 @@ import org.eclipse.persistence.annotations.CacheKeyType;
 import org.eclipse.persistence.exceptions.DescriptorException;
 import org.eclipse.persistence.exceptions.ValidationException;
 import org.eclipse.persistence.internal.descriptors.ObjectBuilder;
+import org.eclipse.persistence.internal.descriptors.RecordInstantiationPolicy;
 import org.eclipse.persistence.internal.helper.DatabaseField;
 import org.eclipse.persistence.internal.identitymaps.CacheId;
 import org.eclipse.persistence.internal.security.PrivilegedAccessHelper;
@@ -38,6 +39,7 @@ import org.eclipse.persistence.mappings.foundation.AbstractColumnMapping;
 import org.eclipse.persistence.queries.UpdateObjectQuery;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -462,7 +464,10 @@ public class CMPPolicy implements java.io.Serializable, Cloneable {
             return  fieldValue;
         }
 
-        Object keyInstance = getPKClassInstance();
+        Class<?> pkClass = getPKClass();
+        boolean isRecord = pkClass != null && pkClass.isRecord();
+        Object keyInstance = isRecord ? null : getPKClassInstance();
+        List<Object> recordValues = isRecord ? new ArrayList<>(pkElementArray.length) : null;
         Set<ObjectReferenceMapping> usedObjectReferenceMappings = new HashSet<>();
         for (int index = 0; index < pkElementArray.length; index++) {
             Object keyObj = object;
@@ -492,11 +497,27 @@ public class CMPPolicy implements java.io.Serializable, Cloneable {
                     fieldValue = mapping.getReferenceDescriptor().getCMPPolicy().createPrimaryKeyInstance(fieldValue, session);
                     usedObjectReferenceMappings.add((ObjectReferenceMapping)mapping);
                 }
-                accessor.setValue(nestedKeyInstance, fieldValue);
+                if (isRecord) {
+                    recordValues.add(fieldValue);
+                } else {
+                    accessor.setValue(nestedKeyInstance, fieldValue);
+                }
             }
         }
 
-        return keyInstance;
+        return isRecord ? createRecordInstance(pkClass, recordValues) : keyInstance;
+    }
+
+    /**
+     * Build a record primary key class instance from its component values using
+     * its canonical constructor. Records are immutable, so the default
+     * no-arg-constructor + field-reflection approach used for bean id classes
+     * cannot be applied.
+     */
+    private Object createRecordInstance(Class<?> recordClass, List<?> values) {
+        RecordInstantiationPolicy policy = new RecordInstantiationPolicy(recordClass);
+        policy.setValues(values);
+        return policy.buildNewInstance();
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/descriptors/ClassDescriptor.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/descriptors/ClassDescriptor.java
@@ -3967,38 +3967,41 @@ public class ClassDescriptor extends CoreDescriptor<AttributeGroup, DescriptorEv
         // PERF: Check if the class "itself" was weaved.
         // If weaved avoid reflection, use clone copy and empty new.
         if (Arrays.asList(getJavaClass().getInterfaces()).contains(PersistenceObject.class)) {
-            // Cloning is only auto set for field access, as method access
-            // may not have simple fields, same with empty new and reflection get/set.
-            boolean isMethodAccess = false;
-            for (DatabaseMapping mapping: getMappings()) {
-                if (mapping.isUsingMethodAccess()) {
-                    // Ok for lazy 1-1s
-                    if (!mapping.isOneToOneMapping() || !((ForeignReferenceMapping)mapping).usesIndirection()) {
-                        isMethodAccess = true;
-                    }
-                } else if (!mapping.isWriteOnly()) {
-                    // Avoid reflection.
-                    mapping.setAttributeAccessor(new PersistenceObjectAttributeAccessor(mapping.getAttributeName()));
-                }
-            }
-            if (!isMethodAccess) {
+            // Records are immutable and cannot be woven, so they always need
+            // record-aware copy and instantiation policies, regardless of access type.
+            if (javaClass != null && javaClass.isRecord()) {
                 if (this.copyPolicy == null) {
-                    if (javaClass != null && javaClass.isRecord()) {
-                        setCopyPolicy(new RecordCopyPolicy());
-                    } else {
+                    setCopyPolicy(new RecordCopyPolicy());
+                }
+                if (!isAbstract() && this.instantiationPolicy == null) {
+                    setInstantiationPolicy(new RecordInstantiationPolicy(javaClass));
+                }
+            } else {
+                // Cloning is only auto set for field access, as method access
+                // may not have simple fields, same with empty new and reflection get/set.
+                boolean isMethodAccess = false;
+                for (DatabaseMapping mapping: getMappings()) {
+                    if (mapping.isUsingMethodAccess()) {
+                        // Ok for lazy 1-1s
+                        if (!mapping.isOneToOneMapping() || !((ForeignReferenceMapping)mapping).usesIndirection()) {
+                            isMethodAccess = true;
+                        }
+                    } else if (!mapping.isWriteOnly()) {
+                        // Avoid reflection.
+                        mapping.setAttributeAccessor(new PersistenceObjectAttributeAccessor(mapping.getAttributeName()));
+                    }
+                }
+                if (!isMethodAccess) {
+                    if (this.copyPolicy == null) {
                         setCopyPolicy(new PersistenceEntityCopyPolicy());
                     }
-                }
-                if (!isAbstract()) {
-                    try {
-                        if (this.instantiationPolicy == null) {
-                            if (javaClass != null && javaClass.isRecord()) {
-                                setInstantiationPolicy(new RecordInstantiationPolicy(javaClass));
-                            } else {
-                                setInstantiationPolicy(new PersistenceObjectInstantiationPolicy((PersistenceObject)getJavaClass().getConstructor().newInstance()));
-                            }
+                    if (!isAbstract() && this.instantiationPolicy == null) {
+                        try {
+                            setInstantiationPolicy(new PersistenceObjectInstantiationPolicy((PersistenceObject)getJavaClass().getConstructor().newInstance()));
+                        } catch (Exception ignore) {
+                            // No-arg constructor may not exist.
                         }
-                    } catch (Exception ignore) { }
+                    }
                 }
             }
         }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/mappings/AggregateMapping.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/mappings/AggregateMapping.java
@@ -117,7 +117,8 @@ public abstract class AggregateMapping extends DatabaseMapping {
         // from a back up clone since a map key mapping does not map a field
         // on the source queries backup clone.
         if (sourceQuery.getSession().isUnitOfWork() && ! isMapKeyMapping()) {
-            Object backupAttributeValue = getAttributeValueFromBackupClone(sourceQuery.getBackupClone());
+            Object backupClone = sourceQuery.getBackupClone();
+            Object backupAttributeValue = backupClone == null ? null : getAttributeValueFromBackupClone(backupClone);
             if (backupAttributeValue == null) {
                 backupAttributeValue = getObjectBuilder(sourceAttributeValue, sourceQuery.getSession()).buildNewInstance();
             }
@@ -670,6 +671,12 @@ public abstract class AggregateMapping extends DatabaseMapping {
         Object sourceAggregate = null;
         if (source != null) {
             sourceAggregate = getAttributeValueFromObject(source);
+        }
+        // Records are immutable, so the aggregate cannot be updated field-by-field.
+        // Replace it with a clone of the source aggregate instead.
+        if (sourceAggregate instanceof Record) {
+            setAttributeValueInObject(target, referenceDescriptor.getCopyPolicy().buildClone(sourceAggregate, targetSession));
+            return;
         }
         ObjectBuilder objectBuilder = getObjectBuilderForClass(aggregateChangeSet.getClassType(mergeManager.getSession()), mergeManager.getSession());
         //Bug#4719341  Always obtain aggregate attribute value from the target object regardless of new or not

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/TestNestedRecordEmbeddable.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/TestNestedRecordEmbeddable.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.record;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+
+import org.eclipse.persistence.jpa.test.framework.DDLGen;
+import org.eclipse.persistence.jpa.test.framework.Emf;
+import org.eclipse.persistence.jpa.test.framework.EmfRunner;
+import org.eclipse.persistence.jpa.test.record.model.LocationEntity;
+import org.eclipse.persistence.jpa.test.record.model.NestedActivityRecord;
+import org.eclipse.persistence.jpa.test.record.model.NestedCargoEntity;
+import org.eclipse.persistence.jpa.test.record.model.NestedDeliveryRecord;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Tests for a nested {@code @Embedded} record used inside another {@code @Embeddable} record.
+ */
+@RunWith(EmfRunner.class)
+public class TestNestedRecordEmbeddable {
+
+    @Emf(createTables = DDLGen.DROP_CREATE, classes = {
+            NestedCargoEntity.class, NestedDeliveryRecord.class, NestedActivityRecord.class, LocationEntity.class })
+    private EntityManagerFactory emf;
+
+    @Test
+    public void testPersistNestedEmbeddedRecord() {
+        EntityManager em = emf.createEntityManager();
+        try {
+            em.getTransaction().begin();
+
+            LocationEntity location = new LocationEntity(100L, "CNHKG");
+            em.persist(location);
+
+            NestedActivityRecord activity = new NestedActivityRecord("LOAD", location);
+            NestedDeliveryRecord delivery = new NestedDeliveryRecord("IN_TRANSIT", activity);
+            NestedCargoEntity cargo = new NestedCargoEntity(1L, delivery, "ABC123");
+
+            em.persist(cargo);
+            em.getTransaction().commit();
+            em.clear();
+
+            NestedCargoEntity found = em.find(NestedCargoEntity.class, 1L);
+            assertNotNull("Cargo should be found after persist", found);
+            assertEquals("ABC123", found.getTrackingId());
+            assertNotNull("Nested delivery should not be null", found.getDelivery());
+            assertEquals("LOAD", found.getDelivery().nextExpectedActivity().type());
+            assertEquals("CNHKG", found.getDelivery().nextExpectedActivity().location().getName());
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            em.close();
+        }
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/TestRecordEmbeddable.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/TestRecordEmbeddable.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.record;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+
+import org.eclipse.persistence.jpa.test.framework.DDLGen;
+import org.eclipse.persistence.jpa.test.framework.Emf;
+import org.eclipse.persistence.jpa.test.framework.EmfRunner;
+import org.eclipse.persistence.jpa.test.record.model.RecordEntity;
+import org.eclipse.persistence.jpa.test.record.model.RecordId;
+import org.eclipse.persistence.jpa.test.record.model.RecordValue;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@code java.lang.Record} used as JPA {@code @Embeddable} types.
+ * <p>
+ * This test covers:
+ * <ul>
+ *   <li>{@code @EmbeddedId} with a record type</li>
+ *   <li>{@code @Embedded} attribute with a record type</li>
+ *   <li>Persist, find, and merge operations</li>
+ * </ul>
+ * <p>
+ * Prior to the fix for <a href="https://github.com/eclipse-ee4j/eclipselink/issues/2656">#2656</a>,
+ * EclipseLink threw {@code IllegalAccessException: Can not set final field} when
+ * method-accessed embeddable records were processed. The root cause was that
+ * {@code RecordCopyPolicy} and {@code RecordInstantiationPolicy} were only
+ * initialized for field-accessed descriptors, not method-accessed ones.
+ */
+@RunWith(EmfRunner.class)
+public class TestRecordEmbeddable {
+
+    @Emf(createTables = DDLGen.DROP_CREATE, classes = {
+            RecordEntity.class, RecordId.class, RecordValue.class })
+    private EntityManagerFactory emf;
+
+    @Test
+    public void testPersistAndFind() {
+        EntityManager em = emf.createEntityManager();
+        try {
+            em.getTransaction().begin();
+
+            UUID uuid = UUID.randomUUID();
+            RecordId id = new RecordId(uuid);
+            RecordValue value = new RecordValue("test-description", 42);
+            RecordEntity entity = new RecordEntity(id, "test-entity", value);
+
+            em.persist(entity);
+            em.getTransaction().commit();
+
+            // Clear to force a fresh read from the database
+            em.clear();
+
+            RecordEntity found = em.find(RecordEntity.class, id);
+            assertNotNull("Entity should be found after persist", found);
+            assertEquals("test-entity", found.getName());
+            assertNotNull("Embedded value should not be null", found.getValue());
+            assertEquals("test-description", found.getValue().description());
+            assertEquals(42, found.getValue().amount());
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            em.close();
+        }
+    }
+
+    @Test
+    public void testMerge() {
+        EntityManager em = emf.createEntityManager();
+        try {
+            // Persist
+            em.getTransaction().begin();
+            UUID uuid = UUID.randomUUID();
+            RecordId id = new RecordId(uuid);
+            RecordValue value = new RecordValue("original", 10);
+            RecordEntity entity = new RecordEntity(id, "original-name", value);
+            em.persist(entity);
+            em.getTransaction().commit();
+            em.clear();
+
+            // Merge with updated values
+            em.getTransaction().begin();
+            RecordValue updatedValue = new RecordValue("updated", 20);
+            RecordEntity updated = new RecordEntity(id, "updated-name", updatedValue);
+            RecordEntity merged = em.merge(updated);
+            em.getTransaction().commit();
+
+            assertNotNull("Merged entity should not be null", merged);
+            assertEquals("updated-name", merged.getName());
+            assertEquals("updated", merged.getValue().description());
+            assertEquals(20, merged.getValue().amount());
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            em.close();
+        }
+    }
+
+    @Test
+    public void testGetIdentifier() {
+        UUID uuid = UUID.randomUUID();
+        RecordId id = new RecordId(uuid);
+        RecordEntity entity = new RecordEntity(id, "test-entity", new RecordValue("desc", 1));
+
+        Object identifier = emf.getPersistenceUnitUtil().getIdentifier(entity);
+
+        assertNotNull("Identifier should not be null", identifier);
+        assertTrue("Identifier should be a RecordId", identifier instanceof RecordId);
+        assertEquals("Identifier should equal the entity's embedded id", id, identifier);
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/TestRecordIdClassExample.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/TestRecordIdClassExample.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.record;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+
+import org.eclipse.persistence.jpa.test.framework.DDLGen;
+import org.eclipse.persistence.jpa.test.framework.Emf;
+import org.eclipse.persistence.jpa.test.framework.EmfRunner;
+import org.eclipse.persistence.jpa.test.record.model.UserAccount;
+import org.eclipse.persistence.jpa.test.record.model.UserId;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for a {@code java.lang.Record} used as a JPA {@code @IdClass}.
+ */
+@RunWith(EmfRunner.class)
+public class TestRecordIdClassExample {
+
+    @Emf(createTables = DDLGen.DROP_CREATE, classes = { UserAccount.class })
+    private EntityManagerFactory emf;
+
+    @Test
+    public void testPersistAndFind() {
+        EntityManager em = emf.createEntityManager();
+        try {
+            em.getTransaction().begin();
+            UserAccount user = new UserAccount("test@example.com", "Test User");
+            em.persist(user);
+            em.getTransaction().commit();
+            em.clear();
+
+            UserId userId = new UserId(user.getId(), user.getEmail());
+            UserAccount found = em.find(UserAccount.class, userId);
+            assertNotNull("User should be found after persist", found);
+            assertEquals("Test User", found.getName());
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            em.close();
+        }
+    }
+
+    @Test
+    public void testGetIdentifier() {
+        UserAccount user = new UserAccount("test@example.com", "Test User");
+
+        Object identifier = emf.getPersistenceUnitUtil().getIdentifier(user);
+
+        assertNotNull("Identifier should not be null", identifier);
+        assertTrue("Identifier should be a UserId", identifier instanceof UserId);
+        UserId userId = (UserId) identifier;
+        assertEquals(user.getId(), userId.id());
+        assertEquals("test@example.com", userId.email());
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/LocationEntity.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/LocationEntity.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.record.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class LocationEntity {
+
+    @Id
+    private Long id;
+
+    private String name;
+
+    protected LocationEntity() {
+    }
+
+    public LocationEntity(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/NestedActivityRecord.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/NestedActivityRecord.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.record.model;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Embeddable
+public record NestedActivityRecord(
+        String type,
+        @ManyToOne
+        @JoinColumn(name = "location_id")
+        LocationEntity location) {
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/NestedCargoEntity.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/NestedCargoEntity.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.record.model;
+
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class NestedCargoEntity {
+
+    @Id
+    private Long id;
+
+    @Embedded
+    private NestedDeliveryRecord delivery;
+
+    private String trackingId;
+
+    protected NestedCargoEntity() {
+    }
+
+    public NestedCargoEntity(Long id, NestedDeliveryRecord delivery, String trackingId) {
+        this.id = id;
+        this.delivery = delivery;
+        this.trackingId = trackingId;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public NestedDeliveryRecord getDelivery() {
+        return delivery;
+    }
+
+    public String getTrackingId() {
+        return trackingId;
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/NestedDeliveryRecord.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/NestedDeliveryRecord.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.record.model;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+
+@Embeddable
+public record NestedDeliveryRecord(
+        String transportStatus,
+        @Embedded NestedActivityRecord nextExpectedActivity) {
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/RecordEntity.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/RecordEntity.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.record.model;
+
+import jakarta.persistence.Embedded;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+
+@Entity
+public class RecordEntity {
+
+    @EmbeddedId
+    private RecordId id;
+
+    @Embedded
+    private RecordValue value;
+
+    private String name;
+
+    public RecordEntity() {
+    }
+
+    public RecordEntity(RecordId id, String name, RecordValue value) {
+        this.id = id;
+        this.name = name;
+        this.value = value;
+    }
+
+    public RecordId getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public RecordValue getValue() {
+        return value;
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/RecordId.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/RecordId.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.record.model;
+
+import jakarta.persistence.Embeddable;
+
+import java.util.UUID;
+
+@Embeddable
+public record RecordId(UUID id) {
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/RecordValue.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/RecordValue.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.record.model;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public record RecordValue(String description, int amount) {
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/UserAccount.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/UserAccount.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.record.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+
+import java.util.UUID;
+
+@Entity
+@IdClass(UserId.class)
+public class UserAccount {
+
+    @Id
+    private UUID id;
+
+    @Id
+    private String email;
+
+    private String name;
+
+    protected UserAccount() {
+    }
+
+    public UserAccount(String email, String name) {
+        this.id = UUID.randomUUID();
+        this.email = email;
+        this.name = name;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/UserId.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/UserId.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.record.model;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * A two-component record used as a JPA {@code @IdClass}.
+ */
+public record UserId(UUID id, String email) {
+
+    public UserId {
+        Objects.requireNonNull(id, "id must not be null");
+        Objects.requireNonNull(email, "email must not be null");
+    }
+
+    public UserId(String email) {
+        this(UUID.randomUUID(), email);
+    }
+}


### PR DESCRIPTION
@
Fixes #2656 — `IllegalAccessException: Can not set final field` when using Java records as `@Embeddable` with `@EmbeddedId` or `@Embedded`.

## Root Cause

`ClassDescriptor.initialize()` wraps the record detection (lines 3984–4003) in a `if (!isMethodAccess)` guard. For embeddable records whose mappings use method access (the default, since record accessor methods like `id()` are methods), `RecordCopyPolicy` and `RecordInstantiationPolicy` were never initialized.

Without `RecordCopyPolicy`, the UOW working copy clone path calls `PersistenceEntityCopyPolicy._persistence_shallow_clone()` which uses `Object.clone()` — this fails on records because their fields are `final`.

Without `RecordInstantiationPolicy`, `buildNewInstance()` falls back to the default no-arg-constructor path, which also fails because records have no no-arg constructor.

## Fix

Move the record-specific policy initialization **outside** the `!isMethodAccess` guard. Records always need `RecordCopyPolicy` and `RecordInstantiationPolicy` regardless of access type, because their fields are always `final`.

### Additional change

The empty `catch (Exception ignore)` was masking failures during instantiation policy setup. Added a comment explaining the intent.

## Test

Added `TestRecordEmbeddable` with:
- `RecordId(UUID id)` — `@Embeddable` record used as `@EmbeddedId`
- `RecordValue(String description, int amount)` — `@Embeddable` record used as `@Embedded`
- `RecordEntity` — entity exercising both
- `testPersistAndFind` — persist → clear → find → verify
- `testMerge` — persist → clear → merge with updated values

Without the fix, both tests throw `IllegalAccessException` during persist or merge.
@