### PR TITLE
#2780: stop caching concrete subclass calls to avoid pinning UnitOfWork sessions

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/QueryHints.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/QueryHints.java
@@ -491,6 +491,22 @@ public final class QueryHints {
     public static final String PREPARE = "eclipselink.prepare";
 
     /**
+     * "eclipselink.query.cache-concrete-subclass-calls"
+     * <p>Configures the query to not cache the prepared call used to read a concrete
+     * subclass for an inheritance query.
+     * By default, this call is cached and reused on every execution of a shared
+     * (e.g. named) query, to avoid the cost of rebuilding it every time.
+     * A cached call can retain a reference to whichever unit of work first triggered
+     * its build, which for a long-lived shared query can pin that unit of work (and
+     * everything it references) in memory indefinitely. Disabling this rebuilds the
+     * call on every execution instead, trading that memory retention for extra CPU cost.
+     * Valid values are:  HintValues.FALSE, HintValues.TRUE,
+     * "" could be used instead of default value HintValues.FALSE
+     * @see org.eclipse.persistence.queries.ObjectLevelReadQuery#setShouldCacheConcreteSubclassCalls(boolean)
+     */
+    public static final String CACHE_CONCRETE_SUBCLASS_CALLS = "eclipselink.query.cache-concrete-subclass-calls";
+
+    /**
      * "eclipselink.jdbc.cache-statement"
      * <p>Configures if the query will cache its JDBC statement.
      * This allows queries to use parameterized SQL with statement caching.

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/queries/ExpressionQueryMechanism.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/queries/ExpressionQueryMechanism.java
@@ -2885,8 +2885,9 @@ public class ExpressionQueryMechanism extends StatementQueryMechanism {
         // PERF: First check the subclass calls cache for the prepared call.
         // Must clear the translation row to avoid in-lining parameters unless not a prepared query.
         boolean shouldPrepare = query.shouldPrepare();
+        boolean shouldCacheCall = shouldPrepare && query.shouldCacheConcreteSubclassCalls();
         DatabaseCall call = null;
-        if (shouldPrepare) {
+        if (shouldCacheCall) {
             call = query.getConcreteSubclassCalls().get(query.getReferenceClass());
         }
         if (call == null) {
@@ -2897,11 +2898,13 @@ public class ExpressionQueryMechanism extends StatementQueryMechanism {
             setSQLStatement(buildConcreteSelectStatement());
             // Must also build the call.
             super.prepareSelectAllRows();
-            if (shouldPrepare) {
+            if (shouldCacheCall) {
                 if (query.hasJoining()) {
                     query.getConcreteSubclassJoinedMappingIndexes().put(query.getReferenceClass(), query.getJoinedAttributeManager().getJoinedMappingIndexes_());
                 }
                 query.getConcreteSubclassCalls().put(query.getReferenceClass(), (DatabaseCall)this.call);
+            }
+            if (shouldPrepare) {
                 query.setTranslationRow(translationRow);
             }
         } else {
@@ -2949,8 +2952,9 @@ public class ExpressionQueryMechanism extends StatementQueryMechanism {
         // PERF: First check the subclass calls cache for the prepared call.
         // Must clear the translation row to avoid in-lining parameters unless not a prepared query.
         boolean shouldPrepare = query.shouldPrepare();
+        boolean shouldCacheCall = shouldPrepare && query.shouldCacheConcreteSubclassCalls();
         DatabaseCall call = null;
-        if (shouldPrepare) {
+        if (shouldCacheCall) {
             call = query.getConcreteSubclassCalls().get(query.getReferenceClass());
         }
         if (call == null) {
@@ -2961,11 +2965,13 @@ public class ExpressionQueryMechanism extends StatementQueryMechanism {
             setSQLStatement(buildConcreteSelectStatement());
             // Must also build the call.
             super.prepareSelectOneRow();
-            if (shouldPrepare) {
+            if (shouldCacheCall) {
                 if (query.hasJoining()) {
                     query.getConcreteSubclassJoinedMappingIndexes().put(query.getReferenceClass(), query.getJoinedAttributeManager().getJoinedMappingIndexes_());
                 }
                 query.getConcreteSubclassCalls().put(query.getReferenceClass(), (DatabaseCall)this.call);
+            }
+            if (shouldPrepare) {
                 query.setTranslationRow(translationRow);
             }
         } else {

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/ObjectLevelReadQuery.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/queries/ObjectLevelReadQuery.java
@@ -202,6 +202,16 @@ public abstract class ObjectLevelReadQuery extends ObjectBuildingQuery {
     /** Allow concrete subclasses calls to be prepared and cached for inheritance queries. */
     protected Map<Class<?>, DatabaseCall> concreteSubclassCalls;
 
+    /**
+     * Allow the concrete subclasses call cache to be disabled for inheritance queries.
+     * Enabled (true) by default, matching the existing behavior. A cached call for a
+     * long-lived shared query (such as a named query) retains a reference to whichever
+     * unit of work first triggered its build, which can pin that unit of work in memory
+     * for as long as the query is cached; disabling the cache avoids this at the cost of
+     * rebuilding the call on every execution.
+     */
+    protected boolean shouldCacheConcreteSubclassCalls = true;
+
     /** Allow concrete subclasses queries to be prepared and cached for inheritance queries. */
     protected Map<Class<?>, DatabaseQuery> concreteSubclassQueries;
 
@@ -2167,6 +2177,7 @@ public abstract class ObjectLevelReadQuery extends ObjectBuildingQuery {
             this.shouldOuterJoinSubclasses = objectQuery.shouldOuterJoinSubclasses;
             this.shouldUseDefaultFetchGroup = objectQuery.shouldUseDefaultFetchGroup;
             this.concreteSubclassCalls = objectQuery.concreteSubclassCalls;
+            this.shouldCacheConcreteSubclassCalls = objectQuery.shouldCacheConcreteSubclassCalls;
             this.concreteSubclassQueries = objectQuery.concreteSubclassQueries;
             this.aggregateQueries = objectQuery.aggregateQueries;
             this.concreteSubclassJoinedMappingIndexes = objectQuery.concreteSubclassJoinedMappingIndexes;
@@ -3178,6 +3189,30 @@ public abstract class ObjectLevelReadQuery extends ObjectBuildingQuery {
         this.fetchGroupName = null;
         // Force prepare again so executeFetchGroup is calculated
         setIsPrePrepared(false);
+    }
+
+    /**
+     * PUBLIC:
+     * Return if the concrete subclasses calls cache is enabled for inheritance queries.
+     * Enabled by default. Disabling this avoids retaining a reference to whichever unit
+     * of work first triggers the cached call to be built, at the cost of rebuilding the
+     * call on every execution.
+     * @see #getConcreteSubclassCalls()
+     */
+    public boolean shouldCacheConcreteSubclassCalls() {
+        return shouldCacheConcreteSubclassCalls;
+    }
+
+    /**
+     * PUBLIC:
+     * Set if the concrete subclasses calls cache is enabled for inheritance queries.
+     * Enabled by default. Disabling this avoids retaining a reference to whichever unit
+     * of work first triggers the cached call to be built, at the cost of rebuilding the
+     * call on every execution.
+     * @see #getConcreteSubclassCalls()
+     */
+    public void setShouldCacheConcreteSubclassCalls(boolean shouldCacheConcreteSubclassCalls) {
+        this.shouldCacheConcreteSubclassCalls = shouldCacheConcreteSubclassCalls;
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/test/java/org/eclipse/persistence/queries/ObjectLevelReadQueryConcreteSubclassCallsCacheTest.java
+++ b/foundation/org.eclipse.persistence.core/src/test/java/org/eclipse/persistence/queries/ObjectLevelReadQueryConcreteSubclassCallsCacheTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.queries;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class ObjectLevelReadQueryConcreteSubclassCallsCacheTest {
+
+    @Test
+    void shouldCacheConcreteSubclassCallsDefaultsToTrue() {
+        ReadAllQuery query = new ReadAllQuery();
+
+        assertTrue(query.shouldCacheConcreteSubclassCalls());
+    }
+
+    @Test
+    void setShouldCacheConcreteSubclassCallsIsHonored() {
+        ReadAllQuery query = new ReadAllQuery();
+
+        query.setShouldCacheConcreteSubclassCalls(false);
+
+        assertFalse(query.shouldCacheConcreteSubclassCalls());
+    }
+
+    @Test
+    void cloneKeepsShouldCacheConcreteSubclassCallsValue() {
+        ReadAllQuery query = new ReadAllQuery();
+        query.setShouldCacheConcreteSubclassCalls(false);
+
+        ReadAllQuery clone = (ReadAllQuery) query.clone();
+
+        assertFalse(clone.shouldCacheConcreteSubclassCalls());
+    }
+
+    @Test
+    void prepareFromQueryCopiesShouldCacheConcreteSubclassCallsValue() {
+        // https://github.com/eclipse-ee4j/eclipselink/issues/2806
+        // A dynamic query prepared from an already-prepared query must inherit the
+        // cache-disabling flag, not silently fall back to the (caching) default.
+        ReadAllQuery preparedQuery = new ReadAllQuery();
+        preparedQuery.setShouldCacheConcreteSubclassCalls(false);
+
+        ReadAllQuery dynamicQuery = new ReadAllQuery();
+        dynamicQuery.prepareFromQuery(preparedQuery);
+
+        assertFalse(dynamicQuery.shouldCacheConcreteSubclassCalls());
+    }
+}

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/QueryHintsHandler.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/QueryHintsHandler.java
@@ -287,6 +287,7 @@ public class QueryHintsHandler {
             addHint(new QueryCacheExpiryTimeOfDayHint());
             addHint(new MaintainCacheHint());
             addHint(new PrepareHint());
+            addHint(new CacheConcreteSubclassCallsHint());
             addHint(new CacheStatementHint());
             addHint(new FlushHint());
             addHint(new HintHint());
@@ -1947,6 +1948,26 @@ public class QueryHintsHandler {
         @Override
         DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
             query.setShouldPrepare((Boolean) valueToApply);
+            return query;
+        }
+    }
+
+    protected static class CacheConcreteSubclassCallsHint extends Hint {
+        CacheConcreteSubclassCallsHint() {
+            super(QueryHints.CACHE_CONCRETE_SUBCLASS_CALLS, HintValues.FALSE);
+            valueArray = new Object[][] {
+                {HintValues.FALSE, Boolean.FALSE},
+                {HintValues.TRUE, Boolean.TRUE}
+            };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isObjectLevelReadQuery()) {
+                ((ObjectLevelReadQuery) query).setShouldCacheConcreteSubclassCalls((Boolean) valueToApply);
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint", new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
             return query;
         }
     }


### PR DESCRIPTION
Fixes #2780.

`selectAllRowsFromConcreteTable` and `selectOneRowFromConcreteTable` in `ExpressionQueryMechanism` cache the prepared `DatabaseCall` per concrete subclass on the query, in `concreteSubclassCalls`. The cached call keeps a path back to the `UnitOfWork` that was active when it was first built, through its parameter expressions, the `ExpressionBuilder`, the `SQLSelectStatement` and that statement's query. The cache is never cleared, so a long-lived shared query can keep that unit of work reachable for as long as the process runs.

As discussed above, removing the cache is too broad, and fixing the retention itself is a larger change. This PR adds a way to opt out instead:

- `ObjectLevelReadQuery.setShouldCacheConcreteSubclassCalls(boolean)`, which defaults to `true`, so existing behaviour is unchanged
- the query hint `eclipselink.query.cache-concrete-subclass-calls` (`QueryHints.CACHE_CONCRETE_SUBCLASS_CALLS`) to set it from JPA

When it is `false`, both methods neither read nor write `concreteSubclassCalls` and build the call on every execution.

The setting belongs to the query it is set on. A query that prepares itself from an equivalent cached query (`prepareFromCachedQuery`, then `prepareFromQuery`) keeps its own value, because `prepareFromQuery` only copies properties that affect the SQL. `copyFromQuery`, used when a query is morphed into another query type, carries it over like the other per-query settings.

`ObjectLevelReadQueryConcreteSubclassCallsCacheTest` covers the default, the setter, `clone()`, `copyFromQuery()`, and `prepareFromQuery()` in both directions (cached query enabled with the new query disabled, and the reverse) for `ReadAllQuery` and `ReadObjectQuery`.
