### PR TITLE
ISSUE-2374: Eager initialize caches + mark them as volatile for thread safety

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/descriptors/DescriptorQueryManager.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/descriptors/DescriptorQueryManager.java
@@ -111,9 +111,9 @@ public class DescriptorQueryManager implements Cloneable, Serializable {
     protected Map<String, List<DatabaseQuery>> queries;
     protected transient Map<DatabaseTable, Expression> tablesJoinExpressions;
     /** PERF: Update call cache for avoiding regenerated update SQL. */
-    protected transient ConcurrentFixedCache cachedUpdateCalls;
+    protected transient volatile ConcurrentFixedCache cachedUpdateCalls;
     /** PERF: Expression query call cache for avoiding regenerated dynamic query SQL. */
-    protected transient ConcurrentFixedCache cachedExpressionQueries;
+    protected transient volatile ConcurrentFixedCache cachedExpressionQueries;
 
     /**
      * queryTimeout has three possible settings: DefaultTimeout, NoTimeout, and 1..N
@@ -141,6 +141,8 @@ public class DescriptorQueryManager implements Cloneable, Serializable {
      */
     public DescriptorQueryManager() {
         this.queries = new LinkedHashMap<>(5);
+        this.cachedUpdateCalls = new ConcurrentFixedCache(10);
+        this.cachedExpressionQueries = new ConcurrentFixedCache(20);
         setDoesExistQuery(new DoesExistQuery());// Always has a does exist.
         this.setQueryTimeout(DefaultTimeout);
         this.setQueryTimeoutUnit(DefaultTimeoutUnit);
@@ -1727,10 +1729,12 @@ public class DescriptorQueryManager implements Cloneable, Serializable {
      * Returns the collection of cached Update calls.
      */
     private ConcurrentFixedCache getCachedUpdateCalls() {
-        if (cachedUpdateCalls == null) {
-            this.cachedUpdateCalls = new ConcurrentFixedCache(10);
+        ConcurrentFixedCache cache = this.cachedUpdateCalls;
+        if (cache == null) {
+            cache = new ConcurrentFixedCache(10);
+            this.cachedUpdateCalls = cache;
         }
-        return this.cachedUpdateCalls;
+        return cache;
     }
 
     /**
@@ -1738,10 +1742,12 @@ public class DescriptorQueryManager implements Cloneable, Serializable {
      * Returns the collection of cached expression queries.
      */
     private ConcurrentFixedCache getCachedExpressionQueries() {
-        if (cachedExpressionQueries == null) {
-            this.cachedExpressionQueries = new ConcurrentFixedCache(20);
+        ConcurrentFixedCache cache = this.cachedExpressionQueries;
+        if (cache == null) {
+            cache = new ConcurrentFixedCache(20);
+            this.cachedExpressionQueries = cache;
         }
-        return this.cachedExpressionQueries;
+        return cache;
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/Project.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/sessions/Project.java
@@ -110,7 +110,7 @@ public class Project extends CoreProject<ClassDescriptor, Login, DatabaseSession
     protected Map<String, SQLResultSetMapping> sqlResultSetMappings;
 
     /** PERF: Provide an JPQL parse cache to optimize dynamic JPQL. */
-    protected transient ConcurrentFixedCache jpqlParseCache;
+    protected transient volatile ConcurrentFixedCache jpqlParseCache;
 
     /** Define the default setting for configuring if dates and calendars are mutable. */
     protected boolean defaultTemporalMutable = false;
@@ -331,10 +331,12 @@ public class Project extends CoreProject<ClassDescriptor, Login, DatabaseSession
      * This is used to optimize dynamic JPQL.
      */
     public ConcurrentFixedCache getJPQLParseCache() {
-        if (jpqlParseCache==null) {
-            jpqlParseCache = new ConcurrentFixedCache(200);
+        ConcurrentFixedCache cache = this.jpqlParseCache;
+        if (cache == null) {
+            cache = new ConcurrentFixedCache(200);
+            this.jpqlParseCache = cache;
         }
-        return jpqlParseCache;
+        return cache;
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/test/java/org/eclipse/persistence/testing/tests/descriptors/DescriptorQueryManagerTest.java
+++ b/foundation/org.eclipse.persistence.core/src/test/java/org/eclipse/persistence/testing/tests/descriptors/DescriptorQueryManagerTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.testing.tests.descriptors;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Vector;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.persistence.descriptors.DescriptorQueryManager;
+import org.eclipse.persistence.internal.helper.DatabaseField;
+import org.eclipse.persistence.queries.ReadAllQuery;
+import org.junit.Test;
+
+public class DescriptorQueryManagerTest {
+
+    private static final int READER_COUNT = 100;
+    private static final int WRITER_COUNT = 10;
+    private static final int MAX_ATTEMPTS = 100000;
+    private static final long LATCH_TIMEOUT_SECONDS = 2;
+    private static final long TASK_TIMEOUT_SECONDS = 8;
+
+    @Test
+    public void concurrentWritesToExpressionQueryCacheDoNotThrowNullPointerException() throws Exception {
+        TestDescriptorQueryManager queryManager = new TestDescriptorQueryManager();
+        ReadAllQuery query = new ReadAllQuery();
+        assertConcurrentCacheAccessDoesNotFail(
+                queryManager::dropExpressionQueryCache,
+                () -> queryManager.getCachedExpressionQuery(query));
+    }
+
+    @Test
+    public void concurrentWritesToUpdateCallCacheDoNotThrowNullPointerException() throws Exception {
+        TestDescriptorQueryManager queryManager = new TestDescriptorQueryManager();
+        Vector<DatabaseField> updateFields = new Vector<>();
+        updateFields.add(new DatabaseField("id"));
+        assertConcurrentCacheAccessDoesNotFail(
+                queryManager::dropUpdateCallCache,
+                () -> queryManager.getCachedUpdateCalls(updateFields));
+    }
+
+    private void assertConcurrentCacheAccessDoesNotFail(Runnable dropCache, Runnable accessCache) throws Exception {
+        int threadCount = READER_COUNT + WRITER_COUNT;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch ready = new CountDownLatch(threadCount);
+        CountDownLatch start = new CountDownLatch(1);
+        AtomicBoolean running = new AtomicBoolean(true);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        try {
+            List<Future<?>> writerFutures = new ArrayList<>(WRITER_COUNT);
+            for (int thread = 0; thread < WRITER_COUNT; thread++) {
+                writerFutures.add(executor.submit(() -> {
+                    ready.countDown();
+                    assertTrue(start.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+                    while (running.get()) {
+                        dropCache.run();
+                    }
+                    return null;
+                }));
+            }
+
+            List<Future<?>> readerFutures = new ArrayList<>(READER_COUNT);
+            for (int thread = 0; thread < READER_COUNT; thread++) {
+                readerFutures.add(executor.submit(() -> {
+                    ready.countDown();
+                    assertTrue(start.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+                    for (int attempt = 0; attempt < MAX_ATTEMPTS && running.get(); attempt++) {
+                        try {
+                            accessCache.run();
+                        } catch (Throwable exception) {
+                            failure.compareAndSet(null, exception);
+                            running.set(false);
+                        }
+                    }
+                    return null;
+                }));
+            }
+
+            assertTrue(ready.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+            start.countDown();
+            for (Future<?> reader : readerFutures) {
+                reader.get(TASK_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            }
+            running.set(false);
+            for (Future<?> writer : writerFutures) {
+                writer.get(TASK_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            }
+        } finally {
+            running.set(false);
+            start.countDown();
+            executor.shutdownNow();
+        }
+
+        Throwable exception = failure.get();
+        if (exception != null) {
+            throw new AssertionError("Parallel cache writes caused cache access failure", exception);
+        }
+    }
+
+    private static class TestDescriptorQueryManager extends DescriptorQueryManager {
+
+        private void dropExpressionQueryCache() {
+            this.cachedExpressionQueries = null;
+        }
+
+        private void dropUpdateCallCache() {
+            this.cachedUpdateCalls = null;
+        }
+    }
+}

--- a/foundation/org.eclipse.persistence.core/src/test/java/org/eclipse/persistence/testing/tests/sessions/ProjectJPQLParseCacheTest.java
+++ b/foundation/org.eclipse.persistence.core/src/test/java/org/eclipse/persistence/testing/tests/sessions/ProjectJPQLParseCacheTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.testing.tests.sessions;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.persistence.sessions.Project;
+import org.junit.Test;
+
+public class ProjectJPQLParseCacheTest {
+
+    private static final int READER_COUNT = 100;
+    private static final int WRITER_COUNT = 10;
+    private static final int MAX_ATTEMPTS = 100000;
+    private static final long LATCH_TIMEOUT_SECONDS = 2;
+    private static final long TASK_TIMEOUT_SECONDS = 8;
+
+    @Test
+    public void concurrentWritesToJPQLParseCacheDoNotThrowNullPointerException() throws Exception {
+        TestProject project = new TestProject();
+        String query = "select e from Employee e";
+        assertConcurrentCacheAccessDoesNotFail(
+                project::dropJPQLParseCache,
+                () -> project.getJPQLParseCache().get(query));
+    }
+
+    private void assertConcurrentCacheAccessDoesNotFail(Runnable dropCache, Runnable accessCache) throws Exception {
+        int threadCount = READER_COUNT + WRITER_COUNT;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch ready = new CountDownLatch(threadCount);
+        CountDownLatch start = new CountDownLatch(1);
+        AtomicBoolean running = new AtomicBoolean(true);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        try {
+            List<Future<?>> writerFutures = new ArrayList<>(WRITER_COUNT);
+            for (int thread = 0; thread < WRITER_COUNT; thread++) {
+                writerFutures.add(executor.submit(() -> {
+                    ready.countDown();
+                    assertTrue(start.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+                    while (running.get()) {
+                        dropCache.run();
+                    }
+                    return null;
+                }));
+            }
+
+            List<Future<?>> readerFutures = new ArrayList<>(READER_COUNT);
+            for (int thread = 0; thread < READER_COUNT; thread++) {
+                readerFutures.add(executor.submit(() -> {
+                    ready.countDown();
+                    assertTrue(start.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+                    for (int attempt = 0; attempt < MAX_ATTEMPTS && running.get(); attempt++) {
+                        try {
+                            accessCache.run();
+                        } catch (Throwable exception) {
+                            failure.compareAndSet(null, exception);
+                            running.set(false);
+                        }
+                    }
+                    return null;
+                }));
+            }
+
+            assertTrue(ready.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+            start.countDown();
+            for (Future<?> reader : readerFutures) {
+                reader.get(TASK_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            }
+            running.set(false);
+            for (Future<?> writer : writerFutures) {
+                writer.get(TASK_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            }
+        } finally {
+            running.set(false);
+            start.countDown();
+            executor.shutdownNow();
+        }
+
+        Throwable exception = failure.get();
+        if (exception != null) {
+            throw new AssertionError("Parallel cache writes caused cache access failure", exception);
+        }
+    }
+
+    private static class TestProject extends Project {
+
+        private void dropJPQLParseCache() {
+            this.jpqlParseCache = null;
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/eclipse-ee4j/eclipselink/issues/2374

- Fixed concurrent lazy initialization races in DescriptorQueryManager caches.
- Improved thread-safe access to Project.jpqlParseCache.
- Added concurrency regression tests covering all affected caches.
- Prevented potential NullPointerException during concurrent cache access.