### PR TITLE
fix: cascade registerNew only for new owners of record aggregates

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/mappings/AggregateObjectMapping.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/mappings/AggregateObjectMapping.java
@@ -940,6 +940,14 @@ public class AggregateObjectMapping extends AggregateMapping implements Relation
         if ((objectReferenced == null)) {
             return;
         }
+        // A record aggregate's collections are eager (the final record components
+        // cannot hold a lazy IndirectList), so its referenced entities are not
+        // registered in the UoW clone mapping. When the owner is not new, those
+        // entities are already persisted, and re-cascading would re-register them
+        // (e.g. an @OneToMany collection held by a record embeddable).
+        if (getAttributeValueFromObject && !uow.isCloneNewObject(object) && this.getReferenceClass().isRecord()) {
+            return;
+        }
         if (!visitedObjects.containsKey(objectReferenced)) {
             visitedObjects.put(objectReferenced, objectReferenced);
             ObjectBuilder builder = getReferenceDescriptor(objectReferenced.getClass(), uow).getObjectBuilder();

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/TestOneToManyInRecord.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/TestOneToManyInRecord.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.record;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+
+import org.eclipse.persistence.jpa.test.framework.DDLGen;
+import org.eclipse.persistence.jpa.test.framework.Emf;
+import org.eclipse.persistence.jpa.test.framework.EmfRunner;
+import org.eclipse.persistence.jpa.test.record.model.RecordAggregateChildEntity;
+import org.eclipse.persistence.jpa.test.record.model.RecordAggregateContainer;
+import org.eclipse.persistence.jpa.test.record.model.RecordAggregateParentEntity;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Tests a {@code @OneToMany} collection held inside an {@code @Embeddable} record.
+ */
+@RunWith(EmfRunner.class)
+public class TestOneToManyInRecord {
+
+    @Emf(createTables = DDLGen.DROP_CREATE, classes = {
+            RecordAggregateParentEntity.class, RecordAggregateContainer.class, RecordAggregateChildEntity.class })
+    private EntityManagerFactory emf;
+
+    @Test
+    public void testPersistThenPersistAgain() {
+        EntityManager em = emf.createEntityManager();
+        try {
+            // First persist
+            em.getTransaction().begin();
+            RecordAggregateChildEntity child = new RecordAggregateChildEntity("child");
+            RecordAggregateParentEntity parent = new RecordAggregateParentEntity(1L, new RecordAggregateContainer(List.of(child)));
+            em.persist(parent);
+            em.getTransaction().commit();
+            em.clear();
+
+            // Load the parent again and re-persist it (as the DDD flow does on update).
+            em.getTransaction().begin();
+            RecordAggregateParentEntity loaded = em.find(RecordAggregateParentEntity.class, 1L);
+            em.persist(loaded);
+            em.getTransaction().commit();
+            em.clear();
+
+            RecordAggregateParentEntity found = em.find(RecordAggregateParentEntity.class, 1L);
+            assertNotNull("Parent should be found", found);
+            assertEquals(1, found.getContainer().children().size());
+            assertEquals("child", found.getContainer().children().get(0).getName());
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            em.close();
+        }
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/RecordAggregateChildEntity.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/RecordAggregateChildEntity.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.record.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+@Entity
+public class RecordAggregateChildEntity {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String name;
+
+    protected RecordAggregateChildEntity() {
+    }
+
+    public RecordAggregateChildEntity(String name) {
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/RecordAggregateContainer.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/RecordAggregateContainer.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.record.model;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+
+import java.util.List;
+
+@Embeddable
+public record RecordAggregateContainer(
+        @OneToMany(cascade = CascadeType.ALL)
+        @JoinColumn(name = "parent_id")
+        List<RecordAggregateChildEntity> children) {
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/RecordAggregateParentEntity.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/RecordAggregateParentEntity.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.record.model;
+
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class RecordAggregateParentEntity {
+
+    @Id
+    private Long id;
+
+    @Embedded
+    private RecordAggregateContainer container;
+
+    protected RecordAggregateParentEntity() {
+    }
+
+    public RecordAggregateParentEntity(Long id, RecordAggregateContainer container) {
+        this.id = id;
+        this.container = container;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public RecordAggregateContainer getContainer() {
+        return container;
+    }
+}


### PR DESCRIPTION
## Problem

A `@OneToMany`/`@ManyToMany` collection held by a record `@Embeddable` is eager — the final record component cannot hold a lazy `IndirectList` — so its referenced entities are not registered in the unit of work clone mapping. On a subsequent `persist`, `AggregateObjectMapping.cascadeRegisterNewIfRequired` cascaded to those entities anyway and re-registered them as new, causing duplicate-key inserts (e.g. the Cargo Tracker sample's `legs_pkey` failure).

## Fix

Skip the aggregate cascade when the owning object is not new, for record aggregates only (the aggregate itself is never registered in the unit of work, so its own "new" state cannot be checked).

## Verification

- Added `TestOneToManyInRecord` reproducing the re-insertion (fails before the fix with a duplicate-key error).
- All record tests pass (7/7).
- The Cargo Tracker sample's full Arquillian/GlassFish suite passes (41/41), previously failing with `duplicate key value violates unique constraint "legs_pkey"`.