### PR TITLE
Fix runWithConnection/callWithConnection returning null Connection inside runInTransaction

### DIFF
--- a/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/test/java/org/eclipse/persistence/testing/tests/jpa/persistence32/EntityManagerFactoryTest.java
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/src/test/java/org/eclipse/persistence/testing/tests/jpa/persistence32/EntityManagerFactoryTest.java
@@ -59,6 +59,8 @@ public class EntityManagerFactoryTest extends AbstractPokemonSuite {
                 new EntityManagerFactoryTest("testRunInTransaction"),
                 new EntityManagerFactoryTest("testRunWithConnection"),
                 new EntityManagerFactoryTest("testCallWithConnection"),
+                new EntityManagerFactoryTest("testRunWithConnectionInRunInTransaction"),
+                new EntityManagerFactoryTest("testCallWithConnectionInRunInTransaction"),
                 new EntityManagerFactoryTest("testCreateCustomEntityManagerFactory"),
                 new EntityManagerFactoryTest("testCreateConflictingCustomEntityManagerFactory"),
                 new EntityManagerFactoryTest("testCreateConflictingConfiguredEntityManagerFactory"),
@@ -188,6 +190,20 @@ public class EntityManagerFactoryTest extends AbstractPokemonSuite {
             Pokemon dbPokemon = em.find(Pokemon.class, 4);
             assertEquals(pokemon, dbPokemon);
         }
+    }
+
+    public void testRunWithConnectionInRunInTransaction() {
+        emf.runInTransaction(em ->
+                em.<Connection>runWithConnection(connection ->
+                        assertNotNull("Connection should be non-null inside runInTransaction", connection)));
+    }
+
+    public void testCallWithConnectionInRunInTransaction() {
+        emf.callInTransaction(em ->
+                em.<Connection, Connection>callWithConnection(connection -> {
+                    assertNotNull("Connection should be non-null inside runInTransaction", connection);
+                    return connection;
+                }));
     }
 
     // Test Persistence.createEntityManagerFactory(PersistenceConfiguration)

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerImpl.java
@@ -1573,14 +1573,22 @@ public class EntityManagerImpl implements org.eclipse.persistence.jpa.JpaEntityM
             return unitOfWork.getAccessor().getDatasourceConnection();
         }
         if (checkForTransaction(false) != null) {
-            unitOfWork.beginEarlyTransaction();
-            accessor = unitOfWork.getAccessor();
-            // Ensure external connection is acquired.
-            accessor.incrementCallCount(unitOfWork.getParent());
-            accessor.decrementCallCount();
-            return accessor.getDatasourceConnection();
+            return acquireDatasourceConnection(unitOfWork);
         }
         return null;
+    }
+
+    /**
+     * Acquires the datasource connection by beginning an early transaction on the given unit of work and forcing
+     * the external connection to be acquired.
+     */
+    private Object acquireDatasourceConnection(UnitOfWorkImpl unitOfWork) {
+        unitOfWork.beginEarlyTransaction();
+        Accessor accessor = unitOfWork.getAccessor();
+        // Ensure external connection is acquired.
+        accessor.incrementCallCount(unitOfWork.getParent());
+        accessor.decrementCallCount();
+        return accessor.getDatasourceConnection();
     }
 
     /**
@@ -3132,12 +3140,7 @@ public class EntityManagerImpl implements org.eclipse.persistence.jpa.JpaEntityM
                     return (T) unitOfWork.getAccessor().getConnection();
                 }
                 if (checkForTransaction(false) != null) {
-                    unitOfWork.beginEarlyTransaction();
-                    Accessor accessor = unitOfWork.getAccessor();
-                    // Ensure external connection is acquired.
-                    accessor.incrementCallCount(unitOfWork.getParent());
-                    accessor.decrementCallCount();
-                    return (T) accessor.getDatasourceConnection();
+                    return (T) acquireDatasourceConnection(unitOfWork);
                 }
                 return null;
             }

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerImpl.java
@@ -1515,7 +1515,7 @@ public class EntityManagerImpl implements org.eclipse.persistence.jpa.JpaEntityM
             getAbstractSession().log(SessionLog.WARNING, SessionLog.CONNECTION, "entity_manager_has_multiple_connections");
         }
         @SuppressWarnings("unchecked")
-        C connection = (C) getAbstractSession().getAccessor().getDatasourceConnection();
+        C connection = (C) getDatasourceConnection();
         try {
             action.accept(connection);
         } catch (Exception e) {
@@ -1532,7 +1532,7 @@ public class EntityManagerImpl implements org.eclipse.persistence.jpa.JpaEntityM
             getAbstractSession().log(SessionLog.WARNING, SessionLog.CONNECTION, "entity_manager_has_multiple_connections");
         }
         @SuppressWarnings("unchecked")
-        C connection = (C) getAbstractSession().getAccessor().getDatasourceConnection();
+        C connection = (C) getDatasourceConnection();
         try {
             return function.apply(connection);
         } catch (Exception e) {
@@ -1541,6 +1541,45 @@ public class EntityManagerImpl implements org.eclipse.persistence.jpa.JpaEntityM
                     ExceptionLocalization.buildMessage(
                             "entity_manager_with_connection_failed", new String[] {e.getLocalizedMessage()}), e);
         }
+    }
+
+    /**
+     * Returns the datasource connection associated with the active persistence context, acquiring it if necessary.
+     * This mirrors the connection resolution used by {@link #unwrap(Class)} for {@code java.sql.Connection}, which
+     * resolves the connection through the transactional {@link UnitOfWork}/{@code ClientSession} accessor rather than
+     * the deployment session accessor. On a server session the deployment session's own accessor is never connected
+     * (connections are pooled and handed out per client session), so reading it directly would return {@code null}.
+     */
+    private Object getDatasourceConnection() {
+        final UnitOfWorkImpl unitOfWork = (UnitOfWorkImpl) getUnitOfWork();
+        Accessor accessor = unitOfWork.getAccessor();
+        if (unitOfWork.getParent().isExclusiveIsolatedClientSession()) {
+            Object conn = accessor.getDatasourceConnection();
+            if (conn == null) {
+                final boolean uowInTran = unitOfWork.isInTransaction();
+                final boolean activeTran = checkForTransaction(false) != null;
+                if (uowInTran || activeTran) {
+                    if (activeTran) {
+                        unitOfWork.beginEarlyTransaction();
+                    }
+                    accessor.incrementCallCount(unitOfWork.getParent());
+                    accessor.decrementCallCount();
+                    conn = accessor.getDatasourceConnection();
+                }
+            }
+            return conn;
+        } else if (unitOfWork.isInTransaction()) {
+            return unitOfWork.getAccessor().getDatasourceConnection();
+        }
+        if (checkForTransaction(false) != null) {
+            unitOfWork.beginEarlyTransaction();
+            accessor = unitOfWork.getAccessor();
+            // Ensure external connection is acquired.
+            accessor.incrementCallCount(unitOfWork.getParent());
+            accessor.decrementCallCount();
+            return accessor.getDatasourceConnection();
+        }
+        return null;
     }
 
     /**

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerImpl.java
@@ -1545,7 +1545,8 @@ public class EntityManagerImpl implements org.eclipse.persistence.jpa.JpaEntityM
 
     /**
      * Returns the datasource connection associated with the active persistence context, acquiring it if necessary.
-     * This mirrors the connection resolution used by {@link #unwrap(Class)} for {@code java.sql.Connection}, which
+     * This is the shared implementation for {@link #runWithConnection(ConnectionConsumer)},
+     * {@link #callWithConnection(ConnectionFunction)} and {@link #unwrap(Class)} for {@code java.sql.Connection}. It
      * resolves the connection through the transactional {@link UnitOfWork}/{@code ClientSession} accessor rather than
      * the deployment session accessor. On a server session the deployment session's own accessor is never connected
      * (connections are pooled and handed out per client session), so reading it directly would return {@code null}.
@@ -3124,40 +3125,7 @@ public class EntityManagerImpl implements org.eclipse.persistence.jpa.JpaEntityM
             } else if (cls.equals(SessionBroker.class)) {
                 return (T) this.getSessionBroker();
             } else if (cls.equals(java.sql.Connection.class)) {
-                final UnitOfWorkImpl unitOfWork = (UnitOfWorkImpl) this.getUnitOfWork();
-                Accessor accessor = unitOfWork.getAccessor();
-                if (unitOfWork.getParent().isExclusiveIsolatedClientSession()) {
-                    // If the ExclusiveIsolatedClientSession hasn't serviced a query prior to the unwrap,
-                    // there will be no available Connection.
-                    java.sql.Connection conn = accessor.getConnection();
-                    if (conn == null) {
-                        final boolean uowInTran = unitOfWork.isInTransaction();
-                        final boolean activeTran = checkForTransaction(false) != null;
-                        if (uowInTran || activeTran) {
-                            if (activeTran) {
-                                unitOfWork.beginEarlyTransaction();
-                            }
-                            accessor.incrementCallCount(unitOfWork.getParent());
-                            accessor.decrementCallCount();
-                            conn = accessor.getConnection();
-                        } 
-                        // if not in a tx, still return null
-                    }
-                    
-                    return (T) conn;
-                } else if (unitOfWork.isInTransaction()) {
-                    return (T) unitOfWork.getAccessor().getConnection();
-                }
-                
-                if (checkForTransaction(false) != null) {
-                    unitOfWork.beginEarlyTransaction();
-                    accessor = unitOfWork.getAccessor();
-                    // Ensure external connection is acquired.
-                    accessor.incrementCallCount(unitOfWork.getParent());
-                    accessor.decrementCallCount();
-                    return (T) accessor.getConnection();
-                }
-                return null;
+                return (T) getDatasourceConnection();
             } else if (cls.getName().equals("jakarta.resource.cci.Connection")) {
                 UnitOfWorkImpl unitOfWork = (UnitOfWorkImpl) this.getUnitOfWork();
                 if(unitOfWork.isInTransaction() || unitOfWork.getParent().isExclusiveIsolatedClientSession()) {

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerImpl.java
@@ -1553,42 +1553,51 @@ public class EntityManagerImpl implements org.eclipse.persistence.jpa.JpaEntityM
      */
     private Object getDatasourceConnection() {
         final UnitOfWorkImpl unitOfWork = (UnitOfWorkImpl) getUnitOfWork();
-        Accessor accessor = unitOfWork.getAccessor();
         if (unitOfWork.getParent().isExclusiveIsolatedClientSession()) {
-            Object conn = accessor.getDatasourceConnection();
-            if (conn == null) {
-                final boolean uowInTran = unitOfWork.isInTransaction();
-                final boolean activeTran = checkForTransaction(false) != null;
-                if (uowInTran || activeTran) {
-                    if (activeTran) {
-                        unitOfWork.beginEarlyTransaction();
-                    }
-                    accessor.incrementCallCount(unitOfWork.getParent());
-                    accessor.decrementCallCount();
-                    conn = accessor.getDatasourceConnection();
-                }
-            }
-            return conn;
+            return getExclusiveIsolatedDatasourceConnection(unitOfWork);
         } else if (unitOfWork.isInTransaction()) {
             return unitOfWork.getAccessor().getDatasourceConnection();
         }
-        if (checkForTransaction(false) != null) {
-            return acquireDatasourceConnection(unitOfWork);
+        return acquireDatasourceConnection(unitOfWork);
+    }
+
+    /**
+     * Returns the datasource connection for an exclusive isolated client session, forcing its acquisition when a
+     * transaction is active. The exclusive isolated client session may not have serviced a query yet, in which case
+     * no connection is available until it is acquired within an active transaction.
+     */
+    private Object getExclusiveIsolatedDatasourceConnection(UnitOfWorkImpl unitOfWork) {
+        Accessor accessor = unitOfWork.getAccessor();
+        Object conn = accessor.getDatasourceConnection();
+        if (conn == null) {
+            final boolean uowInTran = unitOfWork.isInTransaction();
+            final boolean activeTran = checkForTransaction(false) != null;
+            if (uowInTran || activeTran) {
+                if (activeTran) {
+                    unitOfWork.beginEarlyTransaction();
+                }
+                accessor.incrementCallCount(unitOfWork.getParent());
+                accessor.decrementCallCount();
+                conn = accessor.getDatasourceConnection();
+            }
         }
-        return null;
+        return conn;
     }
 
     /**
      * Acquires the datasource connection by beginning an early transaction on the given unit of work and forcing
-     * the external connection to be acquired.
+     * the external connection to be acquired, or returns {@code null} when no transaction is active.
      */
     private Object acquireDatasourceConnection(UnitOfWorkImpl unitOfWork) {
-        unitOfWork.beginEarlyTransaction();
-        Accessor accessor = unitOfWork.getAccessor();
-        // Ensure external connection is acquired.
-        accessor.incrementCallCount(unitOfWork.getParent());
-        accessor.decrementCallCount();
-        return accessor.getDatasourceConnection();
+        if (checkForTransaction(false) != null) {
+            unitOfWork.beginEarlyTransaction();
+            Accessor accessor = unitOfWork.getAccessor();
+            // Ensure external connection is acquired.
+            accessor.incrementCallCount(unitOfWork.getParent());
+            accessor.decrementCallCount();
+            return accessor.getDatasourceConnection();
+        }
+        return null;
     }
 
     /**
@@ -3139,10 +3148,7 @@ public class EntityManagerImpl implements org.eclipse.persistence.jpa.JpaEntityM
                 if(unitOfWork.isInTransaction() || unitOfWork.getParent().isExclusiveIsolatedClientSession()) {
                     return (T) unitOfWork.getAccessor().getConnection();
                 }
-                if (checkForTransaction(false) != null) {
-                    return (T) acquireDatasourceConnection(unitOfWork);
-                }
-                return null;
+                return (T) acquireDatasourceConnection(unitOfWork);
             }
             throw new PersistenceException(ExceptionLocalization.buildMessage("unable_to_unwrap_jpa", new String[]{EntityManager.class.getName(), cls.getName()}));
 


### PR DESCRIPTION
## Problem

GlassFish issue [eclipse-ee4j/glassfish#25988](https://github.com/eclipse-ee4j/glassfish/issues/25988) reports that
`EntityManager.runWithConnection(...)` yields a **null** `Connection` when invoked inside
`EntityManagerFactory.runInTransaction(...)`.

```java
entityManagerFactory.runInTransaction(entityManager -> {
    entityManager.<Connection>runWithConnection(conn -> {
        // conn is null on GlassFish
    });
});
```

## Root cause

`EntityManagerImpl.runWithConnection` / `callWithConnection` resolved the connection from

```java
getAbstractSession().getAccessor().getDatasourceConnection()
```

`getAbstractSession()` is the deployment session. In EclipseLink 5.x JPA this is a `ServerSession`, whose
*own* accessor is never connected — connections live in the server session's connection pools and are handed out
to per-transaction `ClientSession`s. On a Java EE server (GlassFish) that accessor therefore returns `null`.

The correct pattern already exists in `unwrap(Connection.class)`: it resolves the connection through the
**active persistence context** (`getUnitOfWork().getAccessor()`, which delegates to the `ClientSession`) and
forces acquisition via `beginEarlyTransaction()` + `incrementCallCount`/`decrementCallCount` when a transaction is
active.

## Fix

Added a private `getDatasourceConnection()` helper that mirrors `unwrap(Connection.class)` but returns the raw
datasource connection (preserving the generic `<C>` contract of the JPA 3.2 APIs), and used it in both
`runWithConnection` and `callWithConnection`.

## Tests

`EntityManagerFactoryTest` (in `jpa.test.persistence32`, a JSE / RESOURCE_LOCAL + Derby test module) covers both
styles:

- Standalone (pre-existing): `testRunWithConnection`, `testCallWithConnection`
- Nested inside `runInTransaction` (added here): `testRunWithConnectionInRunInTransaction`,
  `testCallWithConnectionInRunInTransaction`

## Verification

The fix works in both modes:

- **JSE (RESOURCE_LOCAL)** — exercised by the `jpa.test.persistence32` tests above; all 29 pass.
- **Jakarta EE server (JTA / `ServerSession`)** — the null-connection bug only manifests here (the deployment
  session's own accessor is never connected). Verified end-to-end on GlassFish 8.0.1 (the exact #25988 repro) by
  replacing the bundled `org.eclipse.persistence.jpa` jar with this patched build: `runWithConnection` inside
  `runInTransaction` now returns a non-null `Connection`.

Note: the RESOURCE_LOCAL harness cannot reproduce the *null* connection (its session accessor is connected), so the
JSE tests guard the JSE path while the GlassFish repro exercises the JTA path.

Fixes eclipse-ee4j/glassfish#25988
