### PR TITLE
Fix SQL Server null offset-temporal binding

### DIFF
--- a/foundation/eclipselink.core.test/src/test/java/org/eclipse/persistence/testing/tests/junit/platform/database/SQLServerPlatformTest.java
+++ b/foundation/eclipselink.core.test/src/test/java/org/eclipse/persistence/testing/tests/junit/platform/database/SQLServerPlatformTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.persistence.testing.tests.junit.platform.database;
+
+import java.sql.Types;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+
+import org.eclipse.persistence.internal.helper.DatabaseField;
+import org.eclipse.persistence.platform.database.SQLServerPlatform;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SQLServerPlatformTest {
+
+    @Test
+    public void testNullOffsetTemporalUsesTimestamp() {
+        SQLServerPlatform platform = new SQLServerPlatform();
+        platform.setDriverSupportsOffsetDateTime(false);
+
+        Assert.assertEquals(Types.TIMESTAMP, platform.getJDBCTypeForSetNull(fieldWithType(OffsetDateTime.class)));
+        Assert.assertEquals(Types.TIMESTAMP, platform.getJDBCTypeForSetNull(fieldWithType(OffsetTime.class)));
+    }
+
+    @Test
+    public void testNullOffsetTemporalUsesTimezone() {
+        SQLServerPlatform platform = new SQLServerPlatform();
+        platform.setDriverSupportsOffsetDateTime(true);
+
+        Assert.assertEquals(Types.TIMESTAMP_WITH_TIMEZONE,
+                platform.getJDBCTypeForSetNull(fieldWithType(OffsetDateTime.class)));
+        Assert.assertEquals(Types.TIME_WITH_TIMEZONE,
+                platform.getJDBCTypeForSetNull(fieldWithType(OffsetTime.class)));
+    }
+
+    @Test
+    public void testExplicitNullSqlTypeIsPreserved() {
+        SQLServerPlatform platform = new SQLServerPlatform();
+        platform.setDriverSupportsOffsetDateTime(false);
+
+        DatabaseField field = fieldWithType(OffsetDateTime.class);
+        field.setSqlType(Types.OTHER);
+
+        Assert.assertEquals(Types.OTHER, platform.getJDBCTypeForSetNull(field));
+    }
+
+    private DatabaseField fieldWithType(Class<?> type) {
+        DatabaseField field = new DatabaseField("OFFSET_DATE_TIME");
+        field.setType(type);
+        return field;
+    }
+}

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/SQLServerPlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/SQLServerPlatform.java
@@ -32,6 +32,7 @@ import org.eclipse.persistence.internal.expressions.FunctionExpression;
 import org.eclipse.persistence.internal.expressions.RelationExpression;
 import org.eclipse.persistence.internal.expressions.SQLSelectStatement;
 import org.eclipse.persistence.internal.helper.ClassConstants;
+import org.eclipse.persistence.internal.helper.ConversionManager;
 import org.eclipse.persistence.internal.helper.DatabaseField;
 import org.eclipse.persistence.internal.helper.DatabaseTable;
 import org.eclipse.persistence.internal.helper.Helper;
@@ -234,6 +235,23 @@ public class SQLServerPlatform extends DatabasePlatform {
         Map<String, Class<?>> classTypeMapping = super.buildJavaTypes();
         classTypeMapping.put("DATETIME2", java.sql.Timestamp.class);
         return classTypeMapping;
+    }
+
+    /**
+     * Return the JDBC type for the given database field to be passed to Statement.setNull.
+     * Use TIMESTAMP for offset temporal types when native driver support is unavailable.
+     */
+    @Override
+    public int getJDBCTypeForSetNull(DatabaseField field) {
+        Class<?> javaType = field == null ? null : ConversionManager.getObjectClass(field.getType());
+
+        if (field != null && field.getSqlType() == DatabaseField.NULL_SQL_TYPE
+                && Boolean.FALSE.equals(driverSupportsOffsetDateTime)
+                && (javaType == OffsetDateTime.class || javaType == OffsetTime.class)) {
+            return java.sql.Types.TIMESTAMP;
+        }
+
+        return super.getJDBCTypeForSetNull(field);
     }
 
     @Override


### PR DESCRIPTION
SQL Server maps OffsetDateTime and OffsetTime to datetime2, whose JDBC type is TIMESTAMP. For drivers without native OffsetDateTime support, EclipseLink already uses the compatible timestamp fallback for non-null values.

The null-binding path did not follow that platform decision: it used the generic TIMESTAMP_WITH_TIMEZONE / TIME_WITH_TIMEZONE types instead. Legacy WebLogic SQL Server drivers reject these types with: "The specified SQL type is not supported by this driver."

This change makes null OffsetDateTime and OffsetTime bindings use TIMESTAMP when driverSupportsOffsetDateTime is false. The flag is set from JDBC driver metadata and is true only for supported Microsoft JDBC driver versions, so supported drivers retain native JDBC 4.2 behavior.

Explicitly configured SQL types continue to take precedence.

Backward compatibility impact is low:

  - No SQL Server DDL or default column mapping changes (datetime2 remains unchanged).
  - Existing tables are unaffected.
  - Non-null bindings are unchanged.
  - Supported Microsoft JDBC drivers are unchanged.
  - Other Java types are unchanged.
  - Legacy drivers change only from a rejected null JDBC type to the existing compatible timestamp fallback.

Test coverage added in foundation/eclipselink.core.test/src/test/java/org/eclipse/persistence/testing/tests/junit/platform/database/SQLServerPlatformTest.java

The tests verify fallback behavior, native-driver behavior, and preservation of explicit SQL types.

Signed-off-by: Vaibhav Vishal <vaibhav.vishal@oracle.com>