### PR TITLE
fix: support Java records as JPA @Embeddable and @EmbeddedId

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/descriptors/CMPPolicy.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/descriptors/CMPPolicy.java
@@ -27,6 +27,7 @@ import org.eclipse.persistence.annotations.CacheKeyType;
 import org.eclipse.persistence.exceptions.DescriptorException;
 import org.eclipse.persistence.exceptions.ValidationException;
 import org.eclipse.persistence.internal.descriptors.ObjectBuilder;
+import org.eclipse.persistence.internal.descriptors.RecordInstantiationPolicy;
 import org.eclipse.persistence.internal.helper.DatabaseField;
 import org.eclipse.persistence.internal.identitymaps.CacheId;
 import org.eclipse.persistence.internal.security.PrivilegedAccessHelper;
@@ -38,8 +39,12 @@ import org.eclipse.persistence.mappings.foundation.AbstractColumnMapping;
 import org.eclipse.persistence.queries.UpdateObjectQuery;
 
 import java.io.Serializable;
+import java.lang.reflect.RecordComponent;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -462,7 +467,10 @@ public class CMPPolicy implements java.io.Serializable, Cloneable {
             return  fieldValue;
         }
 
-        Object keyInstance = getPKClassInstance();
+        Class<?> pkClass = getPKClass();
+        boolean isRecord = pkClass != null && pkClass.isRecord();
+        Object keyInstance = isRecord ? null : getPKClassInstance();
+        Map<String, Object> recordValues = isRecord ? new LinkedHashMap<>() : null;
         Set<ObjectReferenceMapping> usedObjectReferenceMappings = new HashSet<>();
         for (int index = 0; index < pkElementArray.length; index++) {
             Object keyObj = object;
@@ -492,11 +500,35 @@ public class CMPPolicy implements java.io.Serializable, Cloneable {
                     fieldValue = mapping.getReferenceDescriptor().getCMPPolicy().createPrimaryKeyInstance(fieldValue, session);
                     usedObjectReferenceMappings.add((ObjectReferenceMapping)mapping);
                 }
-                accessor.setValue(nestedKeyInstance, fieldValue);
+                if (isRecord) {
+                    recordValues.put(accessor.getAttributeName(), fieldValue);
+                } else {
+                    accessor.setValue(nestedKeyInstance, fieldValue);
+                }
             }
         }
 
-        return keyInstance;
+        return isRecord ? createRecordInstance(pkClass, recordValues) : keyInstance;
+    }
+
+    /**
+     * Build a record primary key class instance from its component values using
+     * its canonical constructor. Records are immutable, so the default
+     * no-arg-constructor + field-reflection approach used for bean id classes
+     * cannot be applied.
+     *
+     * Values are looked up by record component name so that the field order in
+     * the descriptor does not have to match the record component declaration
+     * order.
+     */
+    private Object createRecordInstance(Class<?> recordClass, Map<String, Object> valuesByName) {
+        List<Object> values = new ArrayList<>(valuesByName.size());
+        for (RecordComponent component : recordClass.getRecordComponents()) {
+            values.add(valuesByName.get(component.getName()));
+        }
+        RecordInstantiationPolicy policy = new RecordInstantiationPolicy(recordClass);
+        policy.setValues(values);
+        return policy.buildNewInstance();
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/descriptors/ClassDescriptor.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/descriptors/ClassDescriptor.java
@@ -3967,38 +3967,41 @@ public class ClassDescriptor extends CoreDescriptor<AttributeGroup, DescriptorEv
         // PERF: Check if the class "itself" was weaved.
         // If weaved avoid reflection, use clone copy and empty new.
         if (Arrays.asList(getJavaClass().getInterfaces()).contains(PersistenceObject.class)) {
-            // Cloning is only auto set for field access, as method access
-            // may not have simple fields, same with empty new and reflection get/set.
-            boolean isMethodAccess = false;
-            for (DatabaseMapping mapping: getMappings()) {
-                if (mapping.isUsingMethodAccess()) {
-                    // Ok for lazy 1-1s
-                    if (!mapping.isOneToOneMapping() || !((ForeignReferenceMapping)mapping).usesIndirection()) {
-                        isMethodAccess = true;
-                    }
-                } else if (!mapping.isWriteOnly()) {
-                    // Avoid reflection.
-                    mapping.setAttributeAccessor(new PersistenceObjectAttributeAccessor(mapping.getAttributeName()));
-                }
-            }
-            if (!isMethodAccess) {
+            // Records are immutable and cannot be woven, so they always need
+            // record-aware copy and instantiation policies, regardless of access type.
+            if (javaClass != null && javaClass.isRecord()) {
                 if (this.copyPolicy == null) {
-                    if (javaClass != null && javaClass.isRecord()) {
-                        setCopyPolicy(new RecordCopyPolicy());
-                    } else {
+                    setCopyPolicy(new RecordCopyPolicy());
+                }
+                if (!isAbstract() && this.instantiationPolicy == null) {
+                    setInstantiationPolicy(new RecordInstantiationPolicy(javaClass));
+                }
+            } else {
+                // Cloning is only auto set for field access, as method access
+                // may not have simple fields, same with empty new and reflection get/set.
+                boolean isMethodAccess = false;
+                for (DatabaseMapping mapping: getMappings()) {
+                    if (mapping.isUsingMethodAccess()) {
+                        // Ok for lazy 1-1s
+                        if (!mapping.isOneToOneMapping() || !((ForeignReferenceMapping)mapping).usesIndirection()) {
+                            isMethodAccess = true;
+                        }
+                    } else if (!mapping.isWriteOnly()) {
+                        // Avoid reflection.
+                        mapping.setAttributeAccessor(new PersistenceObjectAttributeAccessor(mapping.getAttributeName()));
+                    }
+                }
+                if (!isMethodAccess) {
+                    if (this.copyPolicy == null) {
                         setCopyPolicy(new PersistenceEntityCopyPolicy());
                     }
-                }
-                if (!isAbstract()) {
-                    try {
-                        if (this.instantiationPolicy == null) {
-                            if (javaClass != null && javaClass.isRecord()) {
-                                setInstantiationPolicy(new RecordInstantiationPolicy(javaClass));
-                            } else {
-                                setInstantiationPolicy(new PersistenceObjectInstantiationPolicy((PersistenceObject)getJavaClass().getConstructor().newInstance()));
-                            }
+                    if (!isAbstract() && this.instantiationPolicy == null) {
+                        try {
+                            setInstantiationPolicy(new PersistenceObjectInstantiationPolicy((PersistenceObject)getJavaClass().getConstructor().newInstance()));
+                        } catch (Exception ignore) {
+                            // No-arg constructor may not exist.
                         }
-                    } catch (Exception ignore) { }
+                    }
                 }
             }
         }

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/TestRecordEmbeddable.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/TestRecordEmbeddable.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.record;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+
+import org.eclipse.persistence.jpa.test.framework.DDLGen;
+import org.eclipse.persistence.jpa.test.framework.Emf;
+import org.eclipse.persistence.jpa.test.framework.EmfRunner;
+import org.eclipse.persistence.jpa.test.record.model.RecordEntity;
+import org.eclipse.persistence.jpa.test.record.model.RecordId;
+import org.eclipse.persistence.jpa.test.record.model.RecordValue;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@code java.lang.Record} used as JPA {@code @Embeddable} types.
+ * <p>
+ * This test covers:
+ * <ul>
+ *   <li>{@code @EmbeddedId} with a record type</li>
+ *   <li>{@code @Embedded} attribute with a record type</li>
+ *   <li>Persist, find, and merge operations</li>
+ * </ul>
+ * <p>
+ * Prior to the fix for <a href="https://github.com/eclipse-ee4j/eclipselink/issues/2656">#2656</a>,
+ * EclipseLink threw {@code IllegalAccessException: Can not set final field} when
+ * method-accessed embeddable records were processed. The root cause was that
+ * {@code RecordCopyPolicy} and {@code RecordInstantiationPolicy} were only
+ * initialized for field-accessed descriptors, not method-accessed ones.
+ */
+@RunWith(EmfRunner.class)
+public class TestRecordEmbeddable {
+
+    @Emf(createTables = DDLGen.DROP_CREATE, classes = {
+            RecordEntity.class, RecordId.class, RecordValue.class })
+    private EntityManagerFactory emf;
+
+    @Test
+    public void testPersistAndFind() {
+        EntityManager em = emf.createEntityManager();
+        try {
+            em.getTransaction().begin();
+
+            UUID uuid = UUID.randomUUID();
+            RecordId id = new RecordId(uuid);
+            RecordValue value = new RecordValue("test-description", 42);
+            RecordEntity entity = new RecordEntity(id, "test-entity", value);
+
+            em.persist(entity);
+            em.getTransaction().commit();
+
+            // Clear to force a fresh read from the database
+            em.clear();
+
+            RecordEntity found = em.find(RecordEntity.class, id);
+            assertNotNull("Entity should be found after persist", found);
+            assertEquals("test-entity", found.getName());
+            assertNotNull("Embedded value should not be null", found.getValue());
+            assertEquals("test-description", found.getValue().description());
+            assertEquals(42, found.getValue().amount());
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            em.close();
+        }
+    }
+
+    @Test
+    public void testMerge() {
+        EntityManager em = emf.createEntityManager();
+        try {
+            // Persist
+            em.getTransaction().begin();
+            UUID uuid = UUID.randomUUID();
+            RecordId id = new RecordId(uuid);
+            RecordValue value = new RecordValue("original", 10);
+            RecordEntity entity = new RecordEntity(id, "original-name", value);
+            em.persist(entity);
+            em.getTransaction().commit();
+            em.clear();
+
+            // Merge with updated values
+            em.getTransaction().begin();
+            RecordValue updatedValue = new RecordValue("updated", 20);
+            RecordEntity updated = new RecordEntity(id, "updated-name", updatedValue);
+            RecordEntity merged = em.merge(updated);
+            em.getTransaction().commit();
+
+            assertNotNull("Merged entity should not be null", merged);
+            assertEquals("updated-name", merged.getName());
+            assertEquals("updated", merged.getValue().description());
+            assertEquals(20, merged.getValue().amount());
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            em.close();
+        }
+    }
+
+    @Test
+    public void testGetIdentifier() {
+        UUID uuid = UUID.randomUUID();
+        RecordId id = new RecordId(uuid);
+        RecordEntity entity = new RecordEntity(id, "test-entity", new RecordValue("desc", 1));
+
+        Object identifier = emf.getPersistenceUnitUtil().getIdentifier(entity);
+
+        assertNotNull("Identifier should not be null", identifier);
+        assertTrue("Identifier should be a RecordId", identifier instanceof RecordId);
+        assertEquals("Identifier should equal the entity's embedded id", id, identifier);
+    }
+
+    @Test
+    public void testPersistAndFindWithNoArgConstructor() {
+        EntityManager em = emf.createEntityManager();
+        try {
+            em.getTransaction().begin();
+
+            // Mirror the original #2656 reproduction: the @EmbeddedId record
+            // is created through its custom no-arg constructor.
+            RecordId id = new RecordId();
+            RecordValue value = new RecordValue("no-arg-description", 7);
+            RecordEntity entity = new RecordEntity(id, "no-arg-entity", value);
+
+            em.persist(entity);
+            em.getTransaction().commit();
+            em.clear();
+
+            RecordEntity found = em.find(RecordEntity.class, id);
+            assertNotNull("Entity should be found after persist", found);
+            assertEquals("no-arg-entity", found.getName());
+            assertEquals("no-arg-description", found.getValue().description());
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            em.close();
+        }
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/TestRecordIdClass.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/TestRecordIdClass.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.record;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+
+import org.eclipse.persistence.jpa.test.framework.DDLGen;
+import org.eclipse.persistence.jpa.test.framework.Emf;
+import org.eclipse.persistence.jpa.test.framework.EmfRunner;
+import org.eclipse.persistence.jpa.test.record.model.RecordIdClass;
+import org.eclipse.persistence.jpa.test.record.model.RecordIdClassEntity;
+import org.eclipse.persistence.jpa.test.record.model.SingleIdClass;
+import org.eclipse.persistence.jpa.test.record.model.SingleIdClassEntity;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for a {@code java.lang.Record} used as a JPA {@code @IdClass}.
+ */
+@RunWith(EmfRunner.class)
+public class TestRecordIdClass {
+
+    @Emf(createTables = DDLGen.DROP_CREATE, classes = { RecordIdClassEntity.class, SingleIdClassEntity.class })
+    private EntityManagerFactory emf;
+
+    @Test
+    public void testPersistAndFind() {
+        EntityManager em = emf.createEntityManager();
+        try {
+            em.getTransaction().begin();
+            RecordIdClassEntity entity = new RecordIdClassEntity("code-1", "description-1");
+            em.persist(entity);
+            em.getTransaction().commit();
+            em.clear();
+
+            RecordIdClass idClass = new RecordIdClass(entity.getId(), entity.getCode());
+            RecordIdClassEntity found = em.find(RecordIdClassEntity.class, idClass);
+            assertNotNull("Entity should be found after persist", found);
+            assertEquals("description-1", found.getDescription());
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            em.close();
+        }
+    }
+
+    @Test
+    public void testGetIdentifier() {
+        RecordIdClassEntity entity = new RecordIdClassEntity("code-1", "description-1");
+
+        Object identifier = emf.getPersistenceUnitUtil().getIdentifier(entity);
+
+        assertNotNull("Identifier should not be null", identifier);
+        assertTrue("Identifier should be a RecordIdClass", identifier instanceof RecordIdClass);
+        RecordIdClass idClass = (RecordIdClass) identifier;
+        assertEquals(entity.getId(), idClass.id());
+        assertEquals("code-1", idClass.code());
+    }
+
+    @Test
+    public void testSingleComponentPersistAndFind() {
+        EntityManager em = emf.createEntityManager();
+        try {
+            em.getTransaction().begin();
+            SingleIdClassEntity entity = new SingleIdClassEntity("description-1");
+            em.persist(entity);
+            em.getTransaction().commit();
+            em.clear();
+
+            // The single-component id class is reconstructed from the entity's
+            // @Id value; the record's no-arg constructor is not used here.
+            SingleIdClass idClass = new SingleIdClass(entity.getId());
+            SingleIdClassEntity found = em.find(SingleIdClassEntity.class, idClass);
+            assertNotNull("Entity should be found after persist", found);
+            assertEquals("description-1", found.getDescription());
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            em.close();
+        }
+    }
+
+    @Test
+    public void testSingleComponentGetIdentifier() {
+        SingleIdClassEntity entity = new SingleIdClassEntity("description-1");
+
+        Object identifier = emf.getPersistenceUnitUtil().getIdentifier(entity);
+
+        assertNotNull("Identifier should not be null", identifier);
+        assertTrue("Identifier should be a SingleIdClass", identifier instanceof SingleIdClass);
+        SingleIdClass idClass = (SingleIdClass) identifier;
+        assertEquals(entity.getId(), idClass.id());
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/RecordEntity.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/RecordEntity.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.record.model;
+
+import jakarta.persistence.Embedded;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+
+@Entity
+public class RecordEntity {
+
+    @EmbeddedId
+    private RecordId id;
+
+    @Embedded
+    private RecordValue value;
+
+    private String name;
+
+    public RecordEntity() {
+    }
+
+    public RecordEntity(RecordId id, String name, RecordValue value) {
+        this.id = id;
+        this.name = name;
+        this.value = value;
+    }
+
+    public RecordId getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public RecordValue getValue() {
+        return value;
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/RecordId.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/RecordId.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.record.model;
+
+import jakarta.persistence.Embeddable;
+
+import java.util.UUID;
+
+@Embeddable
+public record RecordId(UUID id) {
+
+    /**
+     * Custom no-arg constructor that generates a new identifier. This mirrors
+     * the original #2656 reproduction, where the no-arg constructor let
+     * EclipseLink instantiate the record before it failed setting the final
+     * {@code id} field.
+     */
+    public RecordId() {
+        this(UUID.randomUUID());
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/RecordIdClass.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/RecordIdClass.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.record.model;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * A two-component record used as a JPA {@code @IdClass}.
+ */
+public record RecordIdClass(UUID id, String code) {
+
+    public RecordIdClass {
+        Objects.requireNonNull(id, "id must not be null");
+        Objects.requireNonNull(code, "code must not be null");
+    }
+
+    public RecordIdClass(String code) {
+        this(UUID.randomUUID(), code);
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/RecordIdClassEntity.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/RecordIdClassEntity.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.record.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+
+import java.util.UUID;
+
+@Entity
+@IdClass(RecordIdClass.class)
+public class RecordIdClassEntity {
+
+    @Id
+    private UUID id;
+
+    @Id
+    private String code;
+
+    private String description;
+
+    protected RecordIdClassEntity() {
+    }
+
+    public RecordIdClassEntity(String code, String description) {
+        this.id = UUID.randomUUID();
+        this.code = code;
+        this.description = description;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/RecordValue.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/RecordValue.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.record.model;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public record RecordValue(String description, int amount) {
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/SingleIdClass.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/SingleIdClass.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.record.model;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * A single-component record used as a JPA {@code @IdClass}, with a custom
+ * no-arg constructor that generates a new identifier.
+ */
+public record SingleIdClass(UUID id) {
+
+    public SingleIdClass {
+        Objects.requireNonNull(id, "id must not be null");
+    }
+
+    public SingleIdClass() {
+        this(UUID.randomUUID());
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/SingleIdClassEntity.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/SingleIdClassEntity.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.record.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+
+import java.util.UUID;
+
+@Entity
+@IdClass(SingleIdClass.class)
+public class SingleIdClassEntity {
+
+    @Id
+    private UUID id;
+
+    private String description;
+
+    protected SingleIdClassEntity() {
+    }
+
+    public SingleIdClassEntity(String description) {
+        this.id = UUID.randomUUID();
+        this.description = description;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}


### PR DESCRIPTION
@
Fixes #2656 — `IllegalAccessException: Can not set final field` when a `java.lang.Record` is used as a Jakarta Persistence `@Embeddable` (`@EmbeddedId`/`@Embedded`) or as an `@IdClass`.

## Root cause

Two code paths assumed a mutable bean with a no-arg constructor:

1. **Copy/instantiation** — `ClassDescriptor.preInitialize()` only set `RecordCopyPolicy` / `RecordInstantiationPolicy` inside the `!isMethodAccess` branch. Embeddable records typically use method access (record accessor methods like `id()` are methods), so the record-aware policies were never installed, and EclipseLink fell back to field reflection.

2. **Primary key construction** — `CMPPolicy.createPrimaryKeyInstance()` built the id class via `getConstructor().newInstance()` (no-arg) followed by `accessor.setValue(...)`. Records have neither a no-arg constructor nor writable fields.

## Changes

- `ClassDescriptor`: apply record-aware policies to any `java.lang.Record` class regardless of access type.
- `CMPPolicy`: detect a record id class and build it via `RecordInstantiationPolicy` (canonical constructor), mapping values by record component name so descriptor field order is irrelevant.

## Tests

- `TestRecordEmbeddable` — `@EmbeddedId`/`@Embedded` records: persist/find, merge, `getIdentifier`, and a custom no-arg constructor case (`new RecordId()` generating a UUID, mirroring the original #2656 `CopyId`).
- `TestRecordIdClass` — records used as `@IdClass`, both a two-component (`RecordIdClass(UUID, String)`) and a single-component with a custom no-arg constructor (`SingleIdClass(UUID)`), each covering persist/find and `getIdentifier`.
@