### PR TITLE
fix: support nested Java records as JPA @Embeddable attributes

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/mappings/AggregateMapping.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/mappings/AggregateMapping.java
@@ -117,7 +117,8 @@ public abstract class AggregateMapping extends DatabaseMapping {
         // from a back up clone since a map key mapping does not map a field
         // on the source queries backup clone.
         if (sourceQuery.getSession().isUnitOfWork() && ! isMapKeyMapping()) {
-            Object backupAttributeValue = getAttributeValueFromBackupClone(sourceQuery.getBackupClone());
+            Object backupClone = sourceQuery.getBackupClone();
+            Object backupAttributeValue = backupClone == null ? null : getAttributeValueFromBackupClone(backupClone);
             if (backupAttributeValue == null) {
                 backupAttributeValue = getObjectBuilder(sourceAttributeValue, sourceQuery.getSession()).buildNewInstance();
             }
@@ -670,6 +671,12 @@ public abstract class AggregateMapping extends DatabaseMapping {
         Object sourceAggregate = null;
         if (source != null) {
             sourceAggregate = getAttributeValueFromObject(source);
+        }
+        // Records are immutable, so the aggregate cannot be updated field-by-field.
+        // Replace it with a clone of the source aggregate instead.
+        if (sourceAggregate instanceof Record) {
+            setAttributeValueInObject(target, referenceDescriptor.getCopyPolicy().buildClone(sourceAggregate, targetSession));
+            return;
         }
         ObjectBuilder objectBuilder = getObjectBuilderForClass(aggregateChangeSet.getClassType(mergeManager.getSession()), mergeManager.getSession());
         //Bug#4719341  Always obtain aggregate attribute value from the target object regardless of new or not

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/TestNestedRecordEmbeddable.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/TestNestedRecordEmbeddable.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.record;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+
+import org.eclipse.persistence.jpa.test.framework.DDLGen;
+import org.eclipse.persistence.jpa.test.framework.Emf;
+import org.eclipse.persistence.jpa.test.framework.EmfRunner;
+import org.eclipse.persistence.jpa.test.record.model.NestedRecordChild;
+import org.eclipse.persistence.jpa.test.record.model.NestedRecordEntity;
+import org.eclipse.persistence.jpa.test.record.model.NestedRecordParent;
+import org.eclipse.persistence.jpa.test.record.model.NestedRecordSimple;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Tests for a nested {@code @Embedded} record used inside another {@code @Embeddable} record.
+ */
+@RunWith(EmfRunner.class)
+public class TestNestedRecordEmbeddable {
+
+    @Emf(createTables = DDLGen.DROP_CREATE, classes = {
+            NestedRecordEntity.class, NestedRecordParent.class, NestedRecordChild.class, NestedRecordSimple.class })
+    private EntityManagerFactory emf;
+
+    @Test
+    public void testPersistNestedEmbeddedRecord() {
+        EntityManager em = emf.createEntityManager();
+        try {
+            em.getTransaction().begin();
+
+            NestedRecordSimple simple = new NestedRecordSimple(100L, "value-1");
+            em.persist(simple);
+
+            NestedRecordChild child = new NestedRecordChild("kind-1", simple);
+            NestedRecordParent parent = new NestedRecordParent("status-1", child);
+            NestedRecordEntity entity = new NestedRecordEntity(1L, parent, "description-1");
+
+            em.persist(entity);
+            em.getTransaction().commit();
+            em.clear();
+
+            NestedRecordEntity found = em.find(NestedRecordEntity.class, 1L);
+            assertNotNull("Entity should be found after persist", found);
+            assertEquals("description-1", found.getDescription());
+            assertNotNull("Nested parent should not be null", found.getParent());
+            assertEquals("kind-1", found.getParent().child().kind());
+            assertEquals("value-1", found.getParent().child().simple().getValue());
+        } finally {
+            if (em.getTransaction().isActive()) {
+                em.getTransaction().rollback();
+            }
+            em.close();
+        }
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/NestedRecordChild.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/NestedRecordChild.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.record.model;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Embeddable
+public record NestedRecordChild(
+        String kind,
+        @ManyToOne
+        @JoinColumn(name = "simple_id")
+        NestedRecordSimple simple) {
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/NestedRecordEntity.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/NestedRecordEntity.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.record.model;
+
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class NestedRecordEntity {
+
+    @Id
+    private Long id;
+
+    @Embedded
+    private NestedRecordParent parent;
+
+    private String description;
+
+    protected NestedRecordEntity() {
+    }
+
+    public NestedRecordEntity(Long id, NestedRecordParent parent, String description) {
+        this.id = id;
+        this.parent = parent;
+        this.description = description;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public NestedRecordParent getParent() {
+        return parent;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/NestedRecordParent.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/NestedRecordParent.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.record.model;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+
+@Embeddable
+public record NestedRecordParent(
+        String status,
+        @Embedded NestedRecordChild child) {
+}

--- a/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/NestedRecordSimple.java
+++ b/jpa/eclipselink.jpa.test.jse/src/it/java/org/eclipse/persistence/jpa/test/record/model/NestedRecordSimple.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.test.record.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class NestedRecordSimple {
+
+    @Id
+    private Long id;
+
+    private String value;
+
+    protected NestedRecordSimple() {
+    }
+
+    public NestedRecordSimple(Long id, String value) {
+        this.id = id;
+        this.value = value;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}


### PR DESCRIPTION
@
Support `java.lang.Record` used as a nested `@Embedded` attribute inside another `@Embeddable` record.

## Changes

- `AggregateMapping.buildAggregateModifyQuery`: guard against a null backup clone before reading the backup attribute value.
- `AggregateMapping.mergeChangesIntoObject`: a `Record` aggregate is immutable and cannot be mutated field-by-field, so replace it with a `copyPolicy.buildClone(...)` of the source aggregate.

## Test

`TestNestedRecordEmbeddable` persists a `NestedRecordEntity` carrying a `NestedRecordParent` (record) that itself embeds a `NestedRecordChild` (record) referencing a `NestedRecordSimple` entity, then reads it back and verifies the nested values.

Depends on #2817 (record `@Embeddable` policy plumbing).
@