### PR TITLE
ISSUE-2374: Rework query cache test cases

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/test/java/org/eclipse/persistence/descriptors/DescriptorQueryManagerTest.java
+++ b/foundation/org.eclipse.persistence.core/src/test/java/org/eclipse/persistence/descriptors/DescriptorQueryManagerTest.java
@@ -12,17 +12,13 @@
 
 package org.eclipse.persistence.descriptors;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.persistence.internal.helper.DatabaseField;
 import org.eclipse.persistence.queries.ReadAllQuery;
@@ -30,11 +26,7 @@ import org.junit.jupiter.api.Test;
 
 public class DescriptorQueryManagerTest {
 
-    private static final int READER_COUNT = 100;
-    private static final int WRITER_COUNT = 10;
     private static final int MAX_ATTEMPTS = 100000;
-    private static final long LATCH_TIMEOUT_SECONDS = 2;
-    private static final long TASK_TIMEOUT_SECONDS = 8;
 
     @Test
     public void concurrentWritesToExpressionQueryCacheDoNotThrowNullPointerException() throws Exception {
@@ -55,62 +47,45 @@ public class DescriptorQueryManagerTest {
     }
 
     private void assertConcurrentCacheAccessDoesNotFail(Runnable dropCache, Runnable accessCache) throws Exception {
-        int threadCount = READER_COUNT + WRITER_COUNT;
-        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
-        CountDownLatch ready = new CountDownLatch(threadCount);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch ready = new CountDownLatch(2);
         CountDownLatch start = new CountDownLatch(1);
         AtomicBoolean running = new AtomicBoolean(true);
-        AtomicReference<Throwable> failure = new AtomicReference<>();
         try {
-            List<Future<?>> writerFutures = new ArrayList<>(WRITER_COUNT);
-            for (int thread = 0; thread < WRITER_COUNT; thread++) {
-                writerFutures.add(executor.submit(() -> {
-                    ready.countDown();
-                    assertTrue(start.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS));
-                    while (running.get()) {
-                        // race with the readers on every attempt
-                        dropCache.run();
-                    }
-                    return null;
-                }));
-            }
+            Future<?> writer = executor.submit(() -> {
+                ready.countDown();
+                start.await();
+                while (running.get()) {
+                    dropCache.run();
+                }
+                return null;
+            });
 
-            List<Future<?>> readerFutures = new ArrayList<>(READER_COUNT);
-            for (int thread = 0; thread < READER_COUNT; thread++) {
-                readerFutures.add(executor.submit(() -> {
-                    ready.countDown();
-                    assertTrue(start.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS));
-                    for (int attempt = 0; attempt < MAX_ATTEMPTS && running.get(); attempt++) {
-                        try {
-                            // The cache getter may init the cache then read it, but should not read `null`
-                            accessCache.run();
-                        } catch (Throwable exception) {
-                            failure.compareAndSet(null, exception);
-                            running.set(false);
-                        }
-                    }
-                    return null;
-                }));
-            }
+            Future<?> reader = executor.submit(() -> {
+                ready.countDown();
+                start.await();
+                for (int attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+                    accessCache.run();
+                }
+                return null;
+            });
 
-            assertTrue(ready.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+            ready.await();
             start.countDown();
-            for (Future<?> reader : readerFutures) {
-                reader.get(TASK_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+            try {
+                reader.get();
+            } catch (ExecutionException exception) {
+                throw new AssertionError("Parallel cache writes caused failure", exception.getCause());
+            } finally {
+                running.set(false);
             }
-            running.set(false);
-            for (Future<?> writer : writerFutures) {
-                writer.get(TASK_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-            }
+
+            writer.get();
         } finally {
             running.set(false);
             start.countDown();
             executor.shutdownNow();
-        }
-
-        Throwable exception = failure.get();
-        if (exception != null) {
-            throw new AssertionError("Parallel cache writes caused cache access failure", exception);
         }
     }
 }

--- a/foundation/org.eclipse.persistence.core/src/test/java/org/eclipse/persistence/sessions/ProjectJPQLParseCacheTest.java
+++ b/foundation/org.eclipse.persistence.core/src/test/java/org/eclipse/persistence/sessions/ProjectJPQLParseCacheTest.java
@@ -12,27 +12,18 @@
 
 package org.eclipse.persistence.sessions;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
 
 public class ProjectJPQLParseCacheTest {
 
-    private static final int READER_COUNT = 100;
-    private static final int WRITER_COUNT = 10;
     private static final int MAX_ATTEMPTS = 100000;
-    private static final long LATCH_TIMEOUT_SECONDS = 2;
-    private static final long TASK_TIMEOUT_SECONDS = 8;
 
     @Test
     public void concurrentWritesToJPQLParseCacheDoNotThrowNullPointerException() throws Exception {
@@ -44,62 +35,45 @@ public class ProjectJPQLParseCacheTest {
     }
 
     private void assertConcurrentCacheAccessDoesNotFail(Runnable dropCache, Runnable accessCache) throws Exception {
-        int threadCount = READER_COUNT + WRITER_COUNT;
-        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
-        CountDownLatch ready = new CountDownLatch(threadCount);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch ready = new CountDownLatch(2);
         CountDownLatch start = new CountDownLatch(1);
         AtomicBoolean running = new AtomicBoolean(true);
-        AtomicReference<Throwable> failure = new AtomicReference<>();
         try {
-            List<Future<?>> writerFutures = new ArrayList<>(WRITER_COUNT);
-            for (int thread = 0; thread < WRITER_COUNT; thread++) {
-                writerFutures.add(executor.submit(() -> {
-                    ready.countDown();
-                    assertTrue(start.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS));
-                    while (running.get()) {
-                        // race with the readers on every attempt
-                        dropCache.run();
-                    }
-                    return null;
-                }));
-            }
+            Future<?> writer = executor.submit(() -> {
+                ready.countDown();
+                start.await();
+                while (running.get()) {
+                    dropCache.run();
+                }
+                return null;
+            });
 
-            List<Future<?>> readerFutures = new ArrayList<>(READER_COUNT);
-            for (int thread = 0; thread < READER_COUNT; thread++) {
-                readerFutures.add(executor.submit(() -> {
-                    ready.countDown();
-                    assertTrue(start.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS));
-                    for (int attempt = 0; attempt < MAX_ATTEMPTS && running.get(); attempt++) {
-                        try {
-                            // The cache getter may init the cache then read it, but should not read `null`
-                            accessCache.run();
-                        } catch (Throwable exception) {
-                            failure.compareAndSet(null, exception);
-                            running.set(false);
-                        }
-                    }
-                    return null;
-                }));
-            }
+            Future<?> reader = executor.submit(() -> {
+                ready.countDown();
+                start.await();
+                for (int attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+                    accessCache.run();
+                }
+                return null;
+            });
 
-            assertTrue(ready.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+            ready.await();
             start.countDown();
-            for (Future<?> reader : readerFutures) {
-                reader.get(TASK_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+            try {
+                reader.get();
+            } catch (ExecutionException exception) {
+                throw new AssertionError("Parallel cache writes caused failure", exception.getCause());
+            } finally {
+                running.set(false);
             }
-            running.set(false);
-            for (Future<?> writer : writerFutures) {
-                writer.get(TASK_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-            }
+
+            writer.get();
         } finally {
             running.set(false);
             start.countDown();
             executor.shutdownNow();
-        }
-
-        Throwable exception = failure.get();
-        if (exception != null) {
-            throw new AssertionError("Parallel cache writes caused a cache access failure", exception);
         }
     }
 }


### PR DESCRIPTION
It appears that I was too strict with the short timeout. Consequently, the nightly build CI is failing because the parallel query cache test cases are not completing on time.