### PR TITLE
ISSUE-2833: Avoid using mutable singleton visitor in ResultVariableFactory

### DIFF
--- a/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/ResultVariableFactory.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/main/java/org/eclipse/persistence/jpa/jpql/parser/ResultVariableFactory.java
@@ -31,12 +31,6 @@ import org.eclipse.persistence.jpa.jpql.WordParser;
 public final class ResultVariableFactory extends ExpressionFactory {
 
     /**
-     * Caches the visitor that determines if the parent {@link Expression} is the top-level
-     * <code><b>SELECT</b></code> clause.
-     */
-    private SelectClauseVisitor selectClauseVisitor;
-
-    /**
      * The unique identifier of this {@link ResultVariableFactory}.
      */
     public static final String ID = "result_variable";
@@ -56,18 +50,13 @@ public final class ResultVariableFactory extends ExpressionFactory {
                                                  AbstractExpression expression,
                                                  boolean tolerant) {
 
-        SelectClauseVisitor visitor = selectClauseVisitor();
+        SelectClauseVisitor visitor = new SelectClauseVisitor();
 
-        try {
-            if (expression != null) {
-                parent.accept(visitor);
-                if (!visitor.supported) {
-                    expression = null;
-                }
+        if (expression != null) {
+            parent.accept(visitor);
+            if (!visitor.supported) {
+                expression = null;
             }
-        }
-        finally {
-            visitor.supported = false;
         }
 
         // There was already an expression parsed, we'll assume it's a valid
@@ -84,13 +73,6 @@ public final class ResultVariableFactory extends ExpressionFactory {
         // Use the default factory
         ExpressionFactory factory = getExpressionRegistry().getExpressionFactory(LiteralExpressionFactory.ID);
         return factory.buildExpression(parent, wordParser, word, queryBNF, expression, tolerant);
-    }
-
-    private SelectClauseVisitor selectClauseVisitor() {
-        if (selectClauseVisitor == null) {
-            selectClauseVisitor = new SelectClauseVisitor();
-        }
-        return selectClauseVisitor;
     }
 
     /**

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/org/eclipse/persistence/jpa/jpql/parser/ResultVariableFactoryTest.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/org/eclipse/persistence/jpa/jpql/parser/ResultVariableFactoryTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.persistence.jpa.jpql.parser;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.persistence.jpa.jpql.WordParser;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@SuppressWarnings("nls")
+public final class ResultVariableFactoryTest {
+
+    public ResultVariableFactoryTest() {
+    }
+
+    @Test
+    public void testBuildExpressionDoesNotShareSelectClauseVisitor() throws Exception {
+
+        ResultVariableFactory factory = new ResultVariableFactory();
+        CountDownLatch supportedParentVisited = new CountDownLatch(1);
+        CountDownLatch unsupportedBuildCompleted = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        try {
+            Future<ResultVariable> supportedResult = executor.submit(() -> buildResultVariable(
+                    factory,
+                    new TestExpression(true, supportedParentVisited, unsupportedBuildCompleted)
+            ));
+
+            assertTrue(supportedParentVisited.await(10, TimeUnit.SECONDS));
+
+            Future<ResultVariable> unsupportedResult = executor.submit(() -> {
+                try {
+                    return buildResultVariable(factory, new TestExpression(false, null, null));
+                }
+                finally {
+                    unsupportedBuildCompleted.countDown();
+                }
+            });
+
+            assertFalse(unsupportedResult.get(10, TimeUnit.SECONDS).hasSelectExpression());
+            assertTrue(supportedResult.get(10, TimeUnit.SECONDS).hasSelectExpression());
+        }
+        finally {
+            unsupportedBuildCompleted.countDown();
+            executor.shutdownNow();
+        }
+    }
+
+    private ResultVariable buildResultVariable(ResultVariableFactory factory,
+                                               AbstractExpression parent) {
+
+        AbstractExpression expression = new IdentificationVariable(null, "e");
+        return (ResultVariable) factory.buildExpression(
+                parent,
+                new WordParser("AS result"),
+                Expression.AS,
+                null,
+                expression,
+                false
+        );
+    }
+
+    private static final class TestExpression extends AbstractExpression {
+
+        private final CountDownLatch supportedParentVisited;
+        private final boolean supported;
+        private final CountDownLatch unsupportedBuildCompleted;
+
+        TestExpression(boolean supported,
+                       CountDownLatch supportedParentVisited,
+                       CountDownLatch unsupportedBuildCompleted) {
+
+            super(null);
+            this.supported = supported;
+            this.supportedParentVisited = supportedParentVisited;
+            this.unsupportedBuildCompleted = unsupportedBuildCompleted;
+        }
+
+        @Override
+        public void accept(ExpressionVisitor visitor) {
+
+            if (supported) {
+                visitor.visit(new SelectClause(this));
+                supportedParentVisited.countDown();
+
+                try {
+                    assertTrue(unsupportedBuildCompleted.await(10, TimeUnit.SECONDS));
+                }
+                catch (InterruptedException exception) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError(exception);
+                }
+            }
+            else {
+                visitor.visit(new CollectionMemberExpression(this, null));
+            }
+        }
+
+        @Override
+        public void acceptChildren(ExpressionVisitor visitor) {
+        }
+
+        @Override
+        public JPQLQueryBNF getQueryBNF() {
+            return null;
+        }
+
+        @Override
+        protected void parse(WordParser wordParser, boolean tolerant) {
+        }
+
+        @Override
+        protected void toParsedText(StringBuilder writer, boolean actual) {
+        }
+    }
+}

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/org/eclipse/persistence/jpa/tests/jpql/JPQLBasicTest.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/org/eclipse/persistence/jpa/tests/jpql/JPQLBasicTest.java
@@ -27,6 +27,7 @@ public abstract class JPQLBasicTest {
     /**
      * Creates a new <code>JPQLBasicTest</code>.
      */
+    @SuppressWarnings("this-escape")
     protected JPQLBasicTest() {
         super();
         initialize();

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/org/eclipse/persistence/jpa/tests/jpql/parser/AllJPQLParserTests.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/org/eclipse/persistence/jpa/tests/jpql/parser/AllJPQLParserTests.java
@@ -15,6 +15,7 @@
 //
 package org.eclipse.persistence.jpa.tests.jpql.parser;
 
+import org.eclipse.persistence.jpa.jpql.parser.ResultVariableFactoryTest;
 import org.eclipse.persistence.jpa.tests.jpql.JPQLTestRunner;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite.SuiteClasses;
@@ -34,6 +35,7 @@ import org.junit.runners.Suite.SuiteClasses;
     AllEclipseLinkJPQLParserTests2_1.class,
     AllEclipseLinkJPQLParserTests2_4.class,
     AllEclipseLinkJPQLParserTests2_5.class,
+    ResultVariableFactoryTest.class,
     AllJPQLParserConcurrentTests.class
 })
 @RunWith(JPQLTestRunner.class)

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/org/eclipse/persistence/jpa/tests/jpql/tools/spi/java/JavaManagedTypeProvider.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/org/eclipse/persistence/jpa/tests/jpql/tools/spi/java/JavaManagedTypeProvider.java
@@ -77,6 +77,7 @@ public class JavaManagedTypeProvider implements IManagedTypeProvider {
      * {@link org.eclipse.persistence.jpa.jpql.tools.spi.IMapping IMapping} wrapping a persistent attribute or property
      * @exception NullPointerException The {@link IMappingBuilder} cannot be <code>null</code>
      */
+    @SuppressWarnings("this-escape")
     public JavaManagedTypeProvider(IMappingBuilder<Member> mappingBuilder) {
         super();
         initialize(mappingBuilder);

--- a/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/org/eclipse/persistence/jpa/tests/jpql/tools/spi/java/JavaQuery.java
+++ b/jpa/org.eclipse.persistence.jpa.jpql/src/test/java/org/eclipse/persistence/jpa/tests/jpql/tools/spi/java/JavaQuery.java
@@ -49,7 +49,7 @@ public class JavaQuery implements IQuery {
     public JavaQuery(IManagedTypeProvider provider, CharSequence jpqlQuery) {
         super();
         this.provider = provider;
-        setExpression(jpqlQuery);
+        this.jpqlQuery = (jpqlQuery != null) ? jpqlQuery.toString() : ExpressionTools.EMPTY_STRING;
     }
 
     @Override


### PR DESCRIPTION
**Issue:**

 https://github.com/eclipse-ee4j/eclipselink/issues/2833

**Fix:**

**Avoid using mutable, singleton visitor in the factory class**

Each `buildExpression()` invocation creates its own `SelectClauseVisitor`, so concurrent JPQL parses cannot overwrite an another parse’s supported state. 