### PR TITLE
Compensate for TCK 4.0 changes

### DIFF
--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/EntityManagerSetupImpl.java
@@ -838,6 +838,22 @@ public class EntityManagerSetupImpl implements MetadataRefreshListener {
                     updateTunerPostDeploy(deployProperties, classLoaderToUse);
                     this.deployLock.release();
                     isLockAcquired = false;
+                } else if (this.session.isDatabaseSession() && !isValidationOnly(deployProperties, false)) {
+
+                    // The persistence unit is already deployed and logged in, which is what happens
+                    // whenever an EntityManagerFactory is created for a unit that another, still open,
+                    // factory already deployed. The branch above never runs in that case, so without
+                    // this one the schema generation properties passed to this particular
+                    // createEntityManagerFactory or Persistence.generateSchema call would be silently
+                    // ignored.
+                    //
+                    // Nothing in Jakarta Persistence exempts an already deployed unit, and Hibernate
+                    // performs both the script and the database action on every factory it builds.
+                    // This was never tested for before, but in the 4.0 TCK
+                    // ee.jakarta.tck.persistence.se.schemaGeneration.annotations.discriminatorColumn.Client now
+                    // implicitly tests for this.
+
+                    writeDDL(deployProperties, getDatabaseSession(deployProperties), classLoaderToUse);
                 }
                 // 266912: Initialize the Metamodel, a login should have already occurred.
                 try {

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,17 @@
 
 -->
 
+<!--
+
+Running a single test with full logging:
+
+mvn clean install -Ptest1 \
+    -Dit.test=ee.jakarta.tck.persistence.core.EntityGraph.Client \
+    -Djava.util.logging.config.file=logging.properties \
+    -Djpa.provider.implementation.specific.additional.properties=:eclipselink.logging.level=FINEST
+
+-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -1324,6 +1335,67 @@
                 <db.driver.version>${pgsql.version}</db.driver.version>
                 <test.skip.in-memory.db>true</test.skip.in-memory.db>
             </properties>
+        </profile>
+
+        <profile>
+            <id>pgsql-start</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <version>0.49.0</version>
+                        <inherited>false</inherited>
+                        <configuration>
+                            <images>
+                                <image>
+                                    <alias>postgres</alias>
+                                    <name>postgres:17</name>
+
+                                    <run>
+                                        <containerNamePattern>postgresserver</containerNamePattern>
+
+                                        <env>
+                                            <POSTGRES_USER>${db.user}</POSTGRES_USER>
+                                            <POSTGRES_PASSWORD>${db.pwd}</POSTGRES_PASSWORD>
+                                            <POSTGRES_DB>${db.name}</POSTGRES_DB>
+                                        </env>
+
+                                        <ports>
+                                            <port>5432:5432</port>
+                                        </ports>
+
+                                        <!-- Wait until PostgreSQL is really up.
+                                             The image logs "ready to accept connections" once while
+                                             initdb is still running and the server listens on the
+                                             unix socket only, so the port check is what proves it
+                                             can be reached over TCP. -->
+                                        <wait>
+                                            <log><![CDATA[database system is ready to accept connections]]></log>
+                                            <tcp>
+                                                <ports>
+                                                    <port>5432</port>
+                                                </ports>
+                                            </tcp>
+                                            <time>600000</time>
+                                        </wait>
+                                    </run>
+                                </image>
+                            </images>
+                        </configuration>
+
+                        <executions>
+                            <execution>
+                                <id>start-postgres</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>start</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
 
         <profile>


### PR DESCRIPTION
TCK 4.0 exclusively runs on Postgres, so add postgres start for convenience

Schema generation on an already-deployed persistence unit, since TCK doesn't close entity manager and entity manager factory anymore between tests. Without this change, 26 TCK tests fail. See also https://github.com/jakartaee/persistence/issues/1174